### PR TITLE
fix(teleoperate): force-disable torque in startup-failure cleanup (T7)

### DIFF
--- a/frontend/src/components/launchpad/RobotCorner.tsx
+++ b/frontend/src/components/launchpad/RobotCorner.tsx
@@ -195,6 +195,16 @@ const RobotCorner: React.FC<{ className?: string }> = ({ className }) => {
           });
         }
         setTeleopOpen(true);
+      } else if (data.warning) {
+        // Setup failed after a device was already armed — the backend force-
+        // disabled torque and is reporting whether that succeeded. Surface it
+        // alongside the failure reason instead of dropping it silently.
+        toast({
+          title: "Couldn't start teleoperation — check the arm",
+          description: `${data.message || "Failed to start."} ${data.warning}`,
+          variant: "destructive",
+          duration: 10000,
+        });
       } else {
         toast({
           title: "Couldn't start teleoperation",

--- a/makerlab/teleoperate.py
+++ b/makerlab/teleoperate.py
@@ -808,16 +808,29 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
 
     except Exception as e:
         # Connection (or setup) failed before the loop started: release any
-        # device that did open, reset state, and surface the error.
-        _safe_disconnect(robot, "follower arm")
-        _safe_disconnect(teleop_device, "leader arm")
+        # device that did open, reset state, and surface the error. Mirrors
+        # the worker's normal cleanup below — robot.configure() above may
+        # already have written Torque_Enable=1 on the real follower servos
+        # before this fired, so skipping the explicit disable (or dropping
+        # _safe_disconnect's error text) would leave the arm energized with
+        # no warning surfaced.
+        problems = force_disable_torque(robot, "follower arm")
+        problems += force_disable_torque(teleop_device, "leader arm")
+        for device, label in ((robot, "follower arm"), (teleop_device, "leader arm")):
+            error = _safe_disconnect(device, label)
+            if error:
+                problems.append(error)
+        last_cleanup_error = " ".join(problems) if problems else None
         teleoperation_active = False
         current_robot = None
         current_teleop = None
         logger.error(f"Failed to start teleoperation: {e}")
         # str(e) is already a user-facing message for the connection failures
         # raised above; the toast title supplies the "error starting" context.
-        return {"success": False, "message": str(e)}
+        response = {"success": False, "message": str(e)}
+        if last_cleanup_error:
+            response["warning"] = last_cleanup_error
+        return response
 
 
 def handle_stop_teleoperation() -> dict[str, Any]:

--- a/makerlab/teleoperate.py
+++ b/makerlab/teleoperate.py
@@ -418,10 +418,8 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
         # to disable motors one by one.
         port_handler = getattr(bus, "port_handler", None)
         if port_handler is not None:
-            try:
+            with contextlib.suppress(Exception):
                 port_handler.clearPort()
-            except Exception:
-                pass
             with contextlib.suppress(Exception):
                 port_handler.is_using = False
         failed: list[str] = []

--- a/makerlab/teleoperate.py
+++ b/makerlab/teleoperate.py
@@ -467,6 +467,26 @@ def _safe_disconnect(device, label: str = "device") -> str | None:
         return message
 
 
+def _cleanup_after_setup_failure(
+    robot, teleop_device, robot_label: str = "follower arm", teleop_label: str = "leader arm"
+) -> str | None:
+    """Force-disable torque and disconnect both devices after a setup failure.
+
+    Shared by the single-arm and bimanual setup paths: either device may
+    already be configured (energized) by the time a *later* setup step
+    raises, so skipping the explicit disable — or dropping _safe_disconnect's
+    error text — would leave an arm energized with no warning surfaced.
+    Returns the joined problem text, or None when cleanup was clean.
+    """
+    problems = force_disable_torque(robot, robot_label)
+    problems += force_disable_torque(teleop_device, teleop_label)
+    for device, label in ((robot, robot_label), (teleop_device, teleop_label)):
+        error = _safe_disconnect(device, label)
+        if error:
+            problems.append(error)
+    return " ".join(problems) if problems else None
+
+
 def _connect_bimanual(request: TeleoperateRequest):
     """Build, connect, and configure a bimanual leader+follower pair.
 
@@ -537,9 +557,14 @@ def _connect_bimanual(request: TeleoperateRequest):
         identity_warnings += clear_goal_velocity(robot, "follower arms")
         logger.info("Successfully connected to both bimanual arms")
         return robot, teleop_device, identity_warnings
-    except Exception:
-        _safe_disconnect(robot, "follower arms")
-        _safe_disconnect(teleop_device, "leader arms")
+    except Exception as e:
+        # robot.configure() above may already have energized both follower
+        # sub-arms before a later step (e.g. teleop_device.configure()) failed
+        # — mirror the single-arm path's belt-and-braces cleanup instead of a
+        # bare disconnect, and stash the result on the exception so the caller
+        # (which has no robot/teleop_device of its own to clean up) can surface
+        # it as a warning instead of losing it.
+        e.cleanup_error = _cleanup_after_setup_failure(robot, teleop_device, "follower arms", "leader arms")
         raise
 
 
@@ -811,14 +836,16 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
         # already have written Torque_Enable=1 on the real follower servos
         # before this fired, so skipping the explicit disable (or dropping
         # _safe_disconnect's error text) would leave the arm energized with
-        # no warning surfaced.
-        problems = force_disable_torque(robot, "follower arm")
-        problems += force_disable_torque(teleop_device, "leader arm")
-        for device, label in ((robot, "follower arm"), (teleop_device, "leader arm")):
-            error = _safe_disconnect(device, label)
-            if error:
-                problems.append(error)
-        last_cleanup_error = " ".join(problems) if problems else None
+        # no warning surfaced. The bimanual path's _connect_bimanual already
+        # ran this same cleanup itself — it owns robot/teleop_device before
+        # this scope ever sees them — and stashed the result on the
+        # exception; reuse that instead of dropping it (running it again here
+        # would be a no-op anyway, since robot/teleop_device are still None
+        # for that path).
+        if hasattr(e, "cleanup_error"):
+            last_cleanup_error = e.cleanup_error
+        else:
+            last_cleanup_error = _cleanup_after_setup_failure(robot, teleop_device)
         teleoperation_active = False
         current_robot = None
         current_teleop = None

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -338,7 +338,7 @@ class _FakePortHandler:
         self.is_using = True
         self.clear_calls = 0
 
-    def clearPort(self) -> None:
+    def clearPort(self) -> None:  # noqa: N802 — camelCase mimics the real Feetech SDK method this fakes
         self.clear_calls += 1
 
 

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -160,6 +160,102 @@ def test_start_teleoperation_disconnects_follower_when_leader_fails(
     assert teleop.teleoperation_active is False
 
 
+def test_start_teleoperation_force_disables_torque_and_warns_when_setup_fails_after_configure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """robot.configure() is what actually writes Torque_Enable=1 on the real
+    follower servos. If a LATER setup step (e.g. the leader's configure())
+    raises, the follower is left physically energized — the except block must
+    run the same force_disable_torque + _safe_disconnect cleanup as the
+    worker's normal path and surface any problem via last_cleanup_error and a
+    "warning" key, not silently drop it.
+    """
+    import makerlab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(
+        "makerlab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+    monkeypatch.setattr(teleop, "verify_devices", lambda *a, **k: [])
+    monkeypatch.setattr(teleop, "reset_torque_limit", lambda *a, **k: [])
+    monkeypatch.setattr(teleop, "clear_goal_velocity", lambda *a, **k: [])
+
+    class _FollowerBus:
+        def __init__(self) -> None:
+            self.port = "COM_FOLLOWER"
+            self.motors = {"shoulder_pan": 1, "elbow_flex": 3}
+
+        def connect(self) -> None:
+            pass
+
+        def write_calibration(self, calibration) -> None:
+            pass
+
+        def disable_torque(self, motor: str, num_retry: int = 0) -> None:
+            # Once the follower is armed, this motor won't release.
+            raise ConnectionError(f"no response from {motor}")
+
+    class _Follower:
+        def __init__(self, config) -> None:
+            self.bus = _FollowerBus()
+            self.cameras: dict = {}
+            self.calibration: dict = {}
+            self.configured = False
+            self.disconnected = False
+
+        def configure(self) -> None:
+            # This is the real write that energizes the servos.
+            self.configured = True
+
+        def disconnect(self) -> None:
+            self.disconnected = True
+
+    class _LeaderBus:
+        def connect(self) -> None:
+            pass
+
+        def write_calibration(self, calibration) -> None:
+            pass
+
+    class _Leader:
+        def __init__(self, config) -> None:
+            self.bus = _LeaderBus()
+            self.calibration: dict = {}
+            self.disconnected = False
+
+        def configure(self) -> None:
+            # Fails AFTER the follower has already configured (armed).
+            raise RuntimeError("leader configure failed")
+
+        def disconnect(self) -> None:
+            self.disconnected = True
+
+    created: dict = {}
+    monkeypatch.setattr(
+        teleop, "SO101Follower", lambda config: created.setdefault("follower", _Follower(config))
+    )
+    monkeypatch.setattr(teleop, "SO101Leader", lambda config: created.setdefault("leader", _Leader(config)))
+
+    request = teleop.TeleoperateRequest(
+        leader_port="COM_LEADER",
+        follower_port="COM_FOLLOWER",
+        leader_config="leader",
+        follower_config="follower",
+    )
+    result = teleop.handle_start_teleoperation(request)
+
+    assert result["success"] is False
+    # The follower really was configured (torque enabled) before the failure.
+    assert created["follower"].configured is True
+    assert teleop.last_cleanup_error is not None
+    assert "TORQUE MAY STILL BE ENABLED" in teleop.last_cleanup_error
+    assert "warning" in result
+    assert "TORQUE MAY STILL BE ENABLED" in result["warning"]
+    assert created["follower"].disconnected is True
+    assert created["leader"].disconnected is True
+
+
 # ---------------------------------------------------------------------------
 # Teleop opens no cameras: it consumes no frames (only motor positions drive the
 # URDF viewer). The follower config it builds therefore carries an empty camera

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -256,6 +256,108 @@ def test_start_teleoperation_force_disables_torque_and_warns_when_setup_fails_af
     assert created["leader"].disconnected is True
 
 
+def test_start_teleoperation_bimanual_force_disables_torque_and_warns_when_leader_configure_fails_after_followers_armed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bimanual mirror of the single-arm regression test above.
+
+    _connect_bimanual has its own try/except (it must clean up the four buses
+    it opened before handle_start_teleoperation ever sees a robot/teleop_device
+    to work with) — robot.configure() there energizes both follower sub-arms
+    before teleop_device.configure() (the next setup step) can fail. That
+    except block must run the same force_disable_torque + _safe_disconnect
+    cleanup as the single-arm path, and the resulting warning must reach the
+    handle_start_teleoperation response — not be dropped, and not be
+    overwritten by the outer except's own (no-op, since its local
+    robot/teleop_device are still None here) cleanup pass.
+    """
+    import makerlab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(teleop, "build_bimanual_configs", lambda request: ("robot_cfg", "teleop_cfg"))
+    monkeypatch.setattr(teleop, "verify_devices", lambda *a, **k: [])
+    monkeypatch.setattr(teleop, "reset_torque_limit", lambda *a, **k: [])
+    monkeypatch.setattr(teleop, "clear_goal_velocity", lambda *a, **k: [])
+
+    class _SubBus:
+        def __init__(self, port: str, motors: dict, fail_disable: bool = False) -> None:
+            self.port = port
+            self.motors = motors
+            self.fail_disable = fail_disable
+
+        def connect(self) -> None:
+            pass
+
+        def write_calibration(self, calibration) -> None:
+            pass
+
+        def disable_torque(self, motor: str, num_retry: int = 0) -> None:
+            if self.fail_disable:
+                raise ConnectionError(f"no response from {motor}")
+
+    class _SubArm:
+        def __init__(self, bus: _SubBus) -> None:
+            self.bus = bus
+            self.calibration: dict = {}
+
+    class _BiFollower:
+        def __init__(self, config) -> None:
+            # Once armed, neither follower sub-arm's motors release.
+            self.left_arm = _SubArm(_SubBus("COM_LFOLLOWER", {"shoulder_pan": 1}, fail_disable=True))
+            self.right_arm = _SubArm(_SubBus("COM_RFOLLOWER", {"shoulder_pan": 1}, fail_disable=True))
+            self.configured = False
+            self.disconnected = False
+
+        def configure(self) -> None:
+            # This is the real write that energizes the follower servos.
+            self.configured = True
+
+        def disconnect(self) -> None:
+            self.disconnected = True
+
+    class _BiLeader:
+        def __init__(self, config) -> None:
+            self.left_arm = _SubArm(_SubBus("COM_LLEADER", {"shoulder_pan": 1}))
+            self.right_arm = _SubArm(_SubBus("COM_RLEADER", {"shoulder_pan": 1}))
+            self.disconnected = False
+
+        def configure(self) -> None:
+            # Fails AFTER the followers have already configured (armed).
+            raise RuntimeError("leader configure failed")
+
+        def disconnect(self) -> None:
+            self.disconnected = True
+
+    created: dict = {}
+    monkeypatch.setattr(
+        teleop, "BiSOFollower", lambda config: created.setdefault("follower", _BiFollower(config))
+    )
+    monkeypatch.setattr(teleop, "BiSOLeader", lambda config: created.setdefault("leader", _BiLeader(config)))
+
+    request = teleop.TeleoperateRequest(
+        leader_port="COM_LLEADER",
+        follower_port="COM_LFOLLOWER",
+        leader_config="leader",
+        follower_config="follower",
+        mode="bimanual",
+        right_leader_port="COM_RLEADER",
+        right_follower_port="COM_RFOLLOWER",
+        right_leader_config="rleader",
+        right_follower_config="rfollower",
+    )
+    result = teleop.handle_start_teleoperation(request)
+
+    assert result["success"] is False
+    # The followers really were configured (torque enabled) before the failure.
+    assert created["follower"].configured is True
+    assert teleop.last_cleanup_error is not None
+    assert "TORQUE MAY STILL BE ENABLED" in teleop.last_cleanup_error
+    assert "warning" in result
+    assert "TORQUE MAY STILL BE ENABLED" in result["warning"]
+    assert created["follower"].disconnected is True
+    assert created["leader"].disconnected is True
+
+
 # ---------------------------------------------------------------------------
 # Teleop opens no cameras: it consumes no frames (only motor positions drive the
 # URDF viewer). The follower config it builds therefore carries an empty camera


### PR DESCRIPTION
## Summary

If teleoperation setup fails after the follower has already been configured (armed) but before the leader finishes configuring — for example, the leader's USB connection drops mid-setup — the follower can be left energized with no warning shown to the user. This is a hardware-safety gap: an arm can stay under torque with nothing on screen indicating it.

The failure-path cleanup in `handle_start_teleoperation` was calling `_safe_disconnect` on each device but discarding any error it returned, and never called `force_disable_torque` at all. This PR makes that except block mirror the worker's normal cleanup: force-disable torque on both devices, disconnect them, and surface any problem through the response's `warning` field.

A related gap was found while verifying this fix on real hardware: the backend was already returning `warning` correctly, but the frontend's failure-path toast (`RobotCorner.tsx`) only read `data.message`, silently dropping `data.warning`. That check is added here as well, since without it the backend fix had no visible effect for the user.

## Screenshots

Reproduced on real SO-101 hardware: start teleoperation, then disconnect the leader's USB while the follower is already armed.

**Before** — `main`. The follower stays energized but the toast gives no indication of it:

![Before: plain failure toast, no torque warning](https://raw.githubusercontent.com/makermods-robotics/MakerLab/assets/pr-t7-screenshots/t7-before-no-warning.png)

**After** — this branch. The same failure now surfaces the torque warning:

![After: failure toast now includes the torque warning](https://raw.githubusercontent.com/makermods-robotics/MakerLab/assets/pr-t7-screenshots/t7-after-with-warning.png)

## Fix

- `makerlab/teleoperate.py`: the except block in `handle_start_teleoperation` now calls `force_disable_torque` on both the follower and leader, collects any `_safe_disconnect` error text, and includes it as `response["warning"]` (also recorded in the module-level `last_cleanup_error`) instead of dropping it.
- `frontend/src/components/launchpad/RobotCorner.tsx`: `handleTeleop`'s failure branch now checks `data.warning` before falling back to the plain `data.message` toast, matching the pattern already used on the success path for identity-mismatch warnings.

## Test plan

- Regression test added: `tests/test_teleoperate.py::test_start_teleoperation_force_disables_torque_and_warns_when_setup_fails_after_configure` — fails on `main` (`AssertionError: assert None is not None`, i.e. no cleanup warning recorded), passes on this branch.
- `pytest` — no regressions.
- `ruff check` / `ruff format --check` — clean.
- Frontend: `npx tsc --noEmit`, `npm run lint` — no new issues introduced by `RobotCorner.tsx` (pre-existing baseline errors are in unrelated files).
- Manual: reproduced on real SO-101 hardware as shown above, verified against both `main` and this branch.