### PR TITLE
fix(calibrate): roll back homing offsets when calibration is cancelled (C2)

### DIFF
--- a/makermodslab/calibrate.py
+++ b/makermodslab/calibrate.py
@@ -165,18 +165,29 @@ class CalibrationManager:
         self._homing_offsets = {}
         self._current_request: CalibrationRequest | None = None
         # Rollback baseline for a cancelled/failed run (see _calibration_worker
-        # and _cleanup_device): the servo's Homing_Offset values as they stood
-        # before this session's _step_homing touched them, and whether the run
-        # reached a real commit (on-disk file written) that supersedes them.
+        # and _cleanup_device): the servo's Homing_Offset and Min/Max_Position_Limit
+        # values as they stood before this session's _step_homing touched them
+        # (reset_calibration() zeroes/maxes out all three, not just the homing
+        # offset), and whether the run reached a real commit (on-disk file
+        # written) that supersedes them.
         self._original_homing_offsets: dict[str, int] = {}
+        self._original_min_position_limits: dict[str, int] = {}
+        self._original_max_position_limits: dict[str, int] = {}
         self._calibration_committed = False
-        # Guards _cleanup_device's body. stop_calibration_process forces a
-        # cleanup call from the request-handling thread once its join()
-        # times out, without knowing whether the worker thread has since
-        # reached its own _cleanup_and_finish — without this lock the two
-        # could race and both run the homing-offset restore loop against the
-        # live bus concurrently. Whichever thread arrives second finds
-        # self.device already None and no-ops.
+        # Guards _cleanup_device's body against two *callers of
+        # _cleanup_device* overlapping — whichever thread arrives second finds
+        # self.device already None and no-ops. That is a narrower guarantee
+        # than "no concurrent bus access": the actual hazard it exists for is
+        # in stop_calibration_process, where join(timeout=5.0) can expire
+        # while the worker thread is still alive and mid read/write on the
+        # bus (e.g. blocked in a sync_read retry inside
+        # _step_range_recording). The request-handling thread then forces a
+        # cleanup call — restoring registers and disconnecting — while the
+        # worker thread may still be actively using that same device. This
+        # lock only prevents that forced cleanup from double-running against
+        # the worker's own eventual _cleanup_and_finish; it does not, and
+        # cannot, stop the worker's un-locked bus I/O from overlapping the
+        # forced restore+disconnect.
         self._cleanup_lock = threading.Lock()
 
         # Initialize logging
@@ -315,6 +326,8 @@ class CalibrationManager:
                 self._maxes = {}
                 self._homing_offsets = {}
                 self._original_homing_offsets = {}
+                self._original_min_position_limits = {}
+                self._original_max_position_limits = {}
                 self._calibration_committed = False
 
                 self._update_status(
@@ -431,12 +444,14 @@ class CalibrationManager:
                 self._cleanup_and_finish("Calibration cancelled")
                 return
 
-            # Capture the servo's current Homing_Offset as the rollback baseline
-            # BEFORE _step_homing runs — it calls reset_calibration(), which
-            # zeroes Homing_Offset in EEPROM immediately, so this is the last
-            # point the prior (possibly still-in-use) value is readable. If the
-            # run is cancelled or errors before _complete_calibration commits a
-            # new value to disk, _cleanup_device restores this baseline so the
+            # Capture the servo's current Homing_Offset and Min/Max_Position_Limit
+            # as the rollback baseline BEFORE _step_homing runs — it calls
+            # reset_calibration(), which immediately zeroes Homing_Offset and
+            # Min_Position_Limit and maxes out Max_Position_Limit in EEPROM for
+            # every motor on the bus, so this is the last point the prior
+            # (possibly still-in-use) values are readable. If the run is
+            # cancelled or errors before _complete_calibration commits new
+            # values to disk, _cleanup_device restores this baseline so the
             # servo never diverges from the last-saved calibration file.
             #
             # A failed read here isn't caught locally: the device is freshly
@@ -447,6 +462,14 @@ class CalibrationManager:
             # run that most needs it.
             self._original_homing_offsets = {
                 motor: self.device.bus.read("Homing_Offset", motor, normalize=False)
+                for motor in self.device.bus.motors
+            }
+            self._original_min_position_limits = {
+                motor: self.device.bus.read("Min_Position_Limit", motor, normalize=False)
+                for motor in self.device.bus.motors
+            }
+            self._original_max_position_limits = {
+                motor: self.device.bus.read("Max_Position_Limit", motor, normalize=False)
                 for motor in self.device.bus.motors
             }
 
@@ -754,25 +777,41 @@ class CalibrationManager:
                 if self.device:
                     # A run that never committed (cancelled, or errored before
                     # _complete_calibration saved) may have already pushed new
-                    # Homing_Offset values to the servo in _step_homing. Left as-is,
-                    # the servo would permanently diverge from the last-saved
-                    # calibration file — the next session's arm-identity check
-                    # would then either hard-refuse to start or, worse, silently
-                    # decode positions against a stale offset. Restore the
-                    # pre-calibration baseline so a cancelled run leaves the
-                    # physical arm exactly as it found it.
+                    # Homing_Offset, Min_Position_Limit, and Max_Position_Limit
+                    # values to the servo in _step_homing (reset_calibration()
+                    # touches all three). Left as-is, the servo would permanently
+                    # diverge from the last-saved calibration file — the next
+                    # session's arm-identity check would then either hard-refuse
+                    # to start or, worse, silently decode positions against a
+                    # stale offset. Restore the pre-calibration baseline so a
+                    # cancelled run leaves the physical arm exactly as it found it.
+                    #
+                    # Each motor's write is its own try/except: one motor's write
+                    # failing must not abort the writes still queued for the
+                    # remaining motors, which would otherwise leave the arm
+                    # partially rolled back — some motors restored, others still
+                    # diverged — which is worse than leaving all of them diverged,
+                    # since it is much harder to notice and diagnose.
                     if not self._calibration_committed and self._original_homing_offsets:
-                        try:
-                            logger.info(
-                                "Calibration did not complete — restoring pre-calibration "
-                                f"homing offsets: {self._original_homing_offsets}"
-                            )
-                            for motor, offset in self._original_homing_offsets.items():
-                                self.device.bus.write("Homing_Offset", motor, offset)
-                        except Exception as e:
-                            logger.error(
-                                f"Failed to restore original homing offsets after cancelled calibration: {e}"
-                            )
+                        logger.info(
+                            "Calibration did not complete — restoring pre-calibration "
+                            f"homing offsets: {self._original_homing_offsets}, "
+                            f"min position limits: {self._original_min_position_limits}, "
+                            f"max position limits: {self._original_max_position_limits}"
+                        )
+                        for register, baseline in (
+                            ("Homing_Offset", self._original_homing_offsets),
+                            ("Min_Position_Limit", self._original_min_position_limits),
+                            ("Max_Position_Limit", self._original_max_position_limits),
+                        ):
+                            for motor, value in baseline.items():
+                                try:
+                                    self.device.bus.write(register, motor, value)
+                                except Exception as e:
+                                    logger.error(
+                                        f"Failed to restore {register}={value} for {motor} "
+                                        f"after cancelled calibration: {e}"
+                                    )
 
                     logger.info("Disconnecting device...")
                     self.device.disconnect()

--- a/makermodslab/calibrate.py
+++ b/makermodslab/calibrate.py
@@ -164,6 +164,12 @@ class CalibrationManager:
         self._maxes = {}
         self._homing_offsets = {}
         self._current_request: CalibrationRequest | None = None
+        # Rollback baseline for a cancelled/failed run (see _calibration_worker
+        # and _cleanup_device): the servo's Homing_Offset values as they stood
+        # before this session's _step_homing touched them, and whether the run
+        # reached a real commit (on-disk file written) that supersedes them.
+        self._original_homing_offsets: dict[str, int] = {}
+        self._calibration_committed = False
 
         # Initialize logging
         init_logging()
@@ -300,6 +306,8 @@ class CalibrationManager:
                 self._mins = {}
                 self._maxes = {}
                 self._homing_offsets = {}
+                self._original_homing_offsets = {}
+                self._calibration_committed = False
 
                 self._update_status(
                     calibration_active=True,
@@ -414,6 +422,22 @@ class CalibrationManager:
                 logger.info("Calibration stopped after device connection")
                 self._cleanup_and_finish("Calibration cancelled")
                 return
+
+            # Capture the servo's current Homing_Offset as the rollback baseline
+            # BEFORE _step_homing runs — it calls reset_calibration(), which
+            # zeroes Homing_Offset in EEPROM immediately, so this is the last
+            # point the prior (possibly still-in-use) value is readable. If the
+            # run is cancelled or errors before _complete_calibration commits a
+            # new value to disk, _cleanup_device restores this baseline so the
+            # servo never diverges from the last-saved calibration file.
+            try:
+                self._original_homing_offsets = {
+                    motor: self.device.bus.read("Homing_Offset", motor, normalize=False)
+                    for motor in self.device.bus.motors
+                }
+            except Exception as e:
+                logger.warning(f"Could not read baseline homing offsets before calibration: {e}")
+                self._original_homing_offsets = {}
 
             # Start Step 1: Homing
             self._step_homing()
@@ -673,6 +697,10 @@ class CalibrationManager:
 
         logger.info(f"Calibration saved to {self.device.calibration_fpath}")
 
+        # EEPROM and the on-disk file now agree — nothing left for
+        # _cleanup_device to roll back, regardless of what happens below.
+        self._calibration_committed = True
+
         # Robot-record write-back: if this calibration was launched from a tile,
         # update the robot's port + config field for the side that was just calibrated.
         request = self._current_request
@@ -708,6 +736,28 @@ class CalibrationManager:
         """Clean up device connection"""
         try:
             if self.device:
+                # A run that never committed (cancelled, or errored before
+                # _complete_calibration saved) may have already pushed new
+                # Homing_Offset values to the servo in _step_homing. Left as-is,
+                # the servo would permanently diverge from the last-saved
+                # calibration file — the next session's arm-identity check
+                # would then either hard-refuse to start or, worse, silently
+                # decode positions against a stale offset. Restore the
+                # pre-calibration baseline so a cancelled run leaves the
+                # physical arm exactly as it found it.
+                if not self._calibration_committed and self._original_homing_offsets:
+                    try:
+                        logger.info(
+                            "Calibration did not complete — restoring pre-calibration "
+                            f"homing offsets: {self._original_homing_offsets}"
+                        )
+                        for motor, offset in self._original_homing_offsets.items():
+                            self.device.bus.write("Homing_Offset", motor, offset)
+                    except Exception as e:
+                        logger.error(
+                            f"Failed to restore original homing offsets after cancelled calibration: {e}"
+                        )
+
                 logger.info("Disconnecting device...")
                 self.device.disconnect()
                 self.device = None

--- a/makermodslab/calibrate.py
+++ b/makermodslab/calibrate.py
@@ -170,6 +170,14 @@ class CalibrationManager:
         # reached a real commit (on-disk file written) that supersedes them.
         self._original_homing_offsets: dict[str, int] = {}
         self._calibration_committed = False
+        # Guards _cleanup_device's body. stop_calibration_process forces a
+        # cleanup call from the request-handling thread once its join()
+        # times out, without knowing whether the worker thread has since
+        # reached its own _cleanup_and_finish — without this lock the two
+        # could race and both run the homing-offset restore loop against the
+        # live bus concurrently. Whichever thread arrives second finds
+        # self.device already None and no-ops.
+        self._cleanup_lock = threading.Lock()
 
         # Initialize logging
         init_logging()
@@ -430,14 +438,17 @@ class CalibrationManager:
             # run is cancelled or errors before _complete_calibration commits a
             # new value to disk, _cleanup_device restores this baseline so the
             # servo never diverges from the last-saved calibration file.
-            try:
-                self._original_homing_offsets = {
-                    motor: self.device.bus.read("Homing_Offset", motor, normalize=False)
-                    for motor in self.device.bus.motors
-                }
-            except Exception as e:
-                logger.warning(f"Could not read baseline homing offsets before calibration: {e}")
-                self._original_homing_offsets = {}
+            #
+            # A failed read here isn't caught locally: the device is freshly
+            # connected and nothing has been written yet, so there's nothing
+            # cheaper to retry into. Letting it propagate to this method's own
+            # except Exception below aborts the run with a clear error instead
+            # of silently proceeding with no rollback safety net for the one
+            # run that most needs it.
+            self._original_homing_offsets = {
+                motor: self.device.bus.read("Homing_Offset", motor, normalize=False)
+                for motor in self.device.bus.motors
+            }
 
             # Start Step 1: Homing
             self._step_homing()
@@ -734,35 +745,40 @@ class CalibrationManager:
 
     def _cleanup_device(self):
         """Clean up device connection"""
-        try:
-            if self.device:
-                # A run that never committed (cancelled, or errored before
-                # _complete_calibration saved) may have already pushed new
-                # Homing_Offset values to the servo in _step_homing. Left as-is,
-                # the servo would permanently diverge from the last-saved
-                # calibration file — the next session's arm-identity check
-                # would then either hard-refuse to start or, worse, silently
-                # decode positions against a stale offset. Restore the
-                # pre-calibration baseline so a cancelled run leaves the
-                # physical arm exactly as it found it.
-                if not self._calibration_committed and self._original_homing_offsets:
-                    try:
-                        logger.info(
-                            "Calibration did not complete — restoring pre-calibration "
-                            f"homing offsets: {self._original_homing_offsets}"
-                        )
-                        for motor, offset in self._original_homing_offsets.items():
-                            self.device.bus.write("Homing_Offset", motor, offset)
-                    except Exception as e:
-                        logger.error(
-                            f"Failed to restore original homing offsets after cancelled calibration: {e}"
-                        )
+        # Serializes against a concurrent forced cleanup from
+        # stop_calibration_process (see its comment, and _cleanup_lock's
+        # docstring in __init__): only the first caller does real work, a
+        # second concurrent call finds self.device already None below.
+        with self._cleanup_lock:
+            try:
+                if self.device:
+                    # A run that never committed (cancelled, or errored before
+                    # _complete_calibration saved) may have already pushed new
+                    # Homing_Offset values to the servo in _step_homing. Left as-is,
+                    # the servo would permanently diverge from the last-saved
+                    # calibration file — the next session's arm-identity check
+                    # would then either hard-refuse to start or, worse, silently
+                    # decode positions against a stale offset. Restore the
+                    # pre-calibration baseline so a cancelled run leaves the
+                    # physical arm exactly as it found it.
+                    if not self._calibration_committed and self._original_homing_offsets:
+                        try:
+                            logger.info(
+                                "Calibration did not complete — restoring pre-calibration "
+                                f"homing offsets: {self._original_homing_offsets}"
+                            )
+                            for motor, offset in self._original_homing_offsets.items():
+                                self.device.bus.write("Homing_Offset", motor, offset)
+                        except Exception as e:
+                            logger.error(
+                                f"Failed to restore original homing offsets after cancelled calibration: {e}"
+                            )
 
-                logger.info("Disconnecting device...")
-                self.device.disconnect()
-                self.device = None
-        except Exception as e:
-            logger.error(f"Error disconnecting device: {e}")
+                    logger.info("Disconnecting device...")
+                    self.device.disconnect()
+                    self.device = None
+            except Exception as e:
+                logger.error(f"Error disconnecting device: {e}")
 
 
 # Global calibration manager instance

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -221,6 +221,28 @@ def test_start_calibration_check_and_claim_is_atomic(
     )
 
 
+def test_start_calibration_resets_calibration_committed(monkeypatch, tmp_lerobot_home) -> None:
+    """The manager is a long-lived singleton reused across sessions, so a
+    stale True left over from a prior successful run must not survive into a
+    new one — otherwise _cleanup_device would treat this run's own cancelled
+    attempt as already committed and skip the homing-offset/position-limit
+    rollback entirely."""
+    from makermodslab.calibrate import CalibrationManager, CalibrationRequest
+
+    mgr = CalibrationManager()
+    # Avoid spawning the real hardware-touching worker; only the
+    # check-and-claim / reset path is under test here.
+    monkeypatch.setattr(mgr, "_calibration_worker", lambda request: None)
+    mgr._calibration_committed = True  # leftover from a prior successful run
+
+    result = mgr.start_calibration(
+        CalibrationRequest(device_type="teleop", port="/dev/null", config_file="x")
+    )
+
+    assert result["success"] is True
+    assert mgr._calibration_committed is False
+
+
 def test_find_off_center_joints_passes_centered_ranges() -> None:
     """Ranges whose midpoints sit on the raw-tick center (2047) all pass."""
     ranges = {
@@ -260,7 +282,7 @@ def test_find_off_center_joints_tolerance_boundary() -> None:
 
 
 class _FakeBus:
-    """Records Homing_Offset writes; enough surface for _cleanup_device."""
+    """Records register writes; enough surface for _cleanup_device."""
 
     def __init__(self) -> None:
         self.writes: list[tuple[str, str, int]] = []
@@ -274,6 +296,19 @@ class _BrokenBus(_FakeBus):
 
     def write(self, register: str, motor: str, value: int) -> None:
         raise RuntimeError("bus unreachable")
+
+
+class _PartiallyBrokenBus(_FakeBus):
+    """Only the named motor's writes fail; every other motor succeeds."""
+
+    def __init__(self, failing_motor: str) -> None:
+        super().__init__()
+        self._failing_motor = failing_motor
+
+    def write(self, register: str, motor: str, value: int) -> None:
+        if motor == self._failing_motor:
+            raise RuntimeError(f"bus rejected write for {motor}")
+        super().write(register, motor, value)
 
 
 class _FakeDevice:
@@ -307,6 +342,59 @@ def test_cleanup_device_restores_homing_offsets_when_not_committed() -> None:
 
     assert ("Homing_Offset", "shoulder_pan", 15) in bus.writes
     assert ("Homing_Offset", "wrist_roll", -42) in bus.writes
+    assert device.disconnected is True
+    assert mgr.device is None
+
+
+def test_cleanup_device_restores_position_limits_when_not_committed() -> None:
+    """Regression: reset_calibration() (called by _step_homing) doesn't just
+    zero Homing_Offset — it also zeroes Min_Position_Limit and maxes out
+    Max_Position_Limit for every motor on the bus. A cancelled run must roll
+    those back too, or the next session's arm-identity check still sees a
+    servo diverged from the saved calibration file, just via a different
+    pair of registers."""
+    from makermodslab.calibrate import CalibrationManager
+
+    mgr = CalibrationManager()
+    bus = _FakeBus()
+    device = _FakeDevice(bus)
+    mgr.device = device
+    mgr._original_homing_offsets = {"shoulder_pan": 15}
+    mgr._original_min_position_limits = {"shoulder_pan": 120}
+    mgr._original_max_position_limits = {"shoulder_pan": 3980}
+    mgr._calibration_committed = False
+
+    mgr._cleanup_device()
+
+    assert ("Min_Position_Limit", "shoulder_pan", 120) in bus.writes
+    assert ("Max_Position_Limit", "shoulder_pan", 3980) in bus.writes
+    assert device.disconnected is True
+
+
+def test_cleanup_device_restores_remaining_motors_after_one_write_fails() -> None:
+    """One motor's restore write failing must not abort the writes still
+    queued for the remaining motors — the old single try/except around the
+    whole loop meant one bad write left every motor after it in iteration
+    order still diverged: a partially-rolled-back arm, which is worse than a
+    fully-diverged one because it's much harder to notice and diagnose."""
+    from makermodslab.calibrate import CalibrationManager
+
+    mgr = CalibrationManager()
+    bus = _PartiallyBrokenBus(failing_motor="elbow_flex")
+    device = _FakeDevice(bus)
+    mgr.device = device
+    mgr._original_homing_offsets = {
+        "shoulder_pan": 15,
+        "elbow_flex": 7,
+        "wrist_roll": -42,
+    }
+    mgr._calibration_committed = False
+
+    mgr._cleanup_device()  # must not raise despite elbow_flex's write failing
+
+    assert ("Homing_Offset", "shoulder_pan", 15) in bus.writes
+    assert ("Homing_Offset", "wrist_roll", -42) in bus.writes
+    assert not any(write[1] == "elbow_flex" for write in bus.writes)
     assert device.disconnected is True
     assert mgr.device is None
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -257,3 +257,107 @@ def test_find_off_center_joints_tolerance_boundary() -> None:
     assert find_off_center_joints({"elbow_flex": (1447, 3447)}) == []
     # Midpoint 2448 deviates by 401 — just over the line.
     assert find_off_center_joints({"elbow_flex": (1448, 3448)}) == ["elbow_flex"]
+
+
+class _FakeBus:
+    """Records Homing_Offset writes; enough surface for _cleanup_device."""
+
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, str, int]] = []
+
+    def write(self, register: str, motor: str, value: int) -> None:
+        self.writes.append((register, motor, value))
+
+
+class _BrokenBus(_FakeBus):
+    """Every write raises, simulating a bus that's already gone unreachable."""
+
+    def write(self, register: str, motor: str, value: int) -> None:
+        raise RuntimeError("bus unreachable")
+
+
+class _FakeDevice:
+    def __init__(self, bus) -> None:
+        self.bus = bus
+        self.disconnected = False
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+def test_cleanup_device_restores_homing_offsets_when_not_committed() -> None:
+    """Regression for C2: _step_homing writes new Homing_Offset values to the
+    servo's EEPROM immediately (step 1), well before _complete_calibration
+    ever saves the on-disk calibration file (step 3). A calibration cancelled
+    or errored in between used to leave the servo permanently diverged from
+    the last-saved file — the next session's arm-identity fingerprint check
+    (see makerlab/arm_identity.py) would then either hard-refuse to start or
+    silently decode positions against a stale offset. _cleanup_device must
+    restore the pre-calibration baseline whenever the run never committed."""
+    from makerlab.calibrate import CalibrationManager
+
+    mgr = CalibrationManager()
+    bus = _FakeBus()
+    device = _FakeDevice(bus)
+    mgr.device = device
+    mgr._original_homing_offsets = {"shoulder_pan": 15, "wrist_roll": -42}
+    mgr._calibration_committed = False  # cancelled/errored before saving
+
+    mgr._cleanup_device()
+
+    assert ("Homing_Offset", "shoulder_pan", 15) in bus.writes
+    assert ("Homing_Offset", "wrist_roll", -42) in bus.writes
+    assert device.disconnected is True
+    assert mgr.device is None
+
+
+def test_cleanup_device_does_not_restore_once_calibration_committed() -> None:
+    """A calibration that reached _complete_calibration (file saved to disk)
+    must not have its final homing offsets touched during cleanup — EEPROM
+    and the file already agree at that point."""
+    from makerlab.calibrate import CalibrationManager
+
+    mgr = CalibrationManager()
+    bus = _FakeBus()
+    mgr.device = _FakeDevice(bus)
+    mgr._original_homing_offsets = {"shoulder_pan": 15}
+    mgr._calibration_committed = True
+
+    mgr._cleanup_device()
+
+    assert bus.writes == []
+
+
+def test_cleanup_device_skips_restore_when_no_baseline_was_captured() -> None:
+    """If the baseline read itself failed (device unreachable at connect
+    time), there's nothing to roll back to — cleanup must not crash or invent
+    a value."""
+    from makerlab.calibrate import CalibrationManager
+
+    mgr = CalibrationManager()
+    bus = _FakeBus()
+    mgr.device = _FakeDevice(bus)
+    mgr._original_homing_offsets = {}
+    mgr._calibration_committed = False
+
+    mgr._cleanup_device()  # must not raise
+
+    assert bus.writes == []
+
+
+def test_cleanup_device_still_disconnects_if_restore_write_fails() -> None:
+    """A failed rollback write (e.g. the bus just dropped) must be logged, not
+    swallowed silently and not allowed to block the device disconnect."""
+    from makerlab.calibrate import CalibrationManager
+
+    mgr = CalibrationManager()
+    bus = _BrokenBus()
+    device = _FakeDevice(bus)
+    mgr.device = device
+    mgr._original_homing_offsets = {"shoulder_pan": 15}
+    mgr._calibration_committed = False
+
+    mgr._cleanup_device()  # must not raise despite the write failing
+
+    assert device.disconnected is True
+    assert mgr.device is None

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -291,10 +291,10 @@ def test_cleanup_device_restores_homing_offsets_when_not_committed() -> None:
     ever saves the on-disk calibration file (step 3). A calibration cancelled
     or errored in between used to leave the servo permanently diverged from
     the last-saved file — the next session's arm-identity fingerprint check
-    (see makerlab/arm_identity.py) would then either hard-refuse to start or
+    (see makermodslab/arm_identity.py) would then either hard-refuse to start or
     silently decode positions against a stale offset. _cleanup_device must
     restore the pre-calibration baseline whenever the run never committed."""
-    from makerlab.calibrate import CalibrationManager
+    from makermodslab.calibrate import CalibrationManager
 
     mgr = CalibrationManager()
     bus = _FakeBus()
@@ -315,7 +315,7 @@ def test_cleanup_device_does_not_restore_once_calibration_committed() -> None:
     """A calibration that reached _complete_calibration (file saved to disk)
     must not have its final homing offsets touched during cleanup — EEPROM
     and the file already agree at that point."""
-    from makerlab.calibrate import CalibrationManager
+    from makermodslab.calibrate import CalibrationManager
 
     mgr = CalibrationManager()
     bus = _FakeBus()
@@ -332,7 +332,7 @@ def test_cleanup_device_skips_restore_when_no_baseline_was_captured() -> None:
     """If the baseline read itself failed (device unreachable at connect
     time), there's nothing to roll back to — cleanup must not crash or invent
     a value."""
-    from makerlab.calibrate import CalibrationManager
+    from makermodslab.calibrate import CalibrationManager
 
     mgr = CalibrationManager()
     bus = _FakeBus()
@@ -348,7 +348,7 @@ def test_cleanup_device_skips_restore_when_no_baseline_was_captured() -> None:
 def test_cleanup_device_still_disconnects_if_restore_write_fails() -> None:
     """A failed rollback write (e.g. the bus just dropped) must be logged, not
     swallowed silently and not allowed to block the device disconnect."""
-    from makerlab.calibrate import CalibrationManager
+    from makermodslab.calibrate import CalibrationManager
 
     mgr = CalibrationManager()
     bus = _BrokenBus()


### PR DESCRIPTION
## Summary

`_step_homing` writes newly computed `Homing_Offset` values straight to the servo's EEPROM as calibration's step 1 — before range recording (step 2) or `_complete_calibration` (step 3, which is the only place the on-disk calibration file is actually saved). If a manual calibration is cancelled, or errors out, anywhere between step 1 and a successful save, the servo's EEPROM is left holding the new offset while the saved calibration file still holds the old one. Nothing in cleanup restored it — `_cleanup_device` only disconnected the bus.

That divergence then silently corrupts the next session's arm-identity fingerprint check (`makerlab/arm_identity.py`), which relies on the servo's live `Homing_Offset` matching the saved file exactly. Depending on how far positions had drifted at cancel time, the next startup either:
- hard-refuses with an opaque `ArmIdentityError` ("doesn't match calibration... needs recalibration"), even though the file itself is fine, or
- proceeds with only a generic "could not verify this arm" warning, while every position read for the session is decoded against a stale homing offset.

Neither UI messaging nor logs before this fix ever call out "your last calibration attempt was cancelled and left the servo diverged" — the failure surfaces later, disconnected from its cause.

## Fix

Calibration is now transactional with respect to the servo's `Homing_Offset`:

- Right after connecting (before `_step_homing` runs — which calls `reset_calibration()` and zeroes `Homing_Offset` in EEPROM immediately), `CalibrationManager` reads and stashes each motor's current offset as a rollback baseline.
- The run is only considered "committed" once `_complete_calibration` has actually saved the calibration file to disk.
- `_cleanup_device` (the single chokepoint every exit path — cancel, centering/discontinuity errors, any other exception — already funnels through) now restores the stashed baseline whenever cleanup runs on an uncommitted run, before disconnecting. A restore failure is logged loudly rather than swallowed, so the arm-identity guard remains a real backstop instead of a false sense of safety.

Net effect: a cancelled or failed calibration always leaves the physical arm's EEPROM exactly as it found it, so it can never diverge from the last-saved calibration file.

## Follow-up fixes (review pass)

- `reset_calibration()` doesn't only zero `Homing_Offset` — it also zeroes `Min_Position_Limit` and maxes out `Max_Position_Limit` for every motor. The baseline/restore now covers all three registers, not just `Homing_Offset`, closing the same divergence hazard for the position limits.
- The restore loop wrapped every motor's write in one shared `try/except`, so a single motor's write failing aborted the writes still queued for the rest — a partially-rolled-back arm (some motors restored, others still diverged), which is worse than a fully-diverged one since it's harder to notice. Each register write is now its own `try/except`.
- Added a regression test that `start_calibration` resets a stale `_calibration_committed` left over from a prior run (the `CalibrationManager` singleton is reused across sessions).
- Corrected the `_cleanup_lock` docstring: the lock only serializes two *callers of `_cleanup_device`* against each other — it does not stop the worker thread's own un-locked bus I/O from overlapping a forced cleanup. The actual hazard it guards against is in `stop_calibration_process`: `join(timeout=5.0)` can expire while the worker thread is still alive and mid read/write on the bus, and the request thread then forces a cleanup call (restore + disconnect) while that in-flight worker I/O may still be running.

## Test plan

- [x] New regression tests in `tests/test_calibrate.py` (unit-level, no hardware/threads — consistent with this repo's policy against unit-testing subprocess/thread happy paths):
  - `test_cleanup_device_restores_homing_offsets_when_not_committed`
  - `test_cleanup_device_restores_position_limits_when_not_committed`
  - `test_cleanup_device_restores_remaining_motors_after_one_write_fails`
  - `test_cleanup_device_does_not_restore_once_calibration_committed`
  - `test_cleanup_device_skips_restore_when_no_baseline_was_captured`
  - `test_cleanup_device_still_disconnects_if_restore_write_fails`
  - `test_start_calibration_resets_calibration_committed`
- [x] Full suite: `pytest` — 982 passed
- [x] `ruff check` clean on touched files
- [x] `ruff format --check` clean on touched files (the only reported hunks are pre-existing drift already on `main`, unrelated to this change — confirmed by diffing against `origin/main`)
- [x] Verified on real hardware (leader arm): drove a real calibration session via `CalibrationManager` through to the recording step (so `_step_homing` had already reset and rewritten EEPROM), confirmed live `Min_Position_Limit`/`Max_Position_Limit` sat at reset defaults (0/4095) as a positive control, then cancelled mid-recording via `stop_calibration_process()`. A fresh read-only reconnect confirmed `Homing_Offset`, `Min_Position_Limit`, and `Max_Position_Limit` were all restored exactly to their pre-calibration baseline, and no calibration file was left on disk.
