### PR TITLE
fix(rollout): track a handle to the inference startup worker (I1)

### DIFF
--- a/makerlab/rollout.py
+++ b/makerlab/rollout.py
@@ -109,6 +109,17 @@ _last_result: dict[str, Any] | None = None
 # orphaned worker from a stopped session sees its (set) event and bails, while a
 # new session gets a clean one. None while idle.
 _inference_cancel: threading.Event | None = None
+# Handle to the background startup worker (_run_inference_startup) for the
+# CURRENT/most-recently-started session. `_inference_cancel` only aborts the
+# worker at coarse boundaries (before it opens the bus in _prepare_robot,
+# and again after _prepare_robot returns) — nothing interrupts it WHILE
+# _prepare_robot is actually touching hardware, so a stop can leave the
+# worker alive and still driving the bus for a few more seconds. Tracking the
+# thread (mirrors teleoperate.py's `teleoperation_thread`, added for the same
+# reason in T3) lets handle_start_inference refuse a new session while that
+# orphaned worker is still alive, instead of racing it for the same serial
+# port. None once the worker has exited or before any session has started.
+_inference_startup_thread: threading.Thread | None = None
 # Guards mutations to the globals above; held only for the short critical
 # sections in start/stop/status.
 _state_lock = threading.Lock()
@@ -909,7 +920,7 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
     launch modal; the multi-minute Hub download moves off the request thread so
     the UI lands on the inference page and shows download progress there."""
     global inference_active, _inference_started_at, _inference_meta, _inference_cancel
-    global _last_result
+    global _last_result, _inference_startup_thread
 
     # Mutex with teleop and recording: all three drive the same serial bus.
     from . import record as _record, teleoperate as _teleoperate
@@ -932,6 +943,18 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
                 "success": False,
                 "status_code": 409,
                 "message": "Inference is already active. Stop it first.",
+            }
+        if _inference_startup_thread is not None and _inference_startup_thread.is_alive():
+            # A previous session was stopped while its startup worker was
+            # inside _prepare_robot (already touching hardware) or still
+            # unwinding just after — inference_active is already False, but
+            # the worker itself hasn't exited yet. Starting a new session now
+            # would open the same serial port out from under it. Refuse until
+            # it's actually gone.
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "The previous session is still shutting down. Try again in a few seconds.",
             }
         # Claim the slot now so a concurrent caller losing the race sees us, and
         # seed the meta + timer so the phase is visible from the very first
@@ -975,12 +998,16 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
         }
 
     # Everything heavy (download, preflight, spawn) runs off the request thread.
-    threading.Thread(
+    # Tracked so a later start can tell whether a stopped session's worker is
+    # still alive (see the is_alive() guard above) instead of racing it.
+    worker = threading.Thread(
         target=_run_inference_startup,
         args=(request, cancel_event),
         name="inference-startup",
         daemon=True,
-    ).start()
+    )
+    _inference_startup_thread = worker
+    worker.start()
     return {"success": True, "message": "Inference starting"}
 
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -40,6 +40,7 @@ def _reset_rollout_globals(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(rollout, "_inference_meta", {})
     monkeypatch.setattr(rollout, "_inference_cancel", None)
     monkeypatch.setattr(rollout, "_last_result", None)
+    monkeypatch.setattr(rollout, "_inference_startup_thread", None)
 
 
 class _SyncThread:
@@ -907,6 +908,77 @@ def test_terminal_status_is_idempotent_across_polls(monkeypatch) -> None:
     status = rollout.handle_inference_status()
     assert status["inference_active"] is True
     assert "outcome" not in status
+
+
+# ---------------------------------------------------------------------------
+# I1: a stopped startup worker has no tracked thread handle, so it keeps
+# touching hardware after stop() and a new session can't tell it's still
+# running (unlike teleoperate.py's `teleoperation_thread`, which the start
+# guard checks with `.is_alive()` before claiming the slot).
+# ---------------------------------------------------------------------------
+
+
+def test_stopped_startup_worker_blocks_a_new_session_from_starting(monkeypatch) -> None:
+    """`_inference_cancel` only aborts the worker at coarse boundaries (before
+    entering `_prepare_robot`, after it returns) — nothing checks the cancel
+    flag WHILE `_prepare_robot` itself runs, and nothing tracks a handle to the
+    worker thread. So a stop pressed mid-preflight lets the orphaned worker
+    keep opening the bus / writing motor registers, and — because there is no
+    handle to ask "is that worker still alive" — a brand-new start goes ahead
+    and races it for the same serial port.
+
+    Real thread, real Event: the worker blocks inside a stubbed
+    `_prepare_robot` (standing in for the hardware-touching preflight) until
+    released, letting the test control the exact interleaving stop() must
+    protect against."""
+    from makerlab import rollout
+
+    entered_preflight = threading.Event()
+    release_preflight = threading.Event()
+
+    def _blocking_prepare_robot(request):
+        entered_preflight.set()
+        assert release_preflight.wait(timeout=5), "test setup: preflight release never signalled"
+        return [], []
+
+    monkeypatch.setattr(rollout, "_prepare_robot", _blocking_prepare_robot)
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: ref)
+
+    created_threads: list[threading.Thread] = []
+    real_thread = threading.Thread
+
+    def _tracking_thread(*args, **kwargs):
+        t = real_thread(*args, **kwargs)
+        created_threads.append(t)
+        return t
+
+    monkeypatch.setattr(rollout.threading, "Thread", _tracking_thread)
+
+    try:
+        first = rollout.handle_start_inference(_stub_request())
+        assert first["success"] is True
+        assert entered_preflight.wait(timeout=5), "worker never reached _prepare_robot"
+
+        # Stop while the worker is INSIDE _prepare_robot — hardware is already
+        # being touched, and the worker has no way to be interrupted mid-call.
+        stopped = rollout.handle_stop_inference()
+        assert stopped["success"] is True
+        assert rollout.inference_active is False
+
+        # The orphaned worker from the stopped session is still alive (stuck in
+        # _prepare_robot) and still driving hardware. A new session must be
+        # refused rather than being allowed to open the same serial port out
+        # from under it.
+        second = rollout.handle_start_inference(_stub_request())
+        assert second["success"] is False, (
+            "a new session was allowed to start while a stopped session's "
+            "startup worker was still alive and touching hardware"
+        )
+        assert second["status_code"] == 409
+    finally:
+        release_preflight.set()
+        for t in created_threads:
+            t.join(timeout=5)
 
 
 def test_fail_startup_result_is_idempotent_across_polls(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

`handle_start_inference`'s background startup worker (`_run_inference_startup`) resolves/downloads the checkpoint, then runs `_prepare_robot` — which opens the follower serial bus, runs the arm-identity check, and writes torque-limit/goal-velocity registers — before finally spawning the `lerobot-rollout` subprocess.

`_inference_cancel` (an `Event`) only aborts the worker at two coarse checkpoints: before entering `_prepare_robot`, and immediately after it returns. Nothing interrupts the worker *while* `_prepare_robot` itself is running, so a stop pressed during that window lets the "stopped" session keep touching hardware for the remainder of the preflight.

Worse, there was no tracked handle to the worker thread at all. `inference_active` flips back to `False` the instant `stop()` is called (there's no subprocess yet to wait on in this window), so a brand-new start was free to begin immediately — opening the *same* serial port the orphaned worker from the just-stopped session was still using. Two workers could end up driving preflight against the same bus concurrently: a real hardware-safety hazard, and the same family of bug T3 already fixed for `teleoperate.py`'s worker thread.

## Fix

Add `_inference_startup_thread`, tracking the background worker the same way `teleoperate.py` already tracks `teleoperation_thread` (T3). `handle_start_inference` now refuses a new session with a `409` (`"The previous session is still shutting down. Try again in a few seconds."`) while the previous session's startup worker is still alive, instead of racing it for the bus.

## Testing

- New regression test `test_stopped_startup_worker_blocks_a_new_session_from_starting` in `tests/test_rollout.py`: a real thread blocks inside a stubbed `_prepare_robot` to deterministically reproduce the stop-mid-preflight race without hardware. Fails on the pre-fix code, passes now.
- Full suite: `pytest -q` → 859 passed.
- Lint/format clean on touched files (`makerlab/rollout.py` has one pre-existing, unrelated `ruff format` drift at line ~496 — same known whole-repo drift affecting the T7/T3 PRs — left untouched).
- **Verified on real hardware** by the user: triggered the stop-during-preflight race and confirmed the retry now cleanly 409s instead of racing the bus, then succeeds once the orphaned worker actually exits.

Co-authored-by: Opus 4.8 <noreply@anthropic.com>