### PR TITLE
fix(calibrate): make start_calibration's check-and-claim atomic (I4)

### DIFF
--- a/makerlab/calibrate.py
+++ b/makerlab/calibrate.py
@@ -152,7 +152,11 @@ class CalibrationManager:
         self.device: Robot | Teleoperator | None = None
         self.calibration_thread: threading.Thread | None = None
         self.stop_calibration = False
-        self._status_lock = threading.Lock()
+        # RLock (not Lock): start_calibration holds this across its whole
+        # check-and-claim critical section, which itself calls
+        # _update_status — a plain Lock would deadlock on that reentrant
+        # acquisition from the same thread.
+        self._status_lock = threading.RLock()
         self._step_complete = threading.Event()
         self._recording_active = False
         self._start_positions = {}
@@ -232,48 +236,58 @@ class CalibrationManager:
     def start_calibration(self, request: CalibrationRequest) -> dict[str, Any]:
         """Start calibration process"""
         try:
-            if self.status.calibration_active:
-                return {"success": False, "message": "Calibration already active"}
+            # The "already active?" check and the claim (calibration_active =
+            # True below) must be atomic: held under one lock acquisition, not
+            # two separate ones. Without this, two concurrent callers can both
+            # read calibration_active as False before either sets it True, and
+            # both spawn a worker thread against the same arm.
+            with self._status_lock:
+                if self.status.calibration_active:
+                    return {"success": False, "message": "Calibration already active"}
 
-            # Refuse to silently overwrite an existing config file. Completing a
-            # calibration saves "<config_file>.json"; if that name is taken, the
-            # caller must pass overwrite=True (after confirming) or pick another
-            # name. Lets the frontend warn before any data is clobbered.
-            config_dir = calibration_dir_for_device(request.device_type)
-            if config_dir is not None and not request.overwrite:
-                stem = request.config_file[:-5] if request.config_file.endswith(".json") else request.config_file
-                if os.path.exists(os.path.join(config_dir, f"{stem}.json")):
-                    return {
-                        "success": False,
-                        "code": "name_taken",
-                        "message": f"A calibration named '{stem}' already exists. Overwrite it or choose a different name.",
-                    }
+                # Refuse to silently overwrite an existing config file. Completing a
+                # calibration saves "<config_file>.json"; if that name is taken, the
+                # caller must pass overwrite=True (after confirming) or pick another
+                # name. Lets the frontend warn before any data is clobbered.
+                config_dir = calibration_dir_for_device(request.device_type)
+                if config_dir is not None and not request.overwrite:
+                    stem = (
+                        request.config_file[:-5]
+                        if request.config_file.endswith(".json")
+                        else request.config_file
+                    )
+                    if os.path.exists(os.path.join(config_dir, f"{stem}.json")):
+                        return {
+                            "success": False,
+                            "code": "name_taken",
+                            "message": f"A calibration named '{stem}' already exists. Overwrite it or choose a different name.",
+                        }
 
-            # Reset status and clear any previous calibration data
-            self._start_positions = {}
-            self._mins = {}
-            self._maxes = {}
-            self._homing_offsets = {}
+                # Reset status and clear any previous calibration data
+                self._start_positions = {}
+                self._mins = {}
+                self._maxes = {}
+                self._homing_offsets = {}
 
-            self._update_status(
-                calibration_active=True,
-                status="connecting",
-                device_type=request.device_type,
-                error=None,
-                message=f"Starting calibration for {request.device_type}",
-                step=0,
-                current_positions=None,
-                recorded_ranges=None,
-            )
-            self._current_request = request
+                self._update_status(
+                    calibration_active=True,
+                    status="connecting",
+                    device_type=request.device_type,
+                    error=None,
+                    message=f"Starting calibration for {request.device_type}",
+                    step=0,
+                    current_positions=None,
+                    recorded_ranges=None,
+                )
+                self._current_request = request
 
-            # Start calibration in a separate thread
-            self.calibration_thread = threading.Thread(
-                target=self._calibration_worker, args=(request,), daemon=True
-            )
-            self.stop_calibration = False
-            self._step_complete.clear()
-            self.calibration_thread.start()
+                # Start calibration in a separate thread
+                self.calibration_thread = threading.Thread(
+                    target=self._calibration_worker, args=(request,), daemon=True
+                )
+                self.stop_calibration = False
+                self._step_complete.clear()
+                self.calibration_thread.start()
 
             return {"success": True, "message": "Calibration started"}
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -16,6 +16,10 @@ post-recording centering guard."""
 
 from __future__ import annotations
 
+import time
+
+import pytest
+
 from makerlab.calibrate import final_motor_ranges, find_off_center_joints
 
 
@@ -95,6 +99,64 @@ def test_start_calibration_refuses_existing_config_without_overwrite(tmp_lerobot
     # The guard returns before activating or spawning the worker thread.
     assert mgr.status.calibration_active is False
     assert mgr.calibration_thread is None
+
+
+def test_start_calibration_check_and_claim_is_atomic(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """Two callers racing start_calibration must not both win.
+
+    `calibration_active` is read (the "already active?" guard) and later
+    written (claiming the slot) as two separate, unguarded steps — a second
+    caller landing in between sees the same False the first one saw, and both
+    proceed to spawn a worker thread against the same arm. This stalls a real
+    thread between the read and the write (at `calibration_dir_for_device`,
+    already on that path) so the test controls the exact interleaving a lock
+    around the whole check-and-claim must prevent."""
+    import threading
+
+    from makerlab.calibrate import CalibrationManager, CalibrationRequest
+
+    mgr = CalibrationManager()
+    # Avoid spawning the real hardware-touching worker; only start_calibration
+    # (the check-and-claim path) is under test here.
+    monkeypatch.setattr(mgr, "_calibration_worker", lambda request: None)
+
+    reached_stall = threading.Event()
+    release_stall = threading.Event()
+
+    def _stalling_calibration_dir_for_device(device_type: str) -> str | None:
+        reached_stall.set()
+        assert release_stall.wait(timeout=5), "test setup: release never signalled"
+        return None
+
+    monkeypatch.setattr("makerlab.calibrate.calibration_dir_for_device", _stalling_calibration_dir_for_device)
+
+    request = CalibrationRequest(device_type="robot", port="/dev/null", config_file="race", overwrite=True)
+    results: dict[str, dict] = {}
+
+    def _call(key: str) -> None:
+        results[key] = mgr.start_calibration(request)
+
+    t1 = threading.Thread(target=_call, args=("t1",))
+    t1.start()
+    assert reached_stall.wait(timeout=5), "t1 never reached the stall point"
+
+    t2 = threading.Thread(target=_call, args=("t2",))
+    t2.start()
+    # Give t2 a chance to reach (and, if the bug is present, race past) the
+    # same unguarded check t1 already passed.
+    time.sleep(0.05)
+
+    release_stall.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert not t1.is_alive() and not t2.is_alive()
+
+    outcomes = sorted(r["success"] for r in results.values())
+    assert outcomes == [False, True], (
+        f"expected exactly one of the two concurrent starts to win, got {results}"
+    )
 
 
 def test_find_off_center_joints_passes_centered_ranges() -> None:


### PR DESCRIPTION
## Problem

`CalibrationManager.start_calibration` read `self.status.calibration_active` as an unguarded "already running?" check, then — several statements later, after a filesystem existence check and some field resets — claimed the slot by setting it `True` via `_update_status()`. The read and the write were never atomic: a second caller landing in the window between them saw the same `False` the first caller saw, and both proceeded to spawn a worker thread that connects to and drives the same arm.

This was a known, pre-existing gap, called out in T4's own PR body as a follow-up never addressed: T4 widened this same check from 1 condition to 6 (reciprocal mutex against every other hardware-driving feature) without fixing the underlying race in any of them.

## Fix

Hold `self._status_lock` across the entire check-and-claim section of `start_calibration` — from the initial `calibration_active` read through spawning the worker thread — instead of leaving the read unguarded. `_status_lock` is upgraded from `Lock` to `RLock` so the reentrant call into `_update_status()` (which also acquires it) doesn't deadlock.

## Testing

- New regression test `test_start_calibration_check_and_claim_is_atomic` in `tests/test_calibrate.py`: stalls one caller mid-check with a real thread, lets a second caller race it, and asserts exactly one of the two wins. Fails on the pre-fix code (both win), passes now.
- Full suite: `pytest -q` → 859 passed.
- Lint/format clean on touched files (`makerlab/calibrate.py` has pre-existing, unrelated `ruff format` drift at three spots — same known whole-repo drift affecting the T7/T3/I1 PRs — left untouched).

## Scope note

I4 was originally reported as two parts: the non-atomic check above, and "calibration omitted" — read as the auto-calibration dialog missing the session-exit-guard the other four live-hardware surfaces (recording/inference/manual-calibration/teleop) have. Investigation found that omission is intentional, documented design: `RobotConfigDialog.tsx` explicitly states a running batch auto-calibration is meant to survive a dialog/tab close and resume on reopen (it's a bounded backend subprocess, unlike the open-ended teleop/record/inference sessions the guard protects), and wiring it into the guard would break that resume feature. Left untouched per discussion with the user — this PR is the atomicity fix only.

Co-authored-by: Opus 4.8 <noreply@anthropic.com>