### PR TITLE
Add content hints to Advanced Parameters triggers

### DIFF
--- a/frontend/src/components/dialogs/RobotConfigDialog.tsx
+++ b/frontend/src/components/dialogs/RobotConfigDialog.tsx
@@ -1821,9 +1821,14 @@ const RobotConfigWindow = ({
           only the left column. */}
       {robot && (
         <Collapsible className="group space-y-3">
-          <CollapsibleTrigger className="flex w-full items-center justify-between border-b border-border pb-2 text-sm font-semibold text-foreground">
-            <span>Advanced parameters</span>
-            <ChevronDown className="h-4 w-4 transition-transform group-data-[state=open]:rotate-180" />
+          <CollapsibleTrigger className="flex w-full items-start justify-between border-b border-border pb-2 text-sm font-semibold text-foreground">
+            <span className="text-left">
+              <span className="block">Advanced parameters</span>
+              <span className="block text-xs font-normal text-muted-foreground">
+                Auto-calibration torque
+              </span>
+            </span>
+            <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
           </CollapsibleTrigger>
           <CollapsibleContent className={SLIDE}>
             <div className="space-y-2">

--- a/frontend/src/components/studio/RecordingForm.tsx
+++ b/frontend/src/components/studio/RecordingForm.tsx
@@ -203,9 +203,14 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
 
       {/* Advanced */}
       <Collapsible className="group space-y-3">
-        <CollapsibleTrigger className="flex w-full items-center justify-between border-b border-border pb-2 text-sm font-semibold text-foreground">
-          <span>Advanced parameters</span>
-          <ChevronDown className="h-4 w-4 transition-transform group-data-[state=open]:rotate-180" />
+        <CollapsibleTrigger className="flex w-full items-start justify-between border-b border-border pb-2 text-sm font-semibold text-foreground">
+          <span className="text-left">
+            <span className="block">Advanced parameters</span>
+            <span className="block text-xs font-normal text-muted-foreground">
+              Streaming encoding, push to Hub
+            </span>
+          </span>
+          <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
         </CollapsibleTrigger>
         <CollapsibleContent className="space-y-3">
           <div className="flex items-start gap-3">

--- a/frontend/src/components/training/config/AdvancedCard.tsx
+++ b/frontend/src/components/training/config/AdvancedCard.tsx
@@ -109,9 +109,14 @@ const AdvancedCard: React.FC<ConfigComponentProps> = ({
       onOpenChange={setExpanded}
       className="group space-y-4"
     >
-      <CollapsibleTrigger className="flex w-full items-center justify-between border-b border-border pb-2 text-sm font-semibold text-foreground">
-        <span>Advanced parameters</span>
-        <ChevronDown className="h-4 w-4 transition-transform group-data-[state=open]:rotate-180" />
+      <CollapsibleTrigger className="flex w-full items-start justify-between border-b border-border pb-2 text-sm font-semibold text-foreground">
+        <span className="text-left">
+          <span className="block">Advanced parameters</span>
+          <span className="block text-xs font-normal text-muted-foreground">
+            Optimizer, learning rate, log frequency, checkpoints, and more
+          </span>
+        </span>
+        <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
       </CollapsibleTrigger>
 
       <CollapsibleContent className="space-y-6">


### PR DESCRIPTION
## Summary

The "Advanced parameters" collapsible trigger appears in three places in the frontend — Training config, Record a dataset, and the robot config dialog's calibration panel — and in all three, the collapsed label gave no indication of what was inside. Users had to expand the section just to check whether it was relevant to what they were configuring.

This adds a muted one-line subtitle under each trigger naming the fields it contains, with no layout cost when collapsed:

- **Training** (`AdvancedCard.tsx`) — "Optimizer, learning rate, log frequency, checkpoints, and more"
- **Record a dataset** (`RecordingForm.tsx`) — "Streaming encoding, push to Hub"
- **Robot config dialog** (`RobotConfigDialog.tsx`) — "Auto-calibration torque"

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx eslint` on the three changed files shows no new warnings (one pre-existing, unrelated `react-hooks/exhaustive-deps` warning in `RobotConfigDialog.tsx`)
- [x] Verified visually in dev (`makerlab --dev`) across all three locations: Training config form, Record dataset form, and the robot config dialog's calibration panel

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>