### PR TITLE
fix(training): stop the cloud checkpoint watcher from uploading partial checkpoints (MT9)

### DIFF
--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -153,6 +153,33 @@ def _install_plan(spec, python, uv_path, has_pip, has_ensurepip):
     return None, []
 
 
+def _checkpoint_step_ready(step_dir):
+    """Whether `step_dir` (a lerobot checkpoints/<step>/ directory) has been
+    fully written and is safe to upload.
+
+    lerobot's save_checkpoint (lerobot/common/train_utils.py) writes
+    pretrained_model/ first via policy.save_pretrained — which itself writes
+    config.json *before* the much larger model.safetensors (see
+    PreTrainedPolicy._save_pretrained in lerobot/policies/pretrained.py) — and
+    only calls save_training_state, which creates training_state/, once every
+    pretrained_model/ file is already on disk. So pretrained_model/config.json
+    existing is NOT sufficient evidence the step is complete: it can be
+    observed while model.safetensors is still being written, or before it
+    exists at all. training_state/ existing is a reliable "the whole step
+    finished" signal, since save_checkpoint only creates it after
+    pretrained_model/ is done.
+
+    Pure and self-contained (stdlib pathlib only) so its source can be
+    inlined verbatim into WRAPPER_SOURCE the same way _install_plan is,
+    keeping the in-container check and the unit-tested implementation
+    identical.
+    """
+    pretrained_dir = step_dir / "pretrained_model"
+    if not (pretrained_dir / "config.json").is_file():
+        return False
+    return (step_dir / "training_state").is_dir()
+
+
 def _cloud_device(flavor: str) -> str:
     """HF Jobs flavors are NVIDIA GPU boxes except the cpu-* tiers."""
     return "cpu" if flavor.startswith("cpu") else "cuda"
@@ -216,9 +243,11 @@ _CONTAINER_TRAIN_CONFIG_NAME = "train_config.json"
 #
 # Sent verbatim as the value of `python -c '...'`. Wrapper-side arguments
 # (the pinned lerobot spec) come before `--`; anything after `--` is
-# forwarded to the trainer. The __INSTALL_PLAN_SOURCE__ placeholder is
-# replaced with _install_plan's own source below, so the wrapper's installer
-# choice is the exact function the unit tests exercise.
+# forwarded to the trainer. The __INSTALL_PLAN_SOURCE__ and
+# __CHECKPOINT_READY_SOURCE__ placeholders are replaced with _install_plan's
+# and _checkpoint_step_ready's own source below, so the wrapper's installer
+# choice and checkpoint-completeness check are the exact functions the unit
+# tests exercise.
 _WRAPPER_TEMPLATE = r'''
 import importlib.util
 import os, re, shlex, shutil, sys, threading, subprocess
@@ -226,6 +255,8 @@ from pathlib import Path
 from huggingface_hub import HfApi
 
 __INSTALL_PLAN_SOURCE__
+
+__CHECKPOINT_READY_SOURCE__
 
 argv = sys.argv[1:]
 if "--" not in argv:
@@ -397,10 +428,12 @@ def _scan_and_upload():
     for entry in entries:
         if not re.fullmatch(r"\d+", entry.name):
             continue
-        config_json = entry / "pretrained_model" / "config.json"
-        if not config_json.is_file():
-            continue
         if entry.name in seen:
+            continue
+        # config.json can exist while model.safetensors is still being
+        # written (or absent) — training_state/ only appears once the whole
+        # step is on disk. See _checkpoint_step_ready.
+        if not _checkpoint_step_ready(entry):
             continue
         try:
             api.upload_folder(
@@ -449,7 +482,9 @@ print(f"[wrapper] trainer exited with rc={rc}", flush=True)
 sys.exit(rc)
 '''
 
-WRAPPER_SOURCE = _WRAPPER_TEMPLATE.replace("__INSTALL_PLAN_SOURCE__", inspect.getsource(_install_plan))
+WRAPPER_SOURCE = _WRAPPER_TEMPLATE.replace(
+    "__INSTALL_PLAN_SOURCE__", inspect.getsource(_install_plan)
+).replace("__CHECKPOINT_READY_SOURCE__", inspect.getsource(_checkpoint_step_ready))
 
 # HF Jobs' platform default timeout has killed legitimate runs that pushed
 # the model successfully but were still uploading auxiliary files. 2h covers

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -171,21 +171,41 @@ def _checkpoint_step_ready(step_dir):
     training_step.json, then rng_state.safetensors, then (only if an
     optimizer was passed — always true for lerobot's own training loop,
     lerobot/scripts/lerobot_train.py, which never calls save_checkpoint with
-    optimizer=None) optimizer_state.safetensors, then — only if the policy's
-    config has a scheduler (get_scheduler_preset(); e.g. diffusion, pi0,
-    pi0_fast, pi05, smolvla, vqbet — but NOT act, tdmpc, gaussian_actor) —
+    optimizer=None) the optimizer state, then — only if the policy's config
+    has a scheduler (get_scheduler_preset(); e.g. diffusion, pi0, pi0_fast,
+    pi05, smolvla, vqbet — but NOT act, tdmpc, gaussian_actor) —
     scheduler_state.json. So training_state/ merely *existing* is not
     reliable either: it can be observed the instant after mkdir, before any
-    of its files are written. Checking for training_step.json and
-    optimizer_state.safetensors alone would still miss an in-flight
-    scheduler_state.json write for the many policies that do have a
-    scheduler, so whether a scheduler file is required is read off
-    pretrained_model/train_config.json's "scheduler" key instead of a
-    hardcoded policy list — that file is written by cfg.save_pretrained,
-    which save_checkpoint always calls (and returns from) strictly before
-    save_training_state starts, so by the time training_step.json exists
-    (checked above) train_config.json is guaranteed complete; reading it
-    here carries no extra race.
+    of its files are written. Checking for training_step.json and the
+    optimizer state alone would still miss an in-flight scheduler_state.json
+    write for the many policies that do have a scheduler, so whether a
+    scheduler file is required is read off pretrained_model/train_config.json's
+    "scheduler" key instead of a hardcoded policy list — that file is written
+    by cfg.save_pretrained, which save_checkpoint always calls (and returns
+    from) strictly before save_training_state starts, so by the time
+    training_step.json exists (checked above) train_config.json is guaranteed
+    complete; reading it here carries no extra race.
+
+    The optimizer state's own on-disk shape is not fixed either:
+    save_optimizer_state (lerobot/optim/optimizers.py) writes a flat
+    training_state/optimizer_state.safetensors only for a single Optimizer.
+    A policy whose get_optimizer_preset() is a MultiAdamConfig — currently
+    only gaussian_actor, whose SAC-style actor/critic/temperature groups
+    build a dict[str, Optimizer] — takes the dict branch instead: one
+    training_state/<group name>/optimizer_state.safetensors per group,
+    mkdir'd then written the same non-atomic way as the flat case, and never
+    a flat file at all. Which shape to expect is read off train_config.json's
+    "optimizer.type" (draccus's ChoiceRegistry discriminator: "multi_adam"
+    for the dict case). The exact set of group names isn't reliable from
+    train_config.json's "optimizer_groups" — gaussian_actor configures three
+    (actor/critic/temperature) but get_optim_params() only ever builds
+    "actor" — so instead every group subdirectory that has *actually*
+    appeared under training_state/ is required to be complete. This leaves a
+    residual, deliberately-accepted race symmetric with the ones already
+    described above: a poll could land after one group's subdirectory
+    appears but before a second group's mkdir, and see the step as ready one
+    poll early. No shipped multi-optimizer policy has more than one group in
+    practice, so this is theoretical today.
 
     Pure and self-contained (stdlib only: pathlib + json) so its source can
     be inlined verbatim into WRAPPER_SOURCE the same way _install_plan is,
@@ -202,16 +222,27 @@ def _checkpoint_step_ready(step_dir):
         return False
     if not (training_state_dir / "rng_state.safetensors").is_file():
         return False
-    if not (training_state_dir / "optimizer_state.safetensors").is_file():
-        return False
+
     try:
         train_config = json.loads((pretrained_dir / "train_config.json").read_text())
-        needs_scheduler = train_config.get("scheduler") is not None
     except (OSError, ValueError):
         # train_config.json is part of pretrained_model/ and is guaranteed
         # present by this point (checked above via config.json); if it can't
-        # be read/parsed, fail closed and require the scheduler file too.
-        needs_scheduler = True
+        # be read/parsed, fail closed: assume a single optimizer (the flat
+        # check below) and require the scheduler file too.
+        train_config = None
+
+    optimizer_cfg = train_config.get("optimizer") if train_config is not None else None
+    if isinstance(optimizer_cfg, dict) and optimizer_cfg.get("type") == "multi_adam":
+        group_dirs = [p for p in training_state_dir.iterdir() if p.is_dir()]
+        if not group_dirs:
+            return False
+        if any(not (group_dir / "optimizer_state.safetensors").is_file() for group_dir in group_dirs):
+            return False
+    elif not (training_state_dir / "optimizer_state.safetensors").is_file():
+        return False
+
+    needs_scheduler = train_config is None or train_config.get("scheduler") is not None
     return not needs_scheduler or (training_state_dir / "scheduler_state.json").is_file()
 
 

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -157,93 +157,28 @@ def _checkpoint_step_ready(step_dir):
     """Whether `step_dir` (a lerobot checkpoints/<step>/ directory) has been
     fully written and is safe to upload.
 
-    lerobot's save_checkpoint (lerobot/common/train_utils.py) writes
-    pretrained_model/ first via policy.save_pretrained — which itself writes
-    config.json *before* the much larger model.safetensors (see
-    PreTrainedPolicy._save_pretrained in lerobot/policies/pretrained.py) — and
-    only calls save_training_state once every pretrained_model/ file is
-    already on disk. So pretrained_model/config.json existing is NOT
-    sufficient evidence the step is complete: it can be observed while
-    model.safetensors is still being written, or before it exists at all.
+    Reads lerobot's own completion signal instead of reconstructing its
+    internal write order. `checkpoints/last` is a relative symlink that
+    lerobot_train.py points at a step directory via update_last_checkpoint()
+    (lerobot/common/train_utils.py) strictly *after* save_checkpoint() has
+    returned for that step — so the link having advanced to (or past) this
+    step number is proof every file under step_dir is already on disk. The
+    `<=` (not `==`) covers two checkpoints completing inside one poll window.
+    See test_lerobot_last_checkpoint_symlink_matches_our_readiness_check for
+    the upstream contract this assumes.
 
-    save_training_state (lerobot/common/train_utils.py) is itself
-    non-atomic: it does `training_state/.mkdir(...)` *first*, then writes
-    training_step.json, then rng_state.safetensors, then (only if an
-    optimizer was passed — always true for lerobot's own training loop,
-    lerobot/scripts/lerobot_train.py, which never calls save_checkpoint with
-    optimizer=None) the optimizer state, then — only if the policy's config
-    has a scheduler (get_scheduler_preset(); e.g. diffusion, pi0, pi0_fast,
-    pi05, smolvla, vqbet — but NOT act, tdmpc, gaussian_actor) —
-    scheduler_state.json. So training_state/ merely *existing* is not
-    reliable either: it can be observed the instant after mkdir, before any
-    of its files are written. Checking for training_step.json and the
-    optimizer state alone would still miss an in-flight scheduler_state.json
-    write for the many policies that do have a scheduler, so whether a
-    scheduler file is required is read off pretrained_model/train_config.json's
-    "scheduler" key instead of a hardcoded policy list — that file is written
-    by cfg.save_pretrained, which save_checkpoint always calls (and returns
-    from) strictly before save_training_state starts, so by the time
-    training_step.json exists (checked above) train_config.json is guaranteed
-    complete; reading it here carries no extra race.
-
-    The optimizer state's own on-disk shape is not fixed either:
-    save_optimizer_state (lerobot/optim/optimizers.py) writes a flat
-    training_state/optimizer_state.safetensors only for a single Optimizer.
-    A policy whose get_optimizer_preset() is a MultiAdamConfig — currently
-    only gaussian_actor, whose SAC-style actor/critic/temperature groups
-    build a dict[str, Optimizer] — takes the dict branch instead: one
-    training_state/<group name>/optimizer_state.safetensors per group,
-    mkdir'd then written the same non-atomic way as the flat case, and never
-    a flat file at all. Which shape to expect is read off train_config.json's
-    "optimizer.type" (draccus's ChoiceRegistry discriminator: "multi_adam"
-    for the dict case). The exact set of group names isn't reliable from
-    train_config.json's "optimizer_groups" — gaussian_actor configures three
-    (actor/critic/temperature) but get_optim_params() only ever builds
-    "actor" — so instead every group subdirectory that has *actually*
-    appeared under training_state/ is required to be complete. This leaves a
-    residual, deliberately-accepted race symmetric with the ones already
-    described above: a poll could land after one group's subdirectory
-    appears but before a second group's mkdir, and see the step as ready one
-    poll early. No shipped multi-optimizer policy has more than one group in
-    practice, so this is theoretical today.
-
-    Pure and self-contained (stdlib only: pathlib + json) so its source can
-    be inlined verbatim into WRAPPER_SOURCE the same way _install_plan is,
-    keeping the in-container check and the unit-tested implementation
-    identical.
+    Pure and self-contained (stdlib only) so its source can be inlined
+    verbatim into WRAPPER_SOURCE the same way _install_plan is, keeping the
+    in-container check and the unit-tested implementation identical.
     """
-    import json
-
-    pretrained_dir = step_dir / "pretrained_model"
-    if not (pretrained_dir / "config.json").is_file():
-        return False
-    training_state_dir = step_dir / "training_state"
-    if not (training_state_dir / "training_step.json").is_file():
-        return False
-    if not (training_state_dir / "rng_state.safetensors").is_file():
-        return False
+    import os
 
     try:
-        train_config = json.loads((pretrained_dir / "train_config.json").read_text())
-    except (OSError, ValueError):
-        # train_config.json is part of pretrained_model/ and is guaranteed
-        # present by this point (checked above via config.json); if it can't
-        # be read/parsed, fail closed: assume a single optimizer (the flat
-        # check below) and require the scheduler file too.
-        train_config = None
-
-    optimizer_cfg = train_config.get("optimizer") if train_config is not None else None
-    if isinstance(optimizer_cfg, dict) and optimizer_cfg.get("type") == "multi_adam":
-        group_dirs = [p for p in training_state_dir.iterdir() if p.is_dir()]
-        if not group_dirs:
-            return False
-        if any(not (group_dir / "optimizer_state.safetensors").is_file() for group_dir in group_dirs):
-            return False
-    elif not (training_state_dir / "optimizer_state.safetensors").is_file():
+        target = os.readlink(step_dir.parent / "last")
+    except OSError:
         return False
-
-    needs_scheduler = train_config is None or train_config.get("scheduler") is not None
-    return not needs_scheduler or (training_state_dir / "scheduler_state.json").is_file()
+    target = os.path.basename(target.rstrip("/"))
+    return target.isdigit() and step_dir.name.isdigit() and int(step_dir.name) <= int(target)
 
 
 def _cloud_device(flavor: str) -> str:
@@ -408,6 +343,10 @@ except Exception as exc:
     print(f"[wrapper] create_repo failed: {exc}", flush=True)
 
 seen = set()
+# Per-step count of consecutive not-ready polls, so a stalled gate (or a
+# genuinely slow write) surfaces in the log instead of looking identical to
+# "no checkpoint yet" for the whole run.
+waits = {}
 
 # Resume: download the parent checkpoint tree (pretrained_model/ +
 # training_state/) into <output_dir>/checkpoints/<step_dir>/ so lerobot's own
@@ -435,8 +374,23 @@ if resume_from:
         # copytree from the snapshot cache (symlinked files) into a real tree the
         # trainer can read/rewrite; resolve symlinks so lerobot sees plain files.
         shutil.copytree(src, dest, symlinks=False)
-        if not (dest / "training_state").is_dir():
-            print("[wrapper] resume checkpoint has no training_state/; cannot resume", flush=True)
+        # A bare training_state/ is_dir() check would pass a checkpoint that
+        # was itself partially uploaded before this fix existed (the exact
+        # bug this watcher fixes). There is no checkpoints/last symlink to
+        # check here — it lives beside the run's local output dir and is
+        # never pushed to the Hub — so check the files a resume actually
+        # needs directly instead.
+        has_weights = any((dest / "pretrained_model").glob("*.safetensors"))
+        has_training_state = (
+            (dest / "training_state" / "training_step.json").is_file()
+            and (dest / "training_state" / "rng_state.safetensors").is_file()
+        )
+        if not (has_weights and has_training_state):
+            print(
+                f"[wrapper] resume checkpoint at {dest} is incomplete "
+                f"(weights: {has_weights}, training_state: {has_training_state}); cannot resume",
+                flush=True,
+            )
             sys.exit(1)
         seen.add(step_dir)
         print(f"[wrapper] resume checkpoint ready at {dest}", flush=True)
@@ -496,10 +450,20 @@ def _scan_and_upload():
             continue
         if entry.name in seen:
             continue
-        # config.json can exist while model.safetensors is still being
-        # written (or absent) — training_state/ only appears once the whole
-        # step is on disk. See _checkpoint_step_ready.
+        # config.json can exist while the rest of the step is still being
+        # written. See _checkpoint_step_ready.
         if not _checkpoint_step_ready(entry):
+            waits[entry.name] = waits.get(entry.name, 0) + 1
+            if waits[entry.name] in (1, 20, 80):  # ~15s, ~5min, ~20min at the 15s poll interval
+                try:
+                    last_target = os.readlink(root / "last")
+                except OSError:
+                    last_target = None
+                print(
+                    f"[wrapper] checkpoint {entry.name} not complete yet "
+                    f"(poll {waits[entry.name]}); checkpoints/last -> {last_target}",
+                    flush=True,
+                )
             continue
         try:
             api.upload_folder(
@@ -509,6 +473,7 @@ def _scan_and_upload():
                 commit_message=f"checkpoint {entry.name}",
             )
             seen.add(entry.name)
+            waits.pop(entry.name, None)
             print(f"[wrapper] uploaded checkpoint {entry.name}", flush=True)
         except Exception as exc:
             print(f"[wrapper] upload failed for {entry.name}: {exc}", flush=True)
@@ -574,6 +539,7 @@ def resolve_job_timeout(config: TrainingRequest) -> int | str:
     if config.hf_job_timeout:
         return parse_hf_duration(config.hf_job_timeout)
     return HF_JOB_TIMEOUT
+
 
 # Cadence at which the status poller hits inspect_job. inspect_job is the
 # authoritative source for job liveness; the log stream is best-effort and

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -161,23 +161,58 @@ def _checkpoint_step_ready(step_dir):
     pretrained_model/ first via policy.save_pretrained — which itself writes
     config.json *before* the much larger model.safetensors (see
     PreTrainedPolicy._save_pretrained in lerobot/policies/pretrained.py) — and
-    only calls save_training_state, which creates training_state/, once every
-    pretrained_model/ file is already on disk. So pretrained_model/config.json
-    existing is NOT sufficient evidence the step is complete: it can be
-    observed while model.safetensors is still being written, or before it
-    exists at all. training_state/ existing is a reliable "the whole step
-    finished" signal, since save_checkpoint only creates it after
-    pretrained_model/ is done.
+    only calls save_training_state once every pretrained_model/ file is
+    already on disk. So pretrained_model/config.json existing is NOT
+    sufficient evidence the step is complete: it can be observed while
+    model.safetensors is still being written, or before it exists at all.
 
-    Pure and self-contained (stdlib pathlib only) so its source can be
-    inlined verbatim into WRAPPER_SOURCE the same way _install_plan is,
+    save_training_state (lerobot/common/train_utils.py) is itself
+    non-atomic: it does `training_state/.mkdir(...)` *first*, then writes
+    training_step.json, then rng_state.safetensors, then (only if an
+    optimizer was passed — always true for lerobot's own training loop,
+    lerobot/scripts/lerobot_train.py, which never calls save_checkpoint with
+    optimizer=None) optimizer_state.safetensors, then — only if the policy's
+    config has a scheduler (get_scheduler_preset(); e.g. diffusion, pi0,
+    pi0_fast, pi05, smolvla, vqbet — but NOT act, tdmpc, gaussian_actor) —
+    scheduler_state.json. So training_state/ merely *existing* is not
+    reliable either: it can be observed the instant after mkdir, before any
+    of its files are written. Checking for training_step.json and
+    optimizer_state.safetensors alone would still miss an in-flight
+    scheduler_state.json write for the many policies that do have a
+    scheduler, so whether a scheduler file is required is read off
+    pretrained_model/train_config.json's "scheduler" key instead of a
+    hardcoded policy list — that file is written by cfg.save_pretrained,
+    which save_checkpoint always calls (and returns from) strictly before
+    save_training_state starts, so by the time training_step.json exists
+    (checked above) train_config.json is guaranteed complete; reading it
+    here carries no extra race.
+
+    Pure and self-contained (stdlib only: pathlib + json) so its source can
+    be inlined verbatim into WRAPPER_SOURCE the same way _install_plan is,
     keeping the in-container check and the unit-tested implementation
     identical.
     """
+    import json
+
     pretrained_dir = step_dir / "pretrained_model"
     if not (pretrained_dir / "config.json").is_file():
         return False
-    return (step_dir / "training_state").is_dir()
+    training_state_dir = step_dir / "training_state"
+    if not (training_state_dir / "training_step.json").is_file():
+        return False
+    if not (training_state_dir / "rng_state.safetensors").is_file():
+        return False
+    if not (training_state_dir / "optimizer_state.safetensors").is_file():
+        return False
+    try:
+        train_config = json.loads((pretrained_dir / "train_config.json").read_text())
+        needs_scheduler = train_config.get("scheduler") is not None
+    except (OSError, ValueError):
+        # train_config.json is part of pretrained_model/ and is guaranteed
+        # present by this point (checked above via config.json); if it can't
+        # be read/parsed, fail closed and require the scheduler file too.
+        needs_scheduler = True
+    return not needs_scheduler or (training_state_dir / "scheduler_state.json").is_file()
 
 
 def _cloud_device(flavor: str) -> str:

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -19,7 +19,6 @@ integration tests."""
 
 from __future__ import annotations
 
-import json
 import netrc
 import re
 import tomllib
@@ -318,256 +317,60 @@ def test_install_plan_reports_no_installer() -> None:
 # -- checkpoint-completeness check (partial-upload race fix) --
 
 
-def test_checkpoint_step_ready_false_when_step_dir_empty(tmp_path: Path) -> None:
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+def test_checkpoint_step_ready_false_when_no_last_link_exists(tmp_path: Path) -> None:
+    """No checkpoints/last symlink at all — e.g. before the first checkpoint
+    of a run has completed — must not be mistaken for readiness."""
+    from makermodslab.runners.hf_cloud import _checkpoint_step_ready
 
     step_dir = tmp_path / "005000"
     step_dir.mkdir()
     assert _checkpoint_step_ready(step_dir) is False
 
 
-def test_checkpoint_step_ready_false_when_only_config_json_exists(tmp_path: Path) -> None:
-    """The exact race this fixes: lerobot's save_checkpoint writes
-    pretrained_model/config.json before model.safetensors, and only creates
-    training_state/ after all of pretrained_model/ is written. A poll that
-    lands in this window must not consider the step ready."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+def test_checkpoint_step_ready_false_when_last_points_to_an_earlier_step(tmp_path: Path) -> None:
+    """The exact race this fixes: lerobot writes pretrained_model/config.json
+    (and creates training_state/) well before the step is actually complete.
+    Only checkpoints/last advancing to (or past) this step is proof the whole
+    step finished — a step dir existing on its own proves nothing."""
+    from makermodslab.runners.hf_cloud import _checkpoint_step_ready
 
-    step_dir = tmp_path / "005000"
-    pretrained_dir = step_dir / "pretrained_model"
-    pretrained_dir.mkdir(parents=True)
-    (pretrained_dir / "config.json").write_text("{}")
+    step_dir = tmp_path / "010000"
+    step_dir.mkdir()
+    (tmp_path / "005000").mkdir()
+    (tmp_path / "last").symlink_to("005000")
     assert _checkpoint_step_ready(step_dir) is False
 
 
-def test_checkpoint_step_ready_false_when_only_training_state_exists(tmp_path: Path) -> None:
-    """Belt-and-suspenders: training_state/ alone (no pretrained_model/config.json,
-    e.g. a directory mid-construction from something other than save_checkpoint)
-    is not enough either."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+def test_checkpoint_step_ready_true_when_last_points_to_this_step(tmp_path: Path) -> None:
+    from makermodslab.runners.hf_cloud import _checkpoint_step_ready
 
     step_dir = tmp_path / "005000"
-    (step_dir / "training_state").mkdir(parents=True)
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def _write_pretrained(step_dir: Path, scheduler: dict | None = None, optimizer_type: str = "adam") -> Path:
-    """Populate a fully-written pretrained_model/ for `step_dir` (config.json,
-    model.safetensors, train_config.json with the given `scheduler` value —
-    None mirrors a policy with no scheduler preset, e.g. act; a dict mirrors
-    one that has one, e.g. diffusion/pi0/smolvla/vqbet — and `optimizer_type`,
-    draccus's ChoiceRegistry discriminator for the optimizer config: "adam"/
-    "adamw"/etc. for a single-optimizer policy, "multi_adam" for one built from
-    lerobot's MultiAdamConfig, e.g. gaussian_actor)."""
-    pretrained_dir = step_dir / "pretrained_model"
-    pretrained_dir.mkdir(parents=True)
-    (pretrained_dir / "config.json").write_text("{}")
-    (pretrained_dir / "model.safetensors").write_bytes(b"fake-weights")
-    (pretrained_dir / "train_config.json").write_text(
-        json.dumps({"scheduler": scheduler, "optimizer": {"type": optimizer_type}})
-    )
-    return pretrained_dir
-
-
-def test_checkpoint_step_ready_false_when_training_state_freshly_created(tmp_path: Path) -> None:
-    """The race the original fix left open: lerobot's save_training_state does
-    `training_state/.mkdir(...)` *before* writing any of training_step.json /
-    rng_state.safetensors / optimizer_state.safetensors / scheduler_state.json.
-    A poll landing right after the mkdir (and before any of those files exist)
-    must not consider the step ready, even though pretrained_model/ is fully
-    written and training_state/ already exists as a directory."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir)
-    (step_dir / "training_state").mkdir()  # freshly created, empty
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def test_checkpoint_step_ready_false_when_training_state_missing_optimizer(tmp_path: Path) -> None:
-    """Same race, later in the window: training_step.json and rng_state.safetensors
-    have landed but optimizer_state.safetensors (always written — lerobot's own
-    training loop never calls save_checkpoint with optimizer=None) has not."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir)
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def test_checkpoint_step_ready_true_for_no_scheduler_policy(tmp_path: Path) -> None:
-    """A policy with no scheduler preset (train_config.json's "scheduler" is
-    null, e.g. act) is ready once training_step.json, rng_state.safetensors,
-    and optimizer_state.safetensors exist — save_training_state never writes
-    scheduler_state.json for these, so requiring it would leave the step
-    permanently un-uploadable."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, scheduler=None)
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    step_dir.mkdir()
+    (tmp_path / "last").symlink_to("005000")
     assert _checkpoint_step_ready(step_dir) is True
 
 
-def test_checkpoint_step_ready_false_for_scheduler_policy_missing_scheduler_state(
-    tmp_path: Path,
-) -> None:
-    """A policy that does have a scheduler preset (e.g. diffusion/pi0/smolvla/
-    vqbet) is NOT ready until scheduler_state.json lands too, even though
-    optimizer_state.safetensors already exists — the narrower race the
-    original fix's is_dir() check would have missed entirely."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+def test_checkpoint_step_ready_true_when_last_has_advanced_past_this_step(tmp_path: Path) -> None:
+    """<=, not ==: two checkpoints can complete inside one 15s poll window, and
+    a step must not go permanently unuploaded just because the poller missed
+    the instant `last` pointed at it exactly."""
+    from makermodslab.runners.hf_cloud import _checkpoint_step_ready
 
     step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, scheduler={"type": "cosine_decay_with_warmup"})
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def test_checkpoint_step_ready_true_for_scheduler_policy_once_complete(tmp_path: Path) -> None:
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, scheduler={"type": "cosine_decay_with_warmup"})
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
-    (training_state_dir / "scheduler_state.json").write_text("{}")
+    step_dir.mkdir()
+    (tmp_path / "010000").mkdir()
+    (tmp_path / "last").symlink_to("010000")
     assert _checkpoint_step_ready(step_dir) is True
 
 
-def test_checkpoint_step_ready_false_for_multi_optimizer_policy_before_any_group_dir(
-    tmp_path: Path,
-) -> None:
-    """gaussian_actor's MultiAdamConfig preset means lerobot's save_optimizer_state
-    takes the dict branch: it writes one training_state/<name>/optimizer_state.safetensors
-    per named optimizer group, never a flat training_state/optimizer_state.safetensors.
-    Before any group subdirectory has appeared, the step is not ready."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+def test_checkpoint_step_ready_false_when_last_is_not_a_symlink(tmp_path: Path) -> None:
+    """A plain file or directory named `last` (not the symlink lerobot writes)
+    must not be misread as a target step number."""
+    from makermodslab.runners.hf_cloud import _checkpoint_step_ready
 
     step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, optimizer_type="multi_adam")
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def test_checkpoint_step_ready_false_for_multi_optimizer_policy_with_incomplete_group(
-    tmp_path: Path,
-) -> None:
-    """save_optimizer_state's dict branch does `optimizer_dir.mkdir()` for a group
-    before writing that group's optimizer_state.safetensors into it — the same
-    mkdir-then-write race the single-optimizer checks above already guard against,
-    reopened here for the per-group subdirectory."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, optimizer_type="multi_adam")
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    (training_state_dir / "actor").mkdir()  # freshly created, empty
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def test_checkpoint_step_ready_false_for_multi_optimizer_policy_with_one_of_two_groups_done(
-    tmp_path: Path,
-) -> None:
-    """Two optimizer groups (e.g. actor + critic) are being saved; only one has
-    finished writing. The step must not be considered ready until every group
-    subdirectory that has appeared is itself complete."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, optimizer_type="multi_adam")
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    actor_dir = training_state_dir / "actor"
-    actor_dir.mkdir()
-    (actor_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
-    (training_state_dir / "critic").mkdir()  # freshly created, empty
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def test_checkpoint_step_ready_true_for_multi_optimizer_policy_once_group_complete(
-    tmp_path: Path,
-) -> None:
-    """The regression this fixes: a flat training_state/optimizer_state.safetensors
-    check (the pre-fix behaviour) never exists for a MultiAdamConfig policy like
-    gaussian_actor, so the step would never be considered ready. Once its (only)
-    optimizer group has finished writing, the step is ready even though no flat
-    optimizer_state.safetensors file exists directly under training_state/."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, optimizer_type="multi_adam")
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    actor_dir = training_state_dir / "actor"
-    actor_dir.mkdir()
-    (actor_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
-    assert not (training_state_dir / "optimizer_state.safetensors").exists()
-    assert _checkpoint_step_ready(step_dir) is True
-
-
-def test_checkpoint_step_ready_false_for_multi_optimizer_policy_missing_scheduler_state(
-    tmp_path: Path,
-) -> None:
-    """The scheduler check applies independently of single- vs multi-optimizer:
-    a multi_adam policy whose train_config.json also declares a scheduler still
-    needs scheduler_state.json before the step is ready."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    _write_pretrained(step_dir, scheduler={"type": "cosine_decay_with_warmup"}, optimizer_type="multi_adam")
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    actor_dir = training_state_dir / "actor"
-    actor_dir.mkdir()
-    (actor_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
-    assert _checkpoint_step_ready(step_dir) is False
-
-
-def test_checkpoint_step_ready_fails_closed_when_train_config_unreadable(tmp_path: Path) -> None:
-    """If train_config.json is missing or unparsable, don't guess: require
-    scheduler_state.json too (fail closed) rather than risk uploading a step
-    whose training_state/ is still incomplete for a scheduler-having policy."""
-    from makerlab.runners.hf_cloud import _checkpoint_step_ready
-
-    step_dir = tmp_path / "005000"
-    pretrained_dir = step_dir / "pretrained_model"
-    pretrained_dir.mkdir(parents=True)
-    (pretrained_dir / "config.json").write_text("{}")
-    (pretrained_dir / "model.safetensors").write_bytes(b"fake-weights")
-    # no train_config.json written at all
-    training_state_dir = step_dir / "training_state"
-    training_state_dir.mkdir()
-    (training_state_dir / "training_step.json").write_text("{}")
-    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
-    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    step_dir.mkdir()
+    (tmp_path / "last").mkdir()
     assert _checkpoint_step_ready(step_dir) is False
 
 
@@ -575,16 +378,31 @@ def test_wrapper_source_inlines_the_tested_checkpoint_ready_check() -> None:
     """The wrapper's checkpoint-completeness check is _checkpoint_step_ready's
     source inlined verbatim, so the in-container upload gate is exactly the
     function the tests above exercise — and _scan_and_upload must call it
-    instead of checking config.json directly (that was the bug: uploading and
-    marking a step `seen` the moment config.json appeared, even though
-    model.safetensors and training_state/ might not exist yet)."""
+    instead of checking config.json directly."""
     import inspect
 
-    from makerlab.runners.hf_cloud import WRAPPER_SOURCE, _checkpoint_step_ready
+    from makermodslab.runners.hf_cloud import WRAPPER_SOURCE, _checkpoint_step_ready
 
     assert inspect.getsource(_checkpoint_step_ready) in WRAPPER_SOURCE
     assert "__CHECKPOINT_READY_SOURCE__" not in WRAPPER_SOURCE  # placeholder replaced
     assert "_checkpoint_step_ready(entry)" in WRAPPER_SOURCE
+
+
+def test_lerobot_last_checkpoint_symlink_matches_our_readiness_check() -> None:
+    """_checkpoint_step_ready's readiness signal is lerobot's own
+    checkpoints/<LAST_CHECKPOINT_LINK> symlink, which lerobot_train.py points
+    at a step directory via update_last_checkpoint() strictly after
+    save_checkpoint() returns for that step. A lerobot pin bump that renames
+    the link or reorders those two calls should fail here in CI, not ship a
+    gate that silently never passes."""
+    import inspect
+
+    from lerobot.scripts import lerobot_train
+    from lerobot.utils.constants import LAST_CHECKPOINT_LINK
+
+    assert LAST_CHECKPOINT_LINK == "last"
+    src = inspect.getsource(lerobot_train)
+    assert src.index("save_checkpoint(") < src.index("update_last_checkpoint(checkpoint_dir)")
 
 
 # -- wrapper sanity --
@@ -604,15 +422,28 @@ def test_wrapper_source_compiles_and_launches_an_argv_list() -> None:
 
 def test_wrapper_source_handles_resume_download() -> None:
     """Cloud resume: the wrapper must parse --resume-from, download the parent
-    checkpoint tree, refuse when training_state/ is absent, and pre-seed `seen`
-    so it never re-uploads the checkpoint it just pulled down."""
+    checkpoint tree, refuse when the downloaded step is incomplete, and
+    pre-seed `seen` so it never re-uploads the checkpoint it just pulled
+    down."""
     from makermodslab.runners.hf_cloud import WRAPPER_SOURCE
 
     compile(WRAPPER_SOURCE, "<hf-jobs-wrapper>", "exec")  # still valid with the resume block
     assert "--resume-from=" in WRAPPER_SOURCE
     assert "snapshot_download" in WRAPPER_SOURCE
-    assert "training_state" in WRAPPER_SOURCE
     assert "seen.add(step_dir)" in WRAPPER_SOURCE
+
+
+def test_wrapper_source_resume_checks_weights_and_training_state_not_just_a_bare_dir() -> None:
+    """C4: a plain `training_state/` is_dir() check would pass a checkpoint
+    that was itself only partially uploaded before this fix existed — the
+    checkpoints/last symlink used by the live watcher isn't available here
+    (it's never pushed to the Hub), so the resume path checks the files it
+    actually needs directly instead of trusting the directory's existence."""
+    from makermodslab.runners.hf_cloud import WRAPPER_SOURCE
+
+    assert 'any((dest / "pretrained_model").glob("*.safetensors"))' in WRAPPER_SOURCE
+    assert '(dest / "training_state" / "training_step.json").is_file()' in WRAPPER_SOURCE
+    assert '(dest / "training_state" / "rng_state.safetensors").is_file()' in WRAPPER_SOURCE
 
 
 def test_wrapper_source_materializes_a_step_suffixed_finetune_base() -> None:

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -351,16 +351,21 @@ def test_checkpoint_step_ready_false_when_only_training_state_exists(tmp_path: P
     assert _checkpoint_step_ready(step_dir) is False
 
 
-def _write_pretrained(step_dir: Path, scheduler: dict | None = None) -> Path:
+def _write_pretrained(step_dir: Path, scheduler: dict | None = None, optimizer_type: str = "adam") -> Path:
     """Populate a fully-written pretrained_model/ for `step_dir` (config.json,
     model.safetensors, train_config.json with the given `scheduler` value —
     None mirrors a policy with no scheduler preset, e.g. act; a dict mirrors
-    one that has one, e.g. diffusion/pi0/smolvla/vqbet)."""
+    one that has one, e.g. diffusion/pi0/smolvla/vqbet — and `optimizer_type`,
+    draccus's ChoiceRegistry discriminator for the optimizer config: "adam"/
+    "adamw"/etc. for a single-optimizer policy, "multi_adam" for one built from
+    lerobot's MultiAdamConfig, e.g. gaussian_actor)."""
     pretrained_dir = step_dir / "pretrained_model"
     pretrained_dir.mkdir(parents=True)
     (pretrained_dir / "config.json").write_text("{}")
     (pretrained_dir / "model.safetensors").write_bytes(b"fake-weights")
-    (pretrained_dir / "train_config.json").write_text(json.dumps({"scheduler": scheduler}))
+    (pretrained_dir / "train_config.json").write_text(
+        json.dumps({"scheduler": scheduler, "optimizer": {"type": optimizer_type}})
+    )
     return pretrained_dir
 
 
@@ -443,6 +448,107 @@ def test_checkpoint_step_ready_true_for_scheduler_policy_once_complete(tmp_path:
     (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
     (training_state_dir / "scheduler_state.json").write_text("{}")
     assert _checkpoint_step_ready(step_dir) is True
+
+
+def test_checkpoint_step_ready_false_for_multi_optimizer_policy_before_any_group_dir(
+    tmp_path: Path,
+) -> None:
+    """gaussian_actor's MultiAdamConfig preset means lerobot's save_optimizer_state
+    takes the dict branch: it writes one training_state/<name>/optimizer_state.safetensors
+    per named optimizer group, never a flat training_state/optimizer_state.safetensors.
+    Before any group subdirectory has appeared, the step is not ready."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, optimizer_type="multi_adam")
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_false_for_multi_optimizer_policy_with_incomplete_group(
+    tmp_path: Path,
+) -> None:
+    """save_optimizer_state's dict branch does `optimizer_dir.mkdir()` for a group
+    before writing that group's optimizer_state.safetensors into it — the same
+    mkdir-then-write race the single-optimizer checks above already guard against,
+    reopened here for the per-group subdirectory."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, optimizer_type="multi_adam")
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    (training_state_dir / "actor").mkdir()  # freshly created, empty
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_false_for_multi_optimizer_policy_with_one_of_two_groups_done(
+    tmp_path: Path,
+) -> None:
+    """Two optimizer groups (e.g. actor + critic) are being saved; only one has
+    finished writing. The step must not be considered ready until every group
+    subdirectory that has appeared is itself complete."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, optimizer_type="multi_adam")
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    actor_dir = training_state_dir / "actor"
+    actor_dir.mkdir()
+    (actor_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    (training_state_dir / "critic").mkdir()  # freshly created, empty
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_true_for_multi_optimizer_policy_once_group_complete(
+    tmp_path: Path,
+) -> None:
+    """The regression this fixes: a flat training_state/optimizer_state.safetensors
+    check (the pre-fix behaviour) never exists for a MultiAdamConfig policy like
+    gaussian_actor, so the step would never be considered ready. Once its (only)
+    optimizer group has finished writing, the step is ready even though no flat
+    optimizer_state.safetensors file exists directly under training_state/."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, optimizer_type="multi_adam")
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    actor_dir = training_state_dir / "actor"
+    actor_dir.mkdir()
+    (actor_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    assert not (training_state_dir / "optimizer_state.safetensors").exists()
+    assert _checkpoint_step_ready(step_dir) is True
+
+
+def test_checkpoint_step_ready_false_for_multi_optimizer_policy_missing_scheduler_state(
+    tmp_path: Path,
+) -> None:
+    """The scheduler check applies independently of single- vs multi-optimizer:
+    a multi_adam policy whose train_config.json also declares a scheduler still
+    needs scheduler_state.json before the step is ready."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, scheduler={"type": "cosine_decay_with_warmup"}, optimizer_type="multi_adam")
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    actor_dir = training_state_dir / "actor"
+    actor_dir.mkdir()
+    (actor_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    assert _checkpoint_step_ready(step_dir) is False
 
 
 def test_checkpoint_step_ready_fails_closed_when_train_config_unreadable(tmp_path: Path) -> None:

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -314,6 +314,73 @@ def test_install_plan_reports_no_installer() -> None:
     assert _install_plan("spec", "/py", None, False, False) == (None, [])
 
 
+# -- checkpoint-completeness check (partial-upload race fix) --
+
+
+def test_checkpoint_step_ready_false_when_step_dir_empty(tmp_path: Path) -> None:
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    step_dir.mkdir()
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_false_when_only_config_json_exists(tmp_path: Path) -> None:
+    """The exact race this fixes: lerobot's save_checkpoint writes
+    pretrained_model/config.json before model.safetensors, and only creates
+    training_state/ after all of pretrained_model/ is written. A poll that
+    lands in this window must not consider the step ready."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    pretrained_dir = step_dir / "pretrained_model"
+    pretrained_dir.mkdir(parents=True)
+    (pretrained_dir / "config.json").write_text("{}")
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_false_when_only_training_state_exists(tmp_path: Path) -> None:
+    """Belt-and-suspenders: training_state/ alone (no pretrained_model/config.json,
+    e.g. a directory mid-construction from something other than save_checkpoint)
+    is not enough either."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    (step_dir / "training_state").mkdir(parents=True)
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_true_once_training_state_exists(tmp_path: Path) -> None:
+    """Once training_state/ exists, save_checkpoint has already finished
+    writing pretrained_model/ (training_state is created strictly after), so
+    the step is safe to upload."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    pretrained_dir = step_dir / "pretrained_model"
+    pretrained_dir.mkdir(parents=True)
+    (pretrained_dir / "config.json").write_text("{}")
+    (pretrained_dir / "model.safetensors").write_bytes(b"fake-weights")
+    (step_dir / "training_state").mkdir()
+    assert _checkpoint_step_ready(step_dir) is True
+
+
+def test_wrapper_source_inlines_the_tested_checkpoint_ready_check() -> None:
+    """The wrapper's checkpoint-completeness check is _checkpoint_step_ready's
+    source inlined verbatim, so the in-container upload gate is exactly the
+    function the tests above exercise — and _scan_and_upload must call it
+    instead of checking config.json directly (that was the bug: uploading and
+    marking a step `seen` the moment config.json appeared, even though
+    model.safetensors and training_state/ might not exist yet)."""
+    import inspect
+
+    from makerlab.runners.hf_cloud import WRAPPER_SOURCE, _checkpoint_step_ready
+
+    assert inspect.getsource(_checkpoint_step_ready) in WRAPPER_SOURCE
+    assert "__CHECKPOINT_READY_SOURCE__" not in WRAPPER_SOURCE  # placeholder replaced
+    assert "_checkpoint_step_ready(entry)" in WRAPPER_SOURCE
+
+
 # -- wrapper sanity --
 
 

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -19,6 +19,7 @@ integration tests."""
 
 from __future__ import annotations
 
+import json
 import netrc
 import re
 import tomllib
@@ -350,10 +351,104 @@ def test_checkpoint_step_ready_false_when_only_training_state_exists(tmp_path: P
     assert _checkpoint_step_ready(step_dir) is False
 
 
-def test_checkpoint_step_ready_true_once_training_state_exists(tmp_path: Path) -> None:
-    """Once training_state/ exists, save_checkpoint has already finished
-    writing pretrained_model/ (training_state is created strictly after), so
-    the step is safe to upload."""
+def _write_pretrained(step_dir: Path, scheduler: dict | None = None) -> Path:
+    """Populate a fully-written pretrained_model/ for `step_dir` (config.json,
+    model.safetensors, train_config.json with the given `scheduler` value —
+    None mirrors a policy with no scheduler preset, e.g. act; a dict mirrors
+    one that has one, e.g. diffusion/pi0/smolvla/vqbet)."""
+    pretrained_dir = step_dir / "pretrained_model"
+    pretrained_dir.mkdir(parents=True)
+    (pretrained_dir / "config.json").write_text("{}")
+    (pretrained_dir / "model.safetensors").write_bytes(b"fake-weights")
+    (pretrained_dir / "train_config.json").write_text(json.dumps({"scheduler": scheduler}))
+    return pretrained_dir
+
+
+def test_checkpoint_step_ready_false_when_training_state_freshly_created(tmp_path: Path) -> None:
+    """The race the original fix left open: lerobot's save_training_state does
+    `training_state/.mkdir(...)` *before* writing any of training_step.json /
+    rng_state.safetensors / optimizer_state.safetensors / scheduler_state.json.
+    A poll landing right after the mkdir (and before any of those files exist)
+    must not consider the step ready, even though pretrained_model/ is fully
+    written and training_state/ already exists as a directory."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir)
+    (step_dir / "training_state").mkdir()  # freshly created, empty
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_false_when_training_state_missing_optimizer(tmp_path: Path) -> None:
+    """Same race, later in the window: training_step.json and rng_state.safetensors
+    have landed but optimizer_state.safetensors (always written — lerobot's own
+    training loop never calls save_checkpoint with optimizer=None) has not."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir)
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_true_for_no_scheduler_policy(tmp_path: Path) -> None:
+    """A policy with no scheduler preset (train_config.json's "scheduler" is
+    null, e.g. act) is ready once training_step.json, rng_state.safetensors,
+    and optimizer_state.safetensors exist — save_training_state never writes
+    scheduler_state.json for these, so requiring it would leave the step
+    permanently un-uploadable."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, scheduler=None)
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    assert _checkpoint_step_ready(step_dir) is True
+
+
+def test_checkpoint_step_ready_false_for_scheduler_policy_missing_scheduler_state(
+    tmp_path: Path,
+) -> None:
+    """A policy that does have a scheduler preset (e.g. diffusion/pi0/smolvla/
+    vqbet) is NOT ready until scheduler_state.json lands too, even though
+    optimizer_state.safetensors already exists — the narrower race the
+    original fix's is_dir() check would have missed entirely."""
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, scheduler={"type": "cosine_decay_with_warmup"})
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    assert _checkpoint_step_ready(step_dir) is False
+
+
+def test_checkpoint_step_ready_true_for_scheduler_policy_once_complete(tmp_path: Path) -> None:
+    from makerlab.runners.hf_cloud import _checkpoint_step_ready
+
+    step_dir = tmp_path / "005000"
+    _write_pretrained(step_dir, scheduler={"type": "cosine_decay_with_warmup"})
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    (training_state_dir / "scheduler_state.json").write_text("{}")
+    assert _checkpoint_step_ready(step_dir) is True
+
+
+def test_checkpoint_step_ready_fails_closed_when_train_config_unreadable(tmp_path: Path) -> None:
+    """If train_config.json is missing or unparsable, don't guess: require
+    scheduler_state.json too (fail closed) rather than risk uploading a step
+    whose training_state/ is still incomplete for a scheduler-having policy."""
     from makerlab.runners.hf_cloud import _checkpoint_step_ready
 
     step_dir = tmp_path / "005000"
@@ -361,8 +456,13 @@ def test_checkpoint_step_ready_true_once_training_state_exists(tmp_path: Path) -
     pretrained_dir.mkdir(parents=True)
     (pretrained_dir / "config.json").write_text("{}")
     (pretrained_dir / "model.safetensors").write_bytes(b"fake-weights")
-    (step_dir / "training_state").mkdir()
-    assert _checkpoint_step_ready(step_dir) is True
+    # no train_config.json written at all
+    training_state_dir = step_dir / "training_state"
+    training_state_dir.mkdir()
+    (training_state_dir / "training_step.json").write_text("{}")
+    (training_state_dir / "rng_state.safetensors").write_bytes(b"fake-rng")
+    (training_state_dir / "optimizer_state.safetensors").write_bytes(b"fake-optim")
+    assert _checkpoint_step_ready(step_dir) is False
 
 
 def test_wrapper_source_inlines_the_tested_checkpoint_ready_check() -> None:


### PR DESCRIPTION
## Summary
- When training on HF Jobs, the sidecar that uploads checkpoints to the Hub could grab a checkpoint the instant its config file appeared on disk — before the (much larger) model weights file had finished writing, and before the training-state files existed at all.
- Once it uploaded that half-written checkpoint, it never looked at that step again, so a later fine-tune or inference run pulling that checkpoint from the Hub could get a broken/truncated model file with no way to recover it from that job.

## Fixes
- Original fix closed this by re-deriving lerobot's internal per-file write order and asserting the resulting file set — but a review found that approach still had a confirmed gap for `act`/`tdmpc` (the checkpoint's `optimizer_param_groups.json`, written last for those policies, was never checked), and that any ordering-emulation gate has an irreducible last-file race by construction.
- Suggestion recommended replaces that emulation with lerobot's own completion signal: `checkpoints/last`, a symlink `lerobot_train.py` points at a step directory strictly *after* `save_checkpoint()` returns for it. Reading that instead of reconstructing lerobot's internals removes the gap entirely, needs no per-policy scheduler/optimizer knowledge, and survives lerobot renaming any of its state files. Verified against the actual pinned lerobot v0.6.0 source (`train_utils.py`, `optimizers.py`, `lerobot_train.py`).

- **Resume path**: downloading a checkpoint from the Hub to resume a run used to only check that `training_state/` existed as a directory — the same weak check the original fix discredited for the live watcher. The symlink isn't available here (it's never pushed to the Hub), so the resume path now checks the downloaded step's weight and training-state files directly instead.
- **Visibility**: a checkpoint stuck in "not ready" used to fail silently forever, indistinguishable in the log from a normally running job. It now logs after 1/20/80 polls (~15s/~5min/~20min) with the current `checkpoints/last` target, so a stuck gate is diagnosable instead of just looking like nothing is happening.
- **Contract test**: added a test asserting the symlink name and the `save_checkpoint` → `update_last_checkpoint` call ordering the new gate depends on, so a future lerobot pin bump that breaks either fails in CI instead of silently uploading nothing for an entire run.

## Test plan
```
$ .venv/bin/python -m pytest tests/test_runners_hf_cloud.py -q
======================== 37 passed, 5 warnings in 3.34s ========================

$ .venv/bin/python -m pytest -q
====================== 1101 passed, 66 warnings in 18.70s ======================
```
`ruff check` and `ruff format --check` pass clean on both changed files.

This is a race condition inside an HF Jobs cloud container; there is no local UI repro, so the regression tests above (backed by reading the actual pinned lerobot source) are the evidence.
