### PR TITLE
ui(training): drop tested/untested badges from policy selector

### DIFF
--- a/frontend/src/components/training/config/EssentialsCard.tsx
+++ b/frontend/src/components/training/config/EssentialsCard.tsx
@@ -82,18 +82,7 @@ const EssentialsCard: React.FC<
           <SelectContent>
             {POLICY_TYPE_OPTIONS.map((policy) => (
               <SelectItem key={policy.value} value={policy.value}>
-                <span className="flex items-center gap-2">
-                  <span>{policy.display}</span>
-                  <span
-                    className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                      policy.stable
-                        ? "bg-ok/15 text-ok"
-                        : "bg-muted text-muted-foreground"
-                    }`}
-                  >
-                    {policy.stable ? "tested" : "untested"}
-                  </span>
-                </span>
+                {policy.display}
               </SelectItem>
             ))}
           </SelectContent>
@@ -101,7 +90,7 @@ const EssentialsCard: React.FC<
         <p className="text-xs text-muted-foreground">
           {policyLocked
             ? "Set by the base skill — the run trains the same architecture as its source checkpoint."
-            : "The model architecture this run trains. Untested types run at your own risk."}
+            : "The model architecture this run trains."}
         </p>
       </div>
 

--- a/frontend/src/components/training/types.ts
+++ b/frontend/src/components/training/types.ts
@@ -61,32 +61,26 @@ export interface TrainingConfig {
 // The policy types the trainer supports. The model is chosen up-front on the
 // landing page's "Create a model" card (one button per type, short `label`);
 // the training config then shows it frozen using the full `display` name.
-// `stable` = tested on our hardware (user decision 2026-07-03) — a statement
-// about what we've validated in MakerLab, not about upstream lerobot quality.
-// Unstable types stay selectable; the landing card just subdues them.
 export const POLICY_TYPE_OPTIONS: {
   value: string;
   label: string;
   display: string;
-  stable: boolean;
 }[] = [
   {
     value: "act",
     label: "ACT",
     display: "ACT (Action Chunking Transformer)",
-    stable: true,
   },
-  { value: "diffusion", label: "Diffusion", display: "Diffusion Policy", stable: false },
-  { value: "pi0", label: "PI0", display: "PI0", stable: false },
-  { value: "smolvla", label: "SmolVLA", display: "SmolVLA", stable: true },
-  { value: "tdmpc", label: "TD-MPC", display: "TD-MPC", stable: false },
-  { value: "vqbet", label: "VQ-BeT", display: "VQ-BeT", stable: false },
-  { value: "pi0_fast", label: "PI0 Fast", display: "PI0 Fast", stable: false },
+  { value: "diffusion", label: "Diffusion", display: "Diffusion Policy" },
+  { value: "pi0", label: "PI0", display: "PI0" },
+  { value: "smolvla", label: "SmolVLA", display: "SmolVLA" },
+  { value: "tdmpc", label: "TD-MPC", display: "TD-MPC" },
+  { value: "vqbet", label: "VQ-BeT", display: "VQ-BeT" },
+  { value: "pi0_fast", label: "PI0 Fast", display: "PI0 Fast" },
   {
     value: "gaussian_actor",
     label: "Gaussian Actor",
     display: "Gaussian Actor",
-    stable: false,
   },
   // reward_classifier deliberately absent: it isn't a policy in the pinned
   // lerobot (separate RewardModelConfig registry — scores outcomes, doesn't


### PR DESCRIPTION
## What
Removes the green **tested** / grey **untested** badges from the policy-type selector on the training config. Each policy now shows as plain text.

All supported policy types work, so the tested/untested distinction is no longer meaningful.

## Changes
- `EssentialsCard.tsx` — render `policy.display` as plain text (no badge span); drop the "Untested types run at your own risk" clause from the helper text.
- `types.ts` — remove the now-unused `stable` flag from `POLICY_TYPE_OPTIONS` and its stale explanatory comment.

## Verification
`npx tsc --noEmit` → 0 errors. No behavioral change — purely the selector's visual labels.

## Note
Also serves as the live test of the fixed `build_frontend` CI (PR #16): merging this changes frontend source, so CI should rebuild `dist` and self-commit it back to `main` as `makerlab-dist-bot[bot]`.