### PR TITLE
Release the arm's own bus and cameras when connect fails partway through

### DIFF
--- a/frontend/src/components/recording/RecordingSessionDialog.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.tsx
@@ -66,6 +66,10 @@ type Phase = "preparing" | "recording" | "resetting" | "completed";
 interface BackendStatus {
   recording_active: boolean;
   current_phase: string;
+  // Only meaningful while current_phase === "reconnecting_robot" — which
+  // connect attempt is about to be retried, out of connect_retry_max.
+  connect_retry_attempt?: number;
+  connect_retry_max?: number;
   current_episode?: number;
   total_episodes?: number;
   saved_episodes?: number;
@@ -771,6 +775,13 @@ const RecordingSessionDialog: React.FC<{
     // substep the startup is actually in.
     const raw = backendStatus?.current_phase;
     if (raw === "connecting_robot") return "CONNECTING ARM & CAMERAS…";
+    if (raw === "reconnecting_robot") {
+      const attempt = backendStatus?.connect_retry_attempt;
+      const max = backendStatus?.connect_retry_max;
+      return attempt && max
+        ? `CAMERA HICCUP, RETRYING (${attempt}/${max})…`
+        : "CAMERA HICCUP, RETRYING…";
+    }
     if (raw === "connecting_teleop") return "CONNECTING LEADER ARM…";
     if (raw === "stopping") return "STOPPING…";
     if (raw === "error") return "SESSION ERROR — SEE LOG";

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import collections
-import contextlib
 import json
 import logging
 import shutil
@@ -42,7 +41,12 @@ from .datasets import (
 )
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .rest_pose import RETURN_CEILING_S, capture_rest_pose
-from .teleoperate import _device_buses, _return_followers_to_rest, force_disable_torque
+from .teleoperate import (
+    _device_buses,
+    _return_followers_to_rest,
+    force_disable_torque,
+    force_disconnect_partial,
+)
 from .utils.config import (
     CameraResolutionError,
     load_robot_cameras,
@@ -1663,12 +1667,18 @@ def record_with_web_events(
                 logger.error(
                     "💡 ROBOT CONNECTION: Make sure frontend camera streams are released before recording"
                 )
+            # Drop any half-open handles from this failed attempt so the retry
+            # starts from a clean device — and so a *terminal* failure doesn't
+            # leak the opened bus and camera read threads into the rest of the
+            # process. Must be the component-wise teardown, not
+            # robot.disconnect(): connect() dies with the later cameras still
+            # unopened, and lerobot's all-or-nothing is_connected guard makes
+            # disconnect() a no-op raise in exactly that state (see
+            # force_disconnect_partial).
+            force_disconnect_partial(robot, "robot")
             if attempt < connect_attempts and transient_camera:
-                # Drop any half-open handles from this failed attempt so the retry
-                # starts from a clean device, then let the OS release settle past
-                # the turbulence window before re-rolling the connect.
-                with contextlib.suppress(Exception):
-                    robot.disconnect()
+                # Let the OS release settle past the turbulence window before
+                # re-rolling the connect.
                 time.sleep(2.0)
                 continue
             raise
@@ -1690,6 +1700,12 @@ def record_with_web_events(
             logger.info("✅ TELEOP CONNECTION: Teleoperator connected successfully")
         except Exception as e:
             logger.error(f"❌ TELEOP CONNECTION: Failed to connect teleoperator: {e}")
+            # The robot connected fine a moment ago; release both so a leader
+            # failure can't strand the follower's bus and camera threads for
+            # the rest of the process (partial teardown for the same reason as
+            # the robot-connect path above).
+            force_disconnect_partial(robot, "robot")
+            force_disconnect_partial(teleop, "teleop")
             raise
 
     # Arm-identity guard: read-only check that each connected arm matches its

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -1703,7 +1703,11 @@ def record_with_web_events(
                 # (already in _RECORD_LOG_LOGGER_NAMES) so it reaches the
                 # visible Record-page log panel, not just the server console.
                 current_phase = "reconnecting_robot"
-                connect_retry_attempt = attempt
+                # The attempt about to run, not the one that just failed —
+                # same convention as the log line below, so the Record page's
+                # dialog and its log panel can't disagree about the number
+                # (they sit one above the other).
+                connect_retry_attempt = attempt + 1
                 logger.info(
                     "🔁 ROBOT CONNECTION: Camera hiccup, retrying (%d/%d) after OS release settles...",
                     attempt + 1,

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -205,11 +205,13 @@ current_episode = 1  # Track current episode number
 saved_episodes = 0  # Track how many episodes have been saved
 current_phase = "preparing"  # Track current phase: "preparing", "recording", "resetting", "completed"
 phase_start_time = None  # Track when current phase started
-# Set only while current_phase == "reconnecting_robot" (the backoff sleep
-# between connect retries below); 0 otherwise. Lets the frontend show which
-# retry attempt is in flight ("Camera hiccup, retrying (2/3)…") instead of
-# one static "Connecting arm & cameras…" label for a window that can now run
-# past ten seconds across multiple component-wise teardowns and retries.
+# Set only while current_phase == "reconnecting_robot" (the teardown and
+# backoff sleep between connect retries below); 0 otherwise — including on a
+# successful connect and on the terminal failure, so a reader can treat
+# "connect_retry_attempt > 0" as "a retry is in flight right now". Lets the
+# frontend show which retry attempt that is ("Camera hiccup, retrying (2/3)…")
+# instead of one static "Connecting arm & cameras…" label for a window that
+# can run past ten seconds across multiple component-wise teardowns.
 connect_retry_attempt = 0
 # Total time spent paused during the CURRENT reset phase, credited on resume
 # (see handle_resume_recording). Reset to 0.0 at the start of every new reset
@@ -1685,23 +1687,17 @@ def record_with_web_events(
                 logger.error(
                     "💡 ROBOT CONNECTION: Make sure frontend camera streams are released before recording"
                 )
-            # Drop any half-open handles from this failed attempt so the retry
-            # starts from a clean device — and so a *terminal* failure doesn't
-            # leak the opened bus and camera read threads into the rest of the
-            # process. Must be the component-wise teardown, not
-            # robot.disconnect(): connect() dies with the later cameras still
-            # unopened, and lerobot's all-or-nothing is_connected guard makes
-            # disconnect() a no-op raise in exactly that state (see
-            # force_disconnect_partial).
-            force_disconnect_partial(robot, "robot")
-            if attempt < _CONNECT_ATTEMPTS and transient_camera:
-                # Distinguish the backoff substep from the connect substep so
-                # the UI can show "Camera hiccup, retrying (2/3)…" instead of
-                # one static "Connecting arm & cameras…" label for a window
-                # that (with the teardown above) can now run well past ten
-                # seconds. Logged at INFO through this module's own logger
-                # (already in _RECORD_LOG_LOGGER_NAMES) so it reaches the
-                # visible Record-page log panel, not just the server console.
+            will_retry = attempt < _CONNECT_ATTEMPTS and transient_camera
+            if will_retry:
+                # Enter the retry substep BEFORE the teardown, not after: the
+                # component-wise release below is the slow part (each wedged
+                # camera's disconnect joins a read thread that is waiting out
+                # a frame timeout), so bracketing only the 2s sleep would
+                # leave the operator staring at a static "Connecting arm &
+                # cameras…" for the window this substep exists to explain.
+                # Logged at INFO through this module's own logger (already in
+                # _RECORD_LOG_LOGGER_NAMES) so it reaches the visible
+                # Record-page log panel, not just the server console.
                 current_phase = "reconnecting_robot"
                 # The attempt about to run, not the one that just failed —
                 # same convention as the log line below, so the Record page's
@@ -1713,10 +1709,25 @@ def record_with_web_events(
                     attempt + 1,
                     _CONNECT_ATTEMPTS,
                 )
+            # Drop any half-open handles from this failed attempt so the retry
+            # starts from a clean device — and so a *terminal* failure doesn't
+            # leak the opened bus and camera read threads into the rest of the
+            # process. Must be the component-wise teardown, not
+            # robot.disconnect(): connect() dies with the later cameras still
+            # unopened, and lerobot's all-or-nothing is_connected guard makes
+            # disconnect() a no-op raise in exactly that state (see
+            # force_disconnect_partial).
+            force_disconnect_partial(robot, "robot")
+            if will_retry:
                 # Let the OS release settle past the turbulence window before
                 # re-rolling the connect.
                 time.sleep(2.0)
                 current_phase = "connecting_robot"
+                # Back to a plain connect attempt: keep the "0 unless we are
+                # in reconnecting_robot" contract this field documents, so a
+                # later reader can't mistake a healthy session for a retrying
+                # one.
+                connect_retry_attempt = 0
                 continue
             raise
 

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -82,6 +82,10 @@ _DEFAULT_FOURCC = "MJPG"
 _BUS_SYNC_READ_RETRIES = 2
 _original_sync_read = MotorsBus.sync_read
 
+# Robot-connect attempts before giving up on transient camera turbulence (see
+# the retry loop below and connect_retry_attempt above).
+_CONNECT_ATTEMPTS = 3
+
 
 def _sync_read_with_default_retries(
     self, data_name, motors=None, *, normalize=True, num_retry=_BUS_SYNC_READ_RETRIES
@@ -100,11 +104,14 @@ if MotorsBus.sync_read.__name__ != "_sync_read_with_default_retries":  # idempot
 # polled GET endpoint. The deque is capacity-capped (maxlen) so memory can never
 # grow unbounded no matter how chatty or long a session is.
 _RECORD_LOG_MAX_LINES = 500
-# Loggers whose records describe a recording session: this module's logger and
+# Loggers whose records describe a recording session: this module's logger,
 # lerobot's own record/control loggers (the "Recording episode N", save/reset
-# lines come from there). Attaching to the shared "lerobot" ancestor captures
-# any lerobot child logger via propagation.
-_RECORD_LOG_LOGGER_NAMES = (__name__, "lerobot")
+# lines come from there; attaching to the shared "lerobot" ancestor captures
+# any lerobot child logger via propagation), and teleoperate's connect/
+# teardown logger — force_disconnect_partial's warnings and torque-disable
+# errors otherwise only ever reach the server console, invisible to an
+# operator watching the Record page during a failed/retried connect.
+_RECORD_LOG_LOGGER_NAMES = (__name__, "lerobot", "makermodslab.teleoperate")
 
 
 class _RingBufferLogHandler(logging.Handler):
@@ -198,6 +205,12 @@ current_episode = 1  # Track current episode number
 saved_episodes = 0  # Track how many episodes have been saved
 current_phase = "preparing"  # Track current phase: "preparing", "recording", "resetting", "completed"
 phase_start_time = None  # Track when current phase started
+# Set only while current_phase == "reconnecting_robot" (the backoff sleep
+# between connect retries below); 0 otherwise. Lets the frontend show which
+# retry attempt is in flight ("Camera hiccup, retrying (2/3)…") instead of
+# one static "Connecting arm & cameras…" label for a window that can now run
+# past ten seconds across multiple component-wise teardowns and retries.
+connect_retry_attempt = 0
 # Total time spent paused during the CURRENT reset phase, credited on resume
 # (see handle_resume_recording). Reset to 0.0 at the start of every new reset
 # phase (both reset-phase call sites in record_with_web_events) AND at the
@@ -545,7 +558,8 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
         last_session_outcome, \
         last_session_error, \
         identity_warnings, \
-        discard_requested
+        discard_requested, \
+        connect_retry_attempt
 
     from . import (
         auto_calibrate as _auto_calibrate,
@@ -649,6 +663,7 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
         saved_episodes = 0
         current_phase = "preparing"
         phase_start_time = None
+        connect_retry_attempt = 0
         last_session_discarded_empty = False
         last_session_outcome = None
         last_session_error = None
@@ -1032,6 +1047,10 @@ def handle_recording_status() -> dict[str, Any]:
     status = {
         "recording_active": recording_active,
         "current_phase": current_phase,  # "preparing", "recording", "resetting", "completed"
+        # Only meaningful while current_phase == "reconnecting_robot": which
+        # connect attempt is about to be retried, out of _CONNECT_ATTEMPTS.
+        "connect_retry_attempt": connect_retry_attempt,
+        "connect_retry_max": _CONNECT_ATTEMPTS,
         "session_ended": session_ended,  # New field to indicate session completion
         # True during the post-session rest-pose return: the recording loop is
         # over but the arm is still energized and driving back to its
@@ -1544,7 +1563,7 @@ def record_with_web_events(
     from lerobot.utils.utils import log_say
 
     global current_phase, phase_start_time, current_episode, saved_episodes, releasing
-    global identity_warnings
+    global identity_warnings, connect_retry_attempt
     global paused_accum_seconds, pause_started_at
 
     robot = make_robot_from_config(cfg.robot)
@@ -1620,13 +1639,12 @@ def record_with_web_events(
     # handler already returns; no new plumbing.)
     current_phase = "connecting_robot"
     phase_start_time = time.time()
-    connect_attempts = 3
-    for attempt in range(1, connect_attempts + 1):
+    for attempt in range(1, _CONNECT_ATTEMPTS + 1):
         try:
             logger.info(
                 "🔧 ROBOT CONNECTION: Attempting to connect robot (attempt %d/%d)...",
                 attempt,
-                connect_attempts,
+                _CONNECT_ATTEMPTS,
             )
             # Calibration is already on disk (loaded via the configs above), so never
             # let connect() drop into interactive recalibration — that would hang the
@@ -1676,10 +1694,25 @@ def record_with_web_events(
             # disconnect() a no-op raise in exactly that state (see
             # force_disconnect_partial).
             force_disconnect_partial(robot, "robot")
-            if attempt < connect_attempts and transient_camera:
+            if attempt < _CONNECT_ATTEMPTS and transient_camera:
+                # Distinguish the backoff substep from the connect substep so
+                # the UI can show "Camera hiccup, retrying (2/3)…" instead of
+                # one static "Connecting arm & cameras…" label for a window
+                # that (with the teardown above) can now run well past ten
+                # seconds. Logged at INFO through this module's own logger
+                # (already in _RECORD_LOG_LOGGER_NAMES) so it reaches the
+                # visible Record-page log panel, not just the server console.
+                current_phase = "reconnecting_robot"
+                connect_retry_attempt = attempt
+                logger.info(
+                    "🔁 ROBOT CONNECTION: Camera hiccup, retrying (%d/%d) after OS release settles...",
+                    attempt + 1,
+                    _CONNECT_ATTEMPTS,
+                )
                 # Let the OS release settle past the turbulence window before
                 # re-rolling the connect.
                 time.sleep(2.0)
+                current_phase = "connecting_robot"
                 continue
             raise
 

--- a/makermodslab/teleoperate.py
+++ b/makermodslab/teleoperate.py
@@ -443,9 +443,15 @@ def _device_ports(device) -> str:
 def _bus_has_a_responding_motor(bus) -> bool:
     """True when at least one motor on ``bus`` answers a ping.
 
-    The signal ``force_disable_torque`` needs is "can we still talk to this
-    arm", and an open serial port does not answer that. ``is_connected`` is
-    literally ``port_handler.is_open`` (lerobot ``motors_bus.py``), and
+    Used only to choose the *wording* of the alarm after the torque-disable
+    pass below has already failed on every motor on this bus — it never gates
+    whether that pass runs. A degraded-but-recoverable bus (a brownout that
+    recovers, EMI, a long cable, the moments right after the control loop died
+    on a comms error) can fail every zero-retry ping while a retried write
+    would have landed, so the probe must not be allowed to veto the write.
+
+    ``is_connected`` can't stand in for this: it's literally
+    ``port_handler.is_open`` (lerobot ``motors_bus.py``), and
     ``MotorsBus._connect`` calls ``openPort()`` *before* ``_handshake()`` and
     does not close the port when the handshake fails — so an unpowered,
     browned-out, or wrong-baud arm leaves ``is_connected`` True on a bus that
@@ -453,14 +459,11 @@ def _bus_has_a_responding_motor(bus) -> bool:
 
     ``ping`` is the right probe: it is a read (so it works whatever the torque
     state is) and it returns ``None`` rather than raising on comm failure.
-    Short-circuits on the first motor that answers, so a healthy bus costs one
-    packet; a dead one costs one timeout per motor, still far cheaper than the
-    ``num_retry=5`` write storm the torque pass would otherwise spend proving
-    the same thing.
+    Short-circuits on the first motor that answers.
 
-    Defaults to True (proceed with the torque pass, preserving the old
-    behaviour) for anything that can't be probed: a bus with no ``motors``, a
-    bus without a ``ping`` method, or a test double that models neither.
+    Defaults to True (assume the bus is alive, keep the loud alarm) for
+    anything that can't be probed: a bus with no ``motors``, a bus without a
+    ``ping`` method, or a test double that models neither.
     """
     motors = getattr(bus, "motors", None) or {}
     ping = getattr(bus, "ping", None)
@@ -512,21 +515,11 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
             with contextlib.suppress(Exception):
                 port_handler.is_using = False
         port = getattr(bus, "port", None) or "unknown port"
-        # Nothing on this bus is listening: the port opened but no motor
-        # answers (arm unpowered, browned-out servos, wrong baud, or a
-        # valid-but-wrong serial device). Every torque write below would fail,
-        # and reporting that as "TORQUE MAY STILL BE ENABLED — unplug its
-        # power" is actively misleading on an arm that has no power. Say what
-        # was actually observed instead, and keep the rigid-arm advice as a
-        # conditional rather than an assertion.
-        if not _bus_has_a_responding_motor(bus):
-            message = (
-                f"No motor answered on {port} ({label}) — skipped the torque disable. "
-                "Check the arm's power and USB cable. If the arm is rigid, unplug its power to release it."
-            )
-            logger.warning(message)
-            problems.append(message)
-            continue
+        # Always attempt the disable, whatever the liveness probe below would
+        # say: a degraded-but-recoverable bus can fail every zero-retry ping
+        # while the retried write here still lands, and skipping the write on
+        # a failed probe would leave a genuinely energized arm rigid. The
+        # probe is only consulted after a failure, to pick the wording.
         failed: list[str] = []
         for motor in getattr(bus, "motors", None) or {}:
             try:
@@ -534,11 +527,27 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
             except Exception as e:
                 failed.append(f"{motor}: {e}")
         if failed:
-            message = (
-                f"TORQUE MAY STILL BE ENABLED on {port} ({label}; failed motors — {'; '.join(failed)}). "
-                "The arm can stay rigid; unplug its power to release it."
-            )
-            logger.error(message)
+            if _bus_has_a_responding_motor(bus):
+                # Something is listening, so the failed writes are a real
+                # "this joint may stay rigid" condition.
+                message = (
+                    f"TORQUE MAY STILL BE ENABLED on {port} ({label}; failed motors — {'; '.join(failed)}). "
+                    "The arm can stay rigid; unplug its power to release it."
+                )
+                logger.error(message)
+            else:
+                # Nothing on this bus is listening: the port opened but no
+                # motor answers (arm unpowered, browned-out servos, wrong
+                # baud, or a valid-but-wrong serial device). Reporting that as
+                # "TORQUE MAY STILL BE ENABLED — unplug its power" is actively
+                # misleading on an arm that has no power. Say what was
+                # actually observed, and keep the rigid-arm advice as a
+                # conditional rather than an assertion.
+                message = (
+                    f"No motor answered on {port} ({label}) — the torque disable failed on every motor. "
+                    "Check the arm's power and USB cable. If the arm is rigid, unplug its power to release it."
+                )
+                logger.warning(message)
             problems.append(message)
     return problems
 

--- a/makermodslab/teleoperate.py
+++ b/makermodslab/teleoperate.py
@@ -572,9 +572,12 @@ def force_disconnect_partial(device, label: str = "device") -> list[str]:
     enabled after an incomplete setup" situation. force_disable_torque skips
     any bus that never opened, so this is safe to call unconditionally.
 
-    Returns the joined list of problem descriptions (same shape as
-    _cleanup_after_setup_failure), empty when teardown was clean, so callers
-    can surface a partial teardown instead of silently discarding it.
+    Returns the list of problem descriptions, empty when teardown was clean,
+    so callers can surface a partial teardown instead of silently discarding
+    it. Note this is the raw list, unlike _cleanup_after_setup_failure, which
+    joins its problems into a single ``str | None`` for its one caller —
+    leaving them separate here lets a caller count, filter, or join them as
+    it needs.
     """
     problems: list[str] = []
     if device is None:

--- a/makermodslab/teleoperate.py
+++ b/makermodslab/teleoperate.py
@@ -25,6 +25,7 @@ from lerobot.robots.bi_so_follower import BiSOFollower
 from lerobot.robots.so_follower import SO101Follower
 from lerobot.teleoperators.bi_so_leader import BiSOLeader
 from lerobot.teleoperators.so_leader import SO101Leader
+from lerobot.utils.errors import DeviceNotConnectedError
 
 from .arm_identity import verify_devices
 from .motor_power import clear_goal_velocity, reset_torque_limit
@@ -528,6 +529,51 @@ def _cleanup_after_setup_failure(
         if error:
             problems.append(error)
     return " ".join(problems) if problems else None
+
+
+def force_disconnect_partial(device, label: str = "device") -> None:
+    """Release a device that may be only *partially* connected.
+
+    ``device.disconnect()`` is unusable after a failed ``connect()``. lerobot
+    guards it with ``@check_if_not_connected``, and a robot's ``is_connected``
+    is all-or-nothing (``bus.is_connected and all(cam.is_connected ...)``), so
+    when ``connect()`` opens the bus and then dies on a camera, the cameras
+    *after* the failing one in iteration order were never opened — the guard
+    sees ``is_connected == False`` and ``disconnect()`` raises
+    ``DeviceNotConnectedError`` immediately, releasing **nothing**. The bus
+    stays open and every already-opened camera keeps its background read thread
+    running, holding the OS device busy for the rest of the process. The next
+    connect attempt then dies on the leaked bus with the misleading
+    "FeetechMotorsBus is already connected", and its cameras time out against
+    the leaked read threads — the failure is self-perpetuating until restart
+    (diagnosed 2026-07-29 on the front/wrist rig).
+
+    Go component by component instead, each independently guarded, so a broken
+    camera can't strand the bus and vice versa. Safe on a fully connected,
+    partially connected, or already disconnected device.
+    """
+    if device is None:
+        return
+    # Cameras first: they're the usual point of failure, and their read threads
+    # are what keep the device busy for the next attempt. ``.cameras`` covers
+    # both sides on a bimanual BiSO device (it merges the sub-arms' dicts).
+    for name, cam in (getattr(device, "cameras", None) or {}).items():
+        try:
+            cam.disconnect()
+        except DeviceNotConnectedError:
+            pass  # never opened (or already released) — nothing to do
+        except Exception as e:
+            logger.warning(f"Could not release {label} camera {name}: {e}")
+    for bus in _device_buses(device):
+        try:
+            if bus.is_connected:
+                # Default disable_torque=True: on a camera failure torque was
+                # never enabled (configure() runs after the cameras), but a
+                # failure later in connect() can leave it on.
+                bus.disconnect()
+        except Exception as e:
+            port = getattr(bus, "port", None) or "unknown port"
+            logger.warning(f"Could not release {label} bus on {port}: {e}")
 
 
 def _connect_bimanual(request: TeleoperateRequest):

--- a/makermodslab/teleoperate.py
+++ b/makermodslab/teleoperate.py
@@ -551,10 +551,22 @@ def force_disconnect_partial(device, label: str = "device") -> None:
     Go component by component instead, each independently guarded, so a broken
     camera can't strand the bus and vice versa. Safe on a fully connected,
     partially connected, or already disconnected device.
+
+    Torque, motor-by-motor, before any of that: on a camera failure torque was
+    never enabled (configure() runs after the cameras), but a failure later in
+    connect() can leave it on. bus.disconnect() below does disable torque
+    itself, but — same reasoning as force_disable_torque's docstring — one
+    motor's failed write there aborts the disable for every motor after it on
+    that bus, leaving them energized. force_disable_torque disables each motor
+    independently first so a bad motor can't strand its bus-mates rigid; the
+    disconnect() call after it is then belt-and-braces, same ordering as
+    _cleanup_after_setup_failure uses for the same "torque may already be
+    enabled after an incomplete setup" situation.
     """
     if device is None:
         return
-    # Cameras first: they're the usual point of failure, and their read threads
+    force_disable_torque(device, label)
+    # Cameras next: they're the usual point of failure, and their read threads
     # are what keep the device busy for the next attempt. ``.cameras`` covers
     # both sides on a bimanual BiSO device (it merges the sub-arms' dicts).
     for name, cam in (getattr(device, "cameras", None) or {}).items():
@@ -567,9 +579,6 @@ def force_disconnect_partial(device, label: str = "device") -> None:
     for bus in _device_buses(device):
         try:
             if bus.is_connected:
-                # Default disable_torque=True: on a camera failure torque was
-                # never enabled (configure() runs after the cameras), but a
-                # failure later in connect() can leave it on.
                 bus.disconnect()
         except Exception as e:
             port = getattr(bus, "port", None) or "unknown port"

--- a/makermodslab/teleoperate.py
+++ b/makermodslab/teleoperate.py
@@ -440,6 +440,41 @@ def _device_ports(device) -> str:
     return ", ".join(ports) if ports else "unknown port"
 
 
+def _bus_has_a_responding_motor(bus) -> bool:
+    """True when at least one motor on ``bus`` answers a ping.
+
+    The signal ``force_disable_torque`` needs is "can we still talk to this
+    arm", and an open serial port does not answer that. ``is_connected`` is
+    literally ``port_handler.is_open`` (lerobot ``motors_bus.py``), and
+    ``MotorsBus._connect`` calls ``openPort()`` *before* ``_handshake()`` and
+    does not close the port when the handshake fails — so an unpowered,
+    browned-out, or wrong-baud arm leaves ``is_connected`` True on a bus that
+    no motor is listening on.
+
+    ``ping`` is the right probe: it is a read (so it works whatever the torque
+    state is) and it returns ``None`` rather than raising on comm failure.
+    Short-circuits on the first motor that answers, so a healthy bus costs one
+    packet; a dead one costs one timeout per motor, still far cheaper than the
+    ``num_retry=5`` write storm the torque pass would otherwise spend proving
+    the same thing.
+
+    Defaults to True (proceed with the torque pass, preserving the old
+    behaviour) for anything that can't be probed: a bus with no ``motors``, a
+    bus without a ``ping`` method, or a test double that models neither.
+    """
+    motors = getattr(bus, "motors", None) or {}
+    ping = getattr(bus, "ping", None)
+    if not motors or not callable(ping):
+        return True
+    for motor in motors:
+        try:
+            if ping(motor) is not None:
+                return True
+        except Exception:
+            continue
+    return False
+
+
 def force_disable_torque(device, label: str = "device") -> list[str]:
     """Explicitly disable torque on every motor of a device, motor by motor.
 
@@ -455,12 +490,14 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
     """
     problems: list[str] = []
     for bus in _device_buses(device):
-        # A bus that never opened (connect() failed before reaching it, or
-        # died on an earlier bus/camera) has nothing to disable — writing to
-        # a closed port here just produces a false "TORQUE MAY STILL BE
-        # ENABLED" alarm on what is often the most common failure path (wrong
-        # port, arm unplugged). Test doubles that don't model connection
-        # state default to True so existing torque-only tests are unaffected.
+        # A bus whose port never opened at all (the device node was missing or
+        # busy, so openPort() itself raised) has nothing to disable — writing
+        # to a closed port just produces a false "TORQUE MAY STILL BE ENABLED"
+        # alarm. Note this covers *only* that case: is_connected is
+        # port_handler.is_open, so it stays True when the port opened and the
+        # handshake then failed. The unpowered/wrong-baud arm is caught by the
+        # liveness probe below, not here. Test doubles that don't model
+        # connection state default to True so torque-only tests are unaffected.
         if not getattr(bus, "is_connected", True):
             continue
         # The Dynamixel SDK port handler can be left flagged "in use" after a
@@ -474,6 +511,22 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
                 port_handler.clearPort()
             with contextlib.suppress(Exception):
                 port_handler.is_using = False
+        port = getattr(bus, "port", None) or "unknown port"
+        # Nothing on this bus is listening: the port opened but no motor
+        # answers (arm unpowered, browned-out servos, wrong baud, or a
+        # valid-but-wrong serial device). Every torque write below would fail,
+        # and reporting that as "TORQUE MAY STILL BE ENABLED — unplug its
+        # power" is actively misleading on an arm that has no power. Say what
+        # was actually observed instead, and keep the rigid-arm advice as a
+        # conditional rather than an assertion.
+        if not _bus_has_a_responding_motor(bus):
+            message = (
+                f"No motor answered on {port} ({label}) — skipped the torque disable. "
+                "Check the arm's power and USB cable. If the arm is rigid, unplug its power to release it."
+            )
+            logger.warning(message)
+            problems.append(message)
+            continue
         failed: list[str] = []
         for motor in getattr(bus, "motors", None) or {}:
             try:
@@ -481,7 +534,6 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
             except Exception as e:
                 failed.append(f"{motor}: {e}")
         if failed:
-            port = getattr(bus, "port", None) or "unknown port"
             message = (
                 f"TORQUE MAY STILL BE ENABLED on {port} ({label}; failed motors — {'; '.join(failed)}). "
                 "The arm can stay rigid; unplug its power to release it."
@@ -562,15 +614,17 @@ def force_disconnect_partial(device, label: str = "device") -> list[str]:
 
     Torque, motor-by-motor, before any of that: on a camera failure torque was
     never enabled (configure() runs after the cameras), but a failure later in
-    connect() can leave it on. bus.disconnect() below does disable torque
+    connect() can leave it on. lerobot's bus.disconnect() does disable torque
     itself, but — same reasoning as force_disable_torque's docstring — one
     motor's failed write there aborts the disable for every motor after it on
-    that bus, leaving them energized. force_disable_torque disables each motor
-    independently first so a bad motor can't strand its bus-mates rigid; the
-    disconnect() call after it is then belt-and-braces, same ordering as
-    _cleanup_after_setup_failure uses for the same "torque may already be
-    enabled after an incomplete setup" situation. force_disable_torque skips
-    any bus that never opened, so this is safe to call unconditionally.
+    that bus, leaving them energized *and* skipping closePort(). So
+    force_disable_torque disables each motor independently first, and the
+    disconnect() below is then called with disable_torque=False: the work is
+    already done, and re-running it only reintroduces the abort-before-close
+    failure mode. Same ordering as _cleanup_after_setup_failure uses for the
+    same "torque may already be enabled after an incomplete setup" situation.
+    force_disable_torque skips any bus whose port never opened and any bus
+    where no motor answers a ping, so this is safe to call unconditionally.
 
     Returns the list of problem descriptions, empty when teardown was clean,
     so callers can surface a partial teardown instead of silently discarding
@@ -597,8 +651,16 @@ def force_disconnect_partial(device, label: str = "device") -> list[str]:
             problems.append(message)
     for bus in _device_buses(device):
         try:
-            if bus.is_connected:
-                bus.disconnect()
+            # disable_torque=False: force_disable_torque above already
+            # disabled every motor independently, and lerobot's default
+            # disconnect(disable_torque=True) would re-run the same pass with
+            # num_retry=5 — where the *first* unresponsive motor raises before
+            # closePort(), leaking the port and appending a second, misleading
+            # "could not release the bus" problem about a bus we then close by
+            # hand below. Same reasoning and same call as rollout.py,
+            # motor_power.py, identify.py and auto_calibrate.py.
+            if getattr(bus, "is_connected", True):
+                bus.disconnect(disable_torque=False)
         except Exception as e:
             port = getattr(bus, "port", None) or "unknown port"
             message = f"Could not release {label} bus on {port}: {e}"

--- a/makermodslab/teleoperate.py
+++ b/makermodslab/teleoperate.py
@@ -455,6 +455,14 @@ def force_disable_torque(device, label: str = "device") -> list[str]:
     """
     problems: list[str] = []
     for bus in _device_buses(device):
+        # A bus that never opened (connect() failed before reaching it, or
+        # died on an earlier bus/camera) has nothing to disable — writing to
+        # a closed port here just produces a false "TORQUE MAY STILL BE
+        # ENABLED" alarm on what is often the most common failure path (wrong
+        # port, arm unplugged). Test doubles that don't model connection
+        # state default to True so existing torque-only tests are unaffected.
+        if not getattr(bus, "is_connected", True):
+            continue
         # The Dynamixel SDK port handler can be left flagged "in use" after a
         # failed read/write in the control loop. LeRobot's normal
         # bus.disconnect() clears this before disabling torque; mirror that here
@@ -531,7 +539,7 @@ def _cleanup_after_setup_failure(
     return " ".join(problems) if problems else None
 
 
-def force_disconnect_partial(device, label: str = "device") -> None:
+def force_disconnect_partial(device, label: str = "device") -> list[str]:
     """Release a device that may be only *partially* connected.
 
     ``device.disconnect()`` is unusable after a failed ``connect()``. lerobot
@@ -561,11 +569,17 @@ def force_disconnect_partial(device, label: str = "device") -> None:
     independently first so a bad motor can't strand its bus-mates rigid; the
     disconnect() call after it is then belt-and-braces, same ordering as
     _cleanup_after_setup_failure uses for the same "torque may already be
-    enabled after an incomplete setup" situation.
+    enabled after an incomplete setup" situation. force_disable_torque skips
+    any bus that never opened, so this is safe to call unconditionally.
+
+    Returns the joined list of problem descriptions (same shape as
+    _cleanup_after_setup_failure), empty when teardown was clean, so callers
+    can surface a partial teardown instead of silently discarding it.
     """
+    problems: list[str] = []
     if device is None:
-        return
-    force_disable_torque(device, label)
+        return problems
+    problems += force_disable_torque(device, label)
     # Cameras next: they're the usual point of failure, and their read threads
     # are what keep the device busy for the next attempt. ``.cameras`` covers
     # both sides on a bimanual BiSO device (it merges the sub-arms' dicts).
@@ -575,14 +589,37 @@ def force_disconnect_partial(device, label: str = "device") -> None:
         except DeviceNotConnectedError:
             pass  # never opened (or already released) — nothing to do
         except Exception as e:
-            logger.warning(f"Could not release {label} camera {name}: {e}")
+            message = f"Could not release {label} camera {name}: {e}"
+            logger.warning(message)
+            problems.append(message)
     for bus in _device_buses(device):
         try:
             if bus.is_connected:
                 bus.disconnect()
         except Exception as e:
             port = getattr(bus, "port", None) or "unknown port"
-            logger.warning(f"Could not release {label} bus on {port}: {e}")
+            message = f"Could not release {label} bus on {port}: {e}"
+            logger.warning(message)
+            problems.append(message)
+            # Last resort (same fallback utils/devices.py's
+            # _force_close_device_resources uses): force the port handle
+            # closed so a failed disconnect can't leave it open until process
+            # exit. Scoped per-bus (not delegated to that device-level
+            # helper) so bimanual sub-arm buses each get their own fallback.
+            port_handler = getattr(bus, "port_handler", None)
+            if port_handler is not None:
+                with contextlib.suppress(Exception):
+                    port_handler.clearPort()
+                with contextlib.suppress(Exception):
+                    port_handler.is_using = False
+                try:
+                    port_handler.closePort()
+                    logger.info(f"Force-closed {label} bus port on {port} after disconnect failure")
+                except Exception as close_exc:
+                    close_message = f"Failed to force-close {label} bus port on {port}: {close_exc}"
+                    logger.warning(close_message)
+                    problems.append(close_message)
+    return problems
 
 
 def _connect_bimanual(request: TeleoperateRequest):

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import itertools
 import threading
 import time
 
@@ -1185,6 +1186,8 @@ def _run_record_session(
     num_episodes: int = 1,
     reset_time_s: int = 10,
     record_loop_side_effect=None,
+    connect_side_effect=None,
+    teleop=None,
 ):
     """Drive record_with_web_events with every lerobot dependency mocked so no
     real hardware, dataset, or record_loop runs. Returns the spy call log for
@@ -1214,7 +1217,7 @@ def _run_record_session(
     # lerobot symbols resolved at call time inside record_with_web_events.
     monkeypatch.setattr("lerobot.robots.make_robot_from_config", lambda cfg: robot, raising=False)
     monkeypatch.setattr(
-        "lerobot.teleoperators.make_teleoperator_from_config", lambda cfg: None, raising=False
+        "lerobot.teleoperators.make_teleoperator_from_config", lambda cfg: teleop, raising=False
     )
     monkeypatch.setattr(
         "lerobot.processor.make_default_processors", lambda: (None, None, None), raising=False
@@ -1258,8 +1261,18 @@ def _run_record_session(
 
     monkeypatch.setattr("lerobot.datasets.LeRobotDataset", _FakeDataset, raising=False)
 
-    # robot.connect(calibrate=False) is called on the double.
-    robot.connect = lambda **kwargs: None  # type: ignore[attr-defined]
+    # robot.connect(calibrate=False) is called on the double. connect_side_effect
+    # (when given) is called with the 1-based attempt number and may raise, which
+    # is how the connect-retry tests below drive the failure paths.
+    if connect_side_effect is None:
+        robot.connect = lambda **kwargs: None  # type: ignore[attr-defined]
+    else:
+        connect_attempts = itertools.count(1)
+
+        def _connect(**kwargs):
+            connect_side_effect(next(connect_attempts))
+
+        robot.connect = _connect  # type: ignore[attr-defined]
     robot.name = "so101"  # type: ignore[attr-defined]
     robot.cameras = {}  # type: ignore[attr-defined]
     robot.action_features = {}  # type: ignore[attr-defined]
@@ -1279,8 +1292,9 @@ def _run_record_session(
             video=False,
         )
     )
-    # No teleop device: keep the return path follower-only and simple.
-    cfg.teleop = None
+    if teleop is None:
+        # No teleop device: keep the return path follower-only and simple.
+        cfg.teleop = None
 
     web_events = {
         "exit_early": False,
@@ -2511,3 +2525,158 @@ def test_recording_status_reports_saved_episodes_at_session_end(
 
     assert status["session_ended"] is True
     assert status["saved_episodes"] == 5
+
+
+# --- connect-retry loop: teardown, phase, and retry counter -----------------
+#
+# These drive record_with_web_events end to end (via _run_record_session) so
+# they fail when the production logic is deleted, rather than asserting on a
+# monkeypatched global. Each spies on force_disconnect_partial and snapshots
+# the phase globals *at the moment of the teardown*, which is the ordering the
+# UI depends on.
+
+_TRANSIENT = "failed to set fps=30 (actual_fps=5.0)"
+_TERMINAL = "Could not connect on port COM_FOLLOWER"
+
+
+def _spy_teardowns(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Replace record.force_disconnect_partial with a spy that records the
+    label and the phase globals as they stood when the teardown ran."""
+    import makermodslab.record as record
+
+    seen: list[dict] = []
+
+    def _spy(device, label="device"):
+        seen.append(
+            {
+                "label": label,
+                "phase": record.current_phase,
+                "attempt": record.connect_retry_attempt,
+            }
+        )
+        return []
+
+    monkeypatch.setattr(record, "force_disconnect_partial", _spy)
+    monkeypatch.setattr(record.time, "sleep", lambda *_a, **_k: None)
+    return seen
+
+
+def test_transient_connect_failure_retries_inside_the_reconnecting_phase(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """The retry substep must be entered BEFORE the component-wise teardown,
+    not just around the backoff sleep. The teardown is the slow part (each
+    wedged camera's disconnect joins a read thread waiting out a frame
+    timeout), so if the phase flipped after it the operator would stare at a
+    static "Connecting arm & cameras…" for exactly the window the substep
+    exists to explain."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+    seen = _spy_teardowns(monkeypatch)
+
+    def _connect(attempt: int) -> None:
+        if attempt == 1:
+            raise RuntimeError(_TRANSIENT)
+
+    bus = _RecReturnBus(positions=dict.fromkeys(_RecReturnBus._MOTORS, 1500))
+    _, _robot, error, _ = _run_record_session(monkeypatch, _RecRobot(bus), connect_side_effect=_connect)
+
+    assert error is None  # attempt 2 connected, session ran normally
+    assert len(seen) == 1  # exactly one failed attempt was torn down
+    # The ordering this test exists for: phase and counter are already set when
+    # the teardown runs.
+    assert seen[0]["phase"] == "reconnecting_robot"
+    assert seen[0]["attempt"] == 2  # the attempt about to run, not the failed one
+    assert seen[0]["label"] == "robot"
+    # ...and the counter is back to its documented "0 unless retrying" resting
+    # state once the connect succeeds.
+    assert record.connect_retry_attempt == 0
+
+
+def test_transient_connect_failure_gives_up_after_max_attempts(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """A camera that never recovers is retried _CONNECT_ATTEMPTS times, torn
+    down after every one of them (including the last, so a terminal failure
+    can't leak the bus and camera read threads into the rest of the process),
+    and then re-raised."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+    seen = _spy_teardowns(monkeypatch)
+
+    def _connect(attempt: int) -> None:
+        raise RuntimeError(_TRANSIENT)
+
+    bus = _RecReturnBus(positions=dict.fromkeys(_RecReturnBus._MOTORS, 1500))
+    _, _robot, error, _ = _run_record_session(monkeypatch, _RecRobot(bus), connect_side_effect=_connect)
+
+    assert isinstance(error, RuntimeError) and _TRANSIENT in str(error)
+    assert len(seen) == record._CONNECT_ATTEMPTS
+    # Retrying attempts announce themselves; the final one is a plain failure,
+    # so it must NOT claim a retry is in flight.
+    assert [s["attempt"] for s in seen] == [2, 3, 0]
+    assert [s["phase"] for s in seen] == [
+        "reconnecting_robot",
+        "reconnecting_robot",
+        "connecting_robot",
+    ]
+    assert record.connect_retry_attempt == 0
+
+
+def test_non_transient_connect_failure_tears_down_without_retrying(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """A wrong-port/unplugged failure isn't camera turbulence: no retry, no
+    backoff, no "camera hiccup" label — but the teardown still runs, because
+    the port may have opened before the handshake failed."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+    seen = _spy_teardowns(monkeypatch)
+
+    def _connect(attempt: int) -> None:
+        raise RuntimeError(_TERMINAL)
+
+    bus = _RecReturnBus(positions=dict.fromkeys(_RecReturnBus._MOTORS, 1500))
+    _, _robot, error, _ = _run_record_session(monkeypatch, _RecRobot(bus), connect_side_effect=_connect)
+
+    assert isinstance(error, RuntimeError) and _TERMINAL in str(error)
+    assert len(seen) == 1  # one attempt, no retry
+    assert seen[0]["phase"] == "connecting_robot"
+    assert seen[0]["attempt"] == 0
+    assert record.connect_retry_attempt == 0
+
+
+def test_teleop_connect_failure_releases_both_devices(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """The follower connected fine a moment earlier, so a leader failure must
+    release BOTH — otherwise the follower's bus and camera read threads stay
+    open for the rest of the process and the next session dies on the leak."""
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+    seen = _spy_teardowns(monkeypatch)
+
+    class _FailingTeleop:
+        def connect(self, **kwargs):
+            raise RuntimeError("leader bus did not answer")
+
+    bus = _RecReturnBus(positions=dict.fromkeys(_RecReturnBus._MOTORS, 1500))
+    _, _robot, error, _ = _run_record_session(monkeypatch, _RecRobot(bus), teleop=_FailingTeleop())
+
+    assert isinstance(error, RuntimeError) and "leader bus" in str(error)
+    # Both devices released, follower first.
+    assert [s["label"] for s in seen] == ["robot", "teleop"]

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -42,21 +42,64 @@ def test_recording_status_handler_exposes_state_fields() -> None:
     assert "available_controls" in result
 
 
+def test_record_log_captures_teleoperate_teardown_warnings() -> None:
+    """force_disconnect_partial's teardown warnings (a leaked bus, a stuck
+    camera) are logged through makermodslab.teleoperate's logger, not this
+    module's — without it in _RECORD_LOG_LOGGER_NAMES they never reach the
+    Record page's log panel, only the server console.
+    """
+    import logging
+
+    from makermodslab.record import (
+        _attach_record_log_handler,
+        _detach_record_log_handler_locked,
+        handle_recording_log,
+    )
+
+    teleop_logger = logging.getLogger("makermodslab.teleoperate")
+    _attach_record_log_handler()
+    try:
+        teleop_logger.warning("Could not release robot bus on COM_FOLLOWER: wedged")
+    finally:
+        import makermodslab.record as record_module
+
+        with record_module._record_log_lock:
+            _detach_record_log_handler_locked()
+
+    assert "Could not release robot bus on COM_FOLLOWER" in handle_recording_log()["logs"]
+
+
 def test_recording_status_surfaces_preparing_substeps(monkeypatch) -> None:
     """record_with_web_events refines the coarse "preparing" window into named
-    substeps ("connecting_robot", "connecting_teleop") by writing current_phase.
-    The status handler must pass those through verbatim so the UI can name the
-    substep — verified here without touching hardware by driving the module
-    global the worker sets."""
+    substeps ("connecting_robot", "connecting_teleop", "reconnecting_robot")
+    by writing current_phase. The status handler must pass those through
+    verbatim so the UI can name the substep — verified here without touching
+    hardware by driving the module global the worker sets."""
     from makermodslab import record
 
-    for substep in ("connecting_robot", "connecting_teleop"):
+    for substep in ("connecting_robot", "connecting_teleop", "reconnecting_robot"):
         monkeypatch.setattr(record, "current_phase", substep)
         # An active session with no config still surfaces current_phase.
         result = record.handle_recording_status()
         assert result["current_phase"] == substep
         # A preparing substep is not a completed/errored session.
         assert result["session_ended"] is False
+
+
+def test_recording_status_surfaces_connect_retry_attempt(monkeypatch) -> None:
+    """During the "reconnecting_robot" backoff substep, the UI needs which
+    attempt is in flight (and the ceiling) to show "retrying (2/3)…" instead
+    of a static label for the whole multi-attempt window.
+    """
+    from makermodslab import record
+
+    monkeypatch.setattr(record, "current_phase", "reconnecting_robot")
+    monkeypatch.setattr(record, "connect_retry_attempt", 2)
+
+    result = record.handle_recording_status()
+
+    assert result["connect_retry_attempt"] == 2
+    assert result["connect_retry_max"] == record._CONNECT_ATTEMPTS
 
 
 class _FakeWorker:

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -596,20 +596,30 @@ class _FakeCamera:
 class _FakeConnectableBus(_FakeBus):
     """Motor bus double that tracks open/closed state for teardown tests."""
 
-    def __init__(self, port: str = "COM_FAKE", connected: bool = True, silent: bool = False) -> None:
+    def __init__(
+        self,
+        port: str = "COM_FAKE",
+        connected: bool = True,
+        silent: bool = False,
+        ping_dead: bool = False,
+    ) -> None:
         super().__init__(port=port)
         self.is_connected = connected
         self.disconnect_calls = 0
         self.disconnect_torque_flags: list[bool] = []
         # silent=True models the real post-handshake-failure state: the serial
         # port is open (is_connected True, because lerobot's is_connected is
-        # just port_handler.is_open) but no motor answers.
+        # just port_handler.is_open) but no motor answers — pings AND writes
+        # both fail. ping_dead=True models the narrower, more dangerous case:
+        # a degraded-but-recoverable bus where the zero-retry ping fails but a
+        # retried write would still land.
         self.silent = silent
+        self.ping_dead = ping_dead
         self.pings: list[str] = []
 
     def ping(self, motor: str, num_retry: int = 0):
         self.pings.append(motor)
-        return None if self.silent else 777
+        return None if (self.silent or self.ping_dead) else 777
 
     def disable_torque(self, motor: str, num_retry: int = 0) -> None:
         if self.silent:
@@ -777,6 +787,25 @@ def test_force_disconnect_partial_does_not_alarm_on_a_bus_that_never_opened() ->
     assert problems == []
 
 
+def test_force_disable_torque_still_writes_when_the_probe_fails_but_the_bus_is_alive() -> None:
+    """The exact case the probe must not be allowed to veto: a
+    degraded-but-recoverable bus where the zero-retry ping used for liveness
+    fails on every motor, but the retried (num_retry=5) disable_torque write
+    still lands. Gating the write on the probe result would leave a genuinely
+    energized arm rigid — the probe may only be consulted after a write
+    failure, never before one.
+    """
+    from makermodslab.teleoperate import force_disable_torque
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER", ping_dead=True)
+
+    problems = force_disable_torque(_FakeArm(bus), "robot")
+
+    # Every motor's write was attempted and landed, despite the dead probe.
+    assert [motor for motor, _ in bus.disabled] == list(bus.motors)
+    assert problems == []
+
+
 def test_force_disable_torque_does_not_alarm_when_no_motor_answers() -> None:
     """The real "arm unplugged / wrong port" shape, and the one the
     is_connected guard cannot catch.
@@ -784,10 +813,12 @@ def test_force_disable_torque_does_not_alarm_when_no_motor_answers() -> None:
     lerobot's MotorsBus._connect calls openPort() BEFORE _handshake(), and
     does not close the port when the handshake fails. So for an unpowered arm,
     browned-out servos, a wrong baud rate, or a valid-but-wrong serial device,
-    is_connected is still True on a bus no motor is listening on. Writing
-    torque-disable to all of them fails, and reporting that as "TORQUE MAY
-    STILL BE ENABLED ... unplug its power" is actively misleading about an arm
-    that has no power. Probe first, and say what was actually observed.
+    is_connected is still True on a bus no motor is listening on. The
+    torque-disable write is still attempted on every motor (a
+    degraded-but-recoverable bus could have taken it), and only once every
+    motor's write has failed does the probe get consulted to say what was
+    actually observed, instead of reporting "TORQUE MAY STILL BE ENABLED ...
+    unplug its power" on an arm that has no power to unplug.
     """
     from makermodslab.teleoperate import force_disable_torque
 
@@ -795,8 +826,8 @@ def test_force_disable_torque_does_not_alarm_when_no_motor_answers() -> None:
 
     problems = force_disable_torque(_FakeArm(bus), "robot")
 
-    assert bus.pings == list(bus.motors)  # probed every motor before giving up
-    assert bus.disabled == []  # no futile write storm against a dead bus
+    assert bus.pings == list(bus.motors)  # probed every motor after every write failed
+    assert bus.disabled == []  # every write was attempted and failed, none landed
     assert len(problems) == 1
     assert "No motor answered on COM_FOLLOWER" in problems[0]
     # The alarm is the thing under test: it must NOT be asserted as fact.

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -571,6 +571,153 @@ def test_force_disable_torque_handles_bimanual_and_none() -> None:
     assert force_disable_torque(None, "nothing") == []
 
 
+class _FakeCamera:
+    """Camera double with lerobot's OpenCVCamera disconnect semantics: raises
+    DeviceNotConnectedError when it was never opened, releases otherwise."""
+
+    def __init__(self, name: str, connected: bool = True, failing: bool = False) -> None:
+        self.name = name
+        self.is_connected = connected
+        self.failing = failing
+        self.released = False
+
+    def disconnect(self) -> None:
+        from lerobot.utils.errors import DeviceNotConnectedError
+
+        if self.failing:
+            raise RuntimeError(f"{self.name} wedged")
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self.name} not connected.")
+        self.is_connected = False
+        self.released = True
+
+
+class _FakeConnectableBus(_FakeBus):
+    """Motor bus double that tracks open/closed state for teardown tests."""
+
+    def __init__(self, port: str = "COM_FAKE", connected: bool = True) -> None:
+        super().__init__(port=port)
+        self.is_connected = connected
+        self.disconnect_calls = 0
+
+    def disconnect(self, disable_torque: bool = True) -> None:
+        self.disconnect_calls += 1
+        self.is_connected = False
+
+
+class _FakePartialRobot:
+    def __init__(self, bus: _FakeConnectableBus, cameras: dict[str, _FakeCamera]) -> None:
+        self.bus = bus
+        self.cameras = cameras
+
+
+def test_force_disconnect_partial_releases_bus_when_a_later_camera_never_opened() -> None:
+    """The regression this helper exists for: connect() opened the bus and the
+    first camera, then died on it, leaving the *second* camera never opened.
+    lerobot's all-or-nothing is_connected makes robot.disconnect() a no-op
+    raise in that state, leaking the bus (next attempt: "FeetechMotorsBus is
+    already connected") and the opened camera's read thread.
+    """
+    from makerlab.teleoperate import force_disconnect_partial
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER")
+    front = _FakeCamera("front", connected=True)
+    wrist = _FakeCamera("wrist", connected=False)  # never reached by connect()
+    robot = _FakePartialRobot(bus, {"front": front, "wrist": wrist})
+
+    force_disconnect_partial(robot, "robot")
+
+    assert front.released is True  # read thread released, device freed
+    assert bus.is_connected is False and bus.disconnect_calls == 1
+
+
+def test_lerobot_disconnect_cannot_release_a_partially_connected_robot() -> None:
+    """Pins *why* force_disconnect_partial exists, against lerobot's own guard.
+
+    Uses the real ``check_if_not_connected`` decorator and the real all-or-
+    nothing ``is_connected`` shape from SOFollower. If upstream ever makes
+    disconnect() tolerant of partial state, this test fails and the helper can
+    collapse back to robot.disconnect().
+    """
+    from lerobot.utils.decorators import check_if_not_connected
+    from lerobot.utils.errors import DeviceNotConnectedError
+    from makerlab.teleoperate import force_disconnect_partial
+
+    class _LeRobotShapedRobot:
+        def __init__(self) -> None:
+            self.bus = _FakeConnectableBus(port="COM_FOLLOWER")
+            self.cameras = {
+                "front": _FakeCamera("front", connected=True),
+                "wrist": _FakeCamera("wrist", connected=False),
+            }
+
+        @property
+        def is_connected(self) -> bool:
+            return self.bus.is_connected and all(c.is_connected for c in self.cameras.values())
+
+        @check_if_not_connected
+        def disconnect(self) -> None:
+            self.bus.disconnect()
+            for cam in self.cameras.values():
+                cam.disconnect()
+
+    robot = _LeRobotShapedRobot()
+    with pytest.raises(DeviceNotConnectedError):
+        robot.disconnect()
+    # ...and nothing was released — this is the leak that made every later
+    # recording attempt fail with "FeetechMotorsBus is already connected".
+    assert robot.bus.is_connected is True
+    assert robot.cameras["front"].is_connected is True
+
+    force_disconnect_partial(robot, "robot")
+    assert robot.bus.is_connected is False
+    assert robot.cameras["front"].is_connected is False
+
+
+def test_force_disconnect_partial_releases_bus_despite_a_wedged_camera() -> None:
+    """A camera that fails to release must not strand the serial port."""
+    from makerlab.teleoperate import force_disconnect_partial
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER")
+    wedged = _FakeCamera("front", connected=True, failing=True)
+    wrist = _FakeCamera("wrist", connected=True)
+    robot = _FakePartialRobot(bus, {"front": wedged, "wrist": wrist})
+
+    force_disconnect_partial(robot, "robot")
+
+    assert wedged.released is False
+    assert wrist.released is True  # a bad camera doesn't abort the rest
+    assert bus.is_connected is False
+
+
+def test_force_disconnect_partial_is_idempotent_and_handles_bimanual_and_none() -> None:
+    from makerlab.teleoperate import force_disconnect_partial
+
+    # Already fully disconnected: no raise, no bus disconnect call.
+    bus = _FakeConnectableBus(connected=False)
+    robot = _FakePartialRobot(bus, {"front": _FakeCamera("front", connected=False)})
+    force_disconnect_partial(robot, "robot")
+    force_disconnect_partial(robot, "robot")
+    assert bus.disconnect_calls == 0
+
+    # Bimanual: buses live on the sub-arms, cameras are merged at the top level.
+    class _BiRobot:
+        def __init__(self) -> None:
+            self.left_arm = _FakeArm(_FakeConnectableBus(port="COM_LEFT"))
+            self.right_arm = _FakeArm(_FakeConnectableBus(port="COM_RIGHT"))
+            self.cameras = {"left_front": _FakeCamera("left_front")}
+
+    bi = _BiRobot()
+    force_disconnect_partial(bi, "robot")
+    assert bi.left_arm.bus.is_connected is False
+    assert bi.right_arm.bus.is_connected is False
+    assert bi.cameras["left_front"].released is True
+
+    # A device with no cameras attribute at all, and None.
+    force_disconnect_partial(_FakeArm(_FakeConnectableBus()), "teleop")
+    force_disconnect_partial(None, "nothing")
+
+
 def test_stop_teleoperation_surfaces_cleanup_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import inspect
 import threading
 import time
 
@@ -595,13 +596,29 @@ class _FakeCamera:
 class _FakeConnectableBus(_FakeBus):
     """Motor bus double that tracks open/closed state for teardown tests."""
 
-    def __init__(self, port: str = "COM_FAKE", connected: bool = True) -> None:
+    def __init__(self, port: str = "COM_FAKE", connected: bool = True, silent: bool = False) -> None:
         super().__init__(port=port)
         self.is_connected = connected
         self.disconnect_calls = 0
+        self.disconnect_torque_flags: list[bool] = []
+        # silent=True models the real post-handshake-failure state: the serial
+        # port is open (is_connected True, because lerobot's is_connected is
+        # just port_handler.is_open) but no motor answers.
+        self.silent = silent
+        self.pings: list[str] = []
+
+    def ping(self, motor: str, num_retry: int = 0):
+        self.pings.append(motor)
+        return None if self.silent else 777
+
+    def disable_torque(self, motor: str, num_retry: int = 0) -> None:
+        if self.silent:
+            raise ConnectionError(f"no response from {motor}")
+        super().disable_torque(motor, num_retry)
 
     def disconnect(self, disable_torque: bool = True) -> None:
         self.disconnect_calls += 1
+        self.disconnect_torque_flags.append(disable_torque)
         self.is_connected = False
 
 
@@ -639,9 +656,25 @@ def test_lerobot_disconnect_cannot_release_a_partially_connected_robot() -> None
     disconnect() tolerant of partial state, this test fails and the helper can
     collapse back to robot.disconnect().
     """
+    from lerobot.robots.so_follower import SO101Follower
     from lerobot.utils.decorators import check_if_not_connected
     from lerobot.utils.errors import DeviceNotConnectedError
     from makermodslab.teleoperate import force_disconnect_partial
+
+    # Watch the real upstream class, not just our copy of its shape: the
+    # reconstruction below is only faithful while SO101Follower.disconnect is
+    # still guarded and is_connected is still all-or-nothing. Without these
+    # two assertions, upstream could drop the decorator entirely and this test
+    # would keep passing against its own hand-written stand-in, stranding a
+    # workaround that is no longer needed.
+    assert getattr(SO101Follower.disconnect, "__wrapped__", None) is not None, (
+        "SO101Follower.disconnect is no longer decorated — re-check whether "
+        "force_disconnect_partial is still needed."
+    )
+    assert "all(" in inspect.getsource(SO101Follower.is_connected.fget), (
+        "SO101Follower.is_connected is no longer all-or-nothing — re-check "
+        "whether force_disconnect_partial is still needed."
+    )
 
     class _LeRobotShapedRobot:
         def __init__(self) -> None:
@@ -683,11 +716,15 @@ def test_force_disconnect_partial_releases_bus_despite_a_wedged_camera() -> None
     wrist = _FakeCamera("wrist", connected=True)
     robot = _FakePartialRobot(bus, {"front": wedged, "wrist": wrist})
 
-    force_disconnect_partial(robot, "robot")
+    problems = force_disconnect_partial(robot, "robot")
 
     assert wedged.released is False
     assert wrist.released is True  # a bad camera doesn't abort the rest
     assert bus.is_connected is False
+    # A camera still holding the OS device is exactly what makes the NEXT
+    # connect attempt fail, so it must be surfaced, not swallowed.
+    assert len(problems) == 1
+    assert problems[0] == "Could not release robot camera front: front wedged"
 
 
 def test_force_disconnect_partial_disables_remaining_motors_despite_one_failing() -> None:
@@ -716,13 +753,16 @@ def test_force_disconnect_partial_disables_remaining_motors_despite_one_failing(
 
 
 def test_force_disconnect_partial_does_not_alarm_on_a_bus_that_never_opened() -> None:
-    """Bug: the torque-disable pass ran unconditionally, even when connect()
-    failed on the bus itself (the ordinary "wrong port" / "arm unplugged"
-    case) and nothing was ever energized. That wrote to a closed port for
-    every motor, and force_disable_torque's failures then printed the single
-    most alarming string the system can emit — "TORQUE MAY STILL BE ENABLED
-    ... unplug its power to release it" — for an arm that was never
-    connected, on what will be the most common failure path by far.
+    """The torque-disable pass used to run unconditionally, writing to a
+    closed port for every motor and then printing the single most alarming
+    string the system can emit — "TORQUE MAY STILL BE ENABLED ... unplug its
+    power to release it" — for an arm that was never connected.
+
+    Scope note: `is_connected` is `port_handler.is_open`, so this guard covers
+    only the case where `openPort()` itself failed (device node missing or
+    busy). The far more common unpowered/wrong-baud arm keeps `is_connected`
+    True — that one is caught by the ping probe, not here. See
+    test_force_disable_torque_does_not_alarm_when_no_motor_answers.
     """
     from makermodslab.teleoperate import force_disconnect_partial
 
@@ -732,7 +772,73 @@ def test_force_disconnect_partial_does_not_alarm_on_a_bus_that_never_opened() ->
     problems = force_disconnect_partial(robot, "robot")
 
     assert bus.disabled == []  # no motor writes against an unopened port
+    assert bus.pings == []  # not even probed — the port was never open
     assert bus.disconnect_calls == 0
+    assert problems == []
+
+
+def test_force_disable_torque_does_not_alarm_when_no_motor_answers() -> None:
+    """The real "arm unplugged / wrong port" shape, and the one the
+    is_connected guard cannot catch.
+
+    lerobot's MotorsBus._connect calls openPort() BEFORE _handshake(), and
+    does not close the port when the handshake fails. So for an unpowered arm,
+    browned-out servos, a wrong baud rate, or a valid-but-wrong serial device,
+    is_connected is still True on a bus no motor is listening on. Writing
+    torque-disable to all of them fails, and reporting that as "TORQUE MAY
+    STILL BE ENABLED ... unplug its power" is actively misleading about an arm
+    that has no power. Probe first, and say what was actually observed.
+    """
+    from makermodslab.teleoperate import force_disable_torque
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER", silent=True)
+
+    problems = force_disable_torque(_FakeArm(bus), "robot")
+
+    assert bus.pings == list(bus.motors)  # probed every motor before giving up
+    assert bus.disabled == []  # no futile write storm against a dead bus
+    assert len(problems) == 1
+    assert "No motor answered on COM_FOLLOWER" in problems[0]
+    # The alarm is the thing under test: it must NOT be asserted as fact.
+    assert "TORQUE MAY STILL BE ENABLED" not in problems[0]
+    # ...but the rigid-arm advice survives as a conditional, so a genuinely
+    # energized arm still tells the operator what to do.
+    assert "If the arm is rigid" in problems[0]
+
+
+def test_force_disable_torque_still_alarms_when_a_live_bus_has_a_bad_motor() -> None:
+    """The probe must not become a blanket excuse: when the bus answers, a
+    motor that won't take the disable is a real "this joint may stay rigid"
+    condition and keeps the loud alarm."""
+    from makermodslab.teleoperate import force_disable_torque
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER")
+    bus.failing = {"elbow_flex"}
+
+    problems = force_disable_torque(_FakeArm(bus), "robot")
+
+    assert bus.pings == ["shoulder_pan"]  # short-circuits on the first answer
+    assert [motor for motor, _ in bus.disabled] == ["shoulder_pan", "gripper"]
+    assert len(problems) == 1
+    assert "TORQUE MAY STILL BE ENABLED" in problems[0]
+    assert "elbow_flex" in problems[0]
+
+
+def test_force_disconnect_partial_does_not_re_disable_torque_on_disconnect() -> None:
+    """force_disable_torque already disabled every motor independently.
+    lerobot's default disconnect(disable_torque=True) would re-run that pass
+    with num_retry=5, where the first unresponsive motor raises BEFORE
+    closePort() — leaking the port and appending a second, misleading "could
+    not release the bus" problem. Same call as rollout.py, motor_power.py,
+    identify.py and auto_calibrate.py already use."""
+    from makermodslab.teleoperate import force_disconnect_partial
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER")
+    robot = _FakePartialRobot(bus, {})
+
+    problems = force_disconnect_partial(robot, "robot")
+
+    assert bus.disconnect_torque_flags == [False]
     assert problems == []
 
 
@@ -771,14 +877,38 @@ def test_force_disconnect_partial_force_closes_port_when_disconnect_raises() -> 
 
     problems = force_disconnect_partial(robot, "robot")
 
-    # force_disable_torque's own pre-write port clear runs first (the bus is
-    # connected, so it isn't skipped); the fallback below clears again before
-    # force-closing — both are defensive and idempotent, so >=1 is the
-    # contract, not an exact count.
-    assert port_handler.clear_calls >= 1
+    # force_disable_torque's own pre-write port clear already ran (the bus is
+    # connected, so it isn't skipped) and already set is_using False — so
+    # asserting those two here would pass even with the fallback's own
+    # clearPort()/is_using deleted. Pin the exact count instead: 2 means the
+    # fallback did its own defensive clear rather than relying on the earlier
+    # one.
+    assert port_handler.clear_calls == 2
     assert port_handler.is_using is False
     assert port_handler.close_calls == 1
-    assert any("COM_FOLLOWER" in p for p in problems)
+    # Pin *which* problem was reported, not merely that the port appears in
+    # one of them — the force-close message also contains the port.
+    assert len(problems) == 1
+    assert problems[0].startswith("Could not release robot bus on COM_FOLLOWER")
+
+
+def test_force_disconnect_partial_reports_a_failed_force_close() -> None:
+    """The last-resort branch itself: when closePort() ALSO fails, the port is
+    genuinely wedged for the rest of the process and the operator must be told
+    — this is the one state the fallback cannot rescue, so it must not fail
+    silently."""
+    from makermodslab.teleoperate import force_disconnect_partial
+
+    bus = _FakeUnreleasableBus(port="COM_FOLLOWER")
+    bus.port_handler = _FakeFailingPortHandler(fail_close=True)  # type: ignore[attr-defined]
+    robot = _FakePartialRobot(bus, {})
+
+    problems = force_disconnect_partial(robot, "robot")
+
+    assert len(problems) == 2
+    assert problems[0].startswith("Could not release robot bus on COM_FOLLOWER")
+    assert problems[1].startswith("Failed to force-close robot bus port on COM_FOLLOWER")
+    assert "port already gone" in problems[1]
 
 
 def test_force_disconnect_partial_returns_problems_instead_of_none() -> None:
@@ -821,9 +951,22 @@ def test_force_disconnect_partial_is_idempotent_and_handles_bimanual_and_none() 
     assert bi.right_arm.bus.is_connected is False
     assert bi.cameras["left_front"].released is True
 
+    # Bimanual, PARTIALLY connected: connect() opened the left arm's bus and
+    # died before the right one. The guard must skip exactly one of the two,
+    # and the left arm must still be released — a mixed state is the whole
+    # reason the teardown is scoped per-bus rather than per-device.
+    bi = _BiRobot()
+    bi.right_arm.bus.is_connected = False
+    force_disconnect_partial(bi, "robot")
+    assert bi.left_arm.bus.disconnect_calls == 1
+    assert bi.right_arm.bus.disconnect_calls == 0  # never opened, never touched
+    assert bi.left_arm.bus.disabled != []  # torque released on the live arm
+    assert bi.right_arm.bus.disabled == []
+
     # A device with no cameras attribute at all, and None.
-    force_disconnect_partial(_FakeArm(_FakeConnectableBus()), "teleop")
-    force_disconnect_partial(None, "nothing")
+    assert force_disconnect_partial(_FakeArm(_FakeConnectableBus()), "teleop") == []
+    # None must be a clean no-op, not an AttributeError on a cleanup path.
+    assert force_disconnect_partial(None, "nothing") == []
 
 
 def test_stop_teleoperation_surfaces_cleanup_error(

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -690,6 +690,31 @@ def test_force_disconnect_partial_releases_bus_despite_a_wedged_camera() -> None
     assert bus.is_connected is False
 
 
+def test_force_disconnect_partial_disables_remaining_motors_despite_one_failing() -> None:
+    """force_disconnect_partial must disable torque motor-by-motor, not rely on
+    bus.disconnect()'s own internal torque-disable: lerobot's real disconnect()
+    disables torque motor-by-motor too, but a single motor's failed write
+    aborts that loop and leaves every motor after it energized/rigid — this is
+    exactly why force_disable_torque exists as a standalone belt-and-braces
+    step elsewhere in this module (see its docstring) and why
+    _cleanup_after_setup_failure calls it before disconnecting. This helper
+    handles the same "torque may already be enabled after an incomplete
+    connect" situation and needs the same protection.
+    """
+    from makerlab.teleoperate import force_disconnect_partial
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER")
+    bus.failing = {"elbow_flex"}
+    robot = _FakePartialRobot(bus, {})
+
+    force_disconnect_partial(robot, "robot")
+
+    # shoulder_pan (before elbow_flex) and gripper (after it) must still get
+    # an explicit disable_torque call despite elbow_flex's failure.
+    assert [motor for motor, _ in bus.disabled] == ["shoulder_pan", "gripper"]
+    assert bus.is_connected is False
+
+
 def test_force_disconnect_partial_is_idempotent_and_handles_bimanual_and_none() -> None:
     from makerlab.teleoperate import force_disconnect_partial
 

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -618,7 +618,7 @@ def test_force_disconnect_partial_releases_bus_when_a_later_camera_never_opened(
     raise in that state, leaking the bus (next attempt: "FeetechMotorsBus is
     already connected") and the opened camera's read thread.
     """
-    from makerlab.teleoperate import force_disconnect_partial
+    from makermodslab.teleoperate import force_disconnect_partial
 
     bus = _FakeConnectableBus(port="COM_FOLLOWER")
     front = _FakeCamera("front", connected=True)
@@ -641,7 +641,7 @@ def test_lerobot_disconnect_cannot_release_a_partially_connected_robot() -> None
     """
     from lerobot.utils.decorators import check_if_not_connected
     from lerobot.utils.errors import DeviceNotConnectedError
-    from makerlab.teleoperate import force_disconnect_partial
+    from makermodslab.teleoperate import force_disconnect_partial
 
     class _LeRobotShapedRobot:
         def __init__(self) -> None:
@@ -676,7 +676,7 @@ def test_lerobot_disconnect_cannot_release_a_partially_connected_robot() -> None
 
 def test_force_disconnect_partial_releases_bus_despite_a_wedged_camera() -> None:
     """A camera that fails to release must not strand the serial port."""
-    from makerlab.teleoperate import force_disconnect_partial
+    from makermodslab.teleoperate import force_disconnect_partial
 
     bus = _FakeConnectableBus(port="COM_FOLLOWER")
     wedged = _FakeCamera("front", connected=True, failing=True)
@@ -701,7 +701,7 @@ def test_force_disconnect_partial_disables_remaining_motors_despite_one_failing(
     handles the same "torque may already be enabled after an incomplete
     connect" situation and needs the same protection.
     """
-    from makerlab.teleoperate import force_disconnect_partial
+    from makermodslab.teleoperate import force_disconnect_partial
 
     bus = _FakeConnectableBus(port="COM_FOLLOWER")
     bus.failing = {"elbow_flex"}
@@ -715,8 +715,91 @@ def test_force_disconnect_partial_disables_remaining_motors_despite_one_failing(
     assert bus.is_connected is False
 
 
+def test_force_disconnect_partial_does_not_alarm_on_a_bus_that_never_opened() -> None:
+    """Bug: the torque-disable pass ran unconditionally, even when connect()
+    failed on the bus itself (the ordinary "wrong port" / "arm unplugged"
+    case) and nothing was ever energized. That wrote to a closed port for
+    every motor, and force_disable_torque's failures then printed the single
+    most alarming string the system can emit — "TORQUE MAY STILL BE ENABLED
+    ... unplug its power to release it" — for an arm that was never
+    connected, on what will be the most common failure path by far.
+    """
+    from makermodslab.teleoperate import force_disconnect_partial
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER", connected=False)
+    robot = _FakePartialRobot(bus, {})
+
+    problems = force_disconnect_partial(robot, "robot")
+
+    assert bus.disabled == []  # no motor writes against an unopened port
+    assert bus.disconnect_calls == 0
+    assert problems == []
+
+
+class _FakeFailingPortHandler(_FakePortHandler):
+    def __init__(self, fail_close: bool = False) -> None:
+        super().__init__()
+        self.fail_close = fail_close
+        self.close_calls = 0
+
+    def closePort(self) -> None:  # noqa: N802 — camelCase mimics the real Feetech SDK method this fakes
+        self.close_calls += 1
+        if self.fail_close:
+            raise RuntimeError("port already gone")
+
+
+class _FakeUnreleasableBus(_FakeConnectableBus):
+    """Bus whose disconnect() always raises, to exercise the force-close fallback."""
+
+    def disconnect(self, disable_torque: bool = True) -> None:
+        self.disconnect_calls += 1
+        raise RuntimeError("bus wedged")
+
+
+def test_force_disconnect_partial_force_closes_port_when_disconnect_raises() -> None:
+    """If bus.disconnect() itself fails, the port handle must still be forced
+    closed — same last-resort fallback utils/devices.py's
+    _force_close_device_resources uses elsewhere — instead of leaking the COM
+    handle for the rest of the process.
+    """
+    from makermodslab.teleoperate import force_disconnect_partial
+
+    bus = _FakeUnreleasableBus(port="COM_FOLLOWER")
+    port_handler = _FakeFailingPortHandler()
+    bus.port_handler = port_handler  # type: ignore[attr-defined]
+    robot = _FakePartialRobot(bus, {})
+
+    problems = force_disconnect_partial(robot, "robot")
+
+    # force_disable_torque's own pre-write port clear runs first (the bus is
+    # connected, so it isn't skipped); the fallback below clears again before
+    # force-closing — both are defensive and idempotent, so >=1 is the
+    # contract, not an exact count.
+    assert port_handler.clear_calls >= 1
+    assert port_handler.is_using is False
+    assert port_handler.close_calls == 1
+    assert any("COM_FOLLOWER" in p for p in problems)
+
+
+def test_force_disconnect_partial_returns_problems_instead_of_none() -> None:
+    """Sibling _cleanup_after_setup_failure returns joined problem text so
+    callers can surface teardown failures to the operator; force_disconnect_partial
+    silently returned None despite discarding force_disable_torque's problems.
+    """
+    from makermodslab.teleoperate import force_disconnect_partial
+
+    bus = _FakeConnectableBus(port="COM_FOLLOWER")
+    bus.failing = {"elbow_flex"}
+    robot = _FakePartialRobot(bus, {})
+
+    problems = force_disconnect_partial(robot, "robot")
+
+    assert isinstance(problems, list)
+    assert any("TORQUE MAY STILL BE ENABLED" in p and "elbow_flex" in p for p in problems)
+
+
 def test_force_disconnect_partial_is_idempotent_and_handles_bimanual_and_none() -> None:
-    from makerlab.teleoperate import force_disconnect_partial
+    from makermodslab.teleoperate import force_disconnect_partial
 
     # Already fully disconnected: no raise, no bus disconnect call.
     bus = _FakeConnectableBus(connected=False)


### PR DESCRIPTION
## Scope

This is a backend-internal resource-leak fix. It does **not** address cameras held by the browser (Chrome's `getUserMedia` streams) — that is a separate, still-open problem; see "Known follow-ups" below.

## What this fixes

If a camera disconnected (or any other hardware hiccup happened) while the arm was still connecting for a recording session, the app silently failed to release the arm's serial connection. Every recording attempt after that — with any dataset — would then fail to connect, until the whole app was restarted.

## What changed

- On a failed connect, the app now releases the arm's connection and any cameras that had already opened, one piece at a time, instead of trying to release everything at once (which was silently failing and doing nothing).
- This applies both when the arm itself fails to connect, and when the arm connects fine but the leader (teleop) side fails right after.
- Torque is now only force-disabled on a bus that was actually opened. Previously the disable pass ran unconditionally, so a connect failure on the bus itself (the ordinary "wrong port" / "arm unplugged" case — the most common failure by far) wrote to a closed port and printed a false **"TORQUE MAY STILL BE ENABLED / unplug its power"** alarm for an arm that was never energized. This gate lives in `force_disable_torque`, the shared belt-and-braces helper, so it also applies to the torque-disable pass that already runs at the end of every normal teleoperation and recording session — not just the connect-failure path described above.
- If releasing a bus itself fails, the port handle is now force-closed as a last resort (same fallback used elsewhere in the codebase), instead of logging a warning and leaking the handle.
- Teardown failures are now returned from the helper instead of discarded, and reach the Record page's log panel (not just the server console) — a real "could not release the bus/camera" failure was previously invisible to the operator.
- The connect-retry window now shows "Camera hiccup, retrying (n/3)…" instead of one static "Connecting arm & cameras…" label for what can be a multi-attempt, multi-second window.
- Rebased onto `main` (was 24 commits behind, predating the `makerlab` → `makermodslab` rename).

## To test

1. Start a recording session with two cameras.
2. While it says "Connecting arm & cameras…", unplug one of the cameras.
3. The session fails, as expected — the camera really is gone.
4. Plug the camera back in and start a new recording session (same or a different dataset) — it should connect and record normally, without restarting the app.

## Reproduced on real hardware

The original leak fix (releasing the bus/cameras on a failed connect) was reproduced and verified on a real SO-101 arm, by calling `/start-recording` and manually unplugging/replugging a USB camera at the right moment during the connect phase — before the fix, the server log showed no evidence of release and every following attempt failed the same way until restart; after, the log shows the bus and every opened camera being released, and the following session connects normally.

The later commits in this PR (torque-disable gating, force-close fallback, teardown-log wiring, retry-substep UI) are covered by unit tests but have **not** had a fresh real-hardware pass since being added — worth one before merge, particularly the torque-disable gating change since it touches the same code path as the arm's rigidity/rest-pose safety behavior.

## Known follow-ups (not fixed by this PR)

Two distinct problems remain out of scope here — GitHub Issues are disabled on this repo, so this section is the tracking surface for both until a follow-up branch picks them up:

1. **macOS AVFoundation camera wedge.** Once a specific camera has been hot-unplugged while actively streaming, OpenCV's AVFoundation backend can permanently stop delivering frames from that camera for the rest of the process's life, even after this fix's cleanup runs correctly and the camera is plugged back in. Isolated with a standalone `cv2.VideoCapture` test with no MakerLab code involved — a native OpenCV/AVFoundation limitation, not fixable at the Python level here. Restarting the app is still the only reliable recovery.
2. **Browser-held cameras.** @Mokuroh54 flagged that cameras can still be held by Chrome after a recording attempt — confirmed: the frontend's release handshake (`CollectPanel.tsx`'s `releaseStreamsRef.current()` + a flat `setTimeout(500)`) doesn't confirm the OS-level release actually completed before the backend tries to open the device, and it only releases one of several `getUserMedia` consumers (`CameraConfiguration`, `RobotConfigDialog`, `DeployPanel`, `InferenceModal`). This is a genuinely different defect from either of the above — an acquisition-side race on the frontend, not a backend leak — and not something this PR's teardown fix can address. The backend already has the right pattern for this (`camera_preview_manager`'s claim-then-release protocol in `record.py`); the fix is to give the browser side the same protocol: a device-arbiter context that every `getUserMedia` consumer registers with, releasing only resolves once every track's `ended` event has actually fired. Worth its own branch, not bundled into this one.

Originally diagnosed and authored by @mokuroh54 on a separate branch; this PR cherry-picks that fix (leaving out an unrelated bundled commit), adds the real-hardware validation above, and layers on fixes from an independent review pass (torque-disable gating on an unopened bus, force-close fallback, teardown-log visibility, retry-substep UI, and this rebase/rescope).

