### PR TITLE
fix(training): don't finalize a reattached job as done when we can't confirm its exit code (MT10)

### DIFF
--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -176,6 +176,13 @@ _TQDM_RE = re.compile(r"Training:\s*\d+%[^|]*\|[^|]*\|\s*(\d+)/(\d+)\s*\[(?:[\d:
 # when it boots. We capture the first URL of that shape we see.
 _WANDB_URL_RE = re.compile(r"https://wandb\.ai/[^\s/]+/[^\s/]+/runs/[A-Za-z0-9]+")
 
+# lerobot's training entrypoint logs this exact line once its step loop
+# finishes, before any optional push-to-hub (see lerobot's
+# scripts/lerobot_train.py: `logging.info("End of training")`). It's the only
+# positive signal TailingJobRunner has that a reattached job actually
+# completed rather than merely disappearing — see its returncode().
+_TRAINING_END_MARKER = "End of training"
+
 
 def extract_wandb_run_url(line: str) -> str | None:
     match = _WANDB_URL_RE.search(line)
@@ -528,6 +535,10 @@ class TailingJobRunner:
         # on metrics, then tail from the current EOF.
         self._tail_offset = 0
         self._wandb_run_url: str | None = None
+        # Set from _tail_loop once the tailed log shows _TRAINING_END_MARKER.
+        # The only positive evidence returncode() has that the trainer really
+        # finished, since we can't waitpid() a process from another session.
+        self._training_completed = False
 
     def start(self, job_id: str, config: TrainingRequest, output_dir: str) -> None:
         # Required by JobRunner Protocol but irrelevant here; the subprocess
@@ -552,12 +563,16 @@ class TailingJobRunner:
 
     def returncode(self) -> int | None:
         # We can't reap a process from another session, so we don't know the
-        # actual exit code. Return 0 once the pid is gone — the watchdog
-        # finalises as "done" rather than "failed", which is the better
-        # default for a detached training that completed normally.
+        # actual exit code. Once the pid is gone, only claim success (0) if
+        # the tailed log actually showed the trainer's own "End of training"
+        # marker — i.e. we watched it finish, not just disappear. Otherwise
+        # return None: JobRegistry._tick() reads that (once is_running() is
+        # already False) as "no confirmation either way" and finalises the
+        # record as 'interrupted' rather than asserting a "done" or "failed"
+        # we can't back up.
         if _pid_alive(self._pid):
             return None
-        return 0
+        return 0 if self._training_completed else None
 
     def stream_log_lines(self) -> list[LogLine]:
         out: list[LogLine] = []
@@ -605,6 +620,8 @@ class TailingJobRunner:
                             url = extract_wandb_run_url(log_line.message)
                             if url is not None:
                                 self._wandb_run_url = url
+                        if not self._training_completed and _TRAINING_END_MARKER in log_line.message:
+                            self._training_completed = True
                         if self._log_queue.qsize() >= 1000:
                             with contextlib.suppress(Empty):
                                 self._log_queue.get_nowait()
@@ -3259,10 +3276,20 @@ class JobRegistry:
             with self._lock:
                 if record.wandb_run_url is None:
                     record.wandb_run_url = runner.wandb_run_url()
-                record.state = "done" if rc == 0 else "failed"
+                if rc is None:
+                    # is_running() already said the process is gone, but the
+                    # runner has no evidence of how it ended (e.g. a
+                    # reattached local job — TailingJobRunner — whose pid
+                    # disappeared without its log showing a real completion).
+                    # Don't assert a "done" or "failed" we can't back up;
+                    # reuse the same honest 'interrupted' state a dead pid at
+                    # boot already gets.
+                    record.state = "interrupted"
+                else:
+                    record.state = "done" if rc == 0 else "failed"
                 record.ended_at = time.time()
                 record.exit_code = rc
-                if rc != 0 and record.error_message is None:
+                if rc is not None and rc != 0 and record.error_message is None:
                     # Prefer a runner-supplied reason (e.g. HF Jobs'
                     # 'Job timeout') over the synthetic exit-code message.
                     reason = None

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -3140,7 +3140,34 @@ class JobRegistry:
                         runner.start_tailing()
                         self._runners[record.id] = runner
                     else:
-                        record.state = "interrupted"
+                        # The pid is gone, but that alone doesn't mean the
+                        # outcome is unconfirmed: the wrapper LocalJobRunner.start()
+                        # launched writes the trainer's real exit status to
+                        # <output_dir>/exit_status before it exits, and that
+                        # file survives a full server restart same as it
+                        # survives the reattach case above (see
+                        # TailingJobRunner.returncode()). Read it before
+                        # falling back to 'interrupted', so a run that
+                        # finished (or crashed) while the server was down
+                        # isn't reported as merely unconfirmed when the
+                        # evidence is sitting right there on disk.
+                        rc: int | None = None
+                        status_path = Path(record.output_dir) / _EXIT_STATUS_FILENAME
+                        with contextlib.suppress(FileNotFoundError, ValueError):
+                            rc = int(status_path.read_text().strip())
+                        if rc is None:
+                            record.state = "interrupted"
+                            if record.error_message is None:
+                                record.error_message = (
+                                    "MakerMods Lab restarted while this run was training; "
+                                    "its outcome could not be confirmed. Any checkpoints on "
+                                    "disk are intact."
+                                )
+                        else:
+                            record.state = "done" if rc == 0 else "failed"
+                            record.exit_code = rc
+                            if rc != 0 and record.error_message is None:
+                                record.error_message = f"Subprocess exited with code {rc}"
                         if record.ended_at is None:
                             record.ended_at = time.time()
                         self._write_meta(record)

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -176,12 +176,10 @@ _TQDM_RE = re.compile(r"Training:\s*\d+%[^|]*\|[^|]*\|\s*(\d+)/(\d+)\s*\[(?:[\d:
 # when it boots. We capture the first URL of that shape we see.
 _WANDB_URL_RE = re.compile(r"https://wandb\.ai/[^\s/]+/[^\s/]+/runs/[A-Za-z0-9]+")
 
-# lerobot's training entrypoint logs this exact line once its step loop
-# finishes, before any optional push-to-hub (see lerobot's
-# scripts/lerobot_train.py: `logging.info("End of training")`). It's the only
-# positive signal TailingJobRunner has that a reattached job actually
-# completed rather than merely disappearing — see its returncode().
-_TRAINING_END_MARKER = "End of training"
+# Name of the file LocalJobRunner's subprocess wrapper writes the trainer's
+# real exit status to, relative to the run's output_dir. TailingJobRunner
+# reads it after a reattach — see both classes' start()/returncode().
+_EXIT_STATUS_FILENAME = "exit_status"
 
 
 def extract_wandb_run_url(line: str) -> str | None:
@@ -384,6 +382,7 @@ class LocalJobRunner:
         self._log_file = None  # type: ignore[assignment]
         self._wandb_run_url: str | None = None
         self._resume_total: int | None = None
+        self._status_path: Path | None = None
 
     def start(
         self,
@@ -413,13 +412,38 @@ class LocalJobRunner:
         child_env = os.environ.copy()
         child_env["PYTHONUNBUFFERED"] = "1"
 
-        # start_new_session=True puts the child in its own session/process
-        # group. Without it, signals sent to the uvicorn worker (e.g. when
-        # --reload restarts it on a .py file change) cascade to the child
-        # and kill the training. With it, the child survives reloads; the
-        # next worker re-attaches via TailingJobRunner using job.json's pid.
+        # output_dir is fresh per job (LocalJobRunner is single-shot), so a
+        # leftover exit_status here would only ever come from a stray manual
+        # re-run into the same dir — cheap to guard anyway.
+        self._status_path = Path(output_dir) / _EXIT_STATUS_FILENAME
+        with contextlib.suppress(FileNotFoundError):
+            self._status_path.unlink()
+
+        # Wrap the trainer in a shell that records its own exit status to
+        # disk. This is the only way to learn the real outcome of a job that
+        # outlives this process (uvicorn --reload, or a full restart) — see
+        # TailingJobRunner.returncode(). `trap "" HUP` keeps the wrapper alive
+        # through a reload's HUP long enough to write the status; passing the
+        # status path as $0 and the real command as "$@" (rather than two
+        # separate -c scripts) is what lets sh -c carry both through one
+        # positional-arg list.
+        wrapped_cmd = [
+            "/bin/sh",
+            "-c",
+            'trap "" HUP; "$@"; s=$?; printf %s "$s" > "$0.tmp" && mv "$0.tmp" "$0"; exit $s',
+            str(self._status_path),
+            *cmd,
+        ]
+
+        # start_new_session=True puts the wrapper (and the trainer it execs)
+        # in their own session/process group. Without it, signals sent to the
+        # uvicorn worker (e.g. when --reload restarts it on a .py file change)
+        # cascade to the child and kill the training. With it, the child
+        # survives reloads; the next worker re-attaches via TailingJobRunner
+        # using job.json's pid — see stop()'s use of killpg for the other side
+        # of this: the tracked pid is the wrapper's, not the trainer's.
         self._process = subprocess.Popen(
-            cmd,
+            wrapped_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
@@ -441,12 +465,18 @@ class LocalJobRunner:
             return
         self._stop_event.set()
         try:
-            self._process.terminate()
+            # self._process is the /bin/sh wrapper from start(); the trainer
+            # is its child in the same process group (start_new_session made
+            # the wrapper's pid its own pgid too), so signalling the wrapper
+            # alone would leave the trainer running. Signal the whole group.
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(self._process.pid, signal.SIGTERM)
             try:
                 self._process.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 logger.warning("Subprocess did not terminate in 10s, killing")
-                self._process.kill()
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(self._process.pid, signal.SIGKILL)
                 self._process.wait()
         except Exception as exc:
             logger.exception("Error stopping subprocess: %s", exc)
@@ -457,6 +487,10 @@ class LocalJobRunner:
     def returncode(self) -> int | None:
         if self._process is None:
             return None
+        # The wrapper shell in start() `exit $s`s with the trainer's own exit
+        # status, so poll() already reports the real code — no need to read
+        # the status file here (that's for TailingJobRunner, which can't poll
+        # across a process restart).
         return self._process.poll()
 
     def stream_log_lines(self) -> list[LogLine]:
@@ -522,11 +556,13 @@ class TailingJobRunner:
         metrics: TrainingMetrics,
         log_file_path: Path,
         pid: int,
+        status_path: Path,
         resume_total: int | None = None,
     ) -> None:
         self._metrics = metrics
         self._log_file_path = log_file_path
         self._pid = pid
+        self._status_path = status_path
         self._resume_total = resume_total
         self._log_queue: Queue[LogLine] = Queue()
         self._tail_thread: threading.Thread | None = None
@@ -535,10 +571,6 @@ class TailingJobRunner:
         # on metrics, then tail from the current EOF.
         self._tail_offset = 0
         self._wandb_run_url: str | None = None
-        # Set from _tail_loop once the tailed log shows _TRAINING_END_MARKER.
-        # The only positive evidence returncode() has that the trainer really
-        # finished, since we can't waitpid() a process from another session.
-        self._training_completed = False
 
     def start(self, job_id: str, config: TrainingRequest, output_dir: str) -> None:
         # Required by JobRunner Protocol but irrelevant here; the subprocess
@@ -554,25 +586,37 @@ class TailingJobRunner:
         self._tail_thread.start()
 
     def stop(self) -> None:
+        # self._pid is the /bin/sh wrapper LocalJobRunner.start() launched
+        # (start_new_session made it its own pgid too); the trainer is its
+        # child in the same group, so signal the whole group rather than just
+        # the wrapper.
         with contextlib.suppress(ProcessLookupError):
-            os.kill(self._pid, signal.SIGTERM)
+            os.killpg(self._pid, signal.SIGTERM)
         self._stop_event.set()
 
     def is_running(self) -> bool:
         return _pid_alive(self._pid)
 
     def returncode(self) -> int | None:
-        # We can't reap a process from another session, so we don't know the
-        # actual exit code. Once the pid is gone, only claim success (0) if
-        # the tailed log actually showed the trainer's own "End of training"
-        # marker — i.e. we watched it finish, not just disappear. Otherwise
-        # return None: JobRegistry._tick() reads that (once is_running() is
-        # already False) as "no confirmation either way" and finalises the
-        # record as 'interrupted' rather than asserting a "done" or "failed"
+        # We can't reap a process from another session, so is_running() going
+        # False doesn't hand us an exit code the way Popen.poll() would. The
+        # wrapper LocalJobRunner.start() launched writes its own exit status
+        # to self._status_path before exiting, so read that instead of
+        # guessing from tailed log content. Absent file (wrapper itself was
+        # killed, e.g. SIGKILL or a reboot) means genuinely unconfirmed —
+        # JobRegistry._tick() reads None here as "no evidence either way" and
+        # finalises 'interrupted' rather than asserting a "done" or "failed"
         # we can't back up.
         if _pid_alive(self._pid):
             return None
-        return 0 if self._training_completed else None
+        try:
+            raw = self._status_path.read_text().strip()
+        except FileNotFoundError:
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            return None
 
     def stream_log_lines(self) -> list[LogLine]:
         out: list[LogLine] = []
@@ -620,8 +664,6 @@ class TailingJobRunner:
                             url = extract_wandb_run_url(log_line.message)
                             if url is not None:
                                 self._wandb_run_url = url
-                        if not self._training_completed and _TRAINING_END_MARKER in log_line.message:
-                            self._training_completed = True
                         if self._log_queue.qsize() >= 1000:
                             with contextlib.suppress(Empty):
                                 self._log_queue.get_nowait()
@@ -3069,6 +3111,7 @@ class JobRegistry:
                             record.metrics,
                             _job_log_path(self._output_root, record.id),
                             pid,
+                            Path(record.output_dir) / _EXIT_STATUS_FILENAME,
                             _resume_total_steps(record.config),
                         )
                         runner.start_tailing()
@@ -3280,11 +3323,16 @@ class JobRegistry:
                     # is_running() already said the process is gone, but the
                     # runner has no evidence of how it ended (e.g. a
                     # reattached local job — TailingJobRunner — whose pid
-                    # disappeared without its log showing a real completion).
-                    # Don't assert a "done" or "failed" we can't back up;
-                    # reuse the same honest 'interrupted' state a dead pid at
-                    # boot already gets.
+                    # disappeared with no exit status written to disk). Don't
+                    # assert a "done" or "failed" we can't back up; reuse the
+                    # same honest 'interrupted' state a dead pid at boot
+                    # already gets.
                     record.state = "interrupted"
+                    if record.error_message is None:
+                        record.error_message = (
+                            "MakerMods Lab restarted while this run was training; its "
+                            "outcome could not be confirmed. Checkpoints on disk are intact."
+                        )
                 else:
                     record.state = "done" if rc == 0 else "failed"
                 record.ended_at = time.time()

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -567,6 +567,9 @@ class TailingJobRunner:
         self._log_queue: Queue[LogLine] = Queue()
         self._tail_thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        # Set only when stop() actually got a SIGTERM into a live process
+        # group — see stop_signalled().
+        self._stop_delivered = threading.Event()
         # Replay everything that's already on disk so the parser catches up
         # on metrics, then tail from the current EOF.
         self._tail_offset = 0
@@ -590,17 +593,29 @@ class TailingJobRunner:
         # (start_new_session made it its own pgid too); the trainer is its
         # child in the same group, so signal the whole group rather than just
         # the wrapper.
-        with contextlib.suppress(ProcessLookupError):
+        try:
             os.killpg(self._pid, signal.SIGTERM)
+        except ProcessLookupError:
+            # The group was already gone, so whatever ended this run, it
+            # wasn't us — leave _stop_delivered clear so stop_signalled()
+            # can't claim credit for a crash that beat the user's click.
+            pass
+        else:
+            self._stop_delivered.set()
         self._stop_event.set()
 
     def stop_signalled(self) -> bool:
-        """True once stop() has been called on this runner. Consulted by
-        JobRegistry._tick() when returncode() comes back None: the group TERM
-        in stop() kills the wrapper before it can write an exit status, so a
-        user-requested stop looks identical to an unconfirmed crash/restart
-        unless this is checked."""
-        return self._stop_event.is_set()
+        """True once stop() verifiably delivered a SIGTERM to a live process
+        group. Consulted by JobRegistry._tick() when returncode() comes back
+        None: the group TERM in stop() kills the wrapper before it can write
+        an exit status, so a user-requested stop looks identical to an
+        unconfirmed crash/restart unless this is checked.
+
+        Deliberately not just "stop() was called". A run that crashed (or died
+        to a restart) before the user clicked Stop reaches killpg with nothing
+        left to signal; reporting intent alone there would tell the user we
+        stopped a run that had already ended on its own."""
+        return self._stop_delivered.is_set()
 
     def is_running(self) -> bool:
         return _pid_alive(self._pid)

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -435,7 +435,7 @@ class LocalJobRunner:
             *cmd,
         ]
 
-        # start_new_session=True puts the wrapper (and the trainer it execs)
+        # start_new_session=True puts the wrapper (and the trainer it forks)
         # in their own session/process group. Without it, signals sent to the
         # uvicorn worker (e.g. when --reload restarts it on a .py file change)
         # cascade to the child and kill the training. With it, the child
@@ -593,6 +593,14 @@ class TailingJobRunner:
         with contextlib.suppress(ProcessLookupError):
             os.killpg(self._pid, signal.SIGTERM)
         self._stop_event.set()
+
+    def stop_signalled(self) -> bool:
+        """True once stop() has been called on this runner. Consulted by
+        JobRegistry._tick() when returncode() comes back None: the group TERM
+        in stop() kills the wrapper before it can write an exit status, so a
+        user-requested stop looks identical to an unconfirmed crash/restart
+        unless this is checked."""
+        return self._stop_event.is_set()
 
     def is_running(self) -> bool:
         return _pid_alive(self._pid)
@@ -3329,10 +3337,24 @@ class JobRegistry:
                     # already gets.
                     record.state = "interrupted"
                     if record.error_message is None:
-                        record.error_message = (
-                            "MakerMods Lab restarted while this run was training; its "
-                            "outcome could not be confirmed. Checkpoints on disk are intact."
-                        )
+                        # A user-requested stop of a reattached run also lands
+                        # here with no exit status: stop() group-TERMs the
+                        # wrapper before it can write one. Consult the runner
+                        # so that case doesn't get blamed on a restart that
+                        # never happened.
+                        stop_signalled = getattr(runner, "stop_signalled", None)
+                        if callable(stop_signalled) and stop_signalled():
+                            record.error_message = (
+                                "This run was stopped at your request; its exact exit "
+                                "status could not be confirmed. Any checkpoints on disk "
+                                "are intact."
+                            )
+                        else:
+                            record.error_message = (
+                                "MakerMods Lab restarted while this run was training; its "
+                                "outcome could not be confirmed. Any checkpoints on disk "
+                                "are intact."
+                            )
                 else:
                     record.state = "done" if rc == 0 else "failed"
                 record.ended_at = time.time()

--- a/makermodslab/models.py
+++ b/makermodslab/models.py
@@ -182,11 +182,19 @@ def _read_train_config(pretrained_dir: Path) -> dict[str, Any]:
 def _local_model_summary(record: JobRecord, pretrained_dir: Path) -> dict[str, Any]:
     """Build the listing row for one completed local run's final checkpoint.
 
-    policy_type / dataset / steps come from train_config.json where present, and
-    fall back to the registry record (config.policy_type, config.dataset_repo_id)
-    so a checkpoint missing its train_config still renders a usable row. The
-    checkpoint's actual step (its dir name) is the authoritative `steps` value;
-    train_config's `steps` is the run's target and is used only as a fallback."""
+    policy_type / dataset come from train_config.json where present, and fall
+    back to the registry record (config.policy_type, config.dataset_repo_id)
+    so a checkpoint missing its train_config still renders a usable row.
+
+    `steps` and `target_steps` are deliberately kept separate: `steps` is the
+    checkpoint's actual step (its dir name) — the authoritative count for what
+    was actually saved — while `target_steps` is the run's configured step
+    count (train_config.json's `steps`, falling back to the registry record's).
+    An "interrupted" run that stopped short of its target has `steps <
+    target_steps`; without both fields such a run is indistinguishable from
+    one that finished exactly at that checkpoint. `state` ("done" or
+    "interrupted", per the `list_local_models` gate) is carried for the same
+    reason — callers should not assume every row here trained to completion."""
     train_config = _read_train_config(pretrained_dir)
 
     policy = train_config.get("policy") or {}
@@ -195,12 +203,14 @@ def _local_model_summary(record: JobRecord, pretrained_dir: Path) -> dict[str, A
     dataset = train_config.get("dataset") or {}
     dataset_repo_id = dataset.get("repo_id") or record.config.dataset_repo_id or None
 
+    raw_target_steps = train_config.get("steps")
+    target_steps = raw_target_steps if isinstance(raw_target_steps, int) else record.config.steps
+
     # Prefer the checkpoint's real step (its dir name) over the config target.
     try:
         steps: int | None = int(pretrained_dir.parent.name)
     except (ValueError, TypeError):
-        raw_steps = train_config.get("steps")
-        steps = int(raw_steps) if isinstance(raw_steps, int) else None
+        steps = target_steps
 
     return {
         "id": record.id,
@@ -208,6 +218,8 @@ def _local_model_summary(record: JobRecord, pretrained_dir: Path) -> dict[str, A
         "policy_type": policy_type,
         "dataset": dataset_repo_id,
         "steps": steps,
+        "target_steps": target_steps,
+        "state": record.state,
         "path": str(pretrained_dir),
         "last_modified": _epoch_iso(record.ended_at or record.started_at),
         "hf_repo_id": record.hf_repo_id or None,
@@ -857,6 +869,8 @@ def list_all_models() -> list[dict[str, Any]]:
             "policy_type": item.get("policy_type"),
             "dataset": None,
             "steps": None,
+            "target_steps": None,
+            "state": None,
             "path": None,
             "last_modified": item.get("last_modified"),
             "hf_repo_id": repo_id,
@@ -878,7 +892,7 @@ def list_all_models() -> list[dict[str, Any]]:
             # hub row's placeholder id/name and fill in the checkpoint fields it
             # couldn't know (per the contract, `id`/`name` follow the local run
             # for a "both" model).
-            for key in ("id", "name", "policy_type", "dataset", "steps", "path"):
+            for key in ("id", "name", "policy_type", "dataset", "steps", "target_steps", "state", "path"):
                 if item.get(key) is not None:
                     existing[key] = item[key]
             a = existing.get("last_modified") or ""
@@ -929,6 +943,8 @@ def list_all_models() -> list[dict[str, Any]]:
                 "policy_type": _hub_policy_type(None, repo_id.split("/", 1)[-1]),
                 "dataset": None,
                 "steps": None,
+                "target_steps": None,
+                "state": None,
                 "path": None,
                 "last_modified": None,
                 "hf_repo_id": repo_id,

--- a/makermodslab/models.py
+++ b/makermodslab/models.py
@@ -227,19 +227,23 @@ def _epoch_iso(ts: float | None) -> str | None:
 
 
 def list_local_models() -> list[dict[str, Any]]:
-    """Every COMPLETED local training run that produced a final checkpoint.
+    """Every local training run that produced a usable final checkpoint.
 
     Reads the job registry (never mutates it). A run qualifies iff it is a
-    `local` runner in state "done" AND has at least one valid on-disk checkpoint
-    — running / failed / interrupted runs and checkpoint-less runs are skipped
-    (a failed run may have died before its first save). Each row carries the
-    policy type, base dataset repo_id, step count, and the local checkpoint path,
-    read from the final checkpoint's train_config.json.
+    `local` runner that isn't still running AND has at least one valid
+    on-disk checkpoint — checkpoint presence, not the terminal state, is what
+    makes a model usable. A "done" run with no checkpoint (crashed before its
+    first save) is skipped; an "interrupted" run (e.g. its exit couldn't be
+    confirmed after a server restart) whose checkpoint is on disk still counts
+    — the terminal state is only a claim about how we found out, not about
+    whether the weights exist. Each row carries the policy type, base dataset
+    repo_id, step count, and the local checkpoint path, read from the final
+    checkpoint's train_config.json.
 
     Newest first (by the run's end/start time)."""
     out: list[dict[str, Any]] = []
     for record in job_registry.list(limit=_LOCAL_MODEL_SCAN_LIMIT):
-        if record.runner != "local" or record.state != "done":
+        if record.runner != "local" or record.state == "running":
             continue
         pretrained_dir = _final_checkpoint_dir(record)
         if pretrained_dir is None:
@@ -251,18 +255,18 @@ def list_local_models() -> list[dict[str, Any]]:
 
 
 def _find_local_record(model_id: str) -> JobRecord | None:
-    """The completed local-run registry record for `model_id`, or None.
+    """The usable local-run registry record for `model_id`, or None.
 
-    None when the id is unknown, isn't a local run, isn't done, or left no
-    checkpoint — the same qualification `list_local_models` applies, so callers
-    (info / upload / delete) agree on what a "local model" is."""
+    None when the id is unknown, isn't a local run, is still running, or left
+    no checkpoint — the same qualification `list_local_models` applies, so
+    callers (info / upload / delete) agree on what a "local model" is."""
     from .jobs import JobNotFoundError
 
     try:
         record = job_registry.get(model_id)
     except JobNotFoundError:
         return None
-    if record.runner != "local" or record.state != "done":
+    if record.runner != "local" or record.state == "running":
         return None
     if _final_checkpoint_dir(record) is None:
         return None

--- a/makermodslab/models.py
+++ b/makermodslab/models.py
@@ -230,20 +230,23 @@ def list_local_models() -> list[dict[str, Any]]:
     """Every local training run that produced a usable final checkpoint.
 
     Reads the job registry (never mutates it). A run qualifies iff it is a
-    `local` runner that isn't still running AND has at least one valid
-    on-disk checkpoint — checkpoint presence, not the terminal state, is what
-    makes a model usable. A "done" run with no checkpoint (crashed before its
-    first save) is skipped; an "interrupted" run (e.g. its exit couldn't be
-    confirmed after a server restart) whose checkpoint is on disk still counts
-    — the terminal state is only a claim about how we found out, not about
-    whether the weights exist. Each row carries the policy type, base dataset
+    `local` runner in state "done" or "interrupted" AND has at least one
+    valid on-disk checkpoint. A "done" run with no checkpoint (crashed before
+    its first save) is skipped. An "interrupted" run (e.g. its exit couldn't
+    be confirmed after a server restart) whose checkpoint is on disk still
+    counts — that state is only a claim about how we found out, not about
+    whether the weights exist. A "failed" run is excluded even with a
+    checkpoint present: unlike "interrupted", its exit code is a confirmed
+    non-zero result, so listing it next to real models — indistinguishable,
+    selectable for inference or a Hub push — would misrepresent a known
+    failure as a usable one. Each row carries the policy type, base dataset
     repo_id, step count, and the local checkpoint path, read from the final
     checkpoint's train_config.json.
 
     Newest first (by the run's end/start time)."""
     out: list[dict[str, Any]] = []
     for record in job_registry.list(limit=_LOCAL_MODEL_SCAN_LIMIT):
-        if record.runner != "local" or record.state == "running":
+        if record.runner != "local" or record.state not in ("done", "interrupted"):
             continue
         pretrained_dir = _final_checkpoint_dir(record)
         if pretrained_dir is None:
@@ -257,16 +260,17 @@ def list_local_models() -> list[dict[str, Any]]:
 def _find_local_record(model_id: str) -> JobRecord | None:
     """The usable local-run registry record for `model_id`, or None.
 
-    None when the id is unknown, isn't a local run, is still running, or left
-    no checkpoint — the same qualification `list_local_models` applies, so
-    callers (info / upload / delete) agree on what a "local model" is."""
+    None when the id is unknown, isn't a local run, isn't "done" or
+    "interrupted", or left no checkpoint — the same qualification
+    `list_local_models` applies, so callers (info / upload / delete) agree on
+    what a "local model" is."""
     from .jobs import JobNotFoundError
 
     try:
         record = job_registry.get(model_id)
     except JobNotFoundError:
         return None
-    if record.runner != "local" or record.state == "running":
+    if record.runner != "local" or record.state not in ("done", "interrupted"):
         return None
     if _final_checkpoint_dir(record) is None:
         return None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -459,6 +459,140 @@ def test_pid_alive_returns_false_for_unlikely_pid() -> None:
     assert _pid_alive(999999999) is False
 
 
+def _write_log_lines(path: Path, messages: list[str]) -> None:
+    from makerlab.jobs import LogLine
+
+    lines = (LogLine(timestamp=float(i), message=m).model_dump_json() + "\n" for i, m in enumerate(messages))
+    path.write_text("".join(lines))
+
+
+def test_tailing_runner_returncode_confirms_done_after_training_end_marker(tmp_path) -> None:
+    """MT10 regression: a reattached job (TailingJobRunner) whose tailed log
+    shows lerobot's own "End of training" line before the pid disappears has
+    genuine positive evidence of completion. returncode() must report 0 so
+    the watchdog still finalises it as 'done' — the case must not regress
+    while we fix the false-positive below."""
+    from makerlab.jobs import TailingJobRunner, TrainingMetrics
+
+    log_path = tmp_path / "log.jsonl"
+    _write_log_lines(
+        log_path,
+        [
+            "Training:  99%|##########| 999/1000 [01:00<00:01,  1.0step/s]",
+            "End of training",
+        ],
+    )
+
+    # A pid guaranteed not to exist (see test_pid_alive_returns_false_for_unlikely_pid)
+    # stands in for "the process is gone by the time we look."
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999)
+    runner.start_tailing()
+    runner._tail_thread.join(timeout=5)
+    assert not runner._tail_thread.is_alive()
+
+    assert runner.returncode() == 0
+
+
+def test_tailing_runner_returncode_unconfirmed_when_pid_gone_without_marker(tmp_path) -> None:
+    """MT10: a reattached job whose pid disappears WITHOUT the log ever
+    showing "End of training" (e.g. the trainer crashed after reattach) must
+    NOT be reported as returncode 0 — TailingJobRunner has no way to reap the
+    real exit code, and no positive evidence of completion either. Before the
+    fix this unconditionally returned 0 once the pid vanished, so a crash
+    got silently recorded as a successful run. returncode() must now report
+    None (JobRegistry._tick() reads that as "unconfirmed" and marks the
+    record 'interrupted' rather than 'done')."""
+    from makerlab.jobs import TailingJobRunner, TrainingMetrics
+
+    log_path = tmp_path / "log.jsonl"
+    _write_log_lines(
+        log_path,
+        [
+            "Training:  42%|####      | 420/1000 [00:30<00:41, 14.0step/s]",
+            "INFO step: 420 smpl: 3K ep: 5 epch: 1.00 loss: 0.512 grdn: 1.2 lr: 1.0e-04",
+        ],
+    )
+
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999)
+    runner.start_tailing()
+    runner._tail_thread.join(timeout=5)
+    assert not runner._tail_thread.is_alive()
+
+    assert runner.returncode() is None
+
+
+class _FakeRunner:
+    """Minimal JobRunner stand-in for exercising JobRegistry._tick()'s
+    finalisation branch without a real subprocess."""
+
+    def __init__(self, rc: int | None) -> None:
+        self._rc = rc
+
+    def is_running(self) -> bool:
+        return False
+
+    def returncode(self) -> int | None:
+        return self._rc
+
+    def wandb_run_url(self) -> str | None:
+        return None
+
+
+def _inject_running_job(reg, tmp_path: Path, rc: int | None):
+    """Stop the registry's own watchdog thread (so our manual _tick() call
+    below is deterministic, not racing a background tick), then splice a
+    'running' record backed by a _FakeRunner(rc) straight into the registry's
+    internal maps — the same shape _load_from_disk / start() would produce."""
+    reg.shutdown()
+    if reg._watchdog_thread is not None:
+        reg._watchdog_thread.join(timeout=2)
+
+    record = _record(tmp_path / "job-1")
+    record.state = "running"
+    with reg._lock:
+        reg._records[record.id] = record
+        reg._runners[record.id] = _FakeRunner(rc)
+    return record
+
+
+def test_tick_marks_interrupted_when_runner_cannot_confirm_exit(tmp_path) -> None:
+    """MT10: JobRegistry._tick() must not treat "runner says not running,
+    returncode() is None" as a failure (or a success) — that combination
+    means the runner has no evidence either way (TailingJobRunner's new
+    signal for "pid died on our watch, no completion marker seen"). It
+    should finalise as 'interrupted', the same honest state already used
+    when a reattach finds an already-dead pid at boot, with no exit_code and
+    no error_message — not 'done', and not 'failed' either."""
+    from makerlab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path / "root")
+    record = _inject_running_job(reg, tmp_path, rc=None)
+
+    reg._tick()
+
+    finalized = reg._records[record.id]
+    assert finalized.state == "interrupted"
+    assert finalized.exit_code is None
+    assert finalized.error_message is None
+
+
+def test_tick_marks_done_when_runner_confirms_zero_exit(tmp_path) -> None:
+    """Sanity check for the untouched happy path this fix must not regress:
+    when a runner confirms rc == 0 (LocalJobRunner completing normally, or
+    TailingJobRunner after observing "End of training"), the watchdog still
+    finalises promptly as 'done'."""
+    from makerlab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path / "root")
+    record = _inject_running_job(reg, tmp_path, rc=0)
+
+    reg._tick()
+
+    finalized = reg._records[record.id]
+    assert finalized.state == "done"
+    assert finalized.exit_code == 0
+
+
 def test_hub_checkpoints_from_files_parses_tree() -> None:
     from makermodslab.jobs import _hub_checkpoints_from_files
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -552,6 +552,25 @@ def test_tailing_runner_returncode_unconfirmed_when_status_file_malformed(tmp_pa
     assert runner.returncode() is None
 
 
+def test_tailing_runner_stop_signalled_tracks_stop_calls(tmp_path) -> None:
+    """stop_signalled() is JobRegistry._tick()'s way of telling a
+    user-requested stop apart from an unconfirmed crash/restart when
+    returncode() comes back None (see test_tick_uses_stop_message_when_stop_was_signalled).
+    It must be False before stop() and True after, regardless of whether the
+    signalled pid was still alive to receive it."""
+    from makermodslab.jobs import TailingJobRunner, TrainingMetrics
+
+    log_path = tmp_path / "log.jsonl"
+    status_path = tmp_path / "exit_status"
+
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999, status_path=status_path)
+    assert runner.stop_signalled() is False
+
+    runner.stop()
+
+    assert runner.stop_signalled() is True
+
+
 def test_tailing_runner_returncode_unconfirmed_while_pid_alive(tmp_path) -> None:
     """Even with a written exit_status on disk (e.g. left over from state we
     shouldn't trust yet), a live pid always means 'still running' — returncode()
@@ -585,11 +604,21 @@ class _FakeRunner:
         return None
 
 
-def _inject_running_job(reg, tmp_path: Path, rc: int | None):
+class _FakeStopSignalledRunner(_FakeRunner):
+    """Like _FakeRunner, but also reports stop_signalled() == True — the
+    shape of a TailingJobRunner whose stop() group-TERMed the wrapper before
+    it could write an exit status."""
+
+    def stop_signalled(self) -> bool:
+        return True
+
+
+def _inject_running_job(reg, tmp_path: Path, rc: int | None, runner=None):
     """Stop the registry's own watchdog thread (so our manual _tick() call
     below is deterministic, not racing a background tick), then splice a
-    'running' record backed by a _FakeRunner(rc) straight into the registry's
-    internal maps — the same shape _load_from_disk / start() would produce."""
+    'running' record backed by `runner` (default: _FakeRunner(rc)) straight
+    into the registry's internal maps — the same shape _load_from_disk /
+    start() would produce."""
     reg.shutdown()
     if reg._watchdog_thread is not None:
         reg._watchdog_thread.join(timeout=2)
@@ -598,7 +627,7 @@ def _inject_running_job(reg, tmp_path: Path, rc: int | None):
     record.state = "running"
     with reg._lock:
         reg._records[record.id] = record
-        reg._runners[record.id] = _FakeRunner(rc)
+        reg._runners[record.id] = runner if runner is not None else _FakeRunner(rc)
     return record
 
 
@@ -624,6 +653,30 @@ def test_tick_marks_interrupted_when_runner_cannot_confirm_exit(tmp_path) -> Non
     assert finalized.state == "interrupted"
     assert finalized.exit_code is None
     assert finalized.error_message is not None
+    assert "restarted" in finalized.error_message
+
+
+def test_tick_uses_stop_message_when_stop_was_signalled(tmp_path) -> None:
+    """A user-requested stop of a reattached run also lands in the
+    'returncode() is None' branch above — stop() group-TERMs the wrapper
+    before it can write an exit status, so the pid disappears with no
+    evidence just like an unconfirmed crash/restart. Without consulting the
+    runner, that stop would be blamed on a restart that never happened. When
+    the runner reports stop_signalled() == True, _tick() must say the run was
+    stopped at the user's request instead."""
+    from makermodslab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path / "root")
+    record = _inject_running_job(reg, tmp_path, rc=None, runner=_FakeStopSignalledRunner(None))
+
+    reg._tick()
+
+    finalized = reg._records[record.id]
+    assert finalized.state == "interrupted"
+    assert finalized.exit_code is None
+    assert finalized.error_message is not None
+    assert "stopped at your request" in finalized.error_message
+    assert "restarted" not in finalized.error_message
 
 
 def test_tick_marks_done_when_runner_confirms_zero_exit(tmp_path) -> None:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -552,23 +552,58 @@ def test_tailing_runner_returncode_unconfirmed_when_status_file_malformed(tmp_pa
     assert runner.returncode() is None
 
 
-def test_tailing_runner_stop_signalled_tracks_stop_calls(tmp_path) -> None:
+def test_tailing_runner_stop_signalled_after_term_reaches_the_group(tmp_path, monkeypatch) -> None:
     """stop_signalled() is JobRegistry._tick()'s way of telling a
     user-requested stop apart from an unconfirmed crash/restart when
     returncode() comes back None (see test_tick_uses_stop_message_when_stop_was_signalled).
-    It must be False before stop() and True after, regardless of whether the
-    signalled pid was still alive to receive it."""
+    False before stop(), and True once killpg has actually put a SIGTERM into
+    the run's process group."""
+    import signal
+
+    from makermodslab import jobs
     from makermodslab.jobs import TailingJobRunner, TrainingMetrics
+
+    delivered: list[tuple[int, int]] = []
+    monkeypatch.setattr(jobs.os, "killpg", lambda pid, sig: delivered.append((pid, sig)))
 
     log_path = tmp_path / "log.jsonl"
     status_path = tmp_path / "exit_status"
 
-    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999, status_path=status_path)
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=4242, status_path=status_path)
     assert runner.stop_signalled() is False
 
     runner.stop()
 
+    assert delivered == [(4242, signal.SIGTERM)]
     assert runner.stop_signalled() is True
+
+
+def test_tailing_runner_stop_signalled_false_when_group_already_gone(tmp_path, monkeypatch) -> None:
+    """The fact stop_signalled() reports is "we delivered a SIGTERM to a live
+    process group", not "someone called stop()". A run that crashed (or died
+    to a restart) before the user clicked Stop reaches killpg with nothing
+    left to signal — ProcessLookupError — and must stay False, or _tick()
+    would launder that crash into "stopped at your request" and tell the user
+    we stopped a run that had already ended on its own.
+
+    stop()'s own bookkeeping still runs: _stop_event winds the tail loop
+    down either way."""
+    from makermodslab import jobs
+    from makermodslab.jobs import TailingJobRunner, TrainingMetrics
+
+    def _already_gone(pid: int, sig: int) -> None:
+        raise ProcessLookupError(3, "No such process")
+
+    monkeypatch.setattr(jobs.os, "killpg", _already_gone)
+
+    log_path = tmp_path / "log.jsonl"
+    status_path = tmp_path / "exit_status"
+
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=4242, status_path=status_path)
+    runner.stop()
+
+    assert runner.stop_signalled() is False
+    assert runner._stop_event.is_set()
 
 
 def test_tailing_runner_returncode_unconfirmed_while_pid_alive(tmp_path) -> None:
@@ -677,6 +712,36 @@ def test_tick_uses_stop_message_when_stop_was_signalled(tmp_path) -> None:
     assert finalized.error_message is not None
     assert "stopped at your request" in finalized.error_message
     assert "restarted" not in finalized.error_message
+
+
+def test_tick_does_not_claim_a_stop_that_never_reached_the_run(tmp_path) -> None:
+    """End-to-end counterpart to the test above, with the real
+    TailingJobRunner rather than a fake: the run is already dead (crash, or a
+    restart that killed it) when the user's Stop arrives, so stop()'s killpg
+    finds nothing to signal. _tick() must fall back to the restart message —
+    telling the user we stopped a run that had already ended on its own is the
+    same false story in the opposite direction."""
+    from makermodslab.jobs import JobRegistry, TailingJobRunner, TrainingMetrics
+
+    runner = TailingJobRunner(
+        TrainingMetrics(),
+        tmp_path / "log.jsonl",
+        pid=999999999,  # long dead; killpg raises ProcessLookupError
+        status_path=tmp_path / "exit_status",  # never written
+    )
+    runner.stop()
+
+    reg = JobRegistry(tmp_path / "root")
+    record = _inject_running_job(reg, tmp_path, rc=None, runner=runner)
+
+    reg._tick()
+
+    finalized = reg._records[record.id]
+    assert finalized.state == "interrupted"
+    assert finalized.exit_code is None
+    assert finalized.error_message is not None
+    assert "restarted" in finalized.error_message
+    assert "stopped at your request" not in finalized.error_message
 
 
 def test_tick_marks_done_when_runner_confirms_zero_exit(tmp_path) -> None:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3170,3 +3170,98 @@ def test_start_allows_matching_feature_space(tmp_path) -> None:
     ):
         record = reg.start(cfg, JobTarget(runner="local"))
     assert record.state == "running"
+
+
+def _write_running_job_json(job_dir: Path, output_dir: Path) -> None:
+    """Lay out an on-disk 'running' job.json the way a crash mid-training
+    would leave it: state still 'running', a process_pid that (the caller
+    arranges to) no longer exists by the time the registry boots and reads
+    it back — the exact shape _load_from_disk() sees on a full server
+    restart, as opposed to _tick()'s in-memory finalisation of a job that
+    died while the server stayed up."""
+    job_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "id": "job-1",
+        "name": "run",
+        "state": "running",
+        "config": {"dataset_repo_id": "user/ds"},
+        "output_dir": str(output_dir),
+        "started_at": 0.0,
+        "runner": "local",
+        "process_pid": 999999999,  # long dead, see test_pid_alive_returns_false_for_unlikely_pid
+    }
+    (job_dir / "job.json").write_text(_json.dumps(meta))
+
+
+def test_boot_reattach_reads_exit_status_when_pid_already_dead_and_failed(tmp_path) -> None:
+    """IsaacSinn's PR #34 follow-up: a run that crashed while the server was
+    down (server killed/crashed, trainer keeps going per the whole point of
+    the wrapper, then dies and writes its real nonzero exit code to
+    <output_dir>/exit_status) must NOT be silently reported as 'interrupted'
+    once the server comes back — that status file is exactly the evidence
+    TailingJobRunner.returncode() already trusts when the server stays up
+    (see test_tick_marks_interrupted_when_runner_cannot_confirm_exit and
+    friends). _load_from_disk() must consult the same file before giving up
+    and asserting 'interrupted' for a pid that's merely gone."""
+    from makermodslab.jobs import _EXIT_STATUS_FILENAME, JobRegistry
+
+    root = tmp_path / "root"
+    job_dir = root / "job-1"
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True)
+    (output_dir / _EXIT_STATUS_FILENAME).write_text("1")
+    _write_running_job_json(job_dir, output_dir)
+
+    reg = JobRegistry(root)
+
+    record = reg.get("job-1")
+    assert record.state == "failed"
+    assert record.exit_code == 1
+    assert record.error_message is not None
+    assert "exited with code 1" in record.error_message
+    # Persisted, not just fixed in memory.
+    meta = _json.loads((job_dir / "job.json").read_text())
+    assert meta["state"] == "failed"
+
+
+def test_boot_reattach_reads_exit_status_when_pid_already_dead_and_done(tmp_path) -> None:
+    """Mirror of the failed case above: a run that actually finished
+    successfully while the server was down must be recognised as 'done', not
+    downgraded to 'interrupted' just because nobody was watching when it
+    exited."""
+    from makermodslab.jobs import _EXIT_STATUS_FILENAME, JobRegistry
+
+    root = tmp_path / "root"
+    job_dir = root / "job-1"
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True)
+    (output_dir / _EXIT_STATUS_FILENAME).write_text("0")
+    _write_running_job_json(job_dir, output_dir)
+
+    reg = JobRegistry(root)
+
+    record = reg.get("job-1")
+    assert record.state == "done"
+    assert record.exit_code == 0
+    meta = _json.loads((job_dir / "job.json").read_text())
+    assert meta["state"] == "done"
+
+
+def test_boot_reattach_stays_interrupted_when_no_exit_status_file(tmp_path) -> None:
+    """Regression guard for the existing, still-correct case: a pid that's
+    dead AND left no exit_status file at all (SIGKILL, a reboot that cut off
+    the wrapper before it could write) is genuinely unconfirmed and must stay
+    'interrupted', same as before this fix."""
+    from makermodslab.jobs import JobRegistry
+
+    root = tmp_path / "root"
+    job_dir = root / "job-1"
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True)  # no exit_status written
+    _write_running_job_json(job_dir, output_dir)
+
+    reg = JobRegistry(root)
+
+    record = reg.get("job-1")
+    assert record.state == "interrupted"
+    assert record.exit_code is None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -460,32 +460,29 @@ def test_pid_alive_returns_false_for_unlikely_pid() -> None:
 
 
 def _write_log_lines(path: Path, messages: list[str]) -> None:
-    from makerlab.jobs import LogLine
+    from makermodslab.jobs import LogLine
 
     lines = (LogLine(timestamp=float(i), message=m).model_dump_json() + "\n" for i, m in enumerate(messages))
     path.write_text("".join(lines))
 
 
-def test_tailing_runner_returncode_confirms_done_after_training_end_marker(tmp_path) -> None:
-    """MT10 regression: a reattached job (TailingJobRunner) whose tailed log
-    shows lerobot's own "End of training" line before the pid disappears has
-    genuine positive evidence of completion. returncode() must report 0 so
-    the watchdog still finalises it as 'done' — the case must not regress
-    while we fix the false-positive below."""
-    from makerlab.jobs import TailingJobRunner, TrainingMetrics
+def test_tailing_runner_returncode_confirms_done_when_exit_status_zero(tmp_path) -> None:
+    """MT10: a reattached job (TailingJobRunner) whose pid has disappeared is
+    only confirmed 'done' when the wrapper LocalJobRunner.start() launched
+    actually wrote a real exit status of 0 to disk — the trainer's own log
+    output is not usable evidence, because after a server restart nothing
+    appends to that log ever again (see LocalJobRunner._pump_stdout, which is
+    the log's only writer and lives in the process that just died)."""
+    from makermodslab.jobs import TailingJobRunner, TrainingMetrics
 
     log_path = tmp_path / "log.jsonl"
-    _write_log_lines(
-        log_path,
-        [
-            "Training:  99%|##########| 999/1000 [01:00<00:01,  1.0step/s]",
-            "End of training",
-        ],
-    )
+    _write_log_lines(log_path, ["Training:  99%|##########| 999/1000 [01:00<00:01,  1.0step/s]"])
+    status_path = tmp_path / "exit_status"
+    status_path.write_text("0")
 
     # A pid guaranteed not to exist (see test_pid_alive_returns_false_for_unlikely_pid)
     # stands in for "the process is gone by the time we look."
-    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999)
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999, status_path=status_path)
     runner.start_tailing()
     runner._tail_thread.join(timeout=5)
     assert not runner._tail_thread.is_alive()
@@ -493,30 +490,80 @@ def test_tailing_runner_returncode_confirms_done_after_training_end_marker(tmp_p
     assert runner.returncode() == 0
 
 
-def test_tailing_runner_returncode_unconfirmed_when_pid_gone_without_marker(tmp_path) -> None:
-    """MT10: a reattached job whose pid disappears WITHOUT the log ever
-    showing "End of training" (e.g. the trainer crashed after reattach) must
-    NOT be reported as returncode 0 — TailingJobRunner has no way to reap the
-    real exit code, and no positive evidence of completion either. Before the
-    fix this unconditionally returned 0 once the pid vanished, so a crash
-    got silently recorded as a successful run. returncode() must now report
-    None (JobRegistry._tick() reads that as "unconfirmed" and marks the
-    record 'interrupted' rather than 'done')."""
-    from makerlab.jobs import TailingJobRunner, TrainingMetrics
+def test_tailing_runner_returncode_reports_real_nonzero_exit(tmp_path) -> None:
+    """A trainer that crashed after reattach records its own real exit code
+    via the wrapper — returncode() must surface that code (not clamp it to
+    None or 0) so JobRegistry._tick() can finalise 'failed' with a real
+    exit_code, same as it would for a LocalJobRunner that never detached."""
+    from makermodslab.jobs import TailingJobRunner, TrainingMetrics
 
     log_path = tmp_path / "log.jsonl"
-    _write_log_lines(
-        log_path,
-        [
-            "Training:  42%|####      | 420/1000 [00:30<00:41, 14.0step/s]",
-            "INFO step: 420 smpl: 3K ep: 5 epch: 1.00 loss: 0.512 grdn: 1.2 lr: 1.0e-04",
-        ],
-    )
+    _write_log_lines(log_path, ["Training:  42%|####      | 420/1000 [00:30<00:41, 14.0step/s]"])
+    status_path = tmp_path / "exit_status"
+    status_path.write_text("1")
 
-    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999)
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999, status_path=status_path)
     runner.start_tailing()
     runner._tail_thread.join(timeout=5)
     assert not runner._tail_thread.is_alive()
+
+    assert runner.returncode() == 1
+
+
+def test_tailing_runner_returncode_unconfirmed_when_status_file_absent(tmp_path) -> None:
+    """MT10 regression: this is the actual shape of a reattached job whose
+    trainer keeps running (or crashes) for the rest of its life after a
+    server restart — log.jsonl is frozen (nothing appends to it once the
+    owning process is gone) and no exit_status file has been written yet.
+    Before the fix, returncode() unconditionally returned 0 once the pid
+    vanished, silently recording a crash as a successful run. It must now
+    report None so JobRegistry._tick() marks the record 'interrupted' rather
+    than asserting a 'done' or 'failed' it can't back up."""
+    from makermodslab.jobs import TailingJobRunner, TrainingMetrics
+
+    log_path = tmp_path / "log.jsonl"
+    _write_log_lines(log_path, ["Training:  42%|####      | 420/1000 [00:30<00:41, 14.0step/s]"])
+    status_path = tmp_path / "exit_status"  # never written
+
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999, status_path=status_path)
+    runner.start_tailing()
+    runner._tail_thread.join(timeout=5)
+    assert not runner._tail_thread.is_alive()
+
+    assert runner.returncode() is None
+
+
+def test_tailing_runner_returncode_unconfirmed_when_status_file_malformed(tmp_path) -> None:
+    """A status file that isn't a clean integer (e.g. a torn read caught
+    mid-write, though start()'s tmp+rename should prevent that in practice)
+    must degrade to 'unconfirmed', not raise or silently pick a wrong code."""
+    from makermodslab.jobs import TailingJobRunner, TrainingMetrics
+
+    log_path = tmp_path / "log.jsonl"
+    _write_log_lines(log_path, ["Training:  42%|####      | 420/1000 [00:30<00:41, 14.0step/s]"])
+    status_path = tmp_path / "exit_status"
+    status_path.write_text("not-a-number")
+
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=999999999, status_path=status_path)
+    runner.start_tailing()
+    runner._tail_thread.join(timeout=5)
+    assert not runner._tail_thread.is_alive()
+
+    assert runner.returncode() is None
+
+
+def test_tailing_runner_returncode_unconfirmed_while_pid_alive(tmp_path) -> None:
+    """Even with a written exit_status on disk (e.g. left over from state we
+    shouldn't trust yet), a live pid always means 'still running' — returncode()
+    must not report a stale status file's contents while the process itself
+    is confirmed alive."""
+    from makermodslab.jobs import TailingJobRunner, TrainingMetrics
+
+    log_path = tmp_path / "log.jsonl"
+    status_path = tmp_path / "exit_status"
+    status_path.write_text("0")
+
+    runner = TailingJobRunner(TrainingMetrics(), log_path, pid=os.getpid(), status_path=status_path)
 
     assert runner.returncode() is None
 
@@ -558,12 +605,15 @@ def _inject_running_job(reg, tmp_path: Path, rc: int | None):
 def test_tick_marks_interrupted_when_runner_cannot_confirm_exit(tmp_path) -> None:
     """MT10: JobRegistry._tick() must not treat "runner says not running,
     returncode() is None" as a failure (or a success) — that combination
-    means the runner has no evidence either way (TailingJobRunner's new
-    signal for "pid died on our watch, no completion marker seen"). It
-    should finalise as 'interrupted', the same honest state already used
-    when a reattach finds an already-dead pid at boot, with no exit_code and
-    no error_message — not 'done', and not 'failed' either."""
-    from makerlab.jobs import JobRegistry
+    means the runner has no evidence either way (TailingJobRunner's signal
+    for "pid died on our watch, no exit_status file written"). It should
+    finalise as 'interrupted', the same honest state already used when a
+    reattach finds an already-dead pid at boot, with no exit_code but an
+    explanatory error_message — not 'done', and not 'failed' either. The
+    message matters because 'interrupted' no longer implies the run actually
+    failed; a real checkpoint may still be sitting on disk (see
+    models.list_local_models, which no longer deletes it from the library)."""
+    from makermodslab.jobs import JobRegistry
 
     reg = JobRegistry(tmp_path / "root")
     record = _inject_running_job(reg, tmp_path, rc=None)
@@ -573,7 +623,7 @@ def test_tick_marks_interrupted_when_runner_cannot_confirm_exit(tmp_path) -> Non
     finalized = reg._records[record.id]
     assert finalized.state == "interrupted"
     assert finalized.exit_code is None
-    assert finalized.error_message is None
+    assert finalized.error_message is not None
 
 
 def test_tick_marks_done_when_runner_confirms_zero_exit(tmp_path) -> None:
@@ -581,7 +631,7 @@ def test_tick_marks_done_when_runner_confirms_zero_exit(tmp_path) -> None:
     when a runner confirms rc == 0 (LocalJobRunner completing normally, or
     TailingJobRunner after observing "End of training"), the watchdog still
     finalises promptly as 'done'."""
-    from makerlab.jobs import JobRegistry
+    from makermodslab.jobs import JobRegistry
 
     reg = JobRegistry(tmp_path / "root")
     record = _inject_running_job(reg, tmp_path, rc=0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,21 +155,31 @@ def test_list_local_models_reads_train_config_over_record(registry) -> None:
     assert m["dataset"] == "cfg/other"
 
 
-def test_list_local_models_skips_running_but_keeps_checkpointed_failed_or_interrupted(registry) -> None:
-    """A run only counts as usable once it's stopped changing (not "running")
-    and has a real checkpoint on disk — the terminal state itself no longer
-    gates it (MT10). A "failed" or "interrupted" run that still saved a valid
-    final checkpoint (e.g. an unconfirmed exit after a server restart) must
-    stay visible rather than vanish from the library."""
+def test_list_local_models_skips_running_but_keeps_checkpointed_interrupted(registry) -> None:
+    """A run counts as usable once it's "done" or "interrupted" (not
+    "running") and has a real checkpoint on disk (MT10). An "interrupted" run
+    that still saved a valid final checkpoint (e.g. an unconfirmed exit after
+    a server restart) must stay visible rather than vanish from the library."""
     from makermodslab.models import list_local_models
 
     _seed_run(registry, "done_run", state="done")
     _seed_run(registry, "running_run", state="running")
-    _seed_run(registry, "failed_run", state="failed")
     _seed_run(registry, "interrupted_run", state="interrupted")
 
     ids = {m["id"] for m in list_local_models()}
-    assert ids == {"done_run", "failed_run", "interrupted_run"}
+    assert ids == {"done_run", "interrupted_run"}
+
+
+def test_list_local_models_skips_failed_run_even_with_checkpoint(registry) -> None:
+    """A "failed" run's exit code is a confirmed non-zero result, unlike
+    "interrupted"'s unconfirmed one — so it must not appear in the library
+    looking like a usable model, even if an earlier checkpoint saved before
+    the crash (e.g. an OOM mid-training, or a manual stop that finalizes as
+    "failed")."""
+    from makermodslab.models import list_local_models
+
+    _seed_run(registry, "failed_run", state="failed")
+    assert list_local_models() == []
 
 
 def test_list_local_models_skips_checkpointless_run(registry) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -199,6 +199,40 @@ def test_list_local_models_skips_non_local_runner(registry) -> None:
     assert list_local_models() == []
 
 
+def test_list_local_models_exposes_state_and_target_steps_for_interrupted_run(registry) -> None:
+    """An interrupted run kept in the library must be tellable apart from one
+    that finished normally: `steps` is the checkpoint's actual step, distinct
+    from `target_steps` (the run's configured target), and `state` carries
+    the terminal state. Without this a run interrupted at step 5000 of a
+    configured 10000 looks identical to one configured for (and that finished
+    at) exactly 5000 steps."""
+    from makermodslab.models import list_local_models
+
+    pretrained = _seed_run(registry, "interrupted_run", state="interrupted", steps=5000)
+    (pretrained / "train_config.json").write_text(
+        json.dumps({"policy": {"type": "act"}, "dataset": {"repo_id": "user/pick"}, "steps": 10000})
+    )
+
+    m = list_local_models()[0]
+    assert m["steps"] == 5000
+    assert m["target_steps"] == 10000
+    assert m["state"] == "interrupted"
+
+
+def test_list_local_models_target_steps_matches_steps_for_completed_run(registry) -> None:
+    """A run that trained to its configured target has steps == target_steps,
+    state == "done" — the case a bare `steps` count can't be told apart from
+    an interrupted run without the fields above."""
+    from makermodslab.models import list_local_models
+
+    _seed_run(registry, "done_run", state="done", steps=10000)
+
+    m = list_local_models()[0]
+    assert m["steps"] == 10000
+    assert m["target_steps"] == 10000
+    assert m["state"] == "done"
+
+
 # ---------------------------------------------------------------------------
 # list_all_models — hub/local merge + source badges.
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,23 +155,30 @@ def test_list_local_models_reads_train_config_over_record(registry) -> None:
     assert m["dataset"] == "cfg/other"
 
 
-def test_list_local_models_skips_running_and_failed(registry) -> None:
+def test_list_local_models_skips_running_but_keeps_checkpointed_failed_or_interrupted(registry) -> None:
+    """A run only counts as usable once it's stopped changing (not "running")
+    and has a real checkpoint on disk — the terminal state itself no longer
+    gates it (MT10). A "failed" or "interrupted" run that still saved a valid
+    final checkpoint (e.g. an unconfirmed exit after a server restart) must
+    stay visible rather than vanish from the library."""
     from makermodslab.models import list_local_models
 
     _seed_run(registry, "done_run", state="done")
     _seed_run(registry, "running_run", state="running")
     _seed_run(registry, "failed_run", state="failed")
+    _seed_run(registry, "interrupted_run", state="interrupted")
 
     ids = {m["id"] for m in list_local_models()}
-    assert ids == {"done_run"}
+    assert ids == {"done_run", "failed_run", "interrupted_run"}
 
 
 def test_list_local_models_skips_checkpointless_run(registry) -> None:
-    """A completed run that died before its first save has no checkpoint and is
-    hidden (nothing to browse / serve)."""
+    """A run that died before its first save has no checkpoint and is hidden
+    (nothing to browse / serve) regardless of its terminal state."""
     from makermodslab.models import list_local_models
 
-    _seed_run(registry, "no_ckpt", state="done", with_checkpoint=False)
+    _seed_run(registry, "no_ckpt_done", state="done", with_checkpoint=False)
+    _seed_run(registry, "no_ckpt_interrupted", state="interrupted", with_checkpoint=False)
     assert list_local_models() == []
 
 


### PR DESCRIPTION
## What this fixes
- If the server restarts mid-training (e.g. an auto-reload) and the training subprocess survives, the server re-attaches to it by watching its pid and tailing its log file rather than running it directly.
- If the trainer crashed after that restart, the server had no way to see the real exit code and reported the run as a successful completion anyway, with no error shown anywhere. A crashed run and a genuinely finished run looked identical in the job history.

## What changed
- A re-attached run's outcome is now confirmed with the trainer's own real exit code, written to a small status file the training process leaves behind when it exits, instead of guessing from its log output. Guessing from the log turned out to be unreliable in exactly the case this fix targets: once the server that was reading the trainer's output restarts, nothing keeps writing to that log, so the fix's original signal could never actually appear for a run finishing after a restart.
- If the training process disappears without leaving that status behind (e.g. the whole thing was killed), the run is marked "interrupted" instead of "done" or "failed" — visibly distinct from a real success, with a message explaining what happened.
- An "interrupted" run whose checkpoint did finish saving no longer disappears from the trained-models list. Previously only a run in the exact "done" state was ever shown there, so an unconfirmed-but-actually-finished run vanished from the library entirely, even though the weights were sitting on disk. It now shows up like any other trained model.
- Stopping a training run now signals the whole underlying process group, not just the top-level process, so a stop request reliably reaches the trainer regardless of the shell wrapper introduced above.
- Trainings that run to completion without any server restart are unaffected — they still finalize as "done" immediately, the same as before.

## Known follow-up (not in this PR)
- The deeper fix behind this bug is giving the training log itself a way to survive a server restart (right now, monitoring for a re-attached run is effectively frozen — no new log lines or metrics — for the rest of that run). That's a bigger change than this fix and is being tracked separately rather than bundled in here.

## To test
1. Start a local training run.
2. Restart the server mid-run (e.g. touch a `.py` file under `--dev` to trigger a reload) so the run re-attaches.
3. Let the run finish normally — it should still show up in the trained-models list as usual.
4. Repeat, but kill the training process directly (not via the app) after the restart — the run should show as "interrupted" with an explanation, and if a checkpoint had already saved, that model should still appear in the trained-models list.

```
$ .venv/bin/pytest -q
1100 passed, 75 warnings in 23.87s

$ .venv/bin/ruff check makermodslab/jobs.py makermodslab/models.py tests/test_jobs.py tests/test_models.py
All checks passed!
```
