### PR TITLE
fix(server): stop an in-flight inference run on shutdown (I5)

### DIFF
--- a/makerlab/server.py
+++ b/makerlab/server.py
@@ -2553,6 +2553,15 @@ async def shutdown_event():
 
     # Stop any active recording - handled by recording module cleanup
 
+    # An in-flight inference run's `lerobot-rollout` subprocess is a real
+    # child process, independent of this one — it keeps driving the follower
+    # under its policy even after we exit unless we terminate it ourselves.
+    # This fires on a graceful SIGTERM (a plain `kill <pid>`, or uvicorn
+    # `--reload` tearing down the worker process on a file change), which is
+    # exactly when nothing else is left to stop it. handle_stop_inference()
+    # is a no-op (409) when idle, so this is safe to call unconditionally.
+    handle_stop_inference()
+
     if manager:
         manager.stop_broadcast_thread()
     logger.info("✅ Cleanup completed")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -61,6 +61,43 @@ def test_app_exposes_required_endpoints() -> None:
     assert not missing, f"missing routes: {missing}"
 
 
+def test_shutdown_stops_active_inference(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FastAPI's shutdown handler must terminate an in-flight inference
+    subprocess, not just the broadcast thread.
+
+    Without this, `--reload` (uvicorn kills and respawns the worker process
+    on a file change) or a plain PID kill leaves the `lerobot-rollout` child
+    — which is actively driving the follower under a policy — orphaned and
+    running with nobody supervising it, since the parent that would have
+    stopped it is already gone.
+
+    Calls shutdown_event() directly (matches the asyncio.run(mgr.connect(...))
+    pattern already used in this file) instead of relying on TestClient's
+    lifespan + monkeypatch fixture teardown ordering, which isn't guaranteed
+    to leave the patched state in place by the time the shutdown fires."""
+    from makerlab import rollout
+
+    terminate_calls: list[bool] = []
+
+    class _FakeProc:
+        def terminate(self) -> None:
+            terminate_calls.append(True)
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_proc", _FakeProc())
+    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_RUNNING})
+    # Broadcast-thread cleanup isn't under test here.
+    monkeypatch.setattr(server_mod, "manager", None)
+
+    asyncio.run(server_mod.shutdown_event())
+
+    assert terminate_calls, "shutdown did not terminate the in-flight inference subprocess"
+    assert rollout.inference_active is False
+
+
 def test_health_endpoint_returns_200_with_json_object(client: TestClient) -> None:
     response = client.get("/health")
     assert response.status_code == 200


### PR DESCRIPTION
## Problem

`rollout.py`'s inference session spawns `lerobot-rollout` as a real child process — independent of the FastAPI/uvicorn process — to drive the follower under a trained policy. FastAPI's `shutdown_event()` in `server.py` only stopped the WebSocket broadcast thread; it never touched the inference session.

On a graceful shutdown (a plain `kill <pid>`, or uvicorn `--reload` tearing down and respawning the worker process on a file change), the parent that would normally terminate the rollout subprocess is already gone by the time it exits. The child is orphaned and keeps executing the policy — an unsupervised process still commanding real hardware — instead of easing the arm back to its start pose and going limp like a normal stop.

## Fix

Call `handle_stop_inference()` from `shutdown_event()`. It's already idempotent/safe when idle (returns a `409`, no side effects), so this is a one-line, unconditional addition.

## Testing

- New regression test `test_shutdown_stops_active_inference` in `tests/test_server.py`: calls `shutdown_event()` directly with a faked in-flight subprocess and asserts `terminate()` is called. Fails on the pre-fix code, passes now.
- Full suite: `pytest -q` → 859 passed.
- Lint/format clean on touched files.
- **Verified on real hardware** by the user: started a real inference run, killed the server process (`kill <pid>`), confirmed the rollout subprocess was terminated and the follower eased back to its start pose instead of continuing to run the policy orphaned.

Co-authored-by: Opus 4.8 <noreply@anthropic.com>