### PR TITLE
fix(teleoperate): keep tracking a worker that outlives the second-stop join (T3)

### DIFF
--- a/makerlab/teleoperate.py
+++ b/makerlab/teleoperate.py
@@ -872,7 +872,6 @@ def handle_stop_teleoperation() -> dict[str, Any]:
         worker.join(timeout=5.0)
         if worker.is_alive():
             logger.warning("Teleoperation worker did not exit within 5s")
-            teleoperation_thread = None
             return {
                 "success": True,
                 "message": "Release requested, but the worker has not shut down yet",

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -444,6 +444,63 @@ def test_second_stop_during_grace_surfaces_cleanup_error(
     assert "TORQUE MAY STILL BE ENABLED" in result["warning"]
 
 
+class _StuckWorker:
+    """Thread double: never actually exits — join() times out, is_alive() stays True.
+
+    Simulates a worker still mid rest-pose-return/cleanup after a second stop's
+    `join(timeout=5.0)` elapses, so the code must NOT abandon the reference.
+    """
+
+    def __init__(self) -> None:
+        self.join_calls: list[float | None] = []
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_calls.append(timeout)
+
+
+def test_second_stop_timeout_keeps_thread_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: when the second-stop join() times out (the worker is still
+    genuinely alive), `teleoperation_thread` must keep pointing at it instead
+    of being nulled out — nulling it would let a later start's mutex/guard
+    checks wrongly treat the still-running, still-hardware-holding worker as
+    gone (see finish_pending_release, which follows this same discipline).
+    """
+    import threading
+
+    import makerlab.teleoperate as teleop
+
+    worker = _StuckWorker()
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(teleop, "teleoperation_thread", worker)
+    monkeypatch.setattr(teleop, "_release_now", threading.Event())
+    monkeypatch.setattr(teleop, "last_cleanup_error", None)
+
+    result = teleop.handle_stop_teleoperation()
+
+    assert result["success"] is True
+    assert "has not shut down yet" in result["message"]
+    assert "did not shut down within 5s" in result["warning"]
+    # The key regression assertion: the module must still hold the SAME live
+    # thread object, not None.
+    assert teleop.teleoperation_thread is worker
+
+    # A subsequent finish_pending_release() must still recognize the worker as
+    # alive (not treat it as already gone) and attempt its own join.
+    assert teleop.finish_pending_release() is False
+    assert worker.join_calls  # finish_pending_release actually tried to join it
+
+    # A third manual stop press must re-enter the same second-stop branch
+    # (not fall through to "No teleoperation session is active").
+    result2 = teleop.handle_stop_teleoperation()
+    assert result2["message"] != "No teleoperation session is active"
+    assert teleop.teleoperation_thread is worker
+
+
 def test_finish_pending_release_cuts_grace_short(monkeypatch: pytest.MonkeyPatch) -> None:
     """A start arriving during the grace hold must release the arms and free
     the ports instead of failing port-busy for the rest of the grace.


### PR DESCRIPTION
## Summary

T3: a second stop whose `worker.join(timeout=5.0)` times out still set `teleoperation_thread = None`, even though the worker was genuinely still alive and holding the serial port. `finish_pending_release()` and the `is_alive()` guard in `handle_start_teleoperation` both rely on that reference to detect a pending release, so nulling it let a new session start while the old worker was still running -- both owning the same physical hardware at the same time.

The fix removes only that one assignment in the timeout branch, leaving `teleoperation_thread` pointing at the live worker. This matches the discipline `finish_pending_release()` already follows a few lines away in the same file, and it never touches the success-branch nulling (join actually completed), which is correct and unchanged.

### Background on the removed line

`git blame` traces this to commit `6927b30b` ("make torque release reliable and loud on every stop path"), which added the early-return branch specifically so a timeout would honestly report "the worker has not shut down yet" instead of the prior behavior of always reporting a clean stop. The `teleoperation_thread = None` line was carried over unmodified from the previous unconditional version rather than reconsidered for the new timeout-specific branch, leaving the bookkeeping out of step with the message it now returns. Checked every reference to `teleoperation_thread` in the repo: only `finish_pending_release()` and the start-path guard depend on it, and both `record.py` and `rollout.py`'s cross-feature mutex checks read only the `teleoperation_active` boolean, so this change has no effect on that logic.

## Test plan

- [x] New regression test (`test_second_stop_timeout_keeps_thread_reference`) fails against the pre-fix code and passes after the fix
- [x] Full suite: 859 passed, no regressions
- [x] `ruff check` / `ruff format --check` clean on touched files
- [x] Verified against real SO-101 hardware: with cleanup artificially stalled past the 5s join timeout, a new start attempt is now correctly rejected ("still being released. Try again in a few seconds.") instead of reconnecting to the same serial port while the old worker was still mid-cleanup on it; a fresh start succeeds normally once the old worker actually finishes
- [x] Sanity-checked normal start/stop through the live server post-fix -- no regression to the happy path

## Note

While verifying this fix, I found a related but separate, pre-existing race: `handle_stop_teleoperation` never acquires `_state_lock` (unlike `handle_start_teleoperation`), so there is a narrow theoretical window where the success-path nulling could race a brand-new session's freshly spawned worker thread. This is unrelated to T3 and out of scope for this PR; flagging in case it warrants its own ticket.

https://claude.ai/code/session_01WtHH9o7Ewv3VoNXqHxLLoA