### PR TITLE
Add a local-style dataset episode viewer for local and Hub datasets

### DIFF
--- a/docs/superpowers/plans/2026-07-27-episode-viewer-nav-controls.md
+++ b/docs/superpowers/plans/2026-07-27-episode-viewer-nav-controls.md
@@ -1,0 +1,126 @@
+# Episode Viewer Nav Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the episode viewer's Prev/Next buttons visually reflect list boundaries, and add ArrowLeft/ArrowRight/Space keyboard shortcuts for episode navigation and play/pause.
+
+**Architecture:** Both changes live entirely inside the existing `EpisodeViewer` component in `frontend/src/components/dialogs/DatasetDetailDialog.tsx`. No new files, no backend changes.
+
+**Tech Stack:** React + TypeScript, existing `Button` component (`components/ui/button.tsx`) which already applies `disabled:opacity-50 disabled:pointer-events-none`.
+
+## Global Constraints
+
+- Frontend checks only: `npm run lint`, `npx tsc --noEmit` from `frontend/` (per `CLAUDE.md`). No `npm run build` — it can corrupt committed LFS assets elsewhere in the repo (unrelated to this change, but don't run it).
+- No unit tests to add — this is inline UI logic, not a pure helper (per `CLAUDE.md`'s testing rules and the design spec's §3).
+- Manual verification via `makerlab --dev`.
+
+---
+
+### Task 1: Boundary-aware Prev/Next disabling + keyboard shortcuts
+
+**Files:**
+- Modify: `frontend/src/components/dialogs/DatasetDetailDialog.tsx` (inside `EpisodeViewer`, roughly lines 246-345)
+
+**Interfaces:**
+- Consumes: existing `episodes: EpisodeSummary[]`, `selectedEpisode: number`, `gotoEpisode(delta: number)` (already defined at line 246), `handlePlayPause()` (already defined at line 163) — no signature changes to any of these.
+- Produces: no new exports; this is a self-contained behavior change within the component.
+
+- [ ] **Step 1: Add boundary computation next to `gotoEpisode`**
+
+In `EpisodeViewer`, immediately after the existing `gotoEpisode` function (around line 250), add:
+
+```tsx
+  const currentIndex = episodes.findIndex((e) => e.episode_index === selectedEpisode);
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex >= 0 && currentIndex < episodes.length - 1;
+```
+
+- [ ] **Step 2: Wire the computed flags into the Prev/Next buttons' `disabled` props**
+
+Change (around line 322):
+```tsx
+          onClick={() => gotoEpisode(-1)}
+          disabled={!episode}
+          aria-label="Previous episode"
+```
+to:
+```tsx
+          onClick={() => gotoEpisode(-1)}
+          disabled={!episode || !hasPrev}
+          aria-label="Previous episode"
+```
+
+And (around line 341):
+```tsx
+          onClick={() => gotoEpisode(1)}
+          disabled={!episode}
+          aria-label="Next episode"
+```
+to:
+```tsx
+          onClick={() => gotoEpisode(1)}
+          disabled={!episode || !hasNext}
+          aria-label="Next episode"
+```
+
+- [ ] **Step 3: Add the keyboard shortcut effect**
+
+Add a new `useEffect` inside `EpisodeViewer`, placed after the existing prefetch `useEffect` (after line 151, before the `setPlaying(false)` reset effect at line 153) — mirrors the guarded-`window`-listener convention already used in `frontend/src/components/recording/RecordingSessionDialog.tsx:556-582`:
+
+```tsx
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+        return;
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        gotoEpisode(-1);
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        gotoEpisode(1);
+      } else if (e.key === " " || e.code === "Space") {
+        e.preventDefault();
+        handlePlayPause();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [gotoEpisode, handlePlayPause]);
+```
+
+Note: `gotoEpisode` and `handlePlayPause` are plain `const` closures re-created each render (not wrapped in `useCallback`), so this effect re-subscribes every render — that's fine, it's a cheap `addEventListener`/`removeEventListener` pair, and matches the codebase's existing tolerance for this pattern elsewhere.
+
+- [ ] **Step 4: Type-check and lint**
+
+Run from `frontend/`:
+```bash
+npx tsc --noEmit
+npm run lint
+```
+Expected: no new errors beyond whatever pre-existing baseline `CLAUDE.md` notes (there shouldn't be any pre-existing errors touching this file — if there are, confirm they're unrelated to this change before proceeding).
+
+- [ ] **Step 5: Manual verification via `makerlab --dev`**
+
+Start the dev server, open a dataset with 3+ local episodes in the detail dialog:
+- Confirm the Prev button is greyed out (visually dimmed, unclickable) on episode index 0, and re-enables after navigating forward.
+- Confirm the Next button is greyed out on the last episode, and re-enables after navigating back.
+- With focus somewhere in the dialog (not the tag-input field in the info card), press ArrowLeft/ArrowRight and confirm episode navigation; press Space and confirm play/pause toggles.
+- Click into the tag-input field (in `DatasetInfoCard`, right panel) and confirm typing a literal space or arrow keys there does NOT trigger episode navigation or play/pause — it types normally.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/dialogs/DatasetDetailDialog.tsx
+git commit -m "$(cat <<'EOF'
+feat(datasets): boundary-aware episode nav buttons + keyboard shortcuts
+
+Prev/Next now grey out at the actual start/end of the episode list
+instead of only when no episode is selected at all. Adds ArrowLeft/
+ArrowRight to navigate episodes and Space to play/pause, guarded
+against text-input focus to match the existing convention in
+RecordingSessionDialog.
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-07-27-episode-viewer-nav-controls-design.md
+++ b/docs/superpowers/specs/2026-07-27-episode-viewer-nav-controls-design.md
@@ -1,0 +1,37 @@
+# Episode viewer: boundary-aware nav buttons + keyboard shortcuts — design spec
+
+Date: 2026-07-27 · Branch: `feat/dataset-viewer-window` · Status: approved by user
+
+## Goal
+
+`EpisodeViewer` (inline in `frontend/src/components/dialogs/DatasetDetailDialog.tsx`) has Prev/Next episode buttons and a Play/Pause button. Two gaps:
+
+1. Prev/Next are only disabled when there's no episode at all (`disabled={!episode}`), never at the actual start/end of the episode list — so a user can't tell by looking whether there's anywhere left to go.
+2. No keyboard shortcuts — every transport action requires a mouse click.
+
+## 1 · Boundary-aware disabling
+
+Compute the current index once (`episodes.findIndex((e) => e.episode_index === selectedEpisode)`) and derive:
+
+- `hasPrev = currentIndex > 0`
+- `hasNext = currentIndex >= 0 && currentIndex < episodes.length - 1`
+
+Prev button: `disabled={!episode || !hasPrev}`. Next button: `disabled={!episode || !hasNext}`.
+
+No new styling needed — the shared `Button` component (`components/ui/button.tsx`) already applies `disabled:opacity-50 disabled:pointer-events-none`, which is exactly the "transparent, can't click" affordance requested.
+
+## 2 · Keyboard shortcuts
+
+Mirror the existing convention in `RecordingSessionDialog.tsx` (`window`-level `keydown` listener, guarded against text-input focus, `preventDefault()` on handled keys):
+
+- `ArrowLeft` → `gotoEpisode(-1)`
+- `ArrowRight` → `gotoEpisode(1)`
+- `Space` → `handlePlayPause()`
+
+Implementation: a `useEffect` inside `EpisodeViewer` that adds/removes the listener on mount/unmount — no extra "is this active" flag is needed because `EpisodeViewer` itself is only mounted while the dialog is open and episodes are loaded (see `DatasetDetailDialog`'s conditional render).
+
+Guard, copied from the existing convention: skip entirely if `e.target` is an `INPUT`, `TEXTAREA`, or `isContentEditable` — relevant here because the dialog's side panel (`DatasetInfoCard`) contains a tag-input field. `gotoEpisode` already no-ops safely when there's nothing at `episodes[i + delta]`, so the handler doesn't need to duplicate the `hasPrev`/`hasNext` check.
+
+## 3 · Testing
+
+Per `CLAUDE.md`, this is a pure frontend UI change — no unit tests to add (no pure-helper logic beyond what's already inline). Verify manually via `makerlab --dev`: open a dataset with 3+ episodes, confirm Prev is greyed out on episode 0 and Next greyed out on the last episode, and confirm ArrowLeft/ArrowRight/Space work while focus is anywhere in the dialog except the tag-input field.

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -21,6 +21,7 @@ import {
   EpisodeJointSeries,
   EpisodeSummary,
   episodeVideoUrl,
+  getDatasetHubSettings,
   getDatasetInfo,
   getEpisodeJoints,
   listEpisodes,
@@ -465,6 +466,35 @@ const EpisodeViewer: React.FC<{
   );
 };
 
+// Hugging Face's own hosted dataset viewer (the same Space linked from every
+// dataset's Hub page). Its `*.hf.space` subdomain runs with no viewer auth
+// context and sends no framing-blocking headers, so it can embed a PUBLIC
+// repo directly by path. The `huggingface.co/spaces/...` wrapper URL that
+// *does* carry the viewer's own Hub login (needed for a private repo) sends
+// `X-Frame-Options: DENY` and cannot be framed at all — confirmed against
+// live response headers, not assumed. So this is only ever rendered for a
+// Hub dataset already confirmed public; a private one keeps the existing
+// "download to view" message instead of a broken/blank iframe.
+const HUB_SPACE_BASE_URL = "https://lerobot-visualize-dataset.hf.space";
+
+const HubSpaceViewer: React.FC<{ repoId: string }> = ({ repoId }) => (
+  <div className="flex min-h-0 flex-1 flex-col gap-2">
+    <div className="flex-1 overflow-hidden rounded-md border border-border bg-[#0c0f14]">
+      <iframe
+        key={repoId}
+        src={`${HUB_SPACE_BASE_URL}/${repoId}`}
+        className="h-full w-full border-0"
+        allow="autoplay; fullscreen"
+        title={`Hugging Face dataset viewer — ${repoId}`}
+      />
+    </div>
+    <p className="shrink-0 text-center text-[10.5px] text-muted-foreground">
+      Viewing via Hugging Face's hosted dataset viewer — download this dataset
+      to view it here with joint traces.
+    </p>
+  </div>
+);
+
 const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
   repoId,
   open,
@@ -480,6 +510,14 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
   const [cameras, setCameras] = useState<string[]>([]);
   const [selectedEpisode, setSelectedEpisode] = useState<number | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  const [datasetSource, setDatasetSource] = useState<"local" | "hub" | undefined>(undefined);
+  // null = not yet known (still checking, or the check hasn't run because it
+  // isn't needed) — only used to gate the Hub Space iframe fallback below.
+  const [hubPrivate, setHubPrivate] = useState<boolean | null>(null);
+  // Set on a failed privacy check (offline, or a private repo we have no read
+  // access to at all) so the "checking…" state has a terminal fallback
+  // instead of hanging forever when hubPrivate can never resolve.
+  const [hubPrivateCheckFailed, setHubPrivateCheckFailed] = useState(false);
 
   useEffect(() => {
     if (!repoId || !open) return;
@@ -487,6 +525,9 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
     setEpisodesLoading(true);
     setEpisodes(null);
     setCameras([]);
+    setDatasetSource(undefined);
+    setHubPrivate(null);
+    setHubPrivateCheckFailed(false);
     Promise.all([
       listEpisodes(baseUrl, fetchWithHeaders, repoId, controller.signal).catch(() => null),
       getDatasetInfo(baseUrl, fetchWithHeaders, repoId, controller.signal).catch(() => null),
@@ -494,11 +535,31 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
       if (controller.signal.aborted) return;
       setEpisodes(eps);
       setCameras(info?.cameras ?? []);
+      setDatasetSource(info?.source);
       setSelectedEpisode(eps && eps.length > 0 ? eps[0].episode_index : null);
       setEpisodesLoading(false);
     });
     return () => controller.abort();
   }, [repoId, open, baseUrl, fetchWithHeaders, reloadKey]);
+
+  // Only relevant to the Hub Space iframe fallback: when /datasets/episodes
+  // failed (episodes === null) for a dataset that IS on the Hub, find out
+  // whether it's private before offering the embed — a private repo can't be
+  // fetched by the Space's anonymous browser (see HubSpaceViewer above).
+  useEffect(() => {
+    if (!repoId || episodesLoading || episodes !== null || datasetSource !== "hub") return;
+    let cancelled = false;
+    getDatasetHubSettings(baseUrl, fetchWithHeaders, repoId)
+      .then((settings) => {
+        if (!cancelled) setHubPrivate(settings.private);
+      })
+      .catch(() => {
+        if (!cancelled) setHubPrivateCheckFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, episodesLoading, episodes, datasetSource, baseUrl, fetchWithHeaders]);
 
   if (!repoId) return null;
 
@@ -533,6 +594,15 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
                 selectedEpisode={selectedEpisode}
                 onSelectEpisode={setSelectedEpisode}
               />
+            ) : episodes === null && datasetSource === "hub" && hubPrivate === false ? (
+              <HubSpaceViewer repoId={repoId} />
+            ) : episodes === null &&
+              datasetSource === "hub" &&
+              hubPrivate === null &&
+              !hubPrivateCheckFailed ? (
+              <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                Checking Hub visibility…
+              </div>
             ) : (
               <div className="flex flex-1 flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border bg-muted/30 px-6 text-center">
                 <VideoOff className="h-6 w-6 text-muted-foreground" />

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -1,5 +1,11 @@
-import React from "react";
-import { Boxes } from "lucide-react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Boxes, Pause, Play, SkipBack, SkipForward, VideoOff } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -9,7 +15,16 @@ import {
 import { Button } from "@/components/ui/button";
 import { useStudio } from "@/contexts/StudioContext";
 import { useSelectedDataset } from "@/hooks/useSelectedDataset";
+import { useApi } from "@/contexts/ApiContext";
 import DatasetInfoCard from "@/components/landing/DatasetInfoCard";
+import {
+  EpisodeJointSeries,
+  EpisodeSummary,
+  episodeVideoUrl,
+  getDatasetInfo,
+  getEpisodeJoints,
+  listEpisodes,
+} from "@/lib/replayApi";
 
 export interface DatasetDetailDialogProps {
   repoId: string | null;
@@ -20,22 +35,446 @@ export interface DatasetDetailDialogProps {
   onStudioAction?: () => void;
 }
 
+// Six SO-101 joints, in the dataset's fixed column order — a validated
+// categorical set (see dataviz skill palette) so adjacent lines stay
+// distinguishable; cycles defensively if a feature set ever carries more.
+const JOINT_COLORS = [
+  "#2a78d6",
+  "#eb6834",
+  "#1baf7a",
+  "#eda100",
+  "#e87ba4",
+  "#008300",
+];
+
+// Best (cols, tileW, tileH) for `n` tiles inside a box of `boxW` x `boxH`:
+// the search over column counts that a video-gallery layout needs so the
+// camera grid keeps growing/reflowing as cameras are added or the window is
+// resized, instead of a fixed N-up template.
+function computeCameraLayout(
+  n: number,
+  boxW: number,
+  boxH: number,
+  gap = 8,
+  aspect = 16 / 10,
+) {
+  let best = { cols: 1, tileW: boxW, tileH: boxW / aspect };
+  let bestArea = -1;
+  for (let cols = 1; cols <= n; cols++) {
+    const rows = Math.ceil(n / cols);
+    const cellW = (boxW - gap * (cols - 1)) / cols;
+    const cellH = (boxH - gap * (rows - 1)) / rows;
+    let tileW = cellW;
+    let tileH = tileW / aspect;
+    if (tileH > cellH) {
+      tileH = cellH;
+      tileW = tileH * aspect;
+    }
+    const area = tileW * tileH;
+    if (area > bestArea) {
+      bestArea = area;
+      best = { cols, tileW, tileH };
+    }
+  }
+  return best;
+}
+
+const fmtTime = (t: number) => `${t.toFixed(1)}s`;
+
 /**
- * Dataset detail — wraps the existing DatasetInfoCard (unmodified) in a dialog
- * and adds the market action: train a skill from this dataset (→ Train panel,
- * dataset preselected). It stamps the shared selected-dataset key so the
- * studio panels pick it up, exactly like DatasetInfoCard's own ecosystem.
- * (Recording on top of an existing dataset was removed — grow a dataset by
- * recording a new one and merging.)
+ * Episode viewer: a growable grid of camera feeds (one per dataset camera —
+ * reflows on resize and as camera count changes, never a fixed 2-up) with
+ * transport controls and a joint-position chart synced to the playhead. Real
+ * <video> elements pointing at /datasets/episode-video (Range-request backed,
+ * so scrubbing seeks without buffering the whole file); no local data means no
+ * episode list, so this renders a locked "not viewable yet" state instead.
  */
+const EpisodeViewer: React.FC<{
+  repoId: string;
+  cameras: string[];
+  episodes: EpisodeSummary[];
+  selectedEpisode: number;
+  onSelectEpisode: (episodeIndex: number) => void;
+}> = ({ repoId, cameras, episodes, selectedEpisode, onSelectEpisode }) => {
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const [joints, setJoints] = useState<EpisodeJointSeries | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [videoErrors, setVideoErrors] = useState<Record<string, boolean>>({});
+  const [hoverT, setHoverT] = useState<number | null>(null);
+
+  const episode = episodes.find((e) => e.episode_index === selectedEpisode) ?? null;
+  const videoRefs = useRef<Record<string, HTMLVideoElement | null>>({});
+  const primaryCamera = cameras[0];
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setJoints(null);
+    getEpisodeJoints(baseUrl, fetchWithHeaders, repoId, selectedEpisode, controller.signal)
+      .then(setJoints)
+      .catch(() => {
+        if (!controller.signal.aborted) setJoints(null);
+      });
+    return () => controller.abort();
+  }, [baseUrl, fetchWithHeaders, repoId, selectedEpisode]);
+
+  useEffect(() => {
+    setPlaying(false);
+    setCurrentTime(0);
+    setVideoErrors({});
+  }, [selectedEpisode]);
+
+  const forEachVideo = useCallback((fn: (v: HTMLVideoElement) => void) => {
+    Object.values(videoRefs.current).forEach((v) => v && fn(v));
+  }, []);
+
+  const handlePlayPause = () => {
+    if (playing) {
+      forEachVideo((v) => v.pause());
+      setPlaying(false);
+    } else {
+      forEachVideo((v) => {
+        v.play().catch(() => {});
+      });
+      setPlaying(true);
+    }
+  };
+
+  const handleSeek = (t: number) => {
+    const clamped = Math.max(0, Math.min(episode?.duration ?? 0, t));
+    forEachVideo((v) => {
+      v.currentTime = clamped;
+    });
+    setCurrentTime(clamped);
+  };
+
+  const gridWrapRef = useRef<HTMLDivElement>(null);
+  const [layout, setLayout] = useState({ cols: 1, tileW: 100, tileH: 60 });
+  useEffect(() => {
+    const el = gridWrapRef.current;
+    if (!el) return;
+    const recompute = () => {
+      const rect = el.getBoundingClientRect();
+      setLayout(
+        computeCameraLayout(
+          Math.max(1, cameras.length),
+          Math.max(80, rect.width - 16),
+          Math.max(80, rect.height - 16),
+        ),
+      );
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [cameras.length]);
+
+  const jointRanges = useMemo(() => {
+    if (!joints || joints.values.length === 0) return [];
+    return joints.joint_names.map((_, j) => {
+      const vals = joints.values.map((frame) => frame[j]);
+      return { min: Math.min(...vals), max: Math.max(...vals) };
+    });
+  }, [joints]);
+
+  const chartRef = useRef<HTMLDivElement>(null);
+  const handleChartHover = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!episode || !joints) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const frac = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    setHoverT(frac * episode.duration);
+  };
+
+  const scrubFrac = episode?.duration ? currentTime / episode.duration : 0;
+
+  const scrubRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+  const seekFromClientX = (clientX: number) => {
+    const rect = scrubRef.current?.getBoundingClientRect();
+    if (!rect || !episode) return;
+    const frac = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    handleSeek(frac * episode.duration);
+  };
+
+  const gotoEpisode = (delta: number) => {
+    const i = episodes.findIndex((e) => e.episode_index === selectedEpisode);
+    const next = episodes[i + delta];
+    if (next) onSelectEpisode(next.episode_index);
+  };
+
+  if (cameras.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center rounded-md border border-border bg-muted/30 text-sm text-muted-foreground">
+        This dataset has no camera data to view.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      <div
+        ref={gridWrapRef}
+        className="relative flex-1 overflow-auto rounded-md border border-border bg-[#0c0f14]"
+      >
+        <div
+          className="grid justify-center content-center gap-2 p-2"
+          style={{
+            gridTemplateColumns: `repeat(${layout.cols}, ${layout.tileW}px)`,
+            gridAutoRows: `${layout.tileH}px`,
+          }}
+        >
+          {cameras.map((camera) => (
+            <div
+              key={camera}
+              className="relative overflow-hidden rounded border border-white/10 bg-black"
+            >
+              <span className="absolute left-1.5 top-1.5 z-10 rounded bg-black/50 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-100">
+                {camera}
+              </span>
+              {videoErrors[camera] ? (
+                <div className="flex h-full w-full flex-col items-center justify-center gap-1 px-3 text-center text-zinc-300">
+                  <VideoOff className="h-4 w-4" />
+                  <p className="text-[10px] leading-snug">
+                    Can't decode this camera's video in this browser.
+                  </p>
+                </div>
+              ) : (
+                <video
+                  key={`${repoId}:${selectedEpisode}:${camera}`}
+                  ref={(el) => {
+                    videoRefs.current[camera] = el;
+                  }}
+                  src={episodeVideoUrl(baseUrl, repoId, selectedEpisode, camera)}
+                  className="h-full w-full object-cover"
+                  muted
+                  playsInline
+                  onTimeUpdate={
+                    camera === primaryCamera
+                      ? (e) => setCurrentTime(e.currentTarget.currentTime)
+                      : undefined
+                  }
+                  onEnded={camera === primaryCamera ? () => setPlaying(false) : undefined}
+                  onError={() =>
+                    setVideoErrors((prev) => ({ ...prev, [camera]: true }))
+                  }
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={() => gotoEpisode(-1)}
+          disabled={!episode}
+          aria-label="Previous episode"
+        >
+          <SkipBack className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={handlePlayPause}
+          disabled={!episode}
+          aria-label={playing ? "Pause" : "Play"}
+        >
+          {playing ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={() => gotoEpisode(1)}
+          disabled={!episode}
+          aria-label="Next episode"
+        >
+          <SkipForward className="h-3.5 w-3.5" />
+        </Button>
+        <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+          {episode ? `${fmtTime(currentTime)} / ${fmtTime(episode.duration)}` : "—"}
+        </span>
+        <div
+          ref={scrubRef}
+          className="relative h-5 flex-1 cursor-pointer"
+          onPointerDown={(e) => {
+            draggingRef.current = true;
+            forEachVideo((v) => v.pause());
+            setPlaying(false);
+            seekFromClientX(e.clientX);
+          }}
+          onPointerMove={(e) => {
+            if (draggingRef.current) seekFromClientX(e.clientX);
+          }}
+          onPointerUp={() => {
+            draggingRef.current = false;
+          }}
+          onPointerLeave={() => {
+            draggingRef.current = false;
+          }}
+        >
+          <div className="absolute inset-y-0 my-auto h-1 w-full rounded-full bg-muted" />
+          <div
+            className="absolute inset-y-0 my-auto h-1 rounded-full bg-foreground"
+            style={{ width: `${scrubFrac * 100}%` }}
+          />
+          <div
+            className="absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full bg-foreground shadow"
+            style={{ left: `calc(${scrubFrac * 100}% - 6px)` }}
+          />
+        </div>
+      </div>
+
+      <div className="rounded-md border border-border bg-muted/40 p-2">
+        <div className="mb-1 flex items-baseline justify-between">
+          <span className="eyebrow">joint positions — synced to playhead</span>
+          <span className="eyebrow">
+            {episode ? `episode ${episode.episode_index}` : "—"}
+          </span>
+        </div>
+        <div
+          ref={chartRef}
+          className="relative h-[72px]"
+          onMouseMove={handleChartHover}
+          onMouseLeave={() => setHoverT(null)}
+        >
+          {joints && episode && episode.duration > 0 ? (
+            <svg viewBox="0 0 600 72" preserveAspectRatio="none" className="h-full w-full">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <line
+                  key={i}
+                  x1={0}
+                  x2={600}
+                  y1={(i / 4) * 72}
+                  y2={(i / 4) * 72}
+                  stroke="hsl(var(--border))"
+                  strokeWidth={1}
+                />
+              ))}
+              {joints.joint_names.map((_, j) => {
+                const range = jointRanges[j];
+                if (!range) return null;
+                const span = range.max - range.min || 1;
+                const points = joints.timestamps
+                  .map((t, i) => {
+                    const x = (t / episode.duration) * 600;
+                    const v = joints.values[i][j];
+                    const y = 72 - ((v - range.min) / span) * 72;
+                    return `${x.toFixed(1)},${y.toFixed(1)}`;
+                  })
+                  .join(" ");
+                return (
+                  <polyline
+                    key={j}
+                    points={points}
+                    fill="none"
+                    stroke={JOINT_COLORS[j % JOINT_COLORS.length]}
+                    strokeWidth={1.5}
+                    strokeLinejoin="round"
+                    strokeLinecap="round"
+                  />
+                );
+              })}
+              <line
+                x1={scrubFrac * 600}
+                x2={scrubFrac * 600}
+                y1={0}
+                y2={72}
+                stroke="hsl(var(--foreground))"
+                strokeWidth={1}
+                opacity={0.55}
+              />
+            </svg>
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+              {episode ? "Loading joint data…" : "No episode selected"}
+            </div>
+          )}
+          {hoverT != null && joints && episode && (
+            <div
+              className="pointer-events-none absolute top-1 rounded border border-border bg-popover px-1.5 py-1 text-[10px] shadow"
+              style={{
+                left: Math.min(
+                  Math.max((hoverT / episode.duration) * 100, 0),
+                  85,
+                ) + "%",
+              }}
+            >
+              <div className="mb-0.5 font-semibold">t = {hoverT.toFixed(1)}s</div>
+              {joints.joint_names.map((name, j) => {
+                const idx = joints.timestamps.reduce(
+                  (best, t, i) =>
+                    Math.abs(t - hoverT) < Math.abs(joints.timestamps[best] - hoverT) ? i : best,
+                  0,
+                );
+                return (
+                  <div key={name} className="flex items-center gap-1 tabular-nums">
+                    <span
+                      className="h-1.5 w-1.5 shrink-0 rounded-sm"
+                      style={{ background: JOINT_COLORS[j % JOINT_COLORS.length] }}
+                    />
+                    {name}: {joints.values[idx][j].toFixed(1)}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        {joints && (
+          <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1">
+            {joints.joint_names.map((name, j) => (
+              <span key={name} className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-sm"
+                  style={{ background: JOINT_COLORS[j % JOINT_COLORS.length] }}
+                />
+                {name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
 const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
   repoId,
   open,
   onOpenChange,
   onStudioAction,
 }) => {
+  const { baseUrl, fetchWithHeaders } = useApi();
   const { openStudio } = useStudio();
   const { setSelectedDataset } = useSelectedDataset();
+
+  const [episodes, setEpisodes] = useState<EpisodeSummary[] | null>(null);
+  const [episodesLoading, setEpisodesLoading] = useState(true);
+  const [cameras, setCameras] = useState<string[]>([]);
+  const [selectedEpisode, setSelectedEpisode] = useState<number | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!repoId || !open) return;
+    const controller = new AbortController();
+    setEpisodesLoading(true);
+    setEpisodes(null);
+    setCameras([]);
+    Promise.all([
+      listEpisodes(baseUrl, fetchWithHeaders, repoId, controller.signal).catch(() => null),
+      getDatasetInfo(baseUrl, fetchWithHeaders, repoId, controller.signal).catch(() => null),
+    ]).then(([eps, info]) => {
+      if (controller.signal.aborted) return;
+      setEpisodes(eps);
+      setCameras(info?.cameras ?? []);
+      setSelectedEpisode(eps && eps.length > 0 ? eps[0].episode_index : null);
+      setEpisodesLoading(false);
+    });
+    return () => controller.abort();
+  }, [repoId, open, baseUrl, fetchWithHeaders, reloadKey]);
 
   if (!repoId) return null;
 
@@ -48,20 +487,97 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="break-all font-mono text-base">
+      <DialogContent className="flex h-[85vh] max-w-6xl flex-col gap-0 overflow-hidden p-0">
+        <DialogHeader className="shrink-0 space-y-0 border-b border-border px-6 py-4 text-left">
+          <p className="eyebrow">episodes · cameras · joint traces</p>
+          <DialogTitle className="break-all pt-1 font-mono text-base font-semibold">
             {repoId}
           </DialogTitle>
         </DialogHeader>
 
-        <DatasetInfoCard repoId={repoId} />
+        <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_300px]">
+          <div className="flex min-h-0 min-w-0 flex-col gap-3 p-4">
+            {episodesLoading ? (
+              <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                Loading episodes…
+              </div>
+            ) : episodes && episodes.length > 0 && selectedEpisode != null ? (
+              <EpisodeViewer
+                repoId={repoId}
+                cameras={cameras}
+                episodes={episodes}
+                selectedEpisode={selectedEpisode}
+                onSelectEpisode={setSelectedEpisode}
+              />
+            ) : (
+              <div className="flex flex-1 flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border bg-muted/30 px-6 text-center">
+                <VideoOff className="h-6 w-6 text-muted-foreground" />
+                <p className="text-sm font-medium text-foreground">
+                  {episodes && episodes.length === 0
+                    ? "No episodes recorded yet"
+                    : "No viewable footage yet"}
+                </p>
+                <p className="max-w-sm text-xs text-muted-foreground">
+                  {episodes && episodes.length === 0
+                    ? "Record at least one episode into this dataset to view its camera footage here."
+                    : "This dataset isn't downloaded to this machine yet, or predates the format this viewer reads. Downloading it below (if it's on the Hub) may make it viewable."}
+                </p>
+              </div>
+            )}
+          </div>
 
-        <div className="flex flex-col gap-2">
-          <Button onClick={handleTrain} className="w-full gap-2">
-            <Boxes className="h-4 w-4" />
-            Train a skill from this
-          </Button>
+          <div className="flex min-h-0 flex-col divide-y divide-border overflow-y-auto border-l border-border">
+            <div className="flex min-h-0 flex-1 flex-col p-3">
+              <p className="eyebrow mb-2">episodes {episodes ? `(${episodes.length})` : ""}</p>
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                {episodes && episodes.length > 0 ? (
+                  <div className="space-y-0.5">
+                    {episodes.map((ep) => (
+                      <button
+                        key={ep.episode_index}
+                        type="button"
+                        onClick={() => setSelectedEpisode(ep.episode_index)}
+                        className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent ${
+                          selectedEpisode === ep.episode_index
+                            ? "border border-border bg-accent"
+                            : "border border-transparent"
+                        }`}
+                      >
+                        <span className="w-6 shrink-0 font-mono text-[11px] text-muted-foreground">
+                          {String(ep.episode_index).padStart(2, "0")}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate">
+                          Episode {ep.episode_index}
+                        </span>
+                        <span className="shrink-0 font-mono text-[10.5px] tabular-nums text-muted-foreground">
+                          {ep.duration.toFixed(1)}s
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="px-1 text-xs leading-relaxed text-muted-foreground">
+                    Episodes appear here once this dataset is downloaded to your
+                    machine.
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="p-3">
+              <DatasetInfoCard
+                repoId={repoId}
+                onDownloaded={() => setReloadKey((k) => k + 1)}
+              />
+            </div>
+
+            <div className="p-3">
+              <Button onClick={handleTrain} className="w-full gap-2">
+                <Boxes className="h-4 w-4" />
+                Train a skill from this
+              </Button>
+            </div>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -21,7 +21,6 @@ import {
   EpisodeJointSeries,
   EpisodeSummary,
   episodeVideoUrl,
-  getDatasetHubSettings,
   getDatasetInfo,
   getEpisodeJoints,
   listEpisodes,
@@ -466,35 +465,6 @@ const EpisodeViewer: React.FC<{
   );
 };
 
-// Hugging Face's own hosted dataset viewer (the same Space linked from every
-// dataset's Hub page). Its `*.hf.space` subdomain runs with no viewer auth
-// context and sends no framing-blocking headers, so it can embed a PUBLIC
-// repo directly by path. The `huggingface.co/spaces/...` wrapper URL that
-// *does* carry the viewer's own Hub login (needed for a private repo) sends
-// `X-Frame-Options: DENY` and cannot be framed at all — confirmed against
-// live response headers, not assumed. So this is only ever rendered for a
-// Hub dataset already confirmed public; a private one keeps the existing
-// "download to view" message instead of a broken/blank iframe.
-const HUB_SPACE_BASE_URL = "https://lerobot-visualize-dataset.hf.space";
-
-const HubSpaceViewer: React.FC<{ repoId: string }> = ({ repoId }) => (
-  <div className="flex min-h-0 flex-1 flex-col gap-2">
-    <div className="flex-1 overflow-hidden rounded-md border border-border bg-[#0c0f14]">
-      <iframe
-        key={repoId}
-        src={`${HUB_SPACE_BASE_URL}/${repoId}`}
-        className="h-full w-full border-0"
-        allow="autoplay; fullscreen"
-        title={`Hugging Face dataset viewer — ${repoId}`}
-      />
-    </div>
-    <p className="shrink-0 text-center text-[10.5px] text-muted-foreground">
-      Viewing via Hugging Face's hosted dataset viewer — download this dataset
-      to view it here with joint traces.
-    </p>
-  </div>
-);
-
 const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
   repoId,
   open,
@@ -510,14 +480,6 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
   const [cameras, setCameras] = useState<string[]>([]);
   const [selectedEpisode, setSelectedEpisode] = useState<number | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
-  const [datasetSource, setDatasetSource] = useState<"local" | "hub" | undefined>(undefined);
-  // null = not yet known (still checking, or the check hasn't run because it
-  // isn't needed) — only used to gate the Hub Space iframe fallback below.
-  const [hubPrivate, setHubPrivate] = useState<boolean | null>(null);
-  // Set on a failed privacy check (offline, or a private repo we have no read
-  // access to at all) so the "checking…" state has a terminal fallback
-  // instead of hanging forever when hubPrivate can never resolve.
-  const [hubPrivateCheckFailed, setHubPrivateCheckFailed] = useState(false);
 
   useEffect(() => {
     if (!repoId || !open) return;
@@ -525,9 +487,6 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
     setEpisodesLoading(true);
     setEpisodes(null);
     setCameras([]);
-    setDatasetSource(undefined);
-    setHubPrivate(null);
-    setHubPrivateCheckFailed(false);
     Promise.all([
       listEpisodes(baseUrl, fetchWithHeaders, repoId, controller.signal).catch(() => null),
       getDatasetInfo(baseUrl, fetchWithHeaders, repoId, controller.signal).catch(() => null),
@@ -535,31 +494,11 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
       if (controller.signal.aborted) return;
       setEpisodes(eps);
       setCameras(info?.cameras ?? []);
-      setDatasetSource(info?.source);
       setSelectedEpisode(eps && eps.length > 0 ? eps[0].episode_index : null);
       setEpisodesLoading(false);
     });
     return () => controller.abort();
   }, [repoId, open, baseUrl, fetchWithHeaders, reloadKey]);
-
-  // Only relevant to the Hub Space iframe fallback: when /datasets/episodes
-  // failed (episodes === null) for a dataset that IS on the Hub, find out
-  // whether it's private before offering the embed — a private repo can't be
-  // fetched by the Space's anonymous browser (see HubSpaceViewer above).
-  useEffect(() => {
-    if (!repoId || episodesLoading || episodes !== null || datasetSource !== "hub") return;
-    let cancelled = false;
-    getDatasetHubSettings(baseUrl, fetchWithHeaders, repoId)
-      .then((settings) => {
-        if (!cancelled) setHubPrivate(settings.private);
-      })
-      .catch(() => {
-        if (!cancelled) setHubPrivateCheckFailed(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [repoId, episodesLoading, episodes, datasetSource, baseUrl, fetchWithHeaders]);
 
   if (!repoId) return null;
 
@@ -594,15 +533,6 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
                 selectedEpisode={selectedEpisode}
                 onSelectEpisode={setSelectedEpisode}
               />
-            ) : episodes === null && datasetSource === "hub" && hubPrivate === false ? (
-              <HubSpaceViewer repoId={repoId} />
-            ) : episodes === null &&
-              datasetSource === "hub" &&
-              hubPrivate === null &&
-              !hubPrivateCheckFailed ? (
-              <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-                Checking Hub visibility…
-              </div>
             ) : (
               <div className="flex flex-1 flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border bg-muted/30 px-6 text-center">
                 <VideoOff className="h-6 w-6 text-muted-foreground" />
@@ -614,7 +544,7 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
                 <p className="max-w-sm text-xs text-muted-foreground">
                   {episodes && episodes.length === 0
                     ? "Record at least one episode into this dataset to view its camera footage here."
-                    : "This dataset isn't downloaded to this machine yet, or predates the format this viewer reads. Downloading it below (if it's on the Hub) may make it viewable."}
+                    : "A Hub dataset with video streams on demand here — a first-time view of a new episode may take a moment to fetch. This message means the dataset predates the viewer's format, or has no video to show."}
                 </p>
               </div>
             )}

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -106,6 +106,13 @@ const EpisodeViewer: React.FC<{
   const episode = episodes.find((e) => e.episode_index === selectedEpisode) ?? null;
   const videoRefs = useRef<Record<string, HTMLVideoElement | null>>({});
   const primaryCamera = cameras[0];
+  // v3.0 packs consecutive episodes into the same physical mp4 per camera —
+  // this episode's slice starts at `from` within that (possibly shared)
+  // file, not at 0. Every seek/play/boundary check goes through this.
+  const offsetFor = useCallback(
+    (camera: string) => episode?.video_offsets?.[camera]?.from ?? 0,
+    [episode],
+  );
 
   useEffect(() => {
     const controller = new AbortController();
@@ -140,11 +147,26 @@ const EpisodeViewer: React.FC<{
     }
   };
 
+  // Drives currentTime/scrubber from the primary camera's raw (file-relative)
+  // playback position, and is the one place that notices the episode's own
+  // slice has ended — native `ended` never fires here since the underlying
+  // file usually keeps going into the next episode's frames.
+  const handlePrimaryTimeUpdate = (rawTime: number) => {
+    if (!episode) return;
+    const offset = offsetFor(primaryCamera);
+    const t = Math.max(0, Math.min(episode.duration, rawTime - offset));
+    setCurrentTime(t);
+    if (rawTime >= offset + episode.duration - 0.02) {
+      forEachVideo((v) => v.pause());
+      setPlaying(false);
+    }
+  };
+
   const handleSeek = (t: number) => {
     const clamped = Math.max(0, Math.min(episode?.duration ?? 0, t));
-    forEachVideo((v) => {
-      v.currentTime = clamped;
-    });
+    for (const [camera, v] of Object.entries(videoRefs.current)) {
+      if (v) v.currentTime = offsetFor(camera) + clamped;
+    }
     setCurrentTime(clamped);
   };
 
@@ -248,12 +270,14 @@ const EpisodeViewer: React.FC<{
                   className="h-full w-full object-cover"
                   muted
                   playsInline
+                  onLoadedMetadata={(e) => {
+                    e.currentTarget.currentTime = offsetFor(camera);
+                  }}
                   onTimeUpdate={
                     camera === primaryCamera
-                      ? (e) => setCurrentTime(e.currentTarget.currentTime)
+                      ? (e) => handlePrimaryTimeUpdate(e.currentTarget.currentTime)
                       : undefined
                   }
-                  onEnded={camera === primaryCamera ? () => setPlaying(false) : undefined}
                   onError={() =>
                     setVideoErrors((prev) => ({ ...prev, [camera]: true }))
                   }

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -125,6 +125,31 @@ const EpisodeViewer: React.FC<{
     return () => controller.abort();
   }, [baseUrl, fetchWithHeaders, repoId, selectedEpisode]);
 
+  // Warm the backend's cache for the NEXT episode while this one plays, so
+  // advancing often lands on an already-fetched chunk instead of repeating
+  // the same first-time delay (see docs/superpowers/specs/2026-07-24-episode-
+  // prefetch-design.md). A 1-byte Range request drives get_episode_video_path
+  // all the way through — including a Hub hf_hub_download fetch for a
+  // not-yet-cached chunk — without downloading video the user hasn't asked
+  // for yet; FileResponse already supports Range requests (it's how the real
+  // <video> tag seeks). The joints response is discarded — its fetch alone is
+  // what warms the data chunk server-side. Best-effort: any failure here has
+  // zero effect on the real fetch that runs when the user actually navigates
+  // there, so errors are silently swallowed.
+  useEffect(() => {
+    const next = episodes[episodes.findIndex((e) => e.episode_index === selectedEpisode) + 1];
+    if (!next) return;
+    const controller = new AbortController();
+    for (const camera of cameras) {
+      fetchWithHeaders(episodeVideoUrl(baseUrl, repoId, next.episode_index, camera), {
+        headers: { Range: "bytes=0-0" },
+        signal: controller.signal,
+      }).catch(() => {});
+    }
+    getEpisodeJoints(baseUrl, fetchWithHeaders, repoId, next.episode_index, controller.signal).catch(() => {});
+    return () => controller.abort();
+  }, [baseUrl, fetchWithHeaders, repoId, episodes, cameras, selectedEpisode]);
+
   useEffect(() => {
     setPlaying(false);
     setCurrentTime(0);

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -152,12 +152,24 @@ const EpisodeViewer: React.FC<{
       forEachVideo((v) => v.pause());
       setPlaying(false);
     } else {
+      // Parked at (or past) the episode's own end: the underlying mp4 keeps
+      // going into the next episode's frames past this point (see the
+      // v3.0-packing note on offsetFor above), so resuming here would spill
+      // into that footage before the boundary check in
+      // handlePrimaryTimeUpdate catches up. Loop back to this episode's
+      // start instead.
+      if (episode && currentTime >= episode.duration - 0.02) {
+        for (const [camera, v] of Object.entries(videoRefs.current)) {
+          if (v) v.currentTime = offsetFor(camera);
+        }
+        setCurrentTime(0);
+      }
       forEachVideo((v) => {
         v.play().catch(() => {});
       });
       setPlaying(true);
     }
-  }, [playing, forEachVideo]);
+  }, [playing, forEachVideo, episode, currentTime, offsetFor]);
 
   // Drives currentTime/scrubber from the primary camera's raw (file-relative)
   // playback position, and is the one place that notices the episode's own

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -268,6 +268,12 @@ const EpisodeViewer: React.FC<{
         e.preventDefault();
         gotoEpisode(1);
       } else if (e.key === " " || e.code === "Space") {
+        // A focused button already activates on Space natively, and its
+        // onClick calls the same handler we'd call here (Prev/Play/Next/
+        // episode rows) — don't hijack that, or tabbing to any button in
+        // this dialog would silently turn Space into a play/pause toggle
+        // instead of activating the focused control.
+        if (target && target.tagName === "BUTTON") return;
         e.preventDefault();
         handlePlayPause();
       }

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -1,7 +1,6 @@
 import React, {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -17,6 +16,7 @@ import { useStudio } from "@/contexts/StudioContext";
 import { useSelectedDataset } from "@/hooks/useSelectedDataset";
 import { useApi } from "@/contexts/ApiContext";
 import DatasetInfoCard from "@/components/landing/DatasetInfoCard";
+import JointPositionChart from "@/components/dialogs/JointPositionChart";
 import {
   EpisodeJointSeries,
   EpisodeSummary,
@@ -34,18 +34,6 @@ export interface DatasetDetailDialogProps {
    * would otherwise cover the studio (e.g. the library sheet) can close too. */
   onStudioAction?: () => void;
 }
-
-// Six SO-101 joints, in the dataset's fixed column order — a validated
-// categorical set (see dataviz skill palette) so adjacent lines stay
-// distinguishable; cycles defensively if a feature set ever carries more.
-const JOINT_COLORS = [
-  "#2a78d6",
-  "#eb6834",
-  "#1baf7a",
-  "#eda100",
-  "#e87ba4",
-  "#008300",
-];
 
 // Best (cols, tileW, tileH) for `n` tiles inside a box of `boxW` x `boxH`:
 // the search over column counts that a video-gallery layout needs so the
@@ -101,7 +89,6 @@ const EpisodeViewer: React.FC<{
   const [playing, setPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [videoErrors, setVideoErrors] = useState<Record<string, boolean>>({});
-  const [hoverT, setHoverT] = useState<number | null>(null);
 
   const episode = episodes.find((e) => e.episode_index === selectedEpisode) ?? null;
   const videoRefs = useRef<Record<string, HTMLVideoElement | null>>({});
@@ -227,32 +214,6 @@ const EpisodeViewer: React.FC<{
     ro.observe(el);
     return () => ro.disconnect();
   }, [cameras.length]);
-
-  const jointRanges = useMemo(() => {
-    if (!joints || joints.values.length === 0) return [];
-    // Reduce, not Math.min(...vals)/Math.max(...vals) — spreading a large
-    // array into a function call can throw "Maximum call stack size
-    // exceeded" (engine-dependent, but well within reach of a long episode's
-    // frame count), which would blank the whole chart.
-    return joints.joint_names.map((_, j) => {
-      let min = Infinity;
-      let max = -Infinity;
-      for (const frame of joints.values) {
-        const v = frame[j];
-        if (v < min) min = v;
-        if (v > max) max = v;
-      }
-      return { min, max };
-    });
-  }, [joints]);
-
-  const chartRef = useRef<HTMLDivElement>(null);
-  const handleChartHover = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!episode || !joints) return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const frac = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
-    setHoverT(frac * episode.duration);
-  };
 
   const scrubFrac = episode?.duration ? currentTime / episode.duration : 0;
 
@@ -399,115 +360,7 @@ const EpisodeViewer: React.FC<{
         </div>
       </div>
 
-      <div className="rounded-md border border-border bg-muted/40 p-2">
-        <div className="mb-1 flex items-baseline justify-between">
-          <span className="eyebrow">joint positions — synced to playhead</span>
-          <span className="eyebrow">
-            {episode ? `episode ${episode.episode_index}` : "—"}
-          </span>
-        </div>
-        <div
-          ref={chartRef}
-          className="relative h-[72px]"
-          onMouseMove={handleChartHover}
-          onMouseLeave={() => setHoverT(null)}
-        >
-          {joints && episode && episode.duration > 0 ? (
-            <svg viewBox="0 0 600 72" preserveAspectRatio="none" className="h-full w-full">
-              {[0, 1, 2, 3, 4].map((i) => (
-                <line
-                  key={i}
-                  x1={0}
-                  x2={600}
-                  y1={(i / 4) * 72}
-                  y2={(i / 4) * 72}
-                  stroke="hsl(var(--border))"
-                  strokeWidth={1}
-                />
-              ))}
-              {joints.joint_names.map((_, j) => {
-                const range = jointRanges[j];
-                if (!range) return null;
-                const span = range.max - range.min || 1;
-                const points = joints.timestamps
-                  .map((t, i) => {
-                    const x = (t / episode.duration) * 600;
-                    const v = joints.values[i][j];
-                    const y = 72 - ((v - range.min) / span) * 72;
-                    return `${x.toFixed(1)},${y.toFixed(1)}`;
-                  })
-                  .join(" ");
-                return (
-                  <polyline
-                    key={j}
-                    points={points}
-                    fill="none"
-                    stroke={JOINT_COLORS[j % JOINT_COLORS.length]}
-                    strokeWidth={1.5}
-                    strokeLinejoin="round"
-                    strokeLinecap="round"
-                  />
-                );
-              })}
-              <line
-                x1={scrubFrac * 600}
-                x2={scrubFrac * 600}
-                y1={0}
-                y2={72}
-                stroke="hsl(var(--foreground))"
-                strokeWidth={1}
-                opacity={0.55}
-              />
-            </svg>
-          ) : (
-            <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
-              {episode ? "Loading joint data…" : "No episode selected"}
-            </div>
-          )}
-          {hoverT != null && joints && episode && (
-            <div
-              className="pointer-events-none absolute top-1 rounded border border-border bg-popover px-1.5 py-1 text-[10px] shadow"
-              style={{
-                left: Math.min(
-                  Math.max((hoverT / episode.duration) * 100, 0),
-                  85,
-                ) + "%",
-              }}
-            >
-              <div className="mb-0.5 font-semibold">t = {hoverT.toFixed(1)}s</div>
-              {joints.joint_names.map((name, j) => {
-                const idx = joints.timestamps.reduce(
-                  (best, t, i) =>
-                    Math.abs(t - hoverT) < Math.abs(joints.timestamps[best] - hoverT) ? i : best,
-                  0,
-                );
-                return (
-                  <div key={name} className="flex items-center gap-1 tabular-nums">
-                    <span
-                      className="h-1.5 w-1.5 shrink-0 rounded-sm"
-                      style={{ background: JOINT_COLORS[j % JOINT_COLORS.length] }}
-                    />
-                    {name}: {joints.values[idx][j].toFixed(1)}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-        {joints && (
-          <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1">
-            {joints.joint_names.map((name, j) => (
-              <span key={name} className="flex items-center gap-1 text-[10px] text-muted-foreground">
-                <span
-                  className="h-2 w-2 shrink-0 rounded-sm"
-                  style={{ background: JOINT_COLORS[j % JOINT_COLORS.length] }}
-                />
-                {name}
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
+      <JointPositionChart joints={joints} episode={episode} scrubFrac={scrubFrac} />
     </div>
   );
 };

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -257,6 +257,10 @@ const EpisodeViewer: React.FC<{
   // the page or double-fire a focused button's native click.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      // Ignore OS auto-repeat from a held key — holding Space shouldn't
+      // rapid-toggle play/pause, and holding an arrow shouldn't blow through
+      // the episode list faster than an actual keypress.
+      if (e.repeat) return;
       const target = e.target as HTMLElement | null;
       if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
         return;

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -351,6 +351,7 @@ const EpisodeViewer: React.FC<{
           className="relative h-5 flex-1 cursor-pointer"
           onPointerDown={(e) => {
             draggingRef.current = true;
+            e.currentTarget.setPointerCapture(e.pointerId);
             forEachVideo((v) => v.pause());
             setPlaying(false);
             seekFromClientX(e.clientX);
@@ -358,11 +359,9 @@ const EpisodeViewer: React.FC<{
           onPointerMove={(e) => {
             if (draggingRef.current) seekFromClientX(e.clientX);
           }}
-          onPointerUp={() => {
+          onPointerUp={(e) => {
             draggingRef.current = false;
-          }}
-          onPointerLeave={() => {
-            draggingRef.current = false;
+            e.currentTarget.releasePointerCapture(e.pointerId);
           }}
         >
           <div className="absolute inset-y-0 my-auto h-1 w-full rounded-full bg-muted" />

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -92,7 +92,14 @@ const EpisodeViewer: React.FC<{
 
   const episode = episodes.find((e) => e.episode_index === selectedEpisode) ?? null;
   const videoRefs = useRef<Record<string, HTMLVideoElement | null>>({});
-  const primaryCamera = cameras[0];
+  // The camera whose onTimeUpdate drives currentTime/the end-of-episode
+  // boundary check. Falls back off cameras[0] onto the next camera that
+  // hasn't errored — if the "primary" camera fails to decode, its <video>
+  // element is replaced by an error placeholder and never fires
+  // onTimeUpdate, so pinning this to a fixed index would silently stall
+  // playback tracking (auto-pause, the loop-to-start fix, the scrubber)
+  // for the rest of the session.
+  const primaryCamera = cameras.find((c) => !videoErrors[c]) ?? cameras[0];
   // v3.0 packs consecutive episodes into the same physical mp4 per camera —
   // this episode's slice starts at `from` within that (possibly shared)
   // file, not at 0. Every seek/play/boundary check goes through this.

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -174,8 +174,8 @@ const EpisodeViewer: React.FC<{
 
   // Drives currentTime/scrubber from the primary camera's raw (file-relative)
   // playback position, and is the one place that notices the episode's own
-  // slice has ended — native `ended` never fires here since the underlying
-  // file usually keeps going into the next episode's frames.
+  // slice has ended — native `ended` usually doesn't fire here since the
+  // underlying file usually keeps going into the next episode's frames.
   const handlePrimaryTimeUpdate = (rawTime: number) => {
     if (!episode) return;
     const offset = offsetFor(primaryCamera);
@@ -185,6 +185,18 @@ const EpisodeViewer: React.FC<{
       forEachVideo((v) => v.pause());
       setPlaying(false);
     }
+  };
+
+  // Fallback for the (possible) case where this episode's slice is the
+  // physical file's own end — e.g. the last episode in a chunk — and the
+  // video's real duration falls short of `episode.duration` (independently
+  // derived from length/fps, not from the file itself). Native `ended` fires
+  // here before the timeupdate threshold above ever would, and without this
+  // handler `playing` would stay stuck true forever since no further
+  // timeupdate events arrive once playback has actually stopped.
+  const handlePrimaryEnded = () => {
+    forEachVideo((v) => v.pause());
+    setPlaying(false);
   };
 
   const handleSeek = (t: number) => {
@@ -303,6 +315,7 @@ const EpisodeViewer: React.FC<{
                       ? (e) => handlePrimaryTimeUpdate(e.currentTarget.currentTime)
                       : undefined
                   }
+                  onEnded={camera === primaryCamera ? handlePrimaryEnded : undefined}
                   onError={() =>
                     setVideoErrors((prev) => ({ ...prev, [camera]: true }))
                   }

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -147,7 +147,7 @@ const EpisodeViewer: React.FC<{
     Object.values(videoRefs.current).forEach((v) => v && fn(v));
   }, []);
 
-  const handlePlayPause = () => {
+  const handlePlayPause = useCallback(() => {
     if (playing) {
       forEachVideo((v) => v.pause());
       setPlaying(false);
@@ -157,7 +157,7 @@ const EpisodeViewer: React.FC<{
       });
       setPlaying(true);
     }
-  };
+  }, [playing, forEachVideo]);
 
   // Drives currentTime/scrubber from the primary camera's raw (file-relative)
   // playback position, and is the one place that notices the episode's own
@@ -226,11 +226,43 @@ const EpisodeViewer: React.FC<{
     handleSeek(frac * episode.duration);
   };
 
-  const gotoEpisode = (delta: number) => {
-    const i = episodes.findIndex((e) => e.episode_index === selectedEpisode);
-    const next = episodes[i + delta];
-    if (next) onSelectEpisode(next.episode_index);
-  };
+  const gotoEpisode = useCallback(
+    (delta: number) => {
+      const i = episodes.findIndex((e) => e.episode_index === selectedEpisode);
+      const next = episodes[i + delta];
+      if (next) onSelectEpisode(next.episode_index);
+    },
+    [episodes, selectedEpisode, onSelectEpisode],
+  );
+
+  const currentIndex = episodes.findIndex((e) => e.episode_index === selectedEpisode);
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex >= 0 && currentIndex < episodes.length - 1;
+
+  // Mirrors the guarded-window-listener convention in RecordingSessionDialog:
+  // skip when a text field has focus (the info-card tag input in the side
+  // panel), preventDefault on the keys we do handle so Space doesn't scroll
+  // the page or double-fire a focused button's native click.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+        return;
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        gotoEpisode(-1);
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        gotoEpisode(1);
+      } else if (e.key === " " || e.code === "Space") {
+        e.preventDefault();
+        handlePlayPause();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [gotoEpisode, handlePlayPause]);
 
   if (cameras.length === 0) {
     return (
@@ -303,7 +335,7 @@ const EpisodeViewer: React.FC<{
           size="icon"
           className="h-8 w-8 shrink-0"
           onClick={() => gotoEpisode(-1)}
-          disabled={!episode}
+          disabled={!episode || !hasPrev}
           aria-label="Previous episode"
         >
           <SkipBack className="h-3.5 w-3.5" />
@@ -322,7 +354,7 @@ const EpisodeViewer: React.FC<{
           size="icon"
           className="h-8 w-8 shrink-0"
           onClick={() => gotoEpisode(1)}
-          disabled={!episode}
+          disabled={!episode || !hasNext}
           aria-label="Next episode"
         >
           <SkipForward className="h-3.5 w-3.5" />

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -413,7 +413,7 @@ const DatasetDetailDialog: React.FC<DatasetDetailDialogProps> = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex h-[85vh] max-w-6xl flex-col gap-0 overflow-hidden p-0">
         <DialogHeader className="shrink-0 space-y-0 border-b border-border px-6 py-4 text-left">
-          <p className="eyebrow">episodes · cameras · joint traces</p>
+          <p className="eyebrow">MakerLab Dataset Viewer</p>
           <DialogTitle className="break-all pt-1 font-mono text-base font-semibold">
             {repoId}
           </DialogTitle>

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -230,9 +230,19 @@ const EpisodeViewer: React.FC<{
 
   const jointRanges = useMemo(() => {
     if (!joints || joints.values.length === 0) return [];
+    // Reduce, not Math.min(...vals)/Math.max(...vals) — spreading a large
+    // array into a function call can throw "Maximum call stack size
+    // exceeded" (engine-dependent, but well within reach of a long episode's
+    // frame count), which would blank the whole chart.
     return joints.joint_names.map((_, j) => {
-      const vals = joints.values.map((frame) => frame[j]);
-      return { min: Math.min(...vals), max: Math.max(...vals) };
+      let min = Infinity;
+      let max = -Infinity;
+      for (const frame of joints.values) {
+        const v = frame[j];
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+      return { min, max };
     });
   }, [joints]);
 

--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -134,14 +134,27 @@ const EpisodeViewer: React.FC<{
     const next = episodes[episodes.findIndex((e) => e.episode_index === selectedEpisode) + 1];
     if (!next) return;
     const controller = new AbortController();
-    for (const camera of cameras) {
-      fetchWithHeaders(episodeVideoUrl(baseUrl, repoId, next.episode_index, camera), {
-        headers: { Range: "bytes=0-0" },
-        signal: controller.signal,
-      }).catch(() => {});
-    }
-    getEpisodeJoints(baseUrl, fetchWithHeaders, repoId, next.episode_index, controller.signal).catch(() => {});
-    return () => controller.abort();
+    // Debounced: don't kick off a prefetch until the user has settled on
+    // this episode for a moment. Without this, rapid navigation (arrow-key
+    // taps, clicking through the list) fires — and immediately abandons via
+    // the abort below — a prefetch for every episode passed through on the
+    // way to wherever the user actually stops. The frontend abort doesn't
+    // necessarily cancel an in-flight Hub download the backend already
+    // started, so an unthrottled burst can leave several abandoned
+    // hf_hub_download calls running server-side.
+    const timer = window.setTimeout(() => {
+      for (const camera of cameras) {
+        fetchWithHeaders(episodeVideoUrl(baseUrl, repoId, next.episode_index, camera), {
+          headers: { Range: "bytes=0-0" },
+          signal: controller.signal,
+        }).catch(() => {});
+      }
+      getEpisodeJoints(baseUrl, fetchWithHeaders, repoId, next.episode_index, controller.signal).catch(() => {});
+    }, 400);
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
   }, [baseUrl, fetchWithHeaders, repoId, episodes, cameras, selectedEpisode]);
 
   useEffect(() => {

--- a/frontend/src/components/dialogs/JointPositionChart.tsx
+++ b/frontend/src/components/dialogs/JointPositionChart.tsx
@@ -1,0 +1,208 @@
+import React, { useMemo, useRef, useState } from "react";
+import { EpisodeJointSeries, EpisodeSummary } from "@/lib/replayApi";
+
+// Six SO-101 joints, in the dataset's fixed column order — a validated
+// categorical set (see dataviz skill palette) so adjacent lines stay
+// distinguishable; cycles defensively if a feature set ever carries more.
+const JOINT_COLORS = [
+  "#2a78d6",
+  "#eb6834",
+  "#1baf7a",
+  "#eda100",
+  "#e87ba4",
+  "#008300",
+];
+
+// Opacity for a joint's chart line when at least one *other* joint is
+// selected — dimmed rather than removed, so the de-emphasized traces still
+// give spatial context for the ones the user is isolating.
+const DIMMED_LINE_OPACITY = 0.15;
+// Legend chips dim less than the lines: the label still needs to be legible
+// enough to read and click again to re-select it.
+const DIMMED_LEGEND_OPACITY = 0.5;
+
+/**
+ * Joint-position chart synced to the playhead, with a clickable legend: click
+ * a joint to isolate it (the rest dim), click a second to isolate both, click
+ * either again to deselect. No selection means "show everything" — today's
+ * default. Selection is local state, so it naturally persists across episode
+ * changes (the parent doesn't remount this component when switching episodes)
+ * and resets whenever the dialog itself is closed and reopened.
+ */
+const JointPositionChart: React.FC<{
+  joints: EpisodeJointSeries | null;
+  episode: EpisodeSummary | null;
+  scrubFrac: number;
+}> = ({ joints, episode, scrubFrac }) => {
+  const [hoverT, setHoverT] = useState<number | null>(null);
+  const [selectedJoints, setSelectedJoints] = useState<Set<number>>(new Set());
+
+  const toggleJoint = (j: number) => {
+    setSelectedJoints((prev) => {
+      const next = new Set(prev);
+      if (next.has(j)) next.delete(j);
+      else next.add(j);
+      return next;
+    });
+  };
+
+  // Whether joint `j` is emphasized (full opacity) given the current
+  // selection — everything is emphasized when nothing is selected.
+  const isEmphasized = (j: number) => selectedJoints.size === 0 || selectedJoints.has(j);
+
+  const jointRanges = useMemo(() => {
+    if (!joints || joints.values.length === 0) return [];
+    // Reduce, not Math.min(...vals)/Math.max(...vals) — spreading a large
+    // array into a function call can throw "Maximum call stack size
+    // exceeded" (engine-dependent, but well within reach of a long episode's
+    // frame count), which would blank the whole chart.
+    return joints.joint_names.map((_, j) => {
+      let min = Infinity;
+      let max = -Infinity;
+      for (const frame of joints.values) {
+        const v = frame[j];
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+      return { min, max };
+    });
+  }, [joints]);
+
+  const chartRef = useRef<HTMLDivElement>(null);
+  const handleChartHover = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!episode || !joints) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const frac = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    setHoverT(frac * episode.duration);
+  };
+
+  return (
+    <div className="rounded-md border border-border bg-muted/40 p-2">
+      <div className="mb-1 flex items-baseline justify-between">
+        <span className="eyebrow">joint positions — synced to playhead</span>
+        <span className="eyebrow">
+          {episode ? `episode ${episode.episode_index}` : "—"}
+        </span>
+      </div>
+      <div
+        ref={chartRef}
+        className="relative h-[72px]"
+        onMouseMove={handleChartHover}
+        onMouseLeave={() => setHoverT(null)}
+      >
+        {joints && episode && episode.duration > 0 ? (
+          <svg viewBox="0 0 600 72" preserveAspectRatio="none" className="h-full w-full">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <line
+                key={i}
+                x1={0}
+                x2={600}
+                y1={(i / 4) * 72}
+                y2={(i / 4) * 72}
+                stroke="hsl(var(--border))"
+                strokeWidth={1}
+              />
+            ))}
+            {joints.joint_names.map((_, j) => {
+              const range = jointRanges[j];
+              if (!range) return null;
+              const span = range.max - range.min || 1;
+              const points = joints.timestamps
+                .map((t, i) => {
+                  const x = (t / episode.duration) * 600;
+                  const v = joints.values[i][j];
+                  const y = 72 - ((v - range.min) / span) * 72;
+                  return `${x.toFixed(1)},${y.toFixed(1)}`;
+                })
+                .join(" ");
+              return (
+                <polyline
+                  key={j}
+                  points={points}
+                  fill="none"
+                  stroke={JOINT_COLORS[j % JOINT_COLORS.length]}
+                  strokeWidth={1.5}
+                  strokeLinejoin="round"
+                  strokeLinecap="round"
+                  opacity={isEmphasized(j) ? 1 : DIMMED_LINE_OPACITY}
+                />
+              );
+            })}
+            <line
+              x1={scrubFrac * 600}
+              x2={scrubFrac * 600}
+              y1={0}
+              y2={72}
+              stroke="hsl(var(--foreground))"
+              strokeWidth={1}
+              opacity={0.55}
+            />
+          </svg>
+        ) : (
+          <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+            {episode ? "Loading joint data…" : "No episode selected"}
+          </div>
+        )}
+        {hoverT != null && joints && episode && (
+          <div
+            className="pointer-events-none absolute top-1 rounded border border-border bg-popover px-1.5 py-1 text-[10px] shadow"
+            style={{
+              left: Math.min(
+                Math.max((hoverT / episode.duration) * 100, 0),
+                85,
+              ) + "%",
+            }}
+          >
+            <div className="mb-0.5 font-semibold">t = {hoverT.toFixed(1)}s</div>
+            {joints.joint_names.map((name, j) => {
+              if (!isEmphasized(j)) return null;
+              const idx = joints.timestamps.reduce(
+                (best, t, i) =>
+                  Math.abs(t - hoverT) < Math.abs(joints.timestamps[best] - hoverT) ? i : best,
+                0,
+              );
+              return (
+                <div key={name} className="flex items-center gap-1 tabular-nums">
+                  <span
+                    className="h-1.5 w-1.5 shrink-0 rounded-sm"
+                    style={{ background: JOINT_COLORS[j % JOINT_COLORS.length] }}
+                  />
+                  {name}: {joints.values[idx][j].toFixed(1)}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      {joints && (
+        <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1">
+          {joints.joint_names.map((name, j) => {
+            const selected = selectedJoints.has(j);
+            return (
+              <button
+                key={name}
+                type="button"
+                onClick={() => toggleJoint(j)}
+                className={`flex items-center gap-1 rounded px-1 py-0.5 text-[10px] transition-colors ${
+                  selected
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50"
+                }`}
+                style={{ opacity: isEmphasized(j) ? 1 : DIMMED_LEGEND_OPACITY }}
+                aria-pressed={selected}
+              >
+                <span
+                  className="h-2 w-2 shrink-0 rounded-sm"
+                  style={{ background: JOINT_COLORS[j % JOINT_COLORS.length] }}
+                />
+                {name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default JointPositionChart;

--- a/frontend/src/components/dialogs/JointPositionChart.tsx
+++ b/frontend/src/components/dialogs/JointPositionChart.tsx
@@ -78,7 +78,7 @@ const JointPositionChart: React.FC<{
 
   return (
     <div className="rounded-md border border-border bg-muted/40 p-2">
-      <div className="mb-1 flex items-baseline justify-between">
+      <div className="mb-1 flex items-baseline justify-between select-none">
         <span className="eyebrow">joint positions — synced to playhead</span>
         <span className="eyebrow">
           {episode ? `episode ${episode.episode_index}` : "—"}

--- a/frontend/src/components/landing/DatasetInfoCard.tsx
+++ b/frontend/src/components/landing/DatasetInfoCard.tsx
@@ -546,7 +546,7 @@ const HubSyncRow: React.FC<{ repoId: string }> = ({ repoId }) => {
   if (status === "on_hub") {
     return (
       <div className="flex items-center gap-1.5 text-muted-foreground">
-        <span>On Hub</span>
+        <span>Uploaded to HuggingFace</span>
         {hubUrl && (
           <a
             href={hubUrl}

--- a/frontend/src/components/launchpad/LibrarySheet.tsx
+++ b/frontend/src/components/launchpad/LibrarySheet.tsx
@@ -17,6 +17,7 @@ import { useHfAuth } from "@/contexts/HfAuthContext";
 import { useModels } from "@/hooks/useModels";
 import { useDatasets } from "@/hooks/useDatasets";
 import { useSelectedDataset } from "@/hooks/useSelectedDataset";
+import { useHubVideoFilter } from "@/hooks/useHubVideoFilter";
 import { policyTypeDisplayName } from "@/components/training/types";
 import { ModelItem, downloadModel, saveCustomModel } from "@/lib/modelsApi";
 import {
@@ -160,14 +161,19 @@ const LibrarySheet: React.FC<LibrarySheetProps> = ({ open, onOpenChange }) => {
     [models, username],
   );
 
+  // Hides a Hub-only row once it's confirmed to have no video — this tab
+  // opens DatasetDetailDialog on click, so a row without video would just
+  // open to an empty state. See useHubVideoFilter for why the Train picker
+  // must NOT do the same.
+  const videoFilteredDatasets = useHubVideoFilter(datasets);
   const myDatasets = useMemo(
     () =>
-      datasets.filter((d) => {
+      videoFilteredDatasets.filter((d) => {
         if (d.source === "local" || d.source === "both") return true;
         const ns = d.repo_id.includes("/") ? d.repo_id.split("/")[0] : null;
         return !!ns && !!username && ns.toLowerCase() === username.toLowerCase();
       }),
-    [datasets, username],
+    [videoFilteredDatasets, username],
   );
 
   const runSkill = (model: ModelItem) => {

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { useApi } from "@/contexts/ApiContext";
 import { DatasetInfo, DatasetItem, getDatasetInfo } from "@/lib/replayApi";
 import { formatBytes, formatCount, formatDuration } from "@/lib/datasetFormat";
+import { useHubVideoFilter } from "@/hooks/useHubVideoFilter";
 
 /** Where a dataset lives: local cache, the Hub, or both. Styled like the job
  * card's status chip (icon + muted bold text, no pill) so the dataset, job,
@@ -238,17 +239,22 @@ export const DatasetLibraryList: React.FC<{
 }> = ({ datasets, loading, selectedRepoId, onSelect, onView }) => {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<LibraryFilter>("all");
+  // Hides a Hub-only row once it's confirmed to have no video — this surface
+  // wires onView (opens the episode viewer), so a row without video would
+  // just open to an empty state. See useHubVideoFilter for why the Train
+  // picker (which doesn't use this component) must NOT do the same.
+  const videoFilteredDatasets = useHubVideoFilter(datasets);
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return datasets.filter((d) => {
+    return videoFilteredDatasets.filter((d) => {
       if (filter === "local" && d.source === "hub") return false;
       if (filter === "hub" && d.source === "local") return false;
       return q === "" || d.repo_id.toLowerCase().includes(q);
     });
-  }, [datasets, query, filter]);
+  }, [videoFilteredDatasets, query, filter]);
 
-  if (loading && datasets.length === 0) {
+  if (loading && videoFilteredDatasets.length === 0) {
     return (
       <div
         className={cn(
@@ -264,7 +270,7 @@ export const DatasetLibraryList: React.FC<{
     );
   }
 
-  if (datasets.length === 0) {
+  if (videoFilteredDatasets.length === 0) {
     return (
       <div
         className={cn(

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Check, Globe, HardDrive, Lock } from "lucide-react";
+import { Check, Eye, Globe, HardDrive, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import LibraryToolbar from "@/components/library/LibraryToolbar";
 import CappedGrid, { GRID_MIN_H } from "@/components/library/CappedGrid";
@@ -121,7 +121,11 @@ const DatasetCard: React.FC<{
   item: DatasetItem;
   selected: boolean;
   onSelect: () => void;
-}> = ({ item, selected, onSelect }) => (
+  /** Opens the episode viewer for this dataset — separate from select, so it
+   * must stop propagation before the card's own onClick fires. Optional: only
+   * wired up where the viewer dialog is actually rendered. */
+  onView?: (item: DatasetItem) => void;
+}> = ({ item, selected, onSelect, onView }) => (
   <div
     onClick={onSelect}
     className={cn(
@@ -144,12 +148,28 @@ const DatasetCard: React.FC<{
           </span>
         )}
       </div>
-      <Check
-        className={cn(
-          "h-4 w-4 shrink-0 text-primary",
-          selected ? "opacity-100" : "opacity-0",
+      <div className="flex shrink-0 items-center gap-0.5">
+        {onView && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onView(item);
+            }}
+            aria-label="View episodes"
+            title="View episodes"
+            className="rounded p-1 text-muted-foreground hover:text-foreground"
+          >
+            <Eye className="h-3.5 w-3.5" />
+          </button>
         )}
-      />
+        <Check
+          className={cn(
+            "h-4 w-4 shrink-0 text-primary",
+            selected ? "opacity-100" : "opacity-0",
+          )}
+        />
+      </div>
     </div>
     <div className="w-full">
       <div
@@ -212,7 +232,10 @@ export const DatasetLibraryList: React.FC<{
   loading: boolean;
   selectedRepoId: string | null;
   onSelect: (item: DatasetItem) => void;
-}> = ({ datasets, loading, selectedRepoId, onSelect }) => {
+  /** Opens the episode viewer dialog for a dataset; omit where the caller
+   * doesn't render that dialog. */
+  onView?: (item: DatasetItem) => void;
+}> = ({ datasets, loading, selectedRepoId, onSelect, onView }) => {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<LibraryFilter>("all");
 
@@ -284,6 +307,7 @@ export const DatasetLibraryList: React.FC<{
               item={item}
               selected={item.repo_id === selectedRepoId}
               onSelect={() => onSelect(item)}
+              onView={onView}
             />
           ))}
         />

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -136,7 +136,7 @@ const DatasetCard: React.FC<{
         : "border-border hover:border-muted-foreground/40",
     )}
   >
-    <div className="flex w-full items-start justify-between gap-2">
+    <div className="flex w-full items-center justify-between gap-2">
       <div className="flex min-w-0 items-center gap-2">
         <SourceBadge source={item.source} />
         {item.private && (

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -218,10 +218,11 @@ export const DatasetLibraryList: React.FC<{
 }> = ({ datasets, loading, selectedRepoId, onSelect }) => {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<LibraryFilter>("all");
-  // Hides a Hub-only row once it's confirmed to have no video — this surface
-  // wires onView (opens the episode viewer), so a row without video would
-  // just open to an empty state. See useHubVideoFilter for why the Train
-  // picker (which doesn't use this component) must NOT do the same.
+  // Hides a Hub-only row once it's confirmed to have no video. Kept from when
+  // this surface used to open the episode viewer (now removed, see
+  // eye-icon-full-feature); revisit whether this filter still belongs here.
+  // See useHubVideoFilter for why the Train picker (which doesn't use this
+  // component) must NOT do the same.
   const videoFilteredDatasets = useHubVideoFilter(datasets);
 
   const visible = useMemo(() => {

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Check, Globe, HardDrive, Lock } from "lucide-react";
+import { Check, Eye, Globe, HardDrive, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import LibraryToolbar from "@/components/library/LibraryToolbar";
 import CappedGrid, { GRID_MIN_H } from "@/components/library/CappedGrid";
@@ -122,7 +122,11 @@ const DatasetCard: React.FC<{
   item: DatasetItem;
   selected: boolean;
   onSelect: () => void;
-}> = ({ item, selected, onSelect }) => (
+  /** Opens the episode viewer for this dataset — separate from select, so it
+   * must stop propagation before the card's own onClick fires. Optional: only
+   * wired up where the viewer dialog is actually rendered. */
+  onView?: (item: DatasetItem) => void;
+}> = ({ item, selected, onSelect, onView }) => (
   <div
     onClick={onSelect}
     className={cn(
@@ -146,6 +150,20 @@ const DatasetCard: React.FC<{
         )}
       </div>
       <div className="flex shrink-0 items-center gap-0.5">
+        {onView && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onView(item);
+            }}
+            aria-label="View episodes"
+            title="View episodes"
+            className="rounded p-1 text-muted-foreground hover:text-foreground"
+          >
+            <Eye className="h-3.5 w-3.5" />
+          </button>
+        )}
         <Check
           className={cn(
             "h-4 w-4 shrink-0 text-primary",
@@ -215,7 +233,10 @@ export const DatasetLibraryList: React.FC<{
   loading: boolean;
   selectedRepoId: string | null;
   onSelect: (item: DatasetItem) => void;
-}> = ({ datasets, loading, selectedRepoId, onSelect }) => {
+  /** Opens the episode viewer dialog for a dataset; omit where the caller
+   * doesn't render that dialog. */
+  onView?: (item: DatasetItem) => void;
+}> = ({ datasets, loading, selectedRepoId, onSelect, onView }) => {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<LibraryFilter>("all");
   // Hides a Hub-only row once it's confirmed to have no video — this surface
@@ -292,6 +313,7 @@ export const DatasetLibraryList: React.FC<{
               item={item}
               selected={item.repo_id === selectedRepoId}
               onSelect={() => onSelect(item)}
+              onView={onView}
             />
           ))}
         />

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Check, Eye, Globe, HardDrive, Lock } from "lucide-react";
+import { Check, Globe, HardDrive, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import LibraryToolbar from "@/components/library/LibraryToolbar";
 import CappedGrid, { GRID_MIN_H } from "@/components/library/CappedGrid";
@@ -122,13 +122,14 @@ const DatasetCard: React.FC<{
   item: DatasetItem;
   selected: boolean;
   onSelect: () => void;
-  /** Opens the episode viewer for this dataset — separate from select, so it
-   * must stop propagation before the card's own onClick fires. Optional: only
-   * wired up where the viewer dialog is actually rendered. */
+  /** Opens the episode viewer for this dataset. The card itself opens the
+   * viewer on click; selecting is only done via the footer Select button.
+   * Optional: only wired up where the viewer dialog is actually rendered —
+   * falls back to select-on-click if absent. */
   onView?: (item: DatasetItem) => void;
 }> = ({ item, selected, onSelect, onView }) => (
   <div
-    onClick={onSelect}
+    onClick={() => (onView ? onView(item) : onSelect())}
     className={cn(
       "flex w-full cursor-pointer flex-col gap-2 overflow-hidden rounded-md border bg-card p-3 text-left transition-colors",
       selected
@@ -150,20 +151,6 @@ const DatasetCard: React.FC<{
         )}
       </div>
       <div className="flex shrink-0 items-center gap-0.5">
-        {onView && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onView(item);
-            }}
-            aria-label="View episodes"
-            title="View episodes"
-            className="rounded p-1 text-muted-foreground hover:text-foreground"
-          >
-            <Eye className="h-3.5 w-3.5" />
-          </button>
-        )}
         <Check
           className={cn(
             "h-4 w-4 shrink-0 text-primary",
@@ -225,9 +212,9 @@ const FILTERS: Array<{ key: LibraryFilter; label: string }> = [
 ];
 
 /** The library body: search + location filter over a three-up grid of dataset
- * cards. Clicking a card selects it (feeding the Collect panel's header chip +
- * the Train panel via the shared useSelectedDataset store); clicking the
- * selected card deselects. */
+ * cards. Clicking a card opens its episode viewer; the footer Select button
+ * is the only way to select/deselect it (feeding the Collect panel's header
+ * chip + the Train panel via the shared useSelectedDataset store). */
 export const DatasetLibraryList: React.FC<{
   datasets: DatasetItem[];
   loading: boolean;

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -218,11 +218,10 @@ export const DatasetLibraryList: React.FC<{
 }> = ({ datasets, loading, selectedRepoId, onSelect }) => {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<LibraryFilter>("all");
-  // Hides a Hub-only row once it's confirmed to have no video. Kept from when
-  // this surface used to open the episode viewer (now removed, see
-  // eye-icon-full-feature); revisit whether this filter still belongs here.
-  // See useHubVideoFilter for why the Train picker (which doesn't use this
-  // component) must NOT do the same.
+  // Hides a Hub-only row once it's confirmed to have no video — this surface
+  // wires onView (opens the episode viewer), so a row without video would
+  // just open to an empty state. See useHubVideoFilter for why the Train
+  // picker (which doesn't use this component) must NOT do the same.
   const videoFilteredDatasets = useHubVideoFilter(datasets);
 
   const visible = useMemo(() => {

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Check, Eye, Globe, HardDrive, Lock } from "lucide-react";
+import { Check, Globe, HardDrive, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import LibraryToolbar from "@/components/library/LibraryToolbar";
 import CappedGrid, { GRID_MIN_H } from "@/components/library/CappedGrid";
@@ -122,11 +122,7 @@ const DatasetCard: React.FC<{
   item: DatasetItem;
   selected: boolean;
   onSelect: () => void;
-  /** Opens the episode viewer for this dataset — separate from select, so it
-   * must stop propagation before the card's own onClick fires. Optional: only
-   * wired up where the viewer dialog is actually rendered. */
-  onView?: (item: DatasetItem) => void;
-}> = ({ item, selected, onSelect, onView }) => (
+}> = ({ item, selected, onSelect }) => (
   <div
     onClick={onSelect}
     className={cn(
@@ -150,20 +146,6 @@ const DatasetCard: React.FC<{
         )}
       </div>
       <div className="flex shrink-0 items-center gap-0.5">
-        {onView && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onView(item);
-            }}
-            aria-label="View episodes"
-            title="View episodes"
-            className="rounded p-1 text-muted-foreground hover:text-foreground"
-          >
-            <Eye className="h-3.5 w-3.5" />
-          </button>
-        )}
         <Check
           className={cn(
             "h-4 w-4 shrink-0 text-primary",
@@ -233,10 +215,7 @@ export const DatasetLibraryList: React.FC<{
   loading: boolean;
   selectedRepoId: string | null;
   onSelect: (item: DatasetItem) => void;
-  /** Opens the episode viewer dialog for a dataset; omit where the caller
-   * doesn't render that dialog. */
-  onView?: (item: DatasetItem) => void;
-}> = ({ datasets, loading, selectedRepoId, onSelect, onView }) => {
+}> = ({ datasets, loading, selectedRepoId, onSelect }) => {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<LibraryFilter>("all");
   // Hides a Hub-only row once it's confirmed to have no video — this surface
@@ -313,7 +292,6 @@ export const DatasetLibraryList: React.FC<{
               item={item}
               selected={item.repo_id === selectedRepoId}
               onSelect={() => onSelect(item)}
-              onView={onView}
             />
           ))}
         />

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -33,7 +33,6 @@ import {
   SLIDE,
 } from "@/components/studio/panel/primitives";
 import DatasetDetailDialog from "@/components/dialogs/DatasetDetailDialog";
-import type { DatasetItem } from "@/lib/replayApi";
 
 /**
  * Studio panel 1 · Collect. Stacked sections (the shared studio anatomy):
@@ -79,14 +78,15 @@ const CollectPanel: React.FC = () => {
   const [libraryOpen, setLibraryOpen] = useState(!formOpen);
   const [mergeOpen, setMergeOpen] = useState(false);
 
-  // The episode viewer — opened by a dataset card's "view" button, separate
-  // from selecting the card for recording.
+  // The episode viewer dialog stays wired up (below), but its trigger on the
+  // dataset card is held back pending the card/job/skill redesign — no room
+  // confirmed yet for another icon in that layout. To bring it back: restore
+  // an openDatasetDetail(item: DatasetItem) helper that calls
+  // setViewRepo(item.repo_id) + setViewOpen(true), and pass it as
+  // DatasetLibraryList's onView prop below (see git history prior to this
+  // commit for the exact removed code, or the `eye-icon-full-feature` tag).
   const [viewRepo, setViewRepo] = useState<string | null>(null);
   const [viewOpen, setViewOpen] = useState(false);
-  const openDatasetDetail = (item: DatasetItem) => {
-    setViewRepo(item.repo_id);
-    setViewOpen(true);
-  };
 
   // A live session renders as a modal dialog over the studio (the old
   // /recording page). While it runs, the form below stays mounted with its
@@ -420,7 +420,6 @@ const CollectPanel: React.FC = () => {
                   item.repo_id === selectedDataset ? null : item.repo_id,
                 )
               }
-              onView={openDatasetDetail}
             />
           </CollapsibleContent>
         </Collapsible>

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -32,6 +32,8 @@ import {
   PanelHeader,
   SLIDE,
 } from "@/components/studio/panel/primitives";
+import DatasetDetailDialog from "@/components/dialogs/DatasetDetailDialog";
+import type { DatasetItem } from "@/lib/replayApi";
 
 /**
  * Studio panel 1 · Collect. Stacked sections (the shared studio anatomy):
@@ -76,6 +78,15 @@ const CollectPanel: React.FC = () => {
   // while the form is open (still expandable by hand).
   const [libraryOpen, setLibraryOpen] = useState(!formOpen);
   const [mergeOpen, setMergeOpen] = useState(false);
+
+  // The episode viewer — opened by a dataset card's "view" button, separate
+  // from selecting the card for recording.
+  const [viewRepo, setViewRepo] = useState<string | null>(null);
+  const [viewOpen, setViewOpen] = useState(false);
+  const openDatasetDetail = (item: DatasetItem) => {
+    setViewRepo(item.repo_id);
+    setViewOpen(true);
+  };
 
   // A live session renders as a modal dialog over the studio (the old
   // /recording page). While it runs, the form below stays mounted with its
@@ -409,6 +420,7 @@ const CollectPanel: React.FC = () => {
                   item.repo_id === selectedDataset ? null : item.repo_id,
                 )
               }
+              onView={openDatasetDetail}
             />
           </CollapsibleContent>
         </Collapsible>
@@ -422,6 +434,12 @@ const CollectPanel: React.FC = () => {
           clearDatasetInfoCache();
           refresh();
         }}
+      />
+
+      <DatasetDetailDialog
+        repoId={viewRepo}
+        open={viewOpen}
+        onOpenChange={setViewOpen}
       />
 
       {/* The live recording session — a modal dialog over the studio instead

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -32,7 +32,6 @@ import {
   PanelHeader,
   SLIDE,
 } from "@/components/studio/panel/primitives";
-import DatasetDetailDialog from "@/components/dialogs/DatasetDetailDialog";
 
 /**
  * Studio panel 1 · Collect. Stacked sections (the shared studio anatomy):
@@ -78,15 +77,13 @@ const CollectPanel: React.FC = () => {
   const [libraryOpen, setLibraryOpen] = useState(!formOpen);
   const [mergeOpen, setMergeOpen] = useState(false);
 
-  // The episode viewer dialog stays wired up (below), but its trigger on the
-  // dataset card is held back pending the card/job/skill redesign — no room
-  // confirmed yet for another icon in that layout. To bring it back: restore
-  // an openDatasetDetail(item: DatasetItem) helper that calls
-  // setViewRepo(item.repo_id) + setViewOpen(true), and pass it as
-  // DatasetLibraryList's onView prop below (see git history prior to this
-  // commit for the exact removed code, or the `eye-icon-full-feature` tag).
-  const [viewRepo, setViewRepo] = useState<string | null>(null);
-  const [viewOpen, setViewOpen] = useState(false);
+  // The episode viewer's trigger on the dataset card is held back pending the
+  // card/job/skill redesign — no room confirmed yet for another icon in that
+  // layout. The dialog itself was dropped from here too since a dialog with
+  // no trigger is dead state; see the `eye-icon-full-feature` tag for the
+  // full removed feature (viewRepo/viewOpen state, the openDatasetDetail
+  // helper, DatasetDetailDialog render, and DatasetLibraryList's onView prop)
+  // to restore it alongside a real trigger.
 
   // A live session renders as a modal dialog over the studio (the old
   // /recording page). While it runs, the form below stays mounted with its
@@ -433,12 +430,6 @@ const CollectPanel: React.FC = () => {
           clearDatasetInfoCache();
           refresh();
         }}
-      />
-
-      <DatasetDetailDialog
-        repoId={viewRepo}
-        open={viewOpen}
-        onOpenChange={setViewOpen}
       />
 
       {/* The live recording session — a modal dialog over the studio instead

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -32,6 +32,8 @@ import {
   PanelHeader,
   SLIDE,
 } from "@/components/studio/panel/primitives";
+import DatasetDetailDialog from "@/components/dialogs/DatasetDetailDialog";
+import type { DatasetItem } from "@/lib/replayApi";
 
 /**
  * Studio panel 1 · Collect. Stacked sections (the shared studio anatomy):
@@ -77,13 +79,14 @@ const CollectPanel: React.FC = () => {
   const [libraryOpen, setLibraryOpen] = useState(!formOpen);
   const [mergeOpen, setMergeOpen] = useState(false);
 
-  // The episode viewer's trigger on the dataset card is held back pending the
-  // card/job/skill redesign — no room confirmed yet for another icon in that
-  // layout. The dialog itself was dropped from here too since a dialog with
-  // no trigger is dead state; see the `eye-icon-full-feature` tag for the
-  // full removed feature (viewRepo/viewOpen state, the openDatasetDetail
-  // helper, DatasetDetailDialog render, and DatasetLibraryList's onView prop)
-  // to restore it alongside a real trigger.
+  // The episode viewer — opened by a dataset card's "view" button, separate
+  // from selecting the card for recording.
+  const [viewRepo, setViewRepo] = useState<string | null>(null);
+  const [viewOpen, setViewOpen] = useState(false);
+  const openDatasetDetail = (item: DatasetItem) => {
+    setViewRepo(item.repo_id);
+    setViewOpen(true);
+  };
 
   // A live session renders as a modal dialog over the studio (the old
   // /recording page). While it runs, the form below stays mounted with its
@@ -417,6 +420,7 @@ const CollectPanel: React.FC = () => {
                   item.repo_id === selectedDataset ? null : item.repo_id,
                 )
               }
+              onView={openDatasetDetail}
             />
           </CollapsibleContent>
         </Collapsible>
@@ -430,6 +434,12 @@ const CollectPanel: React.FC = () => {
           clearDatasetInfoCache();
           refresh();
         }}
+      />
+
+      <DatasetDetailDialog
+        repoId={viewRepo}
+        open={viewOpen}
+        onOpenChange={setViewOpen}
       />
 
       {/* The live recording session — a modal dialog over the studio instead

--- a/frontend/src/hooks/useHubVideoFilter.ts
+++ b/frontend/src/hooks/useHubVideoFilter.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from "react";
+import { useApi } from "@/contexts/ApiContext";
+import { DatasetItem, getDatasetInfo } from "@/lib/replayApi";
+
+/** Module-level cache of "does this Hub-only repo have video" — shared across
+ * every mount of this hook (the Collect panel's library and the Library sheet
+ * both use it) so a repo's one-time /datasets/info check never re-fires per
+ * surface. Absent from the map = not yet checked; `null` = check in flight;
+ * `true`/`false` = resolved. A failed check is left unset (not cached false)
+ * so a transient network error never permanently hides a real dataset. */
+const hubHasVideoCache = new Map<string, boolean | null>();
+
+/**
+ * Filters `datasets` for library-listing surfaces that open the episode
+ * viewer: a `source === "hub"` (Hub-only, no local copy) row is dropped once
+ * its Hub video check confirms it has none. `"local"`/`"both"` rows pass
+ * through untouched (already-confirmed local content). Pending or failed
+ * checks keep a row visible.
+ *
+ * NOT for the Train picker (TrainPanel/TrainingConfigurator) — training
+ * doesn't require video, so a state-only Hub dataset must stay selectable
+ * there. Only surfaces that open DatasetDetailDialog should use this.
+ */
+export function useHubVideoFilter(datasets: DatasetItem[]): DatasetItem[] {
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  const hubOnlyIds = useMemo(
+    () => datasets.filter((d) => d.source === "hub").map((d) => d.repo_id),
+    [datasets],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+    for (const repoId of hubOnlyIds) {
+      if (hubHasVideoCache.has(repoId)) continue;
+      hubHasVideoCache.set(repoId, null);
+      getDatasetInfo(baseUrl, fetchWithHeaders, repoId, controller.signal)
+        .then((info) => {
+          hubHasVideoCache.set(repoId, info.cameras.length > 0);
+        })
+        .catch(() => {
+          hubHasVideoCache.delete(repoId);
+        })
+        .finally(() => {
+          if (!cancelled) setRefreshTick((n) => n + 1);
+        });
+    }
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [hubOnlyIds, baseUrl, fetchWithHeaders]);
+
+  return useMemo(
+    () => datasets.filter((d) => d.source !== "hub" || hubHasVideoCache.get(d.repo_id) !== false),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refreshTick drives recomputation when the module-level cache mutates; datasets itself is the other real dependency.
+    [datasets, refreshTick],
+  );
+}

--- a/frontend/src/lib/replayApi.ts
+++ b/frontend/src/lib/replayApi.ts
@@ -168,6 +168,72 @@ export async function getDatasetInfo(
   );
 }
 
+export interface EpisodeSummary {
+  episode_index: number;
+  length: number;
+  duration: number;
+  tasks: string[];
+}
+
+/** Per-episode index/length/duration/tasks, for the dataset viewer window's
+ * episode list. 404 when the dataset isn't local, or predates the v3.0
+ * parquet episode layout the viewer reads (older jsonl-metadata datasets
+ * aren't viewable — see makerlab/datasets.py `_read_episode_rows`). */
+export async function listEpisodes(
+  baseUrl: string,
+  fetcher: Fetcher,
+  repoId: string,
+  signal?: AbortSignal,
+): Promise<EpisodeSummary[]> {
+  return apiRequest<EpisodeSummary[]>(
+    baseUrl,
+    fetcher,
+    `/datasets/episodes?repo_id=${encodeURIComponent(repoId)}`,
+    { signal, action: "List episodes" },
+  );
+}
+
+export interface EpisodeJointSeries {
+  joint_names: string[];
+  timestamps: number[];
+  values: number[][];
+}
+
+/** Per-frame timestamp + joint (observation.state) values for one episode,
+ * for the viewer's joint-position chart. */
+export async function getEpisodeJoints(
+  baseUrl: string,
+  fetcher: Fetcher,
+  repoId: string,
+  episodeIndex: number,
+  signal?: AbortSignal,
+): Promise<EpisodeJointSeries> {
+  return apiRequest<EpisodeJointSeries>(
+    baseUrl,
+    fetcher,
+    `/datasets/episode-joints?repo_id=${encodeURIComponent(repoId)}&episode_index=${episodeIndex}`,
+    { signal, action: "Load episode joint data" },
+  );
+}
+
+/** URL for one camera's mp4 for one episode — used directly as a <video> src
+ * (the endpoint supports Range requests, so seeking doesn't need the whole
+ * file). Not routed through `fetchWithHeaders`/apiRequest since a <video> tag
+ * can't attach custom headers to its own request. */
+export function episodeVideoUrl(
+  baseUrl: string,
+  repoId: string,
+  episodeIndex: number,
+  camera: string,
+): string {
+  const params = new URLSearchParams({
+    repo_id: repoId,
+    episode_index: String(episodeIndex),
+    camera,
+  });
+  return `${baseUrl}/datasets/episode-video?${params.toString()}`;
+}
+
 /** Where a dataset with this id lives. "local_only" = a local copy exists but
  * it's not on the Hub (offer upload); "absent" = neither on the Hub nor local
  * (a stale pin / deleted / renamed selection); "unknown" is the

--- a/frontend/src/lib/replayApi.ts
+++ b/frontend/src/lib/replayApi.ts
@@ -173,6 +173,11 @@ export interface EpisodeSummary {
   length: number;
   duration: number;
   tasks: string[];
+  /** Per-camera {from, to} seconds locating this episode's slice WITHIN its
+   * (possibly shared) video file — v3.0 packs consecutive episodes into the
+   * same mp4 per camera, so playback must seek to `from` and stop at `to`
+   * rather than assume the file starts/ends at this episode's boundaries. */
+  video_offsets: Record<string, { from: number; to: number }>;
 }
 
 /** Per-episode index/length/duration/tasks, for the dataset viewer window's

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -720,8 +720,12 @@ def list_episode_summaries(repo_id: str) -> list[dict[str, Any]] | None:
     into whatever episode comes next in that file. The viewer needs each
     camera's slice boundaries to seek to the right start and stop at the
     right end within the shared file.
+
+    A dataset with no local copy falls back to fetching just its episode metadata from the Hub (see _ensure_hub_episodes_root) — None only when neither resolves, or the dataset has no video.
     """
     path = _resolve_local_dataset_path(repo_id)
+    if path is None:
+        path = _ensure_hub_episodes_root(repo_id)
     if path is None:
         return None
     try:

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -773,11 +773,17 @@ def get_episode_video_path(repo_id: str, episode_index: int, camera: str) -> Pat
     """The mp4 file backing one camera's footage for one episode.
 
     None if `repo_id`/`episode_index`/`camera` doesn't resolve, the dataset
-    isn't the v3.0 parquet layout, or the file is missing on disk. `camera` is
-    checked against the dataset's own camera list (from meta/info.json) before
-    it's used to build a path, so it can never point outside the videos dir.
+    isn't the v3.0 parquet layout, or the file is missing/unfetchable.
+    `camera` is checked against the dataset's own camera list (from
+    meta/info.json) before it's used to build a path, so it can never point
+    outside the videos dir. A repo with no local copy falls back to
+    downloading just this one video chunk from the Hub (see
+    _ensure_hub_episodes_root) when the dataset is confirmed to have video.
     """
     path = _resolve_local_dataset_path(repo_id)
+    is_hub = path is None
+    if is_hub:
+        path = _ensure_hub_episodes_root(repo_id)
     if path is None:
         return None
     try:
@@ -798,13 +804,17 @@ def get_episode_video_path(repo_id: str, episode_index: int, camera: str) -> Pat
     if row is None or row.get(chunk_col) is None or row.get(file_col) is None:
         return None
 
-    video_path = (
-        path
-        / "videos"
-        / video_key
-        / f"chunk-{int(row[chunk_col]):03d}"
-        / f"file-{int(row[file_col]):03d}.mp4"
+    rel_video_path = (
+        Path("videos") / video_key / f"chunk-{int(row[chunk_col]):03d}" / f"file-{int(row[file_col]):03d}.mp4"
     )
+    if is_hub:
+        try:
+            return Path(hf_hub_download(repo_id, filename=str(rel_video_path), repo_type="dataset"))
+        except Exception as exc:
+            logger.info("hub video chunk fetch for %s failed: %s", repo_id, exc)
+            return None
+
+    video_path = path / rel_video_path
     return video_path if video_path.is_file() else None
 
 

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -47,6 +47,18 @@ logger = logging.getLogger(__name__)
 
 CAMERA_FEATURE_PREFIX = "observation.images."
 
+
+def _video_camera_names(features: dict[str, Any]) -> list[str]:
+    """Camera feature names actually backed by an mp4 (dtype == "video"), not
+    just any observation.images.* key. A raw-image (dtype == "image") camera
+    feature has no video chunk file for this app's video-serving pipeline to
+    point a <video> tag at, so it doesn't count as "viewable"."""
+    return [
+        key[len(CAMERA_FEATURE_PREFIX) :]
+        for key, spec in features.items()
+        if key.startswith(CAMERA_FEATURE_PREFIX) and isinstance(spec, dict) and spec.get("dtype") == "video"
+    ]
+
 # Errors a per-author / per-listing Hub call may raise that must NOT bubble up
 # and 500 the endpoint. HfHubHTTPError covers HTTP-status failures; httpx.HTTPError
 # is the base of ConnectError / TimeoutException / TransportError, which is what a
@@ -852,7 +864,7 @@ def get_hub_dataset_info(repo_id: str) -> dict[str, Any] | None:
         return None
 
     features = info.get("features") or {}
-    cameras = [key[len(CAMERA_FEATURE_PREFIX) :] for key in features if key.startswith(CAMERA_FEATURE_PREFIX)]
+    cameras = _video_camera_names(features)
 
     row: dict[str, Any] = {
         "repo_id": repo_id,

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -568,14 +568,10 @@ def _dir_size_bytes(path: Path) -> int:
     return total
 
 
-def get_local_dataset_info(repo_id: str) -> dict[str, Any] | None:
-    """Detail view of one locally-cached dataset, for the selection info card.
-
-    Reads ``meta/info.json`` + task metadata and walks the directory for its
-    size on disk — per-dataset on demand, so the cheap ``/datasets`` listing
-    stays cheap. Returns None if `repo_id` escapes the cache root or isn't a
-    local dataset (e.g. it only exists on the Hub).
-    """
+def _resolve_local_dataset_path(repo_id: str) -> Path | None:
+    """Resolve `repo_id` to its local cache directory. None if it escapes the
+    cache root (path traversal) or isn't a local dataset dir (e.g. it only
+    exists on the Hub). Shared by every local-only dataset reader below."""
     root = _lerobot_cache_root().resolve()
     try:
         path = (root / repo_id).resolve()
@@ -585,6 +581,20 @@ def get_local_dataset_info(repo_id: str) -> dict[str, Any] | None:
     if path == root or root not in path.parents:
         return None
     if not _is_dataset_dir(path):
+        return None
+    return path
+
+
+def get_local_dataset_info(repo_id: str) -> dict[str, Any] | None:
+    """Detail view of one locally-cached dataset, for the selection info card.
+
+    Reads ``meta/info.json`` + task metadata and walks the directory for its
+    size on disk — per-dataset on demand, so the cheap ``/datasets`` listing
+    stays cheap. Returns None if `repo_id` escapes the cache root or isn't a
+    local dataset (e.g. it only exists on the Hub).
+    """
+    path = _resolve_local_dataset_path(repo_id)
+    if path is None:
         return None
 
     try:
@@ -614,6 +624,156 @@ def get_local_dataset_info(repo_id: str) -> dict[str, Any] | None:
         # Hub dataset — see get_hub_dataset_info). The card gates its local-only
         # affordances (rename, size, task counts) on this.
         "source": "local",
+    }
+
+
+def _read_episode_rows(meta_dir: Path, columns: list[str] | None = None) -> list[dict[str, Any]] | None:
+    """Every row of ``meta/episodes/chunk-*/file-*.parquet``, column-pruned.
+
+    v3.0-only: older v2.x datasets keep episodes in ``meta/episodes.jsonl``,
+    which has no per-camera video chunk/file-index columns, so the dataset
+    viewer (episode list, video, joint chart) isn't offered for them — callers
+    treat a None return as "not viewable", not an error. Returns None if the
+    directory is absent or nothing could be read.
+    """
+    episodes_dir = meta_dir / "episodes"
+    if not episodes_dir.is_dir():
+        return None
+    rows: list[dict[str, Any]] = []
+    for parquet_path in sorted(episodes_dir.glob("**/*.parquet")):
+        try:
+            table = pq.read_table(parquet_path, columns=columns)
+        except Exception as e:
+            logger.warning(f"Could not read {parquet_path}: {e}")
+            continue
+        rows.extend(table.to_pylist())
+    return rows or None
+
+
+def list_episode_summaries(repo_id: str) -> list[dict[str, Any]] | None:
+    """Per-episode index/length/duration/tasks for the dataset viewer's episode
+    list. None if `repo_id` isn't a local dataset in the v3.0 parquet layout.
+    """
+    path = _resolve_local_dataset_path(repo_id)
+    if path is None:
+        return None
+    try:
+        info = json.loads((path / "meta" / "info.json").read_text())
+    except (OSError, ValueError):
+        return None
+    fps = info.get("fps") or 1
+
+    rows = _read_episode_rows(path / "meta", columns=["episode_index", "tasks", "length"])
+    if rows is None:
+        return None
+    out = [
+        {
+            "episode_index": int(row["episode_index"]),
+            "length": int(row["length"]),
+            "duration": round(int(row["length"]) / fps, 3),
+            "tasks": [str(t) for t in (row.get("tasks") or [])],
+        }
+        for row in rows
+    ]
+    out.sort(key=lambda e: e["episode_index"])
+    return out
+
+
+def get_episode_video_path(repo_id: str, episode_index: int, camera: str) -> Path | None:
+    """The mp4 file backing one camera's footage for one episode.
+
+    None if `repo_id`/`episode_index`/`camera` doesn't resolve, the dataset
+    isn't the v3.0 parquet layout, or the file is missing on disk. `camera` is
+    checked against the dataset's own camera list (from meta/info.json) before
+    it's used to build a path, so it can never point outside the videos dir.
+    """
+    path = _resolve_local_dataset_path(repo_id)
+    if path is None:
+        return None
+    try:
+        info = json.loads((path / "meta" / "info.json").read_text())
+    except (OSError, ValueError):
+        return None
+    features = info.get("features") or {}
+    cameras = [key[len(CAMERA_FEATURE_PREFIX) :] for key in features if key.startswith(CAMERA_FEATURE_PREFIX)]
+    if camera not in cameras:
+        return None
+
+    video_key = f"{CAMERA_FEATURE_PREFIX}{camera}"
+    chunk_col, file_col = f"videos/{video_key}/chunk_index", f"videos/{video_key}/file_index"
+    rows = _read_episode_rows(path / "meta", columns=["episode_index", chunk_col, file_col])
+    if rows is None:
+        return None
+    row = next((r for r in rows if int(r["episode_index"]) == episode_index), None)
+    if row is None or row.get(chunk_col) is None or row.get(file_col) is None:
+        return None
+
+    video_path = (
+        path
+        / "videos"
+        / video_key
+        / f"chunk-{int(row[chunk_col]):03d}"
+        / f"file-{int(row[file_col]):03d}.mp4"
+    )
+    return video_path if video_path.is_file() else None
+
+
+def get_episode_joint_series(repo_id: str, episode_index: int) -> dict[str, Any] | None:
+    """Per-frame timestamp + ``observation.state`` for one episode, for the
+    dataset viewer's joint-position chart. None if it can't be resolved/read
+    (not local, not the v3.0 parquet layout, or the episode doesn't exist).
+    """
+    path = _resolve_local_dataset_path(repo_id)
+    if path is None:
+        return None
+    try:
+        info = json.loads((path / "meta" / "info.json").read_text())
+    except (OSError, ValueError):
+        return None
+    joint_names = ((info.get("features") or {}).get("observation.state") or {}).get("names") or []
+
+    episode_rows = _read_episode_rows(
+        path / "meta", columns=["episode_index", "data/chunk_index", "data/file_index"]
+    )
+    if episode_rows is None:
+        return None
+    row = next((r for r in episode_rows if int(r["episode_index"]) == episode_index), None)
+    if row is None or row.get("data/chunk_index") is None or row.get("data/file_index") is None:
+        return None
+
+    data_path = (
+        path
+        / "data"
+        / f"chunk-{int(row['data/chunk_index']):03d}"
+        / f"file-{int(row['data/file_index']):03d}.parquet"
+    )
+    if not data_path.is_file():
+        return None
+    try:
+        table = pq.read_table(data_path, columns=["episode_index", "timestamp", "observation.state"])
+    except Exception as e:
+        logger.warning(f"Could not read {data_path}: {e}")
+        return None
+
+    frames = sorted(
+        (
+            (float(ts), [float(v) for v in state])
+            for ep, ts, state in zip(
+                table.column("episode_index").to_pylist(),
+                table.column("timestamp").to_pylist(),
+                table.column("observation.state").to_pylist(),
+                strict=True,
+            )
+            if int(ep) == episode_index
+        ),
+        key=lambda pair: pair[0],
+    )
+    if not frames:
+        return None
+    return {
+        "joint_names": [str(n) for n in joint_names],
+        "timestamps": [t for t, _ in frames],
+        "values": [v for _, v in frames],
     }
 
 

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -821,9 +821,15 @@ def get_episode_video_path(repo_id: str, episode_index: int, camera: str) -> Pat
 def get_episode_joint_series(repo_id: str, episode_index: int) -> dict[str, Any] | None:
     """Per-frame timestamp + ``observation.state`` for one episode, for the
     dataset viewer's joint-position chart. None if it can't be resolved/read
-    (not local, not the v3.0 parquet layout, or the episode doesn't exist).
+    (not local, not the v3.0 parquet layout, or the episode doesn't exist). A
+    repo with no local copy falls back to downloading just this one data chunk
+    from the Hub (see _ensure_hub_episodes_root) when the dataset is confirmed
+    to have video.
     """
     path = _resolve_local_dataset_path(repo_id)
+    is_hub = path is None
+    if is_hub:
+        path = _ensure_hub_episodes_root(repo_id)
     if path is None:
         return None
     try:
@@ -841,14 +847,21 @@ def get_episode_joint_series(repo_id: str, episode_index: int) -> dict[str, Any]
     if row is None or row.get("data/chunk_index") is None or row.get("data/file_index") is None:
         return None
 
-    data_path = (
-        path
-        / "data"
+    rel_data_path = (
+        Path("data")
         / f"chunk-{int(row['data/chunk_index']):03d}"
         / f"file-{int(row['data/file_index']):03d}.parquet"
     )
-    if not data_path.is_file():
-        return None
+    if is_hub:
+        try:
+            data_path = Path(hf_hub_download(repo_id, filename=str(rel_data_path), repo_type="dataset"))
+        except Exception as exc:
+            logger.info("hub data chunk fetch for %s failed: %s", repo_id, exc)
+            return None
+    else:
+        data_path = path / rel_data_path
+        if not data_path.is_file():
+            return None
     try:
         table = pq.read_table(data_path, columns=["episode_index", "timestamp", "observation.state"])
     except Exception as e:

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -663,6 +663,50 @@ def _read_episode_rows(meta_dir: Path, columns: list[str] | None = None) -> list
     return rows or None
 
 
+def _hub_dataset_has_video(repo_id: str) -> bool:
+    """Whether `repo_id` (assumed to exist on the Hub) has at least one
+    dtype == "video" camera feature, via the same cached summary /datasets/info
+    already uses — no extra network call beyond what get_hub_dataset_info
+    itself needs."""
+    info = get_hub_dataset_info(repo_id)
+    return bool(info and info["cameras"])
+
+
+def _ensure_hub_episodes_root(repo_id: str) -> Path | None:
+    """Download meta/info.json + every meta/episodes/**/*.parquet chunk for a
+    Hub dataset confirmed to have video, into huggingface_hub's own on-disk
+    cache (~/.cache/huggingface/hub by default) — NOT MakerLab's
+    ~/.cache/huggingface/lerobot dataset cache, and NOT a full dataset
+    snapshot. Returns the snapshot root directory so the existing local-path
+    reading code (_read_episode_rows, etc.) can run against it exactly like a
+    local dataset dir; None if the dataset isn't viewable this way (offline,
+    no video, or the fetch failed).
+
+    The episode-metadata parquet files are small regardless of how large the
+    dataset's actual video is — this never pulls video/data chunks themselves;
+    those are fetched one at a time by get_episode_video_path /
+    get_episode_joint_series only when a specific episode is actually opened.
+    No caching layer beyond hf_hub_download's own: a repeat call re-lists repo
+    files and re-touches already-cached files, which is fast (etag-checked
+    cache hits), not a re-download.
+    """
+    if hf_hub_offline():
+        return None
+    if not _hub_dataset_has_video(repo_id):
+        return None
+    try:
+        info_path = hf_hub_download(repo_id, filename="meta/info.json", repo_type="dataset")
+        root = Path(info_path).parents[1]  # strip "meta/info.json"'s 2 path parts
+        files = shared_hf_api().list_repo_files(repo_id, repo_type="dataset")
+        for f in files:
+            if f.startswith("meta/episodes/") and f.endswith(".parquet"):
+                hf_hub_download(repo_id, filename=f, repo_type="dataset")
+    except Exception as exc:
+        logger.info("hub episode metadata fetch for %s failed: %s", repo_id, exc)
+        return None
+    return root
+
+
 def list_episode_summaries(repo_id: str) -> list[dict[str, Any]] | None:
     """Per-episode index/length/duration/tasks/video_offsets for the dataset
     viewer's episode list. None if `repo_id` isn't a local dataset in the

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -651,8 +651,18 @@ def _read_episode_rows(meta_dir: Path, columns: list[str] | None = None) -> list
 
 
 def list_episode_summaries(repo_id: str) -> list[dict[str, Any]] | None:
-    """Per-episode index/length/duration/tasks for the dataset viewer's episode
-    list. None if `repo_id` isn't a local dataset in the v3.0 parquet layout.
+    """Per-episode index/length/duration/tasks/video_offsets for the dataset
+    viewer's episode list. None if `repo_id` isn't a local dataset in the
+    v3.0 parquet layout.
+
+    ``video_offsets`` matters because v3.0 packs MULTIPLE consecutive
+    episodes into the same physical mp4 per camera (confirmed on real data:
+    episode 0 and 1 of a 2-episode recording share ``chunk-000/file-000.mp4``,
+    distinguished only by ``from_timestamp``/``to_timestamp``) — a naive
+    "serve the episode's video file" playing it start-to-finish runs straight
+    into whatever episode comes next in that file. The viewer needs each
+    camera's slice boundaries to seek to the right start and stop at the
+    right end within the shared file.
     """
     path = _resolve_local_dataset_path(repo_id)
     if path is None:
@@ -662,19 +672,38 @@ def list_episode_summaries(repo_id: str) -> list[dict[str, Any]] | None:
     except (OSError, ValueError):
         return None
     fps = info.get("fps") or 1
+    features = info.get("features") or {}
+    cameras = [key[len(CAMERA_FEATURE_PREFIX) :] for key in features if key.startswith(CAMERA_FEATURE_PREFIX)]
 
-    rows = _read_episode_rows(path / "meta", columns=["episode_index", "tasks", "length"])
+    video_cols: list[str] = []
+    col_to_camera: dict[str, tuple[str, str]] = {}
+    for camera in cameras:
+        video_key = f"{CAMERA_FEATURE_PREFIX}{camera}"
+        from_col, to_col = f"videos/{video_key}/from_timestamp", f"videos/{video_key}/to_timestamp"
+        video_cols += [from_col, to_col]
+        col_to_camera[from_col] = (camera, "from")
+        col_to_camera[to_col] = (camera, "to")
+
+    rows = _read_episode_rows(path / "meta", columns=["episode_index", "tasks", "length", *video_cols])
     if rows is None:
         return None
-    out = [
-        {
-            "episode_index": int(row["episode_index"]),
-            "length": int(row["length"]),
-            "duration": round(int(row["length"]) / fps, 3),
-            "tasks": [str(t) for t in (row.get("tasks") or [])],
-        }
-        for row in rows
-    ]
+    out = []
+    for row in rows:
+        video_offsets: dict[str, dict[str, float]] = {}
+        for col, (camera, which) in col_to_camera.items():
+            value = row.get(col)
+            if value is None:
+                continue
+            video_offsets.setdefault(camera, {})[which] = float(value)
+        out.append(
+            {
+                "episode_index": int(row["episode_index"]),
+                "length": int(row["length"]),
+                "duration": round(int(row["length"]) / fps, 3),
+                "tasks": [str(t) for t in (row.get("tasks") or [])],
+                "video_offsets": video_offsets,
+            }
+        )
     out.sort(key=lambda e: e["episode_index"])
     return out
 

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -59,6 +59,7 @@ def _video_camera_names(features: dict[str, Any]) -> list[str]:
         if key.startswith(CAMERA_FEATURE_PREFIX) and isinstance(spec, dict) and spec.get("dtype") == "video"
     ]
 
+
 # Errors a per-author / per-listing Hub call may raise that must NOT bubble up
 # and 500 the endpoint. HfHubHTTPError covers HTTP-status failures; httpx.HTTPError
 # is the base of ConnectError / TimeoutException / TransportError, which is what a

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -734,7 +734,7 @@ def list_episode_summaries(repo_id: str) -> list[dict[str, Any]] | None:
         return None
     fps = info.get("fps") or 1
     features = info.get("features") or {}
-    cameras = [key[len(CAMERA_FEATURE_PREFIX) :] for key in features if key.startswith(CAMERA_FEATURE_PREFIX)]
+    cameras = _video_camera_names(features)
 
     video_cols: list[str] = []
     col_to_camera: dict[str, tuple[str, str]] = {}
@@ -791,7 +791,7 @@ def get_episode_video_path(repo_id: str, episode_index: int, camera: str) -> Pat
     except (OSError, ValueError):
         return None
     features = info.get("features") or {}
-    cameras = [key[len(CAMERA_FEATURE_PREFIX) :] for key in features if key.startswith(CAMERA_FEATURE_PREFIX)]
+    cameras = _video_camera_names(features)
     if camera not in cameras:
         return None
 

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -902,7 +902,7 @@ def get_episode_joint_series(repo_id: str, episode_index: int) -> dict[str, Any]
                 table.column("observation.state").to_pylist(),
                 strict=True,
             )
-            if int(ep) == episode_index
+            if _safe_int(ep) == episode_index
         ),
         key=lambda pair: pair[0],
     )

--- a/makerlab/datasets.py
+++ b/makerlab/datasets.py
@@ -48,6 +48,19 @@ logger = logging.getLogger(__name__)
 CAMERA_FEATURE_PREFIX = "observation.images."
 
 
+def _safe_int(value: Any) -> int | None:
+    """`int(value)`, or None on a value that can't convert (e.g. a malformed
+    episode_index/chunk_index/file_index in a Hub dataset's own parquet
+    metadata — content this app doesn't control once the dataset isn't ours).
+    Callers treat None as "this row/episode isn't usable," matching the
+    graceful-404 pattern used everywhere else in the episode viewer, instead
+    of letting a bad third-party dataset raise an unhandled ValueError."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _video_camera_names(features: dict[str, Any]) -> list[str]:
     """Camera feature names actually backed by an mp4 (dtype == "video"), not
     just any observation.images.* key. A raw-image (dtype == "image") camera
@@ -750,17 +763,25 @@ def list_episode_summaries(repo_id: str) -> list[dict[str, Any]] | None:
         return None
     out = []
     for row in rows:
+        episode_index = _safe_int(row.get("episode_index"))
+        length = _safe_int(row.get("length"))
+        if episode_index is None or length is None:
+            logger.warning("Skipping episode row with malformed episode_index/length for %s", repo_id)
+            continue
         video_offsets: dict[str, dict[str, float]] = {}
         for col, (camera, which) in col_to_camera.items():
             value = row.get(col)
             if value is None:
                 continue
-            video_offsets.setdefault(camera, {})[which] = float(value)
+            try:
+                video_offsets.setdefault(camera, {})[which] = float(value)
+            except (TypeError, ValueError):
+                continue
         out.append(
             {
-                "episode_index": int(row["episode_index"]),
-                "length": int(row["length"]),
-                "duration": round(int(row["length"]) / fps, 3),
+                "episode_index": episode_index,
+                "length": length,
+                "duration": round(length / fps, 3),
                 "tasks": [str(t) for t in (row.get("tasks") or [])],
                 "video_offsets": video_offsets,
             }
@@ -800,13 +821,17 @@ def get_episode_video_path(repo_id: str, episode_index: int, camera: str) -> Pat
     rows = _read_episode_rows(path / "meta", columns=["episode_index", chunk_col, file_col])
     if rows is None:
         return None
-    row = next((r for r in rows if int(r["episode_index"]) == episode_index), None)
+    row = next((r for r in rows if _safe_int(r.get("episode_index")) == episode_index), None)
     if row is None or row.get(chunk_col) is None or row.get(file_col) is None:
         return None
+    chunk_index, file_index = _safe_int(row[chunk_col]), _safe_int(row[file_col])
+    if chunk_index is None or file_index is None:
+        logger.warning(
+            "Malformed chunk/file index for %s episode %d camera %s", repo_id, episode_index, camera
+        )
+        return None
 
-    rel_video_path = (
-        Path("videos") / video_key / f"chunk-{int(row[chunk_col]):03d}" / f"file-{int(row[file_col]):03d}.mp4"
-    )
+    rel_video_path = Path("videos") / video_key / f"chunk-{chunk_index:03d}" / f"file-{file_index:03d}.mp4"
     if is_hub:
         try:
             return Path(hf_hub_download(repo_id, filename=str(rel_video_path), repo_type="dataset"))
@@ -843,15 +868,15 @@ def get_episode_joint_series(repo_id: str, episode_index: int) -> dict[str, Any]
     )
     if episode_rows is None:
         return None
-    row = next((r for r in episode_rows if int(r["episode_index"]) == episode_index), None)
+    row = next((r for r in episode_rows if _safe_int(r.get("episode_index")) == episode_index), None)
     if row is None or row.get("data/chunk_index") is None or row.get("data/file_index") is None:
         return None
+    chunk_index, file_index = _safe_int(row["data/chunk_index"]), _safe_int(row["data/file_index"])
+    if chunk_index is None or file_index is None:
+        logger.warning("Malformed data chunk/file index for %s episode %d", repo_id, episode_index)
+        return None
 
-    rel_data_path = (
-        Path("data")
-        / f"chunk-{int(row['data/chunk_index']):03d}"
-        / f"file-{int(row['data/file_index']):03d}.parquet"
-    )
+    rel_data_path = Path("data") / f"chunk-{chunk_index:03d}" / f"file-{file_index:03d}.parquet"
     if is_hub:
         try:
             data_path = Path(hf_hub_download(repo_id, filename=str(rel_data_path), repo_type="dataset"))

--- a/makerlab/server.py
+++ b/makerlab/server.py
@@ -33,7 +33,7 @@ from typing import Any, Literal
 import httpx
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from huggingface_hub.errors import HfHubHTTPError
 from pydantic import BaseModel
@@ -602,6 +602,43 @@ def datasets_info(repo_id: str):
     if info is None:
         raise HTTPException(status_code=404, detail=f"Dataset '{repo_id}' not found in the local cache")
     return info
+
+
+@app.get("/datasets/episodes")
+def datasets_episodes(repo_id: str):
+    """Per-episode index/length/duration/tasks for the dataset viewer window.
+    404 when the dataset isn't local or predates the v3.0 parquet episode
+    layout (meta/episodes/chunk-*/file-*.parquet) the viewer reads."""
+    episodes = dataset_browser.list_episode_summaries(repo_id)
+    if episodes is None:
+        raise HTTPException(status_code=404, detail=f"No viewable episode list for '{repo_id}'")
+    return episodes
+
+
+@app.get("/datasets/episode-joints")
+def datasets_episode_joints(repo_id: str, episode_index: int):
+    """Per-frame timestamp + joint (observation.state) values for one episode,
+    for the dataset viewer's joint-position chart."""
+    series = dataset_browser.get_episode_joint_series(repo_id, episode_index)
+    if series is None:
+        raise HTTPException(
+            status_code=404, detail=f"No joint data for episode {episode_index} of '{repo_id}'"
+        )
+    return series
+
+
+@app.get("/datasets/episode-video")
+def datasets_episode_video(repo_id: str, episode_index: int, camera: str):
+    """The mp4 backing one camera's footage for one episode, served straight
+    off disk. FileResponse handles Range requests, so the <video> element can
+    seek without downloading the whole file first."""
+    video_path = dataset_browser.get_episode_video_path(repo_id, episode_index, camera)
+    if video_path is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No video for camera '{camera}', episode {episode_index} of '{repo_id}'",
+        )
+    return FileResponse(video_path, media_type="video/mp4")
 
 
 @app.get("/datasets/hub-status")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1848,3 +1848,106 @@ def test_get_episode_joint_series_hub_fallback_degrades_on_download_failure(
         patch("makerlab.datasets.hf_hub_download", side_effect=RuntimeError("network")),
     ):
         assert ds.get_episode_joint_series("alice/hub_only", 0) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end route coverage for Hub dataset viewer — Tasks 1–5 integrated
+# through the real FastAPI routes without production code changes.
+# ---------------------------------------------------------------------------
+
+
+def test_hub_dataset_viewer_endpoints_end_to_end(
+    client: TestClient, tmp_lerobot_home: Path, tmp_path: Path
+) -> None:
+    """A Hub-only dataset with video is viewable through all three viewer
+    routes without ever being downloaded locally."""
+    _clear_hub_dataset_info_cache()
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    info = {
+        "fps": 30,
+        "total_episodes": 1,
+        "total_frames": 2,
+        "features": {
+            "observation.images.front": {"dtype": "video"},
+            "observation.state": {"names": ["shoulder"]},
+        },
+    }
+    (snapshot / "meta" / "info.json").write_text(json.dumps(info))
+    episodes_dir = snapshot / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0],
+                "tasks": [["pick"]],
+                "length": [2],
+                "videos/observation.images.front/chunk_index": [0],
+                "videos/observation.images.front/file_index": [0],
+                "videos/observation.images.front/from_timestamp": [0.0],
+                "videos/observation.images.front/to_timestamp": [0.066],
+                "data/chunk_index": [0],
+                "data/file_index": [0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+    video_file = snapshot / "videos" / "observation.images.front" / "chunk-000" / "file-000.mp4"
+    video_file.parent.mkdir(parents=True)
+    video_file.write_bytes(b"fake mp4 bytes")
+    data_file = snapshot / "data" / "chunk-000" / "file-000.parquet"
+    data_file.parent.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"episode_index": [0, 0], "timestamp": [0.0, 0.033], "observation.state": [[0.1], [0.2]]}),
+        data_file,
+    )
+
+    def _fake_download(repo_id, filename, repo_type):  # noqa: ARG001
+        return str(snapshot / filename)
+
+    fake_api = MagicMock()
+    fake_api.list_repo_files.return_value = [
+        "meta/info.json",
+        "meta/episodes/chunk-000/file-000.parquet",
+    ]
+
+    with (
+        patch("makerlab.datasets.hf_hub_offline", return_value=False),
+        patch("makerlab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makerlab.datasets.hf_hub_download", side_effect=_fake_download),
+    ):
+        episodes = client.get("/datasets/episodes", params={"repo_id": "alice/hub_only"})
+        assert episodes.status_code == 200
+        assert episodes.json()[0]["episode_index"] == 0
+
+        joints = client.get(
+            "/datasets/episode-joints", params={"repo_id": "alice/hub_only", "episode_index": 0}
+        )
+        assert joints.status_code == 200
+        assert joints.json()["joint_names"] == ["shoulder"]
+
+        video = client.get(
+            "/datasets/episode-video",
+            params={"repo_id": "alice/hub_only", "episode_index": 0, "camera": "front"},
+        )
+        assert video.status_code == 200
+        assert video.content == b"fake mp4 bytes"
+
+
+def test_hub_dataset_viewer_endpoints_404_without_video(
+    client: TestClient, tmp_lerobot_home: Path, tmp_path: Path
+) -> None:
+    """A Hub-only dataset with no dtype=="video" feature never triggers a chunk
+    fetch — /datasets/episodes 404s after only the cheap meta/info.json probe."""
+    _clear_hub_dataset_info_cache()
+    meta = tmp_path / "info.json"
+    meta.write_text(json.dumps({"features": {"observation.images.front": {"dtype": "image"}}}))
+
+    with (
+        patch("makerlab.datasets.hf_hub_offline", return_value=False),
+        patch("makerlab.datasets.hf_hub_download", return_value=str(meta)) as dl,
+    ):
+        resp = client.get("/datasets/episodes", params={"repo_id": "alice/no_video"})
+
+    assert resp.status_code == 404
+    dl.assert_called_once()  # only the meta/info.json probe inside get_hub_dataset_info

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1593,6 +1593,59 @@ def test_list_episode_summaries_returns_none_when_hub_fetch_fails(tmp_lerobot_ho
         assert ds.list_episode_summaries("alice/no_video") is None
 
 
+def test_list_episode_summaries_hub_fallback_filters_non_video_cameras(
+    tmp_lerobot_home: Path, tmp_path: Path
+) -> None:
+    """Hub fallback: dataset with both dtype=='video' and dtype=='image' cameras
+    correctly reads only the video camera's columns, not the image camera's."""
+    from makerlab import datasets as ds
+
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    # Dataset has one video camera and one image camera
+    (snapshot / "meta" / "info.json").write_text(
+        json.dumps(
+            {
+                "fps": 30,
+                "features": {
+                    "observation.images.front": {"dtype": "video"},
+                    "observation.images.raw": {"dtype": "image"},
+                },
+            }
+        )
+    )
+    # Parquet contains only the video camera's columns, not the image camera's
+    episodes_dir = snapshot / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0, 1],
+                "tasks": [["task"], ["task"]],
+                "length": [30, 60],
+                "videos/observation.images.front/from_timestamp": [0.0, 1.0],
+                "videos/observation.images.front/to_timestamp": [1.0, 3.0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+
+    with patch("makerlab.datasets._ensure_hub_episodes_root", return_value=snapshot) as hub_fetch:
+        result = ds.list_episode_summaries("alice/mixed_cameras")
+
+    hub_fetch.assert_called_once_with("alice/mixed_cameras")
+    assert result is not None
+    assert len(result) == 2
+    assert [e["episode_index"] for e in result] == [0, 1]
+    # Verify video_offsets only contains the video camera, not the image camera
+    assert result[0]["video_offsets"] == {
+        "front": {"from": 0.0, "to": 1.0},
+    }
+    assert result[1]["video_offsets"] == {
+        "front": {"from": 1.0, "to": 3.0},
+    }
+
+
 def test_get_episode_video_path_local_unchanged(tmp_lerobot_home: Path) -> None:
     from makerlab import datasets as ds
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1425,6 +1425,97 @@ def test_get_local_dataset_info_marks_source_local(tmp_lerobot_home: Path) -> No
 
 
 # ---------------------------------------------------------------------------
+# On-demand Hub episode-metadata fetch — the foundation the viewer's Hub
+# fallback (Tasks 3-5) builds on. Downloads meta/info.json + the small
+# meta/episodes/**/*.parquet chunks (never video/data chunks themselves) into
+# huggingface_hub's own cache, so the existing local-path parsing code can run
+# against that snapshot dir unmodified.
+# ---------------------------------------------------------------------------
+
+
+def test_hub_dataset_has_video_true_and_false() -> None:
+    from makerlab import datasets as ds
+
+    with patch("makerlab.datasets.get_hub_dataset_info", return_value={"cameras": ["front"]}):
+        assert ds._hub_dataset_has_video("alice/pick") is True
+    with patch("makerlab.datasets.get_hub_dataset_info", return_value={"cameras": []}):
+        assert ds._hub_dataset_has_video("alice/pick") is False
+    with patch("makerlab.datasets.get_hub_dataset_info", return_value=None):
+        assert ds._hub_dataset_has_video("alice/pick") is False
+
+
+def test_ensure_hub_episodes_root_returns_none_offline() -> None:
+    from makerlab import datasets as ds
+
+    with (
+        patch("makerlab.datasets.hf_hub_offline", return_value=True),
+        patch("makerlab.datasets.get_hub_dataset_info") as info,
+    ):
+        assert ds._ensure_hub_episodes_root("alice/pick") is None
+    info.assert_not_called()
+
+
+def test_ensure_hub_episodes_root_returns_none_when_no_video() -> None:
+    from makerlab import datasets as ds
+
+    with (
+        patch("makerlab.datasets.hf_hub_offline", return_value=False),
+        patch("makerlab.datasets.get_hub_dataset_info", return_value={"cameras": []}),
+        patch("makerlab.datasets.hf_hub_download") as dl,
+    ):
+        assert ds._ensure_hub_episodes_root("alice/no_video") is None
+    dl.assert_not_called()
+
+
+def test_ensure_hub_episodes_root_downloads_info_and_episode_chunks(tmp_path: Path) -> None:
+    from makerlab import datasets as ds
+
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    (snapshot / "meta" / "info.json").write_text("{}")
+
+    fake_api = MagicMock()
+    fake_api.list_repo_files.return_value = [
+        "meta/info.json",
+        "meta/episodes/chunk-000/file-000.parquet",
+        "meta/episodes/chunk-000/file-001.parquet",
+        "meta/stats.json",  # not an episodes parquet — must be skipped
+        "videos/observation.images.front/chunk-000/file-000.mp4",  # not fetched here
+    ]
+    downloaded: list[str] = []
+
+    def _fake_download(repo_id, filename, repo_type):  # noqa: ARG001
+        downloaded.append(filename)
+        return str(snapshot / filename)
+
+    with (
+        patch("makerlab.datasets.hf_hub_offline", return_value=False),
+        patch("makerlab.datasets.get_hub_dataset_info", return_value={"cameras": ["front"]}),
+        patch("makerlab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makerlab.datasets.hf_hub_download", side_effect=_fake_download),
+    ):
+        root = ds._ensure_hub_episodes_root("alice/pick")
+
+    assert root == snapshot
+    assert downloaded == [
+        "meta/info.json",
+        "meta/episodes/chunk-000/file-000.parquet",
+        "meta/episodes/chunk-000/file-001.parquet",
+    ]
+
+
+def test_ensure_hub_episodes_root_degrades_on_fetch_failure() -> None:
+    from makerlab import datasets as ds
+
+    with (
+        patch("makerlab.datasets.hf_hub_offline", return_value=False),
+        patch("makerlab.datasets.get_hub_dataset_info", return_value={"cameras": ["front"]}),
+        patch("makerlab.datasets.hf_hub_download", side_effect=RuntimeError("hub down")),
+    ):
+        assert ds._ensure_hub_episodes_root("alice/pick") is None
+
+
+# ---------------------------------------------------------------------------
 # _fan_out_hub_authors — the OVERALL fan-out deadline actually bounds a hung
 # author. The shared HfApi httpx client has timeout=None, so this budget is the
 # ONLY timeout in the stack: a blackholed connection must be abandoned (and

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1593,6 +1593,109 @@ def test_list_episode_summaries_returns_none_when_hub_fetch_fails(tmp_lerobot_ho
         assert ds.list_episode_summaries("alice/no_video") is None
 
 
+def test_get_episode_video_path_local_unchanged(tmp_lerobot_home: Path) -> None:
+    from makerlab import datasets as ds
+
+    d = _write_info(
+        tmp_lerobot_home,
+        "alice/local",
+        {"features": {"observation.images.front": {"dtype": "video"}}},
+    )
+    episodes_dir = d / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0],
+                "videos/observation.images.front/chunk_index": [0],
+                "videos/observation.images.front/file_index": [0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+    video_dir = d / "videos" / "observation.images.front" / "chunk-000"
+    video_dir.mkdir(parents=True)
+    (video_dir / "file-000.mp4").write_bytes(b"fake mp4")
+
+    with patch("makerlab.datasets._ensure_hub_episodes_root") as hub_fetch:
+        result = ds.get_episode_video_path("alice/local", 0, "front")
+
+    hub_fetch.assert_not_called()
+    assert result == video_dir / "file-000.mp4"
+
+
+def test_get_episode_video_path_hub_fallback_downloads_one_chunk(
+    tmp_lerobot_home: Path, tmp_path: Path
+) -> None:
+    """No local copy: fetches ONLY the one video chunk file the episode/camera
+    needs, via hf_hub_download — not the whole dataset."""
+    from makerlab import datasets as ds
+
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    (snapshot / "meta" / "info.json").write_text(
+        json.dumps({"features": {"observation.images.front": {"dtype": "video"}}})
+    )
+    episodes_dir = snapshot / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0],
+                "videos/observation.images.front/chunk_index": [0],
+                "videos/observation.images.front/file_index": [0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+    downloaded_video = snapshot / "videos" / "observation.images.front" / "chunk-000" / "file-000.mp4"
+    downloaded_video.parent.mkdir(parents=True)
+    downloaded_video.write_bytes(b"fake mp4")
+
+    with (
+        patch("makerlab.datasets._ensure_hub_episodes_root", return_value=snapshot),
+        patch("makerlab.datasets.hf_hub_download", return_value=str(downloaded_video)) as dl,
+    ):
+        result = ds.get_episode_video_path("alice/hub_only", 0, "front")
+
+    dl.assert_called_once_with(
+        "alice/hub_only",
+        filename="videos/observation.images.front/chunk-000/file-000.mp4",
+        repo_type="dataset",
+    )
+    assert result == downloaded_video
+
+
+def test_get_episode_video_path_hub_fallback_degrades_on_download_failure(
+    tmp_lerobot_home: Path, tmp_path: Path
+) -> None:
+    from makerlab import datasets as ds
+
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    (snapshot / "meta" / "info.json").write_text(
+        json.dumps({"features": {"observation.images.front": {"dtype": "video"}}})
+    )
+    episodes_dir = snapshot / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0],
+                "videos/observation.images.front/chunk_index": [0],
+                "videos/observation.images.front/file_index": [0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+
+    with (
+        patch("makerlab.datasets._ensure_hub_episodes_root", return_value=snapshot),
+        patch("makerlab.datasets.hf_hub_download", side_effect=RuntimeError("network")),
+    ):
+        assert ds.get_episode_video_path("alice/hub_only", 0, "front") is None
+
+
 # ---------------------------------------------------------------------------
 # _fan_out_hub_authors — the OVERALL fan-out deadline actually bounds a hung
 # author. The shared HfApi httpx client has timeout=None, so this budget is the

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1753,3 +1753,98 @@ def test_fan_out_hub_authors_no_timeout_when_all_finish(
     monkeypatch.setattr(ds, "_HUB_FANOUT_TIMEOUT_S", 0.5)
     result = ds._fan_out_hub_authors(["a", "b", "c"], lambda author: author.upper())
     assert result == ["A", "B", "C"]
+
+
+def test_get_episode_joint_series_local_unchanged(tmp_lerobot_home: Path) -> None:
+    from makerlab import datasets as ds
+
+    d = _write_info(
+        tmp_lerobot_home,
+        "alice/local",
+        {"features": {"observation.state": {"names": ["shoulder", "elbow"]}}},
+    )
+    episodes_dir = d / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"episode_index": [0], "data/chunk_index": [0], "data/file_index": [0]}),
+        episodes_dir / "file-000.parquet",
+    )
+    data_dir = d / "data" / "chunk-000"
+    data_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0, 0],
+                "timestamp": [0.0, 0.033],
+                "observation.state": [[0.1, 0.2], [0.15, 0.25]],
+            }
+        ),
+        data_dir / "file-000.parquet",
+    )
+
+    with patch("makerlab.datasets._ensure_hub_episodes_root") as hub_fetch:
+        result = ds.get_episode_joint_series("alice/local", 0)
+
+    hub_fetch.assert_not_called()
+    assert result is not None
+    assert result["joint_names"] == ["shoulder", "elbow"]
+    assert result["timestamps"] == [0.0, 0.033]
+
+
+def test_get_episode_joint_series_hub_fallback_downloads_one_chunk(
+    tmp_lerobot_home: Path, tmp_path: Path
+) -> None:
+    from makerlab import datasets as ds
+
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    (snapshot / "meta" / "info.json").write_text(
+        json.dumps({"features": {"observation.state": {"names": ["shoulder"]}}})
+    )
+    episodes_dir = snapshot / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"episode_index": [0], "data/chunk_index": [0], "data/file_index": [0]}),
+        episodes_dir / "file-000.parquet",
+    )
+    downloaded_data = snapshot / "data" / "chunk-000" / "file-000.parquet"
+    downloaded_data.parent.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"episode_index": [0], "timestamp": [0.0], "observation.state": [[0.5]]}),
+        downloaded_data,
+    )
+
+    with (
+        patch("makerlab.datasets._ensure_hub_episodes_root", return_value=snapshot),
+        patch("makerlab.datasets.hf_hub_download", return_value=str(downloaded_data)) as dl,
+    ):
+        result = ds.get_episode_joint_series("alice/hub_only", 0)
+
+    dl.assert_called_once_with(
+        "alice/hub_only", filename="data/chunk-000/file-000.parquet", repo_type="dataset"
+    )
+    assert result is not None
+    assert result["joint_names"] == ["shoulder"]
+    assert result["values"] == [[0.5]]
+
+
+def test_get_episode_joint_series_hub_fallback_degrades_on_download_failure(
+    tmp_lerobot_home: Path, tmp_path: Path
+) -> None:
+    from makerlab import datasets as ds
+
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    (snapshot / "meta" / "info.json").write_text(json.dumps({"features": {}}))
+    episodes_dir = snapshot / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"episode_index": [0], "data/chunk_index": [0], "data/file_index": [0]}),
+        episodes_dir / "file-000.parquet",
+    )
+
+    with (
+        patch("makerlab.datasets._ensure_hub_episodes_root", return_value=snapshot),
+        patch("makerlab.datasets.hf_hub_download", side_effect=RuntimeError("network")),
+    ):
+        assert ds.get_episode_joint_series("alice/hub_only", 0) is None

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -328,6 +328,19 @@ def test_datasets_info_endpoint(client: TestClient, tmp_lerobot_home: Path) -> N
     assert missing.status_code == 404
 
 
+def test_video_camera_names_filters_by_dtype() -> None:
+    from makerlab.datasets import _video_camera_names
+
+    features = {
+        "observation.images.front": {"dtype": "video"},
+        "observation.images.raw": {"dtype": "image"},
+        "observation.images.wrist": {"dtype": "video"},
+        "observation.state": {"dtype": "float32"},
+        "action": {"dtype": "float32"},
+    }
+    assert _video_camera_names(features) == ["front", "wrist"]
+
+
 # --- Hub sync status --------------------------------------------------------
 
 
@@ -1281,9 +1294,9 @@ def test_get_hub_dataset_info_maps_meta(tmp_path: Path) -> None:
             "fps": 30,
             "robot_type": "so101_follower",
             "features": {
-                "observation.images.front": {},
-                "observation.images.wrist": {},
-                "observation.state": {},
+                "observation.images.front": {"dtype": "video"},
+                "observation.images.wrist": {"dtype": "video"},
+                "observation.state": {"dtype": "float32"},
             },
         },
     )
@@ -1305,6 +1318,36 @@ def test_get_hub_dataset_info_maps_meta(tmp_path: Path) -> None:
         "size_bytes": None,
         "source": "hub",
     }
+
+
+def test_get_hub_dataset_info_excludes_non_video_camera_features(tmp_path: Path) -> None:
+    """A camera-prefixed feature that isn't dtype == "video" (e.g. raw stored
+    images) has no mp4 chunk for this app's video pipeline to serve, so it's
+    excluded from `cameras` — the same field the Hub listing filter and viewer
+    gate both key off."""
+    from makerlab import datasets as ds
+
+    _clear_hub_dataset_info_cache()
+    meta = _write_hub_meta(
+        tmp_path,
+        {
+            "total_episodes": 4,
+            "total_frames": 100,
+            "fps": 30,
+            "features": {
+                "observation.images.front": {"dtype": "image"},
+                "observation.state": {"dtype": "float32"},
+            },
+        },
+    )
+    with (
+        patch("makerlab.datasets.hf_hub_offline", return_value=False),
+        patch("makerlab.datasets.hf_hub_download", return_value=str(meta)),
+    ):
+        row = ds.get_hub_dataset_info("alice/image_only")
+
+    assert row is not None
+    assert row["cameras"] == []
 
 
 def test_get_hub_dataset_info_offline_returns_none() -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1516,6 +1516,84 @@ def test_ensure_hub_episodes_root_degrades_on_fetch_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# list_episode_summaries — Hub fallback for episode metadata (Task 3).
+# ---------------------------------------------------------------------------
+
+
+def test_list_episode_summaries_local_unchanged(tmp_lerobot_home: Path) -> None:
+    """Existing local behavior is untouched: a local dataset never touches the
+    Hub fallback."""
+    from makerlab import datasets as ds
+
+    d = _write_info(
+        tmp_lerobot_home,
+        "alice/local",
+        {"fps": 30, "features": {"observation.images.front": {"dtype": "video"}}},
+    )
+    episodes_dir = d / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0],
+                "tasks": [["task"]],
+                "length": [30],
+                "videos/observation.images.front/from_timestamp": [0.0],
+                "videos/observation.images.front/to_timestamp": [1.0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+
+    with patch("makerlab.datasets._ensure_hub_episodes_root") as hub_fetch:
+        result = ds.list_episode_summaries("alice/local")
+
+    hub_fetch.assert_not_called()
+    assert result is not None
+    assert result[0]["episode_index"] == 0
+
+
+def test_list_episode_summaries_hub_fallback(tmp_lerobot_home: Path, tmp_path: Path) -> None:
+    """No local copy: falls back to reading the Hub-fetched snapshot root."""
+    from makerlab import datasets as ds
+
+    snapshot = tmp_path / "snapshot"
+    (snapshot / "meta").mkdir(parents=True)
+    (snapshot / "meta" / "info.json").write_text(
+        json.dumps({"fps": 30, "features": {"observation.images.front": {"dtype": "video"}}})
+    )
+    episodes_dir = snapshot / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0, 1],
+                "tasks": [["task"], ["task"]],
+                "length": [30, 60],
+                "videos/observation.images.front/from_timestamp": [0.0, 1.0],
+                "videos/observation.images.front/to_timestamp": [1.0, 3.0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+
+    with patch("makerlab.datasets._ensure_hub_episodes_root", return_value=snapshot) as hub_fetch:
+        result = ds.list_episode_summaries("alice/hub_only")
+
+    hub_fetch.assert_called_once_with("alice/hub_only")
+    assert result is not None
+    assert [e["episode_index"] for e in result] == [0, 1]
+    assert result[1]["duration"] == 2.0  # 60 frames / 30 fps
+
+
+def test_list_episode_summaries_returns_none_when_hub_fetch_fails(tmp_lerobot_home: Path) -> None:
+    from makerlab import datasets as ds
+
+    with patch("makerlab.datasets._ensure_hub_episodes_root", return_value=None):
+        assert ds.list_episode_summaries("alice/no_video") is None
+
+
+# ---------------------------------------------------------------------------
 # _fan_out_hub_authors — the OVERALL fan-out deadline actually bounds a hung
 # author. The shared HfApi httpx client has timeout=None, so this budget is the
 # ONLY timeout in the stack: a blackholed connection must be abandoned (and

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1922,6 +1922,44 @@ def test_get_episode_joint_series_returns_none_on_malformed_chunk_index(tmp_lero
     assert ds.get_episode_joint_series("alice/local", 0) is None
 
 
+def test_get_episode_joint_series_skips_malformed_data_row(tmp_lerobot_home: Path) -> None:
+    """A malformed episode_index in the *data* parquet chunk itself (as
+    opposed to the meta/episodes row already covered above) is skipped, not a
+    raised exception that 500s the endpoint — the well-formed frames for the
+    requested episode still come back."""
+    from makerlab import datasets as ds
+
+    d = _write_info(
+        tmp_lerobot_home,
+        "alice/local",
+        {"features": {"observation.state": {"names": ["shoulder", "elbow"]}}},
+    )
+    episodes_dir = d / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"episode_index": [0], "data/chunk_index": [0], "data/file_index": [0]}),
+        episodes_dir / "file-000.parquet",
+    )
+    data_dir = d / "data" / "chunk-000"
+    data_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [float("nan"), 0.0],
+                "timestamp": [0.0, 0.033],
+                "observation.state": [[0.1, 0.2], [0.15, 0.25]],
+            }
+        ),
+        data_dir / "file-000.parquet",
+    )
+
+    result = ds.get_episode_joint_series("alice/local", 0)
+
+    assert result is not None
+    assert result["timestamps"] == [0.033]
+    assert result["values"] == [[0.15, 0.25]]
+
+
 def test_get_episode_joint_series_hub_fallback_downloads_one_chunk(
     tmp_lerobot_home: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1646,6 +1646,38 @@ def test_list_episode_summaries_hub_fallback_filters_non_video_cameras(
     }
 
 
+def test_list_episode_summaries_skips_malformed_episode_row(tmp_lerobot_home: Path) -> None:
+    """A malformed episode_index (e.g. a NaN from a third-party Hub dataset
+    with corrupt metadata) is skipped, not a raised exception that 500s the
+    whole endpoint — the good rows still come back."""
+    from makerlab import datasets as ds
+
+    d = _write_info(
+        tmp_lerobot_home,
+        "alice/local",
+        {"fps": 30, "features": {"observation.images.front": {"dtype": "video"}}},
+    )
+    episodes_dir = d / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [float("nan"), 1.0],
+                "tasks": [["task"], ["task"]],
+                "length": [30, 60],
+                "videos/observation.images.front/from_timestamp": [0.0, 1.0],
+                "videos/observation.images.front/to_timestamp": [1.0, 3.0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+
+    result = ds.list_episode_summaries("alice/local")
+
+    assert result is not None
+    assert [e["episode_index"] for e in result] == [1]
+
+
 def test_get_episode_video_path_local_unchanged(tmp_lerobot_home: Path) -> None:
     from makerlab import datasets as ds
 
@@ -1675,6 +1707,32 @@ def test_get_episode_video_path_local_unchanged(tmp_lerobot_home: Path) -> None:
 
     hub_fetch.assert_not_called()
     assert result == video_dir / "file-000.mp4"
+
+
+def test_get_episode_video_path_returns_none_on_malformed_chunk_index(tmp_lerobot_home: Path) -> None:
+    """A malformed chunk_index/file_index (e.g. a NaN from a corrupt or
+    adversarial Hub dataset) 404s gracefully instead of raising."""
+    from makerlab import datasets as ds
+
+    d = _write_info(
+        tmp_lerobot_home,
+        "alice/local",
+        {"features": {"observation.images.front": {"dtype": "video"}}},
+    )
+    episodes_dir = d / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": [0],
+                "videos/observation.images.front/chunk_index": [float("nan")],
+                "videos/observation.images.front/file_index": [0],
+            }
+        ),
+        episodes_dir / "file-000.parquet",
+    )
+
+    assert ds.get_episode_video_path("alice/local", 0, "front") is None
 
 
 def test_get_episode_video_path_hub_fallback_downloads_one_chunk(
@@ -1842,6 +1900,26 @@ def test_get_episode_joint_series_local_unchanged(tmp_lerobot_home: Path) -> Non
     assert result is not None
     assert result["joint_names"] == ["shoulder", "elbow"]
     assert result["timestamps"] == [0.0, 0.033]
+
+
+def test_get_episode_joint_series_returns_none_on_malformed_chunk_index(tmp_lerobot_home: Path) -> None:
+    """A malformed data/chunk_index (e.g. a NaN from a corrupt or adversarial
+    Hub dataset) 404s gracefully instead of raising."""
+    from makerlab import datasets as ds
+
+    d = _write_info(
+        tmp_lerobot_home,
+        "alice/local",
+        {"features": {"observation.state": {"names": ["shoulder"]}}},
+    )
+    episodes_dir = d / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"episode_index": [0], "data/chunk_index": [float("nan")], "data/file_index": [0]}),
+        episodes_dir / "file-000.parquet",
+    )
+
+    assert ds.get_episode_joint_series("alice/local", 0) is None
 
 
 def test_get_episode_joint_series_hub_fallback_downloads_one_chunk(


### PR DESCRIPTION
## Summary

Adds a windowed episode viewer to the dataset detail dialog: a growable camera grid with transport controls and a joint-position chart synced to the playhead. This replaces the previous behavior, where a dataset on the Hub but not downloaded locally could only be viewed through an embedded Hugging Face Space iframe (a different UI, no joint chart, and no support for private repos).

For a Hub-only dataset, the backend now fetches just the specific files a viewing session touches — episode metadata always, and one video chunk / one data chunk per episode and camera actually opened — via `hf_hub_download`, rather than requiring a full dataset download first. The same viewer component is used regardless of whether a dataset is local or Hub-only.

## How to access it

Open **My library** (top bar) → **My datasets** tab → click any dataset row. This opens the episode viewer for both locally downloaded datasets and Hub-only datasets you own or have pinned.

The Collect panel's dataset cards work the same way: click anywhere on a card to open its viewer. Selecting a dataset for recording is done via the card's **Select** button, which is unaffected.

- The episode list, camera grid, and joint-position chart all sync to the playhead; scrubbing seeks without buffering the whole video.
- A Hub-only dataset streams on demand — a first-time view of a new episode may take a moment while its chunk is fetched; the app now also prefetches the next episode's chunks in the background while the current one plays, so advancing episode-to-episode is usually instant after the first.
- A Hub dataset with no video (e.g. state-only) is filtered out of the library listing rather than showing a broken or empty viewer.
- Private Hub datasets you own are now viewable too (the previous iframe embed could never carry your Hub login).

## Screenshot

The viewer open on a Hub-only bimanual dataset (`makermods/pen_holder_bi_20260723_161553`), not downloaded locally — camera grid, joint traces, and episode list, opened via My library → My datasets:

![Episode viewer on a Hub-only dataset](https://raw.githubusercontent.com/makermods-robotics/MakerLab/assets/pr-18-screenshots/episode-viewer-hub-dataset.png)

## Test plan

- [x] Backend: `pytest` — 877 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] Frontend: `npm run lint`, `npx tsc --noEmit`, `npm run build` — no new issues vs. pre-existing baseline
- [x] Manual: verified in `makerlab --dev` against a real Hub-only bimanual dataset (camera grid, joint traces, episode list, and the "not downloaded" / "Download to this machine" affordances all working as expected)
- [x] Manual: verified in the Collect panel that clicking a dataset card opens the viewer without selecting it, and that the Select button still selects/deselects without opening the viewer

