### PR TITLE
fix(record): stop erasing saved_episodes on terminal recording status (R5)

### DIFF
--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -746,8 +746,11 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
                 recording_active = False
                 recording_start_time = None
                 phase_start_time = None
-                current_episode = 1
-                saved_episodes = 0
+                # current_episode/saved_episodes are deliberately left as-is:
+                # handle_recording_status reports saved_episodes in the terminal
+                # (session_ended) status, and the next session already resets both
+                # under the lock in handle_start_recording. Zeroing them here would
+                # erase the count before any poll can read it.
                 logger.info("Recording session ended")
 
         recording_thread = threading.Thread(target=recording_worker, name="recording-worker", daemon=True)
@@ -1027,6 +1030,10 @@ def handle_recording_status() -> dict[str, Any]:
         status["outcome"] = last_session_outcome
         status["error"] = last_session_error
         status["hint"] = friendly_hint(last_session_error)
+        # The frontend's exit handoff reads this to show/pass along how many
+        # episodes actually got saved — it must survive past recording_active
+        # flipping False, not just live-poll while recording is in progress.
+        status["saved_episodes"] = saved_episodes
 
     # Warn-but-allow arm-identity findings (the guard runs in the worker, after
     # the start response) — the frontend shows these as a non-blocking toast.

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1013,6 +1013,11 @@ def test_worker_quit_discards_fresh_dataset_with_saved_episodes(
         assert status["session_ended"] is True
         assert status["discarded_empty"] is True
         assert not (tmp_lerobot_home / status["dataset_repo_id"]).exists()
+        # saved_episodes still reports what was recorded before the quit, even
+        # though the dataset directory itself was deleted — the two are
+        # independent facts (discarded_empty is what tells the frontend nothing
+        # was kept on disk).
+        assert status["saved_episodes"] == 2
     finally:
         record.discard_requested = False  # don't leak the armed flag into later tests
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -2059,6 +2059,12 @@ def test_worker_reports_ok_outcome_on_clean_end(monkeypatch: pytest.MonkeyPatch,
     assert status["outcome"] == "ok"
     assert status["error"] is None
     assert status["hint"] is None
+    # Regression (R5): the worker's finally block used to zero saved_episodes
+    # the instant it flipped recording_active False, and handle_recording_status
+    # only ever echoed saved_episodes while recording_active was True — so the
+    # terminal status silently reported nothing saved even though 2 episodes
+    # were recorded.
+    assert status["saved_episodes"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -2188,3 +2194,21 @@ def test_stop_and_wait_lets_an_already_in_progress_release_finish_gracefully(
     assert finished_gracefully.is_set(), "an already-in-progress graceful return was aborted early"
     assert not forced.is_set(), "stop_and_wait force-released a session already mid graceful return"
     worker.join(timeout=2.0)
+
+
+def test_recording_status_reports_saved_episodes_at_session_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The terminal status must keep reporting saved_episodes once the session
+    has ended — the frontend's exit handoff (RecordingSessionDialog) reads this
+    field to tell the user, and the upload flow, how many episodes exist."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr(record, "current_phase", "completed")
+    monkeypatch.setattr(record, "saved_episodes", 5)
+
+    status = record.handle_recording_status()
+
+    assert status["session_ended"] is True
+    assert status["saved_episodes"] == 5


### PR DESCRIPTION
## Summary

### What this fixes
- When a recording session finished, the app could tell the user "0 episodes saved" even when episodes really were recorded — hiding real data and blocking the normal path to uploading it.

### What changed
- The server used to wipe its own count of saved episodes at the exact moment a session ended, before the app ever got a chance to read it, and it also only reported that count while a session was still running. Now the count survives to the very last status check and is included once the session is marked as ended.

### To test
1. Record a session with at least one episode, then let it finish normally (or click Done).
2. Confirm the "episode(s) saved" count shown on the way to Upload matches what was actually recorded, instead of showing 0.

## Reproduced (test-based)

This is a pure backend state-management bug — no hardware interaction needed to trigger it, so the repro here is a test-based before/after rather than curl/hardware logs.

**Before (`main`, `makerlab/record.py`):** temporarily swapped this branch's `tests/test_record.py` (with its 3 new/extended `saved_episodes` assertions) onto `main`'s `record.py` and ran:

```
$ pytest tests/test_record.py -k "saved_episodes or worker_reports_ok_outcome_on_clean_end" -v

FAILED tests/test_record.py::test_worker_quit_discards_fresh_dataset_with_saved_episodes - KeyError: 'saved_episodes'
FAILED tests/test_record.py::test_worker_reports_ok_outcome_on_clean_end - KeyError: 'saved_episodes'
FAILED tests/test_record.py::test_recording_status_reports_saved_episodes_at_session_end - KeyError: 'saved_episodes'
3 failed, 57 deselected
```

All three fail because `handle_recording_status()`'s terminal (`session_ended`) response never contains the `saved_episodes` key at all on `main` — not "reports 0", genuinely absent, which is what turns into a silent `0` on the frontend's `backendStatus.saved_episodes || 0` fallback.

**After (this branch):**

```
$ pytest tests/test_record.py -q
60 passed
```

## Fix

Two compounding bugs in `makerlab/record.py`, both in the recording session's finish path:

1. `recording_worker`'s `finally` block reset the module globals `current_episode = 1` / `saved_episodes = 0` in the same breath it flipped `recording_active = False` — i.e. it zeroed the true count at the exact moment "session ended" became observable, before any status poll could read it. Removed that reset (left a comment explaining why): the next session already re-initializes both under the lock in `handle_start_recording`'s claim section, so the reset here was redundant *and* destructive.
2. `handle_recording_status()` only ever added `saved_episodes` to its response inside `if recording_active and recording_config:` — so even without bug #1, the field would never appear once a session ended. Added it to the existing `if session_ended:` branch, alongside the other terminal-only fields (`discarded_empty`, `outcome`, `error`, `hint`).

`current_episode`/`total_episodes` reporting is deliberately left gated on `recording_active` as before — the frontend only reads those two for live progress display, never in the exit-handoff payload, so widening their exposure wasn't needed for this fix.

No frontend changes: `RecordingSessionDialog.tsx` already reads `saved_episodes` correctly (`backendStatus.saved_episodes || 0`) in its exit-handoff — it was just never given a real value to read once a session ended.

## Test plan

- [x] 3 regression tests (1 new focused unit test, 1 new assertion on an existing end-to-end worker-thread test, 1 new assertion on the existing quit/discard test) — all fail on `main` with `KeyError: 'saved_episodes'`, all pass on this branch.
- [x] Full suite: `pytest` — 885 passed.
- [x] `ruff check` / `ruff format --check` on touched files — clean.
- [x] Independently reviewed by a second agent pass: confirmed both halves of the bug are closed, traced the locking around session start for any new race introduced by removing the reset (found none — pre-existing, unrelated to this fix), confirmed the frontend needs no changes.

## Screenshots

None apply — backend-only fix (`makerlab/record.py`); no UI is touched.
