### PR TITLE
fix(training): give cloud uploads a single visibility policy + a real user choice

### DIFF
--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -89,6 +89,9 @@ function configToRequest(c: TrainingConfig): TrainingRequest {
   return {
     target: c.target,
     dataset_repo_id: c.dataset_repo_id,
+    // Only meaningful for a cloud run; harmless otherwise (the backend only
+    // consults it if it ends up needing to push the dataset itself).
+    dataset_private: c.dataset_private,
     policy_type: c.policy_type,
     job_name: c.job_name,
     steps: c.steps,
@@ -164,6 +167,9 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
         : { runner: "local" },
     // Controlled fields — overlaid from props below; placeholders here.
     dataset_repo_id: "",
+    // MakerLab's default dataset-visibility policy (public); the user can
+    // flip this via LocalDatasetCloudNotice's toggle when it's shown.
+    dataset_private: false,
     policy_type: "act",
     job_name: "",
     // On resume, everything but steps is inherited from the checkpoint's
@@ -429,7 +435,10 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     if (needsUpload) {
       setUploadError(null);
       setIsStarting(true);
-      const err = await startUpload([], false /* public: MakerLab uploads are public by default */);
+      // Honor whatever the user picked in LocalDatasetCloudNotice's visibility
+      // toggle (defaults to public — MakerLab's default policy — but the
+      // choice is the user's to make, not a hardcoded literal).
+      const err = await startUpload([], config.dataset_private);
       if (err) {
         setUploadError(err);
         setIsStarting(false);
@@ -544,6 +553,8 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
             offline={offline}
             uploading={uploading}
             errorMessage={uploadError}
+            isPrivate={config.dataset_private}
+            onIsPrivateChange={(v) => updateConfig("dataset_private", v)}
           />
         </div>
       ) : null}

--- a/frontend/src/components/training/config/LocalDatasetCloudNotice.tsx
+++ b/frontend/src/components/training/config/LocalDatasetCloudNotice.tsx
@@ -78,8 +78,10 @@ const LocalDatasetCloudNotice: React.FC<LocalDatasetCloudNoticeProps> = ({
             Hugging Face Cloud trains from the Hub, so{" "}
             <span className="font-medium">{repoId}</span>
             {sizeLabel ? ` (~${sizeLabel})` : ""} will be uploaded as a{" "}
-            <span className="font-medium">private</span> dataset before training
-            starts.
+            <span className="font-medium">public</span> dataset before training
+            starts — including any camera footage it contains. You can make it
+            private afterward from the dataset's "Visibility &amp; tags"
+            settings.
           </p>
           {uploading ? (
             <p className="mt-2 flex items-center gap-2 text-amber-700 dark:text-amber-100">

--- a/frontend/src/components/training/config/LocalDatasetCloudNotice.tsx
+++ b/frontend/src/components/training/config/LocalDatasetCloudNotice.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { AlertTriangle, Loader2, UploadCloud, WifiOff } from "lucide-react";
+import VisibilityToggle from "@/components/landing/VisibilityToggle";
 
 interface LocalDatasetCloudNoticeProps {
   /** The local-only dataset the cloud run would train on. */
@@ -14,6 +15,14 @@ interface LocalDatasetCloudNoticeProps {
   uploading: boolean;
   /** Last upload error, shown in-place so the user doesn't lose it to a toast. */
   errorMessage?: string | null;
+  /** The visibility this upload will actually use — the user's real, in-flow
+   * choice, not a hardcoded claim. Defaults to public (MakerLab's default
+   * policy), matching the same toggle UploadDatasetDialog offers for the
+   * dataset-library upload flow. */
+  isPrivate: boolean;
+  /** Flips `isPrivate`. Disabled while `uploading`, same as
+   * UploadDatasetDialog's identical toggle. */
+  onIsPrivateChange: (isPrivate: boolean) => void;
 }
 
 const formatSize = (bytes: number): string => {
@@ -33,8 +42,17 @@ const formatSize = (bytes: number): string => {
  * targeted at a dataset that exists only on this machine. HF Jobs trains from
  * the Hub, so the dataset must be uploaded first — the Start button becomes
  * "Upload & start training" and the upload is chained before the job launches
- * (see Training.tsx). In offline mode the upload is impossible, so this turns
- * into a hard block instead.
+ * (see TrainingConfigurator's handleStart). In offline mode the upload is
+ * impossible, so this turns into a hard block instead.
+ *
+ * Visibility is a real choice made HERE, not an assertion about a hardcoded
+ * backend literal: the toggle drives both the explicit upload
+ * (useDatasetUpload's `start(tags, isPrivate)`) and, via
+ * TrainingConfig.dataset_private / TrainingRequest.dataset_private, the
+ * backend's belt-and-braces re-upload fallback in
+ * HfCloudJobRunner._ensure_dataset_on_hub — so whichever push site actually
+ * fires, it uses what the user picked, not an independently-hardcoded
+ * default.
  */
 const LocalDatasetCloudNotice: React.FC<LocalDatasetCloudNoticeProps> = ({
   repoId,
@@ -42,6 +60,8 @@ const LocalDatasetCloudNotice: React.FC<LocalDatasetCloudNoticeProps> = ({
   offline,
   uploading,
   errorMessage,
+  isPrivate,
+  onIsPrivateChange,
 }) => {
   const sizeLabel = sizeBytes != null ? formatSize(sizeBytes) : null;
 
@@ -77,12 +97,24 @@ const LocalDatasetCloudNotice: React.FC<LocalDatasetCloudNoticeProps> = ({
           <p className="mt-1 text-amber-700/80 dark:text-amber-200/80">
             Hugging Face Cloud trains from the Hub, so{" "}
             <span className="font-medium">{repoId}</span>
-            {sizeLabel ? ` (~${sizeLabel})` : ""} will be uploaded as a{" "}
-            <span className="font-medium">public</span> dataset before training
-            starts — including any camera footage it contains. You can make it
-            private afterward from the dataset's "Visibility &amp; tags"
-            settings.
+            {sizeLabel ? ` (~${sizeLabel})` : ""} will be uploaded to the Hub
+            before training starts.
           </p>
+          <div className="mt-3 space-y-1.5">
+            <VisibilityToggle
+              value={isPrivate}
+              onChange={onIsPrivateChange}
+              idBase={`cloud-upload-visibility-${repoId}`}
+              disabled={uploading}
+            />
+            <p className="text-amber-700/80 dark:text-amber-200/80">
+              {isPrivate
+                ? "Only you will be able to see this dataset."
+                : "Anyone will be able to see this dataset — including any camera footage it contains."}{" "}
+              You can change this later from the dataset's "Visibility &amp;
+              tags" settings.
+            </p>
+          </div>
           {uploading ? (
             <p className="mt-2 flex items-center gap-2 text-amber-700 dark:text-amber-100">
               <Loader2 className="w-4 h-4 animate-spin" />

--- a/frontend/src/components/training/types.ts
+++ b/frontend/src/components/training/types.ts
@@ -3,6 +3,11 @@ export interface TrainingConfig {
 
   // Dataset configuration
   dataset_repo_id: string;
+  // Visibility to upload dataset_repo_id with, when a cloud run needs to push
+  // it first (see LocalDatasetCloudNotice's visibility toggle). Only shown /
+  // meaningful while that notice is up; defaults to public (MakerLab's
+  // default policy — see DATASET_DEFAULT_PRIVATE on the backend).
+  dataset_private: boolean;
 
   // Policy configuration
   policy_type: string;

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -27,6 +27,14 @@ export type MetricsHistoryPoint = {
 // these; defaults on the server fill in the rest.
 export interface TrainingRequest {
   dataset_repo_id: string;
+  // Cloud only. The user's explicit visibility choice from the pre-upload
+  // notice shown when a cloud run targets a local-only dataset (see
+  // LocalDatasetCloudNotice's visibility toggle) -- honored by the backend's
+  // belt-and-braces upload fallback (HfCloudJobRunner._ensure_dataset_on_hub)
+  // in case the explicit "Upload & start training" pre-step didn't already
+  // put the dataset on the Hub. Undefined defers to the backend's default
+  // visibility policy.
+  dataset_private?: boolean;
   policy_type: string;
   // Optional user-supplied display name; blank ⇒ backend auto-names the run.
   job_name?: string;

--- a/makerlab/record.py
+++ b/makerlab/record.py
@@ -42,6 +42,7 @@ from .motor_power import clear_goal_velocity, reset_torque_limit
 from .rest_pose import capture_rest_pose
 from .teleoperate import _device_buses, _return_followers_to_rest, force_disable_torque
 from .utils.config import (
+    DATASET_DEFAULT_PRIVATE,
     validate_dataset_repo_id,
     with_makerlab_tag,
 )
@@ -297,7 +298,10 @@ class RecordingRequest(BaseModel):
 class UploadRequest(BaseModel):
     dataset_repo_id: str
     tags: list[str] = []
-    private: bool = False
+    # MakerLab's default dataset-visibility policy (see DATASET_DEFAULT_PRIVATE)
+    # -- callers that let the user choose (UploadDatasetDialog's visibility
+    # toggle) send an explicit value; this is just the fallback.
+    private: bool = DATASET_DEFAULT_PRIVATE
 
 
 class DatasetInfoRequest(BaseModel):

--- a/makerlab/runners/hf_cloud.py
+++ b/makerlab/runners/hf_cloud.py
@@ -44,7 +44,7 @@ from packaging.requirements import Requirement
 
 from ..jobs import LogLine, TrainingMetrics, extract_wandb_run_url, parse_metrics_into
 from ..train import TrainingRequest, build_training_command, parse_hf_duration
-from ..utils.config import with_makerlab_tag
+from ..utils.config import DATASET_DEFAULT_PRIVATE, with_makerlab_tag
 from ..utils.hf_auth import cached_whoami, shared_hf_api
 
 logger = logging.getLogger(__name__)
@@ -414,6 +414,22 @@ def resolve_job_timeout(config: TrainingRequest) -> int | str:
         return parse_hf_duration(config.hf_job_timeout)
     return HF_JOB_TIMEOUT
 
+
+def resolve_dataset_private(explicit: bool | None) -> bool:
+    """The Hub visibility to use if `_ensure_dataset_on_hub` has to push a
+    local-only dataset itself.
+
+    Precedence: an explicit choice (TrainingRequest.dataset_private, set from
+    the frontend's pre-upload visibility toggle when it showed the "this
+    dataset is only on this machine" notice) always wins. `None` -- a local
+    run, an older client, or a cloud run whose dataset the frontend believed
+    was already on the Hub (so it never offered the choice) -- falls back to
+    DATASET_DEFAULT_PRIVATE, the same policy record.py's UploadRequest.private
+    defaults to.
+    """
+    return DATASET_DEFAULT_PRIVATE if explicit is None else explicit
+
+
 # Cadence at which the status poller hits inspect_job. inspect_job is the
 # authoritative source for job liveness; the log stream is best-effort and
 # may drop during long runs (NAT eviction, laptop sleep, proxy idle timeout)
@@ -522,7 +538,7 @@ class HfCloudJobRunner:
 
         # Cloud pods can't see the host's LeRobot cache. If the dataset
         # only exists locally, push it to the Hub before submitting.
-        self._ensure_dataset_on_hub(config.dataset_repo_id)
+        self._ensure_dataset_on_hub(config.dataset_repo_id, resolve_dataset_private(config.dataset_private))
 
         # Mutate the config so build_training_command emits the right flags.
         # The mutated config is what gets persisted in JobRecord.config, so
@@ -638,13 +654,20 @@ class HfCloudJobRunner:
         except Exception as exc:
             logger.warning("Could not write upload log line: %s", exc)
 
-    def _ensure_dataset_on_hub(self, repo_id: str) -> None:
+    def _ensure_dataset_on_hub(self, repo_id: str, private: bool) -> None:
         """If the dataset is local-only, push it to the Hub.
 
         The cloud pod resolves the dataset by repo_id; it can't see the
         host's `~/.cache/huggingface/lerobot`. We push synchronously and
         let any failure bubble up — JobRegistry.start marks the record
         as failed with the exception message.
+
+        `private` is the caller-resolved visibility (see
+        resolve_dataset_private): MakerLab's default is public (datasets it
+        pushes carry the required org/product tags -- see with_makerlab_tag /
+        REQUIRED_HUB_TAGS -- so they're discoverable), but this honors an
+        explicit user choice from the frontend's pre-upload notice when one
+        was made, rather than silently re-deciding visibility on its own.
         """
         try:
             self._api.dataset_info(repo_id)
@@ -658,22 +681,17 @@ class HfCloudJobRunner:
             # — same behaviour as before.
             return
 
-        self._log_line(f"[upload] dataset {repo_id} not on Hub; pushing local copy (public)...")
+        visibility = "private" if private else "public"
+        self._log_line(f"[upload] dataset {repo_id} not on Hub; pushing local copy ({visibility})...")
         from lerobot.datasets import LeRobotDataset
 
         try:
-            # Public by default: MakerLab's global policy is that datasets it pushes
-            # to the Hub are public and carry the required org/product tags (see
-            # with_makerlab_tag / REQUIRED_HUB_TAGS). This implicit cloud-run upload
-            # follows that same default so all MakerLab-produced datasets are
-            # discoverable. (This intentionally reverses the earlier private
-            # default — an implicit upload of a local-only dataset is now public.)
-            LeRobotDataset(repo_id).push_to_hub(tags=with_makerlab_tag(None), private=False)
+            LeRobotDataset(repo_id).push_to_hub(tags=with_makerlab_tag(None), private=private)
         except Exception as exc:
             msg = f"Failed to upload local dataset {repo_id} to Hub: {exc}"
             self._log_line(f"[upload] {msg}")
             raise RuntimeError(msg) from exc
-        self._log_line(f"[upload] dataset {repo_id} uploaded.")
+        self._log_line(f"[upload] dataset {repo_id} uploaded ({visibility}).")
 
     def _tail_loop(self) -> None:
         """Stream HfApi.fetch_job_logs, teeing each line to disk and the

--- a/makerlab/train.py
+++ b/makerlab/train.py
@@ -107,6 +107,17 @@ class TrainingRequest(BaseModel):
     dataset_revision: str | None = None
     dataset_root: str | None = None
     dataset_episodes: list[int] | None = None
+    # Cloud only. HfCloudJobRunner may need to push `dataset_repo_id` to the
+    # Hub itself before training (see runners/hf_cloud.py's
+    # _ensure_dataset_on_hub) if it turns out not to be there yet -- e.g. the
+    # frontend's own pre-upload step (TrainingConfigurator's "Upload & start
+    # training") was skipped because the dataset was believed to already be on
+    # the Hub. When the frontend DID show that pre-upload notice, this carries
+    # the user's actual choice from its visibility toggle so the same choice
+    # governs both the explicit upload and this belt-and-braces fallback.
+    # None (local runs, older clients, or a cloud run that never showed the
+    # notice) defers to DATASET_DEFAULT_PRIVATE.
+    dataset_private: bool | None = None
 
     # Policy configuration
     policy_type: str = "act"

--- a/makerlab/utils/config.py
+++ b/makerlab/utils/config.py
@@ -90,6 +90,17 @@ MAKERLAB_TAG = "MakerLab"
 # truth — add to it here rather than sprinkling literals at push sites.
 REQUIRED_HUB_TAGS = ["makermods", "openbooth", MAKERLAB_TAG]
 
+# MakerLab's default Hub-visibility policy for datasets it pushes: PUBLIC
+# unless the uploader explicitly opts into private. This is a deliberate
+# product decision (datasets should be discoverable by default), not an
+# oversight -- but it must be applied from exactly one place. Every push site
+# that decides visibility on the uploader's behalf (record.py's UploadManager,
+# runners/hf_cloud.py's implicit pre-cloud-job upload) reads this constant
+# instead of hardcoding the literal, and any explicit choice a user makes in
+# the UI (e.g. TrainingRequest.dataset_private, UploadRequest.private) always
+# overrides it. Change the policy here and every push site follows.
+DATASET_DEFAULT_PRIVATE = False
+
 
 def with_makerlab_tag(tags: list[str] | None) -> list[str]:
     """Return `tags` with the REQUIRED_HUB_TAGS appended (deduped, order preserved).

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -922,6 +922,17 @@ def _join_upload(mgr, timeout: float = 5.0) -> None:
         thread.join(timeout=timeout)
 
 
+def test_upload_request_private_defaults_to_shared_dataset_visibility_policy() -> None:
+    """UploadRequest.private isn't its own independently-hardcoded literal --
+    it defers to DATASET_DEFAULT_PRIVATE, the same constant
+    runners/hf_cloud.py's resolve_dataset_private falls back to. This is the
+    single source of truth both push sites share."""
+    from makerlab.record import UploadRequest
+    from makerlab.utils.config import DATASET_DEFAULT_PRIVATE
+
+    assert UploadRequest(dataset_repo_id="tester/ds").private is DATASET_DEFAULT_PRIVATE
+
+
 def test_upload_manager_start_runs_and_completes(monkeypatch: pytest.MonkeyPatch) -> None:
     """A start pushes in a worker thread and lands in state "done" with the
     dataset_url, invalidating the cached hub status."""

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -389,3 +389,24 @@ def test_resolve_job_timeout_uses_request_value_normalised_to_seconds() -> None:
     assert resolve_job_timeout(TrainingRequest(dataset_repo_id="x", hf_job_timeout="45m")) == 2700
     assert resolve_job_timeout(TrainingRequest(dataset_repo_id="x", hf_job_timeout="3h30m")) == 12600
     assert resolve_job_timeout(TrainingRequest(dataset_repo_id="x", hf_job_timeout="2h")) == 7200
+
+
+def test_resolve_dataset_private_falls_back_to_shared_default_when_unset() -> None:
+    """No explicit choice (local run, older client, or a cloud run whose
+    dataset the frontend believed was already on the Hub) defers to
+    DATASET_DEFAULT_PRIVATE -- the SAME constant record.py's
+    UploadRequest.private defaults to, so both push sites agree absent an
+    explicit user choice."""
+    from makerlab.runners.hf_cloud import resolve_dataset_private
+    from makerlab.utils.config import DATASET_DEFAULT_PRIVATE
+
+    assert resolve_dataset_private(None) is DATASET_DEFAULT_PRIVATE
+
+
+def test_resolve_dataset_private_honors_explicit_choice_either_way() -> None:
+    """An explicit choice (the frontend's pre-upload visibility toggle) always
+    wins over the default policy, in both directions."""
+    from makerlab.runners.hf_cloud import resolve_dataset_private
+
+    assert resolve_dataset_private(True) is True
+    assert resolve_dataset_private(False) is False

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -275,6 +275,25 @@ def test_hf_job_timeout_defaults_to_none_and_round_trips() -> None:
     assert TrainingRequest.model_validate_json(req.model_dump_json()).hf_job_timeout == "3h30m"
 
 
+def test_dataset_private_defaults_to_none_and_round_trips() -> None:
+    """Absent (older persisted JobRecord.config JSON, or a local run that never
+    showed the cloud pre-upload notice) loads as None -- the signal for
+    "no explicit user choice" that runners/hf_cloud.py's resolve_dataset_private
+    falls back on. An explicit choice survives a JSON round-trip untouched."""
+    from makerlab.train import TrainingRequest
+
+    assert TrainingRequest(dataset_repo_id="x").dataset_private is None
+
+    legacy = TrainingRequest.model_validate({"dataset_repo_id": "x", "policy_type": "act"})
+    assert legacy.dataset_private is None
+
+    private_req = TrainingRequest(dataset_repo_id="x", dataset_private=True)
+    assert TrainingRequest.model_validate_json(private_req.model_dump_json()).dataset_private is True
+
+    public_req = TrainingRequest(dataset_repo_id="x", dataset_private=False)
+    assert TrainingRequest.model_validate_json(public_req.model_dump_json()).dataset_private is False
+
+
 @pytest.mark.parametrize(
     "value,stored",
     [("2h", "2h"), ("3h30m", "3h30m"), ("  45m  ", "45m"), (None, None), ("", None), ("   ", None)],

--- a/tests/test_utils_config.py
+++ b/tests/test_utils_config.py
@@ -793,6 +793,16 @@ def test_with_makerlab_tag_always_includes_makermods_and_openbooth() -> None:
         assert "openbooth" in out
 
 
+def test_dataset_default_private_is_the_public_policy_literal() -> None:
+    """DATASET_DEFAULT_PRIVATE is MakerLab's single source of truth for
+    dataset-visibility policy (public by default) -- record.py's
+    UploadRequest.private and runners/hf_cloud.py's resolve_dataset_private
+    both read this constant instead of hardcoding the literal independently."""
+    from makerlab.utils.config import DATASET_DEFAULT_PRIVATE
+
+    assert DATASET_DEFAULT_PRIVATE is False
+
+
 def test_clear_config_references_unassigns_matching_records(tmp_lerobot_home: Path) -> None:
     """Deleting a config unassigns every robot that pointed at it — on the
     right side (device_type) only — and reports which fields were cleared."""


### PR DESCRIPTION
## Summary

The cloud-training notice promised a private upload while both actual dataset push paths (`TrainingConfigurator.tsx`, `runners/hf_cloud.py`) were hardcoded to push public. A text-only fix to the notice would have papered over the deeper issue: visibility was never actually the user's choice anywhere in the cloud-upload flow, just two independently hardcoded literals that happened to agree.

This fix instead gives dataset visibility a single source of truth and a real in-flow choice:

- `utils/config.py` adds one `DATASET_DEFAULT_PRIVATE` constant as the policy of record; every push site (`record.py`'s `UploadRequest.private` default, `hf_cloud.py`'s implicit pre-cloud-job upload) reads it instead of hardcoding `False`.
- `LocalDatasetCloudNotice.tsx` now shows a real visibility toggle (reusing the existing `VisibilityToggle` component from `UploadDatasetDialog`) instead of asserting a fixed outcome. The user's choice flows through `TrainingConfig.dataset_private` / `TrainingRequest.dataset_private` to both the explicit "Upload & start training" pre-step and the backend's belt-and-braces fallback in `HfCloudJobRunner._ensure_dataset_on_hub`, so whichever push site actually fires, it honors what the user picked.
- Explicit choices always override the default; `None` (local runs, older clients, or a cloud run that never showed the notice) falls back to `DATASET_DEFAULT_PRIVATE`.

Note: `record.py`'s `RecordingRequest.private` has the same hardcoded-`False` shape but wasn't touched here — flagging as a possible follow-up, out of scope for this issue per our one-issue-per-PR convention.

## Test plan

- [ ] `pytest` (full suite): 863 passed
- [x] `npx tsc --noEmit`: clean
- [x] `npm run lint`: clean on touched files (3 errors / 22 warnings remain, all pre-existing on `main`, unrelated to this change)
- [x] `npm run build`: succeeds (rebuilt `dist/` discarded before pushing; CI rebuilds and commits it separately)

https://claude.ai/code/session_01WtHH9o7Ewv3VoNXqHxLLoA
