### PR TITLE
fix(mutex): guard calibration, auto-calibration, and wiggle in the cross-feature mutex (T4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Frontend checks (run from `frontend/`): `npm run lint`, `npx tsc --noEmit`, `npm
 
 ### State model & mutual exclusion
 
-Each feature module owns module-level globals (`recording_active`, `teleoperation_active`, `inference_active`) protected by per-feature locks. Teleoperation, recording, and inference **are mutually exclusive, enforced in code** — not by a shared lock, but by reciprocal active-flag checks at each feature's start (e.g. `handle_start_teleoperation` refuses while recording or inference is active). New features that drive the robot must add the same reciprocal checks.
+Each feature module owns module-level globals (`recording_active`, `teleoperation_active`, `inference_active`, plus `calibrate.calibration_is_active()`, `auto_calibrate.auto_calibration_is_active()`, and `wiggle.wiggle_active`) protected by per-feature locks. Teleoperation, recording, inference, manual calibration, auto-calibration, and wiggle **are all mutually exclusive, enforced in code** — not by a shared lock, but by reciprocal active-flag checks at each feature's start (e.g. `handle_start_teleoperation` refuses while recording, inference, calibration, auto-calibration, or a wiggle is active). New features that drive the robot must add the same reciprocal checks against every existing one.
 
 ### WebSocket broadcast
 

--- a/makerlab/auto_calibrate.py
+++ b/makerlab/auto_calibrate.py
@@ -209,6 +209,32 @@ class _AutoCalArmRunner:
             if self.status.active:
                 return {"success": False, "message": "Auto-calibration is already running"}
 
+            # Mutex with every other feature that drives the same serial bus
+            # (see CLAUDE.md's "State model & mutual exclusion"). Lazy
+            # imports to dodge circular imports at module load time (matches
+            # the existing pattern in teleoperate.py/record.py/rollout.py).
+            from . import (
+                calibrate as _calibrate,
+                record as _record,
+                rollout as _rollout,
+                teleoperate as _teleoperate,
+                wiggle as _wiggle,
+            )
+
+            if _teleoperate.teleoperation_active:
+                return {"success": False, "message": "Teleoperation is currently active. Stop it first."}
+            if _record.recording_active:
+                return {"success": False, "message": "Recording is currently active. Stop it first."}
+            if _rollout.inference_active:
+                return {"success": False, "message": "Inference is currently active. Stop it first."}
+            if _calibrate.calibration_is_active():
+                return {"success": False, "message": "Calibration is currently active. Stop it first."}
+            if _wiggle.wiggle_active:
+                return {
+                    "success": False,
+                    "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
+                }
+
             if request.device_type not in ("teleop", "robot"):
                 return {"success": False, "message": "Invalid device type"}
             if not request.port:
@@ -518,6 +544,35 @@ class AutoCalibrationBatchManager:
             if self._active():
                 return {"success": False, "message": "A batch auto-calibration is already running"}
 
+            # Mutex with every other feature that drives the same serial bus
+            # (see CLAUDE.md's "State model & mutual exclusion"). Checked
+            # up front, before launching any arm, so a doomed batch refuses
+            # cleanly instead of partially launching some arms before a
+            # later arm's own runner.start() hits the same check mid-loop
+            # (belt-and-braces with that per-runner check). Lazy imports to
+            # dodge circular imports at module load time.
+            from . import (
+                calibrate as _calibrate,
+                record as _record,
+                rollout as _rollout,
+                teleoperate as _teleoperate,
+                wiggle as _wiggle,
+            )
+
+            if _teleoperate.teleoperation_active:
+                return {"success": False, "message": "Teleoperation is currently active. Stop it first."}
+            if _record.recording_active:
+                return {"success": False, "message": "Recording is currently active. Stop it first."}
+            if _rollout.inference_active:
+                return {"success": False, "message": "Inference is currently active. Stop it first."}
+            if _calibrate.calibration_is_active():
+                return {"success": False, "message": "Calibration is currently active. Stop it first."}
+            if _wiggle.wiggle_active:
+                return {
+                    "success": False,
+                    "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
+                }
+
             arms = request.arms
             # --- Fail-fast validation, before touching any hardware. ---
             if not arms:
@@ -638,3 +693,10 @@ class AutoCalibrationBatchManager:
 
 auto_calibration_manager = AutoCalibrationManager()
 auto_calibration_batch_manager = AutoCalibrationBatchManager()
+
+
+def auto_calibration_is_active() -> bool:
+    """True while EITHER the single-arm manager or a batch run owns a serial
+    bus. Reads the singletons' real state so other feature modules'
+    reciprocal mutex checks (see CLAUDE.md) can't drift out of sync."""
+    return auto_calibration_manager.status.active or auto_calibration_batch_manager._active()

--- a/makerlab/calibrate.py
+++ b/makerlab/calibrate.py
@@ -235,6 +235,35 @@ class CalibrationManager:
             if self.status.calibration_active:
                 return {"success": False, "message": "Calibration already active"}
 
+            # Mutex with every other feature that drives the same serial bus
+            # (see CLAUDE.md's "State model & mutual exclusion"). Lazy
+            # imports to dodge circular imports at module load time (matches
+            # the existing pattern in teleoperate.py/record.py/rollout.py).
+            from . import (
+                auto_calibrate as _auto_calibrate,
+                record as _record,
+                rollout as _rollout,
+                teleoperate as _teleoperate,
+                wiggle as _wiggle,
+            )
+
+            if _teleoperate.teleoperation_active:
+                return {"success": False, "message": "Teleoperation is currently active. Stop it first."}
+            if _record.recording_active:
+                return {"success": False, "message": "Recording is currently active. Stop it first."}
+            if _rollout.inference_active:
+                return {"success": False, "message": "Inference is currently active. Stop it first."}
+            if _auto_calibrate.auto_calibration_is_active():
+                return {
+                    "success": False,
+                    "message": "Auto-calibration is currently active. Stop it first.",
+                }
+            if _wiggle.wiggle_active:
+                return {
+                    "success": False,
+                    "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
+                }
+
             # Refuse to silently overwrite an existing config file. Completing a
             # calibration saves "<config_file>.json"; if that name is taken, the
             # caller must pass overwrite=True (after confirming) or pick another
@@ -671,3 +700,13 @@ class CalibrationManager:
 
 # Global calibration manager instance
 calibration_manager = CalibrationManager()
+
+
+def calibration_is_active() -> bool:
+    """True while a manual calibration session owns the serial bus.
+
+    Reads the singleton's real state (no separately-tracked boolean) so other
+    feature modules' reciprocal mutex checks (see CLAUDE.md) can't drift from
+    the manager's own status.
+    """
+    return calibration_manager.status.calibration_active

--- a/makerlab/record.py
+++ b/makerlab/record.py
@@ -439,7 +439,13 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
         identity_warnings, \
         discard_requested
 
-    from . import rollout as _rollout, teleoperate as _teleoperate
+    from . import (
+        auto_calibrate as _auto_calibrate,
+        calibrate as _calibrate,
+        rollout as _rollout,
+        teleoperate as _teleoperate,
+        wiggle as _wiggle,
+    )
 
     # Claim the active flag under the lock so two concurrent starts can't both
     # pass the precondition check.
@@ -471,6 +477,15 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
             return {"success": False, "message": "Teleoperation is currently active. Stop it first."}
         if _rollout.inference_active:
             return {"success": False, "message": "Inference is currently active. Stop it first."}
+        if _calibrate.calibration_is_active():
+            return {"success": False, "message": "Calibration is currently active. Stop it first."}
+        if _auto_calibrate.auto_calibration_is_active():
+            return {"success": False, "message": "Auto-calibration is currently active. Stop it first."}
+        if _wiggle.wiggle_active:
+            return {
+                "success": False,
+                "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
+            }
         # Refuse a malformed dataset name up front (before claiming the flag or
         # touching hardware). Rejecting beats silent sanitization: "whoo/" used to
         # smuggle in a namespace and land the dataset at "user/whoo/".

--- a/makerlab/rollout.py
+++ b/makerlab/rollout.py
@@ -911,8 +911,15 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
     global inference_active, _inference_started_at, _inference_meta, _inference_cancel
     global _last_result
 
-    # Mutex with teleop and recording: all three drive the same serial bus.
-    from . import record as _record, teleoperate as _teleoperate
+    # Mutex with every other feature that drives the same serial bus (see
+    # CLAUDE.md's "State model & mutual exclusion").
+    from . import (
+        auto_calibrate as _auto_calibrate,
+        calibrate as _calibrate,
+        record as _record,
+        teleoperate as _teleoperate,
+        wiggle as _wiggle,
+    )
 
     with _state_lock:
         if _teleoperate.teleoperation_active:
@@ -932,6 +939,24 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
                 "success": False,
                 "status_code": 409,
                 "message": "Inference is already active. Stop it first.",
+            }
+        if _calibrate.calibration_is_active():
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "Calibration is currently active. Stop it first.",
+            }
+        if _auto_calibrate.auto_calibration_is_active():
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "Auto-calibration is currently active. Stop it first.",
+            }
+        if _wiggle.wiggle_active:
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
             }
         # Claim the slot now so a concurrent caller losing the race sees us, and
         # seed the meta + timer so the phase is visible from the very first

--- a/makerlab/teleoperate.py
+++ b/makerlab/teleoperate.py
@@ -556,7 +556,13 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
     global teleoperation_active, teleoperation_thread, current_robot, current_teleop, last_cleanup_error
     global releasing, last_session_outcome, last_session_error
 
-    from . import record as _record, rollout as _rollout
+    from . import (
+        auto_calibrate as _auto_calibrate,
+        calibrate as _calibrate,
+        record as _record,
+        rollout as _rollout,
+        wiggle as _wiggle,
+    )
 
     # A previous session (teleop or recording) may still be holding torque for
     # its release grace — cut it short so this start doesn't fail on a busy
@@ -579,6 +585,15 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
             return {"success": False, "message": "Recording is currently active. Stop it first."}
         if _rollout.inference_active:
             return {"success": False, "message": "Inference is currently active. Stop it first."}
+        if _calibrate.calibration_is_active():
+            return {"success": False, "message": "Calibration is currently active. Stop it first."}
+        if _auto_calibrate.auto_calibration_is_active():
+            return {"success": False, "message": "Auto-calibration is currently active. Stop it first."}
+        if _wiggle.wiggle_active:
+            return {
+                "success": False,
+                "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
+            }
         # Per-session state reset, under the same lock that claims the active
         # flag: a stale _release_now from a previous session's double-stop
         # would otherwise cut EVERY later grace/return short until the server

--- a/makerlab/wiggle.py
+++ b/makerlab/wiggle.py
@@ -31,6 +31,13 @@ _WIGGLE_OFFSET = 200
 _WIGGLE_REPEATS = 3
 _WIGGLE_TIMEOUT_S = 15.0
 
+# True while a wiggle is actually driving the gripper (set just before the
+# blocking drive, cleared in a finally so it can never stick set on a
+# timeout/exception). Wiggle has no "stop" button — it's a brief, bounded
+# one-shot action — so this is the self-check half of the reciprocal mutex
+# with teleop/record/inference/calibration/auto-calibration (see CLAUDE.md).
+wiggle_active = False
+
 
 def plan_wiggle(current: int, min_limit: int, max_limit: int, offset: int = _WIGGLE_OFFSET) -> tuple[int, int, int]:
     """Plan a (high, low, rest) jog that stays inside the servo's programmed limits.
@@ -91,9 +98,59 @@ async def wiggle_gripper(port: str) -> dict:
     ({"success": bool, "message": str}) — logical failures (port busy, arm off)
     are reported, not raised, so the endpoint stays HTTP 200 like the rest of the
     feature handlers.
+
+    Guarded by the same reciprocal mutex as every other feature that drives the
+    servos (see CLAUDE.md): refuses while teleop/record/inference/calibration/
+    auto-calibration is active, and refuses a second concurrent wiggle via
+    ``wiggle_active`` (there is no shared lock, just a self-check like the
+    other five). Wiggle has no "stop" button — it's a brief, bounded one-shot
+    action — so the rejection messages tell the caller to wait rather than to
+    stop something.
     """
+    global wiggle_active
+
     if not port or not port.strip():
         return {"success": False, "message": "No port provided."}
+
+    # Lazy imports to dodge circular imports at module load time (matches the
+    # existing pattern in teleoperate.py/record.py/rollout.py).
+    from . import (
+        auto_calibrate as _auto_calibrate,
+        calibrate as _calibrate,
+        record as _record,
+        rollout as _rollout,
+        teleoperate as _teleoperate,
+    )
+
+    if wiggle_active:
+        return {"success": False, "message": "A gripper wiggle is already in progress."}
+    if _teleoperate.teleoperation_active:
+        return {
+            "success": False,
+            "message": "Teleoperation is currently active — wait for it to stop before wiggling.",
+        }
+    if _record.recording_active:
+        return {
+            "success": False,
+            "message": "Recording is currently active — wait for it to stop before wiggling.",
+        }
+    if _rollout.inference_active:
+        return {
+            "success": False,
+            "message": "Inference is currently active — wait for it to stop before wiggling.",
+        }
+    if _calibrate.calibration_is_active():
+        return {
+            "success": False,
+            "message": "Calibration is currently active — wait for it to stop before wiggling.",
+        }
+    if _auto_calibrate.auto_calibration_is_active():
+        return {
+            "success": False,
+            "message": "Auto-calibration is currently active — wait for it to stop before wiggling.",
+        }
+
+    wiggle_active = True
     try:
         await asyncio.wait_for(
             asyncio.to_thread(_wiggle_gripper_sync, port.strip()),
@@ -108,3 +165,5 @@ async def wiggle_gripper(port: str) -> dict:
     except Exception as e:
         logger.exception("Wiggle failed")
         return {"success": False, "message": f"Failed to wiggle the gripper: {e}"}
+    finally:
+        wiggle_active = False

--- a/tests/test_auto_calibrate.py
+++ b/tests/test_auto_calibrate.py
@@ -95,6 +95,58 @@ def _join_stop(mgr) -> None:
         mgr._thread.join(timeout=5)
 
 
+def test_auto_calibration_blocked_when_teleoperation_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auto-calibration must refuse to start while teleop owns the same
+    serial bus, rather than opening a second connection on a live port."""
+    import makerlab.auto_calibrate as ac
+
+    monkeypatch.setattr("makerlab.teleoperate.teleoperation_active", True)
+    mgr = ac.AutoCalibrationManager()
+    result = mgr.start(ac.AutoCalibrationRequest(device_type="robot", port="/dev/arm", config_file="c"))
+    assert result["success"] is False
+    assert "Teleoperation" in result["message"]
+
+
+def test_auto_calibration_blocked_when_recording_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.auto_calibrate as ac
+
+    monkeypatch.setattr("makerlab.record.recording_active", True)
+    mgr = ac.AutoCalibrationManager()
+    result = mgr.start(ac.AutoCalibrationRequest(device_type="robot", port="/dev/arm", config_file="c"))
+    assert result["success"] is False
+    assert "Recording" in result["message"]
+
+
+def test_auto_calibration_blocked_when_inference_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.auto_calibrate as ac
+
+    monkeypatch.setattr("makerlab.rollout.inference_active", True)
+    mgr = ac.AutoCalibrationManager()
+    result = mgr.start(ac.AutoCalibrationRequest(device_type="robot", port="/dev/arm", config_file="c"))
+    assert result["success"] is False
+    assert "Inference" in result["message"]
+
+
+def test_auto_calibration_blocked_when_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.auto_calibrate as ac
+
+    monkeypatch.setattr("makerlab.calibrate.calibration_manager.status.calibration_active", True)
+    mgr = ac.AutoCalibrationManager()
+    result = mgr.start(ac.AutoCalibrationRequest(device_type="robot", port="/dev/arm", config_file="c"))
+    assert result["success"] is False
+    assert "Calibration" in result["message"]
+
+
+def test_auto_calibration_blocked_when_wiggle_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.auto_calibrate as ac
+
+    monkeypatch.setattr("makerlab.wiggle.wiggle_active", True)
+    mgr = ac.AutoCalibrationManager()
+    result = mgr.start(ac.AutoCalibrationRequest(device_type="robot", port="/dev/arm", config_file="c"))
+    assert result["success"] is False
+    assert "wiggle" in result["message"].lower()
+
+
 def test_auto_calibration_rejects_bad_device() -> None:
     import makerlab.auto_calibrate as ac
 
@@ -801,6 +853,36 @@ def _join_batch(mgr) -> None:
             runner._thread.join(timeout=2)
         if runner._stop_thread is not None:
             runner._stop_thread.join(timeout=5)
+
+
+def test_batch_blocked_when_teleoperation_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A batch launch must refuse up front (before starting any arm) while
+    teleop owns a serial bus, rather than partially launching some arms."""
+    monkeypatch.setattr("makerlab.teleoperate.teleoperation_active", True)
+    mgr = auto_calibrate.AutoCalibrationBatchManager()
+    arms = [_arm(port="/dev/a", name="n1")]
+    result = mgr.start(auto_calibrate.AutoCalibrationBatchRequest(arms=arms))
+    assert result["success"] is False
+    assert "Teleoperation" in result["message"]
+    assert mgr._runners == []  # nothing launched
+
+
+def test_batch_blocked_when_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("makerlab.calibrate.calibration_manager.status.calibration_active", True)
+    mgr = auto_calibrate.AutoCalibrationBatchManager()
+    arms = [_arm(port="/dev/a", name="n1")]
+    result = mgr.start(auto_calibrate.AutoCalibrationBatchRequest(arms=arms))
+    assert result["success"] is False
+    assert "Calibration" in result["message"]
+
+
+def test_batch_blocked_when_wiggle_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("makerlab.wiggle.wiggle_active", True)
+    mgr = auto_calibrate.AutoCalibrationBatchManager()
+    arms = [_arm(port="/dev/a", name="n1")]
+    result = mgr.start(auto_calibrate.AutoCalibrationBatchRequest(arms=arms))
+    assert result["success"] is False
+    assert "wiggle" in result["message"].lower()
 
 
 def test_batch_rejects_empty() -> None:

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -75,6 +75,68 @@ def test_calibration_manager_rejects_double_start_via_message() -> None:
     assert "already" in result.get("message", "").lower()
 
 
+def test_start_calibration_blocked_when_teleoperation_active(monkeypatch) -> None:
+    """Calibration must refuse to start while teleop owns the same serial
+    bus, rather than opening a second connection on a live port."""
+    from makerlab.calibrate import CalibrationManager, CalibrationRequest
+
+    monkeypatch.setattr("makerlab.teleoperate.teleoperation_active", True)
+    mgr = CalibrationManager()
+    result = mgr.start_calibration(
+        CalibrationRequest(device_type="teleop", port="/dev/null", config_file="x")
+    )
+    assert result["success"] is False
+    assert "Teleoperation" in result["message"]
+
+
+def test_start_calibration_blocked_when_recording_active(monkeypatch) -> None:
+    from makerlab.calibrate import CalibrationManager, CalibrationRequest
+
+    monkeypatch.setattr("makerlab.record.recording_active", True)
+    mgr = CalibrationManager()
+    result = mgr.start_calibration(
+        CalibrationRequest(device_type="teleop", port="/dev/null", config_file="x")
+    )
+    assert result["success"] is False
+    assert "Recording" in result["message"]
+
+
+def test_start_calibration_blocked_when_inference_active(monkeypatch) -> None:
+    from makerlab.calibrate import CalibrationManager, CalibrationRequest
+
+    monkeypatch.setattr("makerlab.rollout.inference_active", True)
+    mgr = CalibrationManager()
+    result = mgr.start_calibration(
+        CalibrationRequest(device_type="teleop", port="/dev/null", config_file="x")
+    )
+    assert result["success"] is False
+    assert "Inference" in result["message"]
+
+
+def test_start_calibration_blocked_when_auto_calibration_active(monkeypatch) -> None:
+    from makerlab.calibrate import CalibrationManager, CalibrationRequest
+
+    monkeypatch.setattr("makerlab.auto_calibrate.auto_calibration_manager.status.active", True)
+    mgr = CalibrationManager()
+    result = mgr.start_calibration(
+        CalibrationRequest(device_type="teleop", port="/dev/null", config_file="x")
+    )
+    assert result["success"] is False
+    assert "Auto-calibration" in result["message"]
+
+
+def test_start_calibration_blocked_when_wiggle_active(monkeypatch) -> None:
+    from makerlab.calibrate import CalibrationManager, CalibrationRequest
+
+    monkeypatch.setattr("makerlab.wiggle.wiggle_active", True)
+    mgr = CalibrationManager()
+    result = mgr.start_calibration(
+        CalibrationRequest(device_type="teleop", port="/dev/null", config_file="x")
+    )
+    assert result["success"] is False
+    assert "wiggle" in result["message"].lower()
+
+
 def test_start_calibration_refuses_existing_config_without_overwrite(tmp_lerobot_home) -> None:
     """Completing calibration saves <config_file>.json; if that name already
     exists, start must refuse (code=name_taken) unless overwrite=True — so no

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1160,6 +1160,60 @@ def test_delete_refusal_wording_is_action_neutral(tmp_lerobot_home, monkeypatch:
     assert result["message"].endswith("Stop it first.")
 
 
+def _stub_recording_request():
+    import makerlab.record as record
+
+    return record.RecordingRequest(
+        leader_port="/dev/leader",
+        follower_port="/dev/follower",
+        leader_config="leader",
+        follower_config="follower",
+        dataset_repo_id="tester/ds",
+        single_task="pick",
+    )
+
+
+def test_start_recording_blocked_when_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recording must refuse to start while manual calibration owns the same
+    serial bus, rather than opening a second connection on a live port."""
+    import makerlab.record as record
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr("makerlab.calibrate.calibration_manager.status.calibration_active", True)
+
+    result = record.handle_start_recording(_stub_recording_request())
+    assert result == {
+        "success": False,
+        "message": "Calibration is currently active. Stop it first.",
+    }
+
+
+def test_start_recording_blocked_when_auto_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.record as record
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr("makerlab.auto_calibrate.auto_calibration_manager.status.active", True)
+
+    result = record.handle_start_recording(_stub_recording_request())
+    assert result == {
+        "success": False,
+        "message": "Auto-calibration is currently active. Stop it first.",
+    }
+
+
+def test_start_recording_blocked_when_wiggle_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.record as record
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr("makerlab.wiggle.wiggle_active", True)
+
+    result = record.handle_start_recording(_stub_recording_request())
+    assert result == {
+        "success": False,
+        "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
+    }
+
+
 def test_start_recording_resume_skips_timestamp_stamp(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resume must append to the EXISTING directory: the repo_id is used
     verbatim (no '_<timestamp>' suffix), unlike a fresh session which stamps

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -393,6 +393,38 @@ def test_handle_start_inference_blocked_when_already_active(monkeypatch) -> None
     assert "already active" in result["message"]
 
 
+def test_handle_start_inference_blocked_when_calibration_active(monkeypatch) -> None:
+    """Inference must refuse to start while manual calibration owns the same
+    serial bus, rather than opening a second connection on a live port."""
+    from makerlab.rollout import handle_start_inference
+
+    monkeypatch.setattr("makerlab.calibrate.calibration_manager.status.calibration_active", True)
+    result = handle_start_inference(_stub_request())
+    assert result["success"] is False
+    assert result["status_code"] == 409
+    assert "Calibration" in result["message"]
+
+
+def test_handle_start_inference_blocked_when_auto_calibration_active(monkeypatch) -> None:
+    from makerlab.rollout import handle_start_inference
+
+    monkeypatch.setattr("makerlab.auto_calibrate.auto_calibration_manager.status.active", True)
+    result = handle_start_inference(_stub_request())
+    assert result["success"] is False
+    assert result["status_code"] == 409
+    assert "Auto-calibration" in result["message"]
+
+
+def test_handle_start_inference_blocked_when_wiggle_active(monkeypatch) -> None:
+    from makerlab.rollout import handle_start_inference
+
+    monkeypatch.setattr("makerlab.wiggle.wiggle_active", True)
+    result = handle_start_inference(_stub_request())
+    assert result["success"] is False
+    assert result["status_code"] == 409
+    assert "wiggle" in result["message"].lower()
+
+
 def test_handle_start_inference_pins_return_to_initial_position(monkeypatch, tmp_path) -> None:
     """The stop dialog promises the follower eases back to its start pose on
     teardown. That behaviour is lerobot's `return_to_initial_position`, which

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -160,6 +160,58 @@ def test_start_teleoperation_disconnects_follower_when_leader_fails(
     assert teleop.teleoperation_active is False
 
 
+def _stub_teleop_request():
+    from makerlab.teleoperate import TeleoperateRequest
+
+    return TeleoperateRequest(
+        leader_port="/dev/leader",
+        follower_port="/dev/follower",
+        leader_config="leader",
+        follower_config="follower",
+    )
+
+
+def test_start_teleoperation_blocked_when_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Teleoperation must refuse to start while manual calibration owns the
+    same serial bus, rather than opening a second connection on a live port."""
+    import makerlab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr("makerlab.calibrate.calibration_manager.status.calibration_active", True)
+
+    result = teleop.handle_start_teleoperation(_stub_teleop_request())
+    assert result == {
+        "success": False,
+        "message": "Calibration is currently active. Stop it first.",
+    }
+
+
+def test_start_teleoperation_blocked_when_auto_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr("makerlab.auto_calibrate.auto_calibration_manager.status.active", True)
+
+    result = teleop.handle_start_teleoperation(_stub_teleop_request())
+    assert result == {
+        "success": False,
+        "message": "Auto-calibration is currently active. Stop it first.",
+    }
+
+
+def test_start_teleoperation_blocked_when_wiggle_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makerlab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr("makerlab.wiggle.wiggle_active", True)
+
+    result = teleop.handle_start_teleoperation(_stub_teleop_request())
+    assert result == {
+        "success": False,
+        "message": "A gripper wiggle is currently in progress. Wait for it to finish.",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Teleop opens no cameras: it consumes no frames (only motor positions drive the
 # URDF viewer). The follower config it builds therefore carries an empty camera

--- a/tests/test_wiggle.py
+++ b/tests/test_wiggle.py
@@ -28,6 +28,93 @@ async def test_wiggle_gripper_rejects_empty_port() -> None:
     assert result == {"success": False, "message": "No port provided."}
 
 
+async def test_wiggle_gripper_blocked_when_already_wiggling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A second concurrent wiggle must refuse rather than opening a second
+    connection on the same port a live wiggle is already driving."""
+    from makerlab.wiggle import wiggle_gripper
+
+    monkeypatch.setattr("makerlab.wiggle.wiggle_active", True)
+    result = await wiggle_gripper("/dev/fake")
+    assert result["success"] is False
+    assert "already in progress" in result["message"]
+
+
+async def test_wiggle_gripper_blocked_when_teleoperation_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from makerlab.wiggle import wiggle_gripper
+
+    monkeypatch.setattr("makerlab.teleoperate.teleoperation_active", True)
+    result = await wiggle_gripper("/dev/fake")
+    assert result["success"] is False
+    assert "Teleoperation" in result["message"]
+
+
+async def test_wiggle_gripper_blocked_when_recording_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from makerlab.wiggle import wiggle_gripper
+
+    monkeypatch.setattr("makerlab.record.recording_active", True)
+    result = await wiggle_gripper("/dev/fake")
+    assert result["success"] is False
+    assert "Recording" in result["message"]
+
+
+async def test_wiggle_gripper_blocked_when_inference_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from makerlab.wiggle import wiggle_gripper
+
+    monkeypatch.setattr("makerlab.rollout.inference_active", True)
+    result = await wiggle_gripper("/dev/fake")
+    assert result["success"] is False
+    assert "Inference" in result["message"]
+
+
+async def test_wiggle_gripper_blocked_when_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from makerlab.wiggle import wiggle_gripper
+
+    monkeypatch.setattr("makerlab.calibrate.calibration_manager.status.calibration_active", True)
+    result = await wiggle_gripper("/dev/fake")
+    assert result["success"] is False
+    assert "Calibration" in result["message"]
+
+
+async def test_wiggle_gripper_blocked_when_auto_calibration_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from makerlab.wiggle import wiggle_gripper
+
+    monkeypatch.setattr("makerlab.auto_calibrate.auto_calibration_manager.status.active", True)
+    result = await wiggle_gripper("/dev/fake")
+    assert result["success"] is False
+    assert "Auto-calibration" in result["message"]
+
+
+async def test_wiggle_gripper_clears_wiggle_active_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """wiggle_active must be reset once the drive finishes, so a later wiggle
+    isn't wrongly refused forever."""
+    import makerlab.wiggle as wiggle
+
+    monkeypatch.setattr(wiggle, "_wiggle_gripper_sync", lambda port: None)
+
+    result = await wiggle.wiggle_gripper("/dev/fake")
+    assert result["success"] is True
+    assert wiggle.wiggle_active is False
+
+
+async def test_wiggle_gripper_clears_wiggle_active_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """wiggle_active must be reset even when the drive raises, so one failed
+    wiggle can't wedge every later wiggle attempt shut."""
+    import makerlab.wiggle as wiggle
+
+    def boom(port: str) -> None:
+        raise RuntimeError("no device on port")
+
+    monkeypatch.setattr(wiggle, "_wiggle_gripper_sync", boom)
+
+    result = await wiggle.wiggle_gripper("/dev/fake")
+    assert result["success"] is False
+    assert wiggle.wiggle_active is False
+
+
 def test_wiggle_endpoint_success(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     # Stub the blocking hardware call so the happy path runs without a device.
     monkeypatch.setattr("makerlab.wiggle._wiggle_gripper_sync", lambda port: None)


### PR DESCRIPTION
## Summary

T4: teleoperation, recording, and inference already refused to start while either of the other two was active (CLAUDE.md's reciprocal active-flag mutex), but manual calibration, auto-calibration (single and batch), and the gripper wiggle were never wired into that mutex in either direction. Any of these six could open a second connection on a serial port another feature already owned.

- Added `calibrate.calibration_is_active()` and `auto_calibrate.auto_calibration_is_active()` as thin accessors over each manager's existing state (no new tracked booleans, so nothing can drift out of sync with the manager's own status).
- Added a `wiggle_active` flag to `wiggle.py`, which previously had no persistent state at all.
- All six start paths (`handle_start_teleoperation`, `handle_start_recording`, `handle_start_inference`, `CalibrationManager.start_calibration`, `_AutoCalArmRunner.start`, `AutoCalibrationBatchManager.start`, `wiggle_gripper`) now check the other five before proceeding, matching each file's existing check/message conventions -- including `rollout.py`'s `status_code: 409` convention on its rejection responses.
- Updated the one relevant sentence in CLAUDE.md's "State model & mutual exclusion" section to reflect the expanded mutex.

## Test plan

- [x] New regression tests across all six call sites, each confirmed to fail against the pre-fix code and pass after
- [x] Full suite: 888 passed, no regressions
- [x] `ruff check` / `ruff format --check` clean on touched files (aside from pre-existing findings on lines outside this diff)
- [x] Verified against real SO-101 hardware through the live server's actual endpoints: `/wiggle` against an active teleoperation session previously opened a second serial connection and surfaced a raw I/O error ("multiple access on port?"); it now refuses cleanly with "Teleoperation is currently active -- wait for it to stop before wiggling."
- [x] Verified the reverse directions the same way: teleop/wiggle/auto-calibration all correctly refuse while manual calibration is active; a second concurrent wiggle refuses with "A gripper wiggle is already in progress."; auto-calibration's mutex check runs before any subprocess spawns, so a refusal never touches hardware

## Follow-ups identified while testing (not in scope for this PR)

- `calibrate.py::start_calibration` does not hold a lock around its checks-then-claim sequence, unlike the other five features -- a pre-existing race (confirmed two concurrent calls can both succeed), which this PR extends from one condition to six. Worth its own fix.
- Auto-calibration's frontend dialog has no session-exit-guard cleanup (unlike teleop/recording/inference/manual-calibration), so an abandoned auto-calibration session now blocks the other five features until its subprocess finishes, not just itself. Self-resolves; a frontend follow-up would close the gap.

https://claude.ai/code/session_01WtHH9o7Ewv3VoNXqHxLLoA