### PR TITLE
fix(teleoperate): keep tracking a worker that outlives the second-stop join (T3)

### DIFF
--- a/makerlab/teleoperate.py
+++ b/makerlab/teleoperate.py
@@ -872,7 +872,6 @@ def handle_stop_teleoperation() -> dict[str, Any]:
         worker.join(timeout=5.0)
         if worker.is_alive():
             logger.warning("Teleoperation worker did not exit within 5s")
-            teleoperation_thread = None
             return {
                 "success": True,
                 "message": "Release requested, but the worker has not shut down yet",

--- a/makerlab/teleoperate.py
+++ b/makerlab/teleoperate.py
@@ -418,10 +418,8 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
         # to disable motors one by one.
         port_handler = getattr(bus, "port_handler", None)
         if port_handler is not None:
-            try:
+            with contextlib.suppress(Exception):
                 port_handler.clearPort()
-            except Exception:
-                pass
             with contextlib.suppress(Exception):
                 port_handler.is_using = False
         failed: list[str] = []

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -444,6 +444,63 @@ def test_second_stop_during_grace_surfaces_cleanup_error(
     assert "TORQUE MAY STILL BE ENABLED" in result["warning"]
 
 
+class _StuckWorker:
+    """Thread double: never actually exits — join() times out, is_alive() stays True.
+
+    Simulates a worker still mid rest-pose-return/cleanup after a second stop's
+    `join(timeout=5.0)` elapses, so the code must NOT abandon the reference.
+    """
+
+    def __init__(self) -> None:
+        self.join_calls: list[float | None] = []
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_calls.append(timeout)
+
+
+def test_second_stop_timeout_keeps_thread_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: when the second-stop join() times out (the worker is still
+    genuinely alive), `teleoperation_thread` must keep pointing at it instead
+    of being nulled out — nulling it would let a later start's mutex/guard
+    checks wrongly treat the still-running, still-hardware-holding worker as
+    gone (see finish_pending_release, which follows this same discipline).
+    """
+    import threading
+
+    import makerlab.teleoperate as teleop
+
+    worker = _StuckWorker()
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(teleop, "teleoperation_thread", worker)
+    monkeypatch.setattr(teleop, "_release_now", threading.Event())
+    monkeypatch.setattr(teleop, "last_cleanup_error", None)
+
+    result = teleop.handle_stop_teleoperation()
+
+    assert result["success"] is True
+    assert "has not shut down yet" in result["message"]
+    assert "did not shut down within 5s" in result["warning"]
+    # The key regression assertion: the module must still hold the SAME live
+    # thread object, not None.
+    assert teleop.teleoperation_thread is worker
+
+    # A subsequent finish_pending_release() must still recognize the worker as
+    # alive (not treat it as already gone) and attempt its own join.
+    assert teleop.finish_pending_release() is False
+    assert worker.join_calls  # finish_pending_release actually tried to join it
+
+    # A third manual stop press must re-enter the same second-stop branch
+    # (not fall through to "No teleoperation session is active").
+    result2 = teleop.handle_stop_teleoperation()
+    assert result2["message"] != "No teleoperation session is active"
+    assert teleop.teleoperation_thread is worker
+
+
 def test_finish_pending_release_cuts_grace_short(monkeypatch: pytest.MonkeyPatch) -> None:
     """A start arriving during the grace hold must release the arms and free
     the ports instead of failing port-busy for the rest of the grace.

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -242,7 +242,7 @@ class _FakePortHandler:
         self.is_using = True
         self.clear_calls = 0
 
-    def clearPort(self) -> None:
+    def clearPort(self) -> None:  # noqa: N802 — camelCase mimics the real Feetech SDK method this fakes
         self.clear_calls += 1
 
 


### PR DESCRIPTION
## What this fixes
- Stopping teleoperation twice in a row quickly (which the app itself suggests — "Press Stop again to release it now") could let a new teleoperation session start before the previous one had actually finished shutting down.
- When that happened, the new session and the still-running old one fought over the same arm connection — causing errors, and possibly leaving torque enabled when it shouldn't be.

## What changed
- The server now correctly waits for the previous teleoperation session to fully finish before letting a new one start, instead of assuming it was already done.
- This closes a narrow timing gap that only shows up when Stop is pressed twice quickly, followed right away by Start.

## To test
1. Start teleoperation.
2. Stop it, then immediately stop it again (the "press Stop again to release it now" case).
3. Right away, try to start teleoperation again.
4. Expect: the new session starts cleanly only after the old one has finished — no connection errors, and torque isn't left on unexpectedly.

## Reproduced on real hardware

This isn't something a person can reliably trigger by hand (it needs a stop, a second stop, and a start within a multi-second window while a background thread happens to still be mid-cleanup), so it was reproduced with a temporary, uncommitted debug delay in the worker's cleanup path and driven directly against the running server's API with scripted timing — no UI involved, same endpoints the buttons call.

Sequence: start teleoperation, stop, stop again (this one blocks for the 5s join), then immediately request start again.

**Before — `main`.** The second start is wrongly accepted while the first worker is still alive, and the two collide on the same serial port:

```
=== 3) SECOND STOP — expect ~5s block ===
{"success":true,"message":"Release requested, but the worker has not shut down yet", ...}   (blocked 5.0s, as expected)

=== 4) THIRD ACTION: START AGAIN, IMMEDIATELY ===
{"success":true,"message":"Teleoperation started successfully", ...}   (returned instantly — the old worker was still alive)
```

Server log for that window:
```
17:42:28  WARNING  Teleoperation worker did not exit within 5s
17:42:28  INFO     POST /stop-teleoperation 200 OK
17:42:28  INFO     Starting teleoperation with leader port: ...
17:42:28  INFO     Successfully connected to both devices
17:42:28  INFO     Starting teleoperation loop...
17:42:32  ERROR    Error getting joint positions: device reports readiness to read but returned no data (device disconnected or multiple access on port?)
17:42:32  ERROR    TORQUE MAY STILL BE ENABLED on ... (follower arm; failed motors — ... Port is in use!; ...)
17:42:32  ERROR    Error during teleoperation loop: device reports readiness to read but returned no data (device disconnected or multiple access on port?)
```
The new session's control loop crashed 4 seconds in, from real contention with the still-alive first worker on the same port, and a torque-disable write failed with "Port is in use!" as a direct result.

**After — this branch.** The third request now waits for the still-alive worker to actually finish (via `finish_pending_release`, which already existed for this exact purpose) before starting the new session — no error, no port contention, just correctly serialized:

```
=== 3) SECOND STOP — expect ~5s block ===
{"success":true,"message":"Release requested, but the worker has not shut down yet", ...}   (blocked 5.0s, as expected)

=== 4) THIRD ACTION: START AGAIN, IMMEDIATELY ===
{"success":true,"message":"Teleoperation started successfully", ...}   (returned after ~3s — waited for the old worker)
```

Server log for that window — the old worker's cleanup completes, then the new session starts, same timestamp, no overlap:
```
17:56:07  INFO     Butter SOFollower disconnected.
17:56:07  INFO     Teleoperation stopped
17:56:07  INFO     Starting teleoperation with leader port: ...
```

## Fix

`makerlab/teleoperate.py`: removed the `teleoperation_thread = None` line in the second-stop timeout branch of `handle_stop_teleoperation`. The module-level reference now survives until the worker genuinely exits, matching the discipline `finish_pending_release` already relies on.

## Test plan

- Regression test added: `tests/test_teleoperate.py::test_second_stop_timeout_keeps_thread_reference` — fails on `main` (`AssertionError: assert None is <_StuckWorker ...>`, i.e. the reference was wrongly dropped), passes on this branch.
- `pytest tests/test_teleoperate.py` — 47 passed.
- `ruff check` / `ruff format --check` — clean (also dropped two incidental lint regressions unrelated to this fix that had crept into the branch).
- Manual: reproduced the race on real SO-101 hardware as shown above, verified against both `main` and this branch.

## Screenshots

None apply — this is a backend-only change (`teleoperate.py`'s stop-path thread bookkeeping); no UI is touched.
