### PR TITLE
ci(frontend): push rebuilt dist via GitHub App token

### DIFF
--- a/.github/workflows/build_frontend.yml
+++ b/.github/workflows/build_frontend.yml
@@ -17,10 +17,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived token from the dist-bot GitHub App. The default
+      # GITHUB_TOKEN / github-actions[bot] cannot be granted PR-bypass on a
+      # protected branch (GitHub blocks the first-party token), so it can't
+      # push the rebuilt dist back to `main`. A real GitHub App can be added to
+      # the branch's PR-bypass list, and its token expires when the job ends.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.DIST_BOT_APP_ID }}
+          private-key: ${{ secrets.DIST_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v7.0.0
         with:
           lfs: true
-          persist-credentials: false
+          # Check out with the App token; persist-credentials defaults to true
+          # so the final `git push` reuses it on the origin remote.
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@v6
         with:
           # Vite 8 requires ^20.19.0 or >=22.12.0; on Node 18 `npm run build`
@@ -35,15 +47,17 @@ jobs:
         working-directory: frontend
         run: npm run build
       - name: Commit dist if changed
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
+          git config user.name  "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           if [[ -n "$(git status --porcelain frontend/dist)" ]]; then
             git add frontend/dist
             git commit -m "ci: rebuild frontend/dist [skip ci]"
-            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
+            # Pushes as the App (credentials persisted by checkout above), which
+            # is on main's PR-bypass list. dist is path-excluded from this
+            # workflow's triggers and the message carries [skip ci], so this push
+            # does not start another run.
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           else
             echo "frontend/dist already up to date"
           fi


### PR DESCRIPTION
## What
Makes the `build_frontend` workflow able to commit the rebuilt `frontend/dist` back to protected `main`, by pushing as the **makerlab-dist-bot** GitHub App instead of the default `github-actions[bot]`.

## Why
Two stacked bugs had left `dist` stale:
1. **Broken lockfile** (fixed earlier on main) — CI's `npm ci` failed on Linux.
2. **Push-back rejected** — with `npm ci` fixed, the workflow builds `dist` but its final push is rejected by branch protection: `GH006: Protected branch update failed — Changes must be made through a pull request`. The first-party `GITHUB_TOKEN` **cannot** be granted PR-bypass on a protected branch.

## Fix
Use a GitHub App token (`actions/create-github-app-token`):
- App `makerlab-dist-bot` — Contents: read/write, installed on this repo, added to `main`'s PR-bypass list.
- Mint a short-lived token per run, check out + push with it. Token expires when the job ends.
- `dist` is path-excluded from the workflow triggers and the commit carries `[skip ci]`, so the push-back does not trigger another run.

## Requires (already configured)
Repo secrets `DIST_BOT_APP_ID` and `DIST_BOT_PRIVATE_KEY`.

## Testing
After merge, a trivial `frontend/src` change → PR → merge should make CI rebuild and self-commit `dist` as `makerlab-dist-bot[bot]`.