### PR TITLE
fix(rollout): track a handle to the inference startup worker (I1)

### DIFF
--- a/makerlab/rollout.py
+++ b/makerlab/rollout.py
@@ -109,6 +109,17 @@ _last_result: dict[str, Any] | None = None
 # orphaned worker from a stopped session sees its (set) event and bails, while a
 # new session gets a clean one. None while idle.
 _inference_cancel: threading.Event | None = None
+# Handle to the background startup worker (_run_inference_startup) for the
+# CURRENT/most-recently-started session. `_inference_cancel` only aborts the
+# worker at coarse boundaries (before it opens the bus in _prepare_robot,
+# and again after _prepare_robot returns) — nothing interrupts it WHILE
+# _prepare_robot is actually touching hardware, so a stop can leave the
+# worker alive and still driving the bus for a few more seconds. Tracking the
+# thread (mirrors teleoperate.py's `teleoperation_thread`, added for the same
+# reason in T3) lets handle_start_inference refuse a new session while that
+# orphaned worker is still alive, instead of racing it for the same serial
+# port. None once the worker has exited or before any session has started.
+_inference_startup_thread: threading.Thread | None = None
 # Guards mutations to the globals above; held only for the short critical
 # sections in start/stop/status.
 _state_lock = threading.Lock()
@@ -909,7 +920,7 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
     launch modal; the multi-minute Hub download moves off the request thread so
     the UI lands on the inference page and shows download progress there."""
     global inference_active, _inference_started_at, _inference_meta, _inference_cancel
-    global _last_result
+    global _last_result, _inference_startup_thread
 
     # Mutex with teleop and recording: all three drive the same serial bus.
     from . import record as _record, teleoperate as _teleoperate
@@ -932,6 +943,18 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
                 "success": False,
                 "status_code": 409,
                 "message": "Inference is already active. Stop it first.",
+            }
+        if _inference_startup_thread is not None and _inference_startup_thread.is_alive():
+            # A previous session was stopped while its startup worker was
+            # inside _prepare_robot (already touching hardware) or still
+            # unwinding just after — inference_active is already False, but
+            # the worker itself hasn't exited yet. Starting a new session now
+            # would open the same serial port out from under it. Refuse until
+            # it's actually gone.
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "The previous session is still shutting down. Try again in a few seconds.",
             }
         # Claim the slot now so a concurrent caller losing the race sees us, and
         # seed the meta + timer so the phase is visible from the very first
@@ -975,12 +998,16 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
         }
 
     # Everything heavy (download, preflight, spawn) runs off the request thread.
-    threading.Thread(
+    # Tracked so a later start can tell whether a stopped session's worker is
+    # still alive (see the is_alive() guard above) instead of racing it.
+    worker = threading.Thread(
         target=_run_inference_startup,
         args=(request, cancel_event),
         name="inference-startup",
         daemon=True,
-    ).start()
+    )
+    _inference_startup_thread = worker
+    worker.start()
     return {"success": True, "message": "Inference starting"}
 
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -40,6 +40,7 @@ def _reset_rollout_globals(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(rollout, "_inference_meta", {})
     monkeypatch.setattr(rollout, "_inference_cancel", None)
     monkeypatch.setattr(rollout, "_last_result", None)
+    monkeypatch.setattr(rollout, "_inference_startup_thread", None)
 
 
 class _SyncThread:
@@ -907,6 +908,77 @@ def test_terminal_status_is_idempotent_across_polls(monkeypatch) -> None:
     status = rollout.handle_inference_status()
     assert status["inference_active"] is True
     assert "outcome" not in status
+
+
+# ---------------------------------------------------------------------------
+# I1: a stopped startup worker has no tracked thread handle, so it keeps
+# touching hardware after stop() and a new session can't tell it's still
+# running (unlike teleoperate.py's `teleoperation_thread`, which the start
+# guard checks with `.is_alive()` before claiming the slot).
+# ---------------------------------------------------------------------------
+
+
+def test_stopped_startup_worker_blocks_a_new_session_from_starting(monkeypatch) -> None:
+    """`_inference_cancel` only aborts the worker at coarse boundaries (before
+    entering `_prepare_robot`, after it returns) — nothing checks the cancel
+    flag WHILE `_prepare_robot` itself runs, and nothing tracks a handle to the
+    worker thread. So a stop pressed mid-preflight lets the orphaned worker
+    keep opening the bus / writing motor registers, and — because there is no
+    handle to ask "is that worker still alive" — a brand-new start goes ahead
+    and races it for the same serial port.
+
+    Real thread, real Event: the worker blocks inside a stubbed
+    `_prepare_robot` (standing in for the hardware-touching preflight) until
+    released, letting the test control the exact interleaving stop() must
+    protect against."""
+    from makerlab import rollout
+
+    entered_preflight = threading.Event()
+    release_preflight = threading.Event()
+
+    def _blocking_prepare_robot(request):
+        entered_preflight.set()
+        assert release_preflight.wait(timeout=5), "test setup: preflight release never signalled"
+        return [], []
+
+    monkeypatch.setattr(rollout, "_prepare_robot", _blocking_prepare_robot)
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: ref)
+
+    created_threads: list[threading.Thread] = []
+    real_thread = threading.Thread
+
+    def _tracking_thread(*args, **kwargs):
+        t = real_thread(*args, **kwargs)
+        created_threads.append(t)
+        return t
+
+    monkeypatch.setattr(rollout.threading, "Thread", _tracking_thread)
+
+    try:
+        first = rollout.handle_start_inference(_stub_request())
+        assert first["success"] is True
+        assert entered_preflight.wait(timeout=5), "worker never reached _prepare_robot"
+
+        # Stop while the worker is INSIDE _prepare_robot — hardware is already
+        # being touched, and the worker has no way to be interrupted mid-call.
+        stopped = rollout.handle_stop_inference()
+        assert stopped["success"] is True
+        assert rollout.inference_active is False
+
+        # The orphaned worker from the stopped session is still alive (stuck in
+        # _prepare_robot) and still driving hardware. A new session must be
+        # refused rather than being allowed to open the same serial port out
+        # from under it.
+        second = rollout.handle_start_inference(_stub_request())
+        assert second["success"] is False, (
+            "a new session was allowed to start while a stopped session's "
+            "startup worker was still alive and touching hardware"
+        )
+        assert second["status_code"] == 409
+    finally:
+        release_preflight.set()
+        for t in created_threads:
+            t.join(timeout=5)
 
 
 def test_fail_startup_result_is_idempotent_across_polls(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`_run_inference_startup`'s background worker does the download, then the arm-identity/register preflight (which opens the follower serial bus), then spawns the rollout subprocess. A stop request only aborts the worker at the two coarse boundaries — before the preflight starts and right after it returns — via `_inference_cancel`. Nothing interrupts the worker *while* the preflight is actually mid-flight on the bus.

That leaves a window: stop a session while its worker is inside the preflight, then start a new one immediately, and the new session's worker opens the same follower port while the old (already "stopped") worker is still holding it open. `inference_active` was already `False` by the time the second start is evaluated — nothing tracked whether the orphaned worker itself had actually exited — so the mutex check let it through. This is the same class of bug T3 fixed for teleoperation's stop path, applied to inference's startup path.

The fix tracks a handle to the startup worker thread (`_inference_startup_thread`, mirroring `teleoperate.py`'s `teleoperation_thread`) and has `handle_start_inference` refuse a new session while a previous session's worker is still alive, instead of racing it for the port.

## Reproduced on real hardware

To get a human-timeable window on the otherwise-fast preflight, I temporarily added a 10-second `time.sleep()` inside `_preflight_arm_identity`, right after it opens the follower bus (reverted before pushing — this branch ships no debug code). Sequence: start inference, wait 2s (worker is now inside the preflight, holding the port), stop, then immediately start a second session against the same port.

**Before (`main`):** the second start was accepted outright, and both workers held live connections to the same physical serial port at the same time:

```
$ curl -s -X POST localhost:8000/start-inference -d '{"follower_port":"/dev/tty.usbmodem5B3E0901701", ...}'
{"success":true,"message":"Inference starting"}

$ curl -s -X POST localhost:8000/stop-inference
{"success":true,"message":"Inference stopped"}

$ curl -s -X POST localhost:8000/start-inference -d '{"follower_port":"/dev/tty.usbmodem5B3E0901701", ...}'
{"success":true,"message":"Inference starting"}
```

Server log for the same window (worker #1 and worker #2 both hold the port open at once, 18:44:21–18:44:28):

```
INFO 18:44:18 rollout.py:463 DEMO: holding follower port open for identity check (10s) (TEMP)   # worker #1 opens the port
INFO:     "POST /stop-inference HTTP/1.1" 200 OK                                                 # inference_active -> False; worker #1 keeps running
INFO 18:44:21 rollout.py:463 DEMO: holding follower port open for identity check (10s) (TEMP)   # worker #2 opens the SAME port — worker #1 is still holding it
WARNING 18:44:28 identity.py:409 Could not verify the follower arm on /dev/tty.usbmodem5B3E0901701: its servos'
        homing offsets match no saved calibration (a factory reset or an interrupted calibration leaves them
        unset). Starting with 'Butter' anyway — recalibrate this arm if it behaves oddly.
INFO 18:44:28 rollout.py:806 Inference startup abandoned after preflight (stop requested)        # worker #1 finally bails
INFO 18:44:31 rollout.py:900 Inference started: pid=28179 policy=/tmp/fake-policy-dir            # worker #2 proceeds
```

For roughly 7 seconds, two independent, uncoordinated threads each held their own open connection to the same physical servo bus — exactly the condition that produced the corrupted write in T4's reproduction, just not guaranteed to hit the same instant here.

**After (this branch):** identical sequence, second start rejected before it ever touches the port:

```
$ curl -s -X POST localhost:8000/start-inference -d '{"follower_port":"/dev/tty.usbmodem5B3E0901701", ...}'
{"success":true,"message":"Inference starting"}

$ curl -s -X POST localhost:8000/stop-inference
{"success":true,"message":"Inference stopped"}

$ curl -s -X POST localhost:8000/start-inference -d '{"follower_port":"/dev/tty.usbmodem5B3E0901701", ...}'
{"detail":"The previous session is still shutting down. Try again in a few seconds."}
```

Server log:

```
INFO 18:46:53 rollout.py:474 DEMO: holding follower port open for identity check (10s) (TEMP)   # worker #1 opens the port
INFO:     "POST /stop-inference HTTP/1.1" 200 OK
INFO:     "POST /start-inference HTTP/1.1" 409 Conflict                                          # rejected — no second connection ever opened
INFO 18:47:03 rollout.py:817 Inference startup abandoned after preflight (stop requested)        # worker #1's own abandon path, undisturbed
```

Only one worker ever touches the bus.

## Fix

- New module global `_inference_startup_thread: threading.Thread | None`, set to the worker thread right before `.start()` in `handle_start_inference`.
- `handle_start_inference` now refuses (`409`, "The previous session is still shutting down. Try again in a few seconds.") when `_inference_startup_thread is not None and _inference_startup_thread.is_alive()`, before claiming the slot.
- No change to `_inference_cancel`'s existing coarse-boundary aborts — this is a belt-and-braces check for the window those boundaries don't cover.

## Test plan

- [x] New regression test `test_stopped_startup_worker_blocks_a_new_session_from_starting` — `pytest tests/test_rollout.py`: 60 passed.
- [x] Same test copied onto a `main` worktree and run against `main`'s code: `AttributeError: module 'makerlab.rollout' has no attribute '_inference_startup_thread'` — confirming the tracking this PR adds doesn't exist there.
- [x] `ruff check` clean on the touched files; no format regressions beyond pre-existing drift already present on `main`.
- [x] Reproduced the concurrent-port-access window on real hardware on `main` (above) and confirmed the clean rejection on this branch.

## Follow-up (found in review, tracked separately)

Reviewing and reproducing this fix surfaced a real gap in the recovery path it leaves behind, confirmed by actually driving the fixed code (not just inspection): once a session is stopped mid-`_prepare_robot`, the orphaned worker is invisible on `/inference-status` (identical payload to true idle) and a second `stop-inference` call is a plain 409 no-op — unlike `teleoperate.py`'s second-stop (T3), which joins its worker with a timeout and reports honestly either way. `_prepare_robot` has no cooperative cancellation checkpoint, so a true force-release isn't possible the way T3's is, but status visibility and a bounded second-stop join are.

Per the one-branch-per-issue rule this is its own issue (**I6**), not bundled here: **#27** (`fix/i6-inference-startup-no-forced-recovery`), stacked on this branch since it depends on `_inference_startup_thread`. Rebase target for #27 once this PR merges: `main`.


## Screenshots

None apply — this is a backend-only change (`rollout.py`'s inference-startup worker handle); no UI is touched.
