### PR TITLE
Extract camera-error transience check; hold the capture_ retry marker

### DIFF
--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -447,6 +447,37 @@ def _build_camera_configs(cameras: dict, default_backend) -> dict:
     return camera_configs
 
 
+def _is_transient_camera_error(msg: str) -> bool:
+    """True when a robot-connect failure is transient camera-session
+    turbulence, curable by a clean re-connect, rather than a real failure.
+
+    An AVCaptureSession opened into another session's asynchronous teardown
+    (e.g. right after a hot-unplug) intermittently comes up wrong —
+    forensically established 2026-07-09, extended 2026-07-31 after the
+    capture_width/height case below was caught reproducing on the bench with
+    no retry and no cleanup:
+      * "failed to set fps=30 (actual_fps=5.0)" — cold-open fps read-back
+      * "failed to set capture_width=..."/"failed to set capture_height=..."
+        — cold-open width/height read-back (the same read-back failure as
+        fps, just from lerobot's width/height negotiation step instead)
+      * "do not match configured" — session landed the neighboring native
+        format (e.g. 640x360 instead of 640x480), caught on the later
+        frame-size check
+      * "timed out waiting for frame" — session came up frame-dead (opens
+        fine, background reader never receives a frame)
+    """
+    low = msg.lower()
+    return any(
+        marker in low
+        for marker in (
+            "failed to set fps",
+            "failed to set capture_",
+            "do not match configured",
+            "timed out waiting for frame",
+        )
+    )
+
+
 def create_record_config(request: RecordingRequest, cameras: dict | None = None) -> RecordConfig:
     """Create a RecordConfig from the recording request.
 
@@ -1632,23 +1663,7 @@ def record_with_web_events(
             break
         except Exception as e:
             msg = str(e)
-            # Transient camera-session turbulence, all observed on this bench and
-            # all curable by a clean re-connect (an AVCaptureSession opened into
-            # another session's asynchronous teardown intermittently comes up
-            # wrong — forensically established 2026-07-09):
-            #   * "failed to set fps=30 (actual_fps=5.0)" — cold-open fps read-back
-            #   * "do not match configured"   — session landed the neighboring
-            #     native format (e.g. 640x360 instead of 640x480)
-            #   * "timed out waiting for frame" — session came up frame-dead
-            #     (opens fine, background reader never receives a frame)
-            transient_camera = any(
-                marker in msg.lower()
-                for marker in (
-                    "failed to set fps",
-                    "do not match configured",
-                    "timed out waiting for frame",
-                )
-            )
+            transient_camera = _is_transient_camera_error(msg)
             logger.error(f"❌ ROBOT CONNECTION: Failed to connect robot: {e}")
             # If robot connection fails due to camera conflict, provide clear error
             if (

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -455,21 +455,37 @@ def _is_transient_camera_error(msg: str) -> bool:
     (e.g. right after a hot-unplug) intermittently comes up wrong —
     forensically established 2026-07-09:
       * "failed to set fps=30 (actual_fps=5.0)" — cold-open fps read-back
-      * "do not match configured" — session landed the neighboring native
-        format (e.g. 640x360 instead of 640x480), caught on the later
-        frame-size check
       * "timed out waiting for frame" — session came up frame-dead (opens
         fine, background reader never receives a frame)
+      * "read thread is not running" — the same frame-dead session after its
+        background reader has already died (see below)
+
+    What reaches us, and what doesn't. Only `connect()`'s own exceptions land
+    here; anything raised inside a camera's background reader thread does not.
+    That matters for the wrong-native-format case (session lands 640x360
+    instead of 640x480): lerobot detects it in `_postprocess_image`, which
+    runs *only* in `_read_loop`, so its "do not match configured" text never
+    propagates — after 12 consecutive mismatches the loop dies and the caller
+    sees `async_read`'s "read thread is not running" instead (or, if the
+    reader is merely stalled, the timeout above). "do not match configured" is
+    kept in the tuple as a cheap guard in case upstream ever surfaces it
+    synchronously, but do not expect it to fire; "read thread is not running"
+    is the marker that actually catches that case today.
 
     NOT included: "failed to set capture_" (width/height mismatch). That
     string is also produced when a camera simply doesn't support the
     configured resolution — a permanent misconfiguration, not turbulence —
-    and `utils/errors.py::friendly_hint` already classifies it that way for
-    the operator. Folding it into this retryable set would make the two
-    classifiers disagree about the same string, and burn ~9s retrying a
-    failure that can't succeed (see PR #38 discussion) before showing the
-    operator the correct "click Auto" hint. Don't add it here without first
-    resolving that conflict in `friendly_hint` too.
+    and `utils/errors.py::friendly_hint` classifies it that way for the
+    operator. Retrying it would burn ~4s of backoff plus three connects on a
+    failure that cannot succeed before showing the correct "click Auto" hint.
+
+    Note "failed to set fps" has the *same* permanent-misconfiguration mode
+    (an operator can type an fps the device can't do, in the same settings
+    panel), so it is retried on the optimistic reading and then, if it never
+    recovers, handed to `friendly_hint`'s matching fps branch for the same
+    "click Auto" guidance. Keep those two in sync: any marker added here that
+    can also be a permanent misconfiguration needs a `friendly_hint` branch,
+    or the operator waits out the retries and gets no advice at the end.
     """
     low = msg.lower()
     return any(
@@ -477,6 +493,7 @@ def _is_transient_camera_error(msg: str) -> bool:
         for marker in (
             "failed to set fps",
             "do not match configured",
+            "read thread is not running",
             "timed out waiting for frame",
         )
     )

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -453,25 +453,29 @@ def _is_transient_camera_error(msg: str) -> bool:
 
     An AVCaptureSession opened into another session's asynchronous teardown
     (e.g. right after a hot-unplug) intermittently comes up wrong —
-    forensically established 2026-07-09, extended 2026-07-31 after the
-    capture_width/height case below was caught reproducing on the bench with
-    no retry and no cleanup:
+    forensically established 2026-07-09:
       * "failed to set fps=30 (actual_fps=5.0)" — cold-open fps read-back
-      * "failed to set capture_width=..."/"failed to set capture_height=..."
-        — cold-open width/height read-back (the same read-back failure as
-        fps, just from lerobot's width/height negotiation step instead)
       * "do not match configured" — session landed the neighboring native
         format (e.g. 640x360 instead of 640x480), caught on the later
         frame-size check
       * "timed out waiting for frame" — session came up frame-dead (opens
         fine, background reader never receives a frame)
+
+    NOT included: "failed to set capture_" (width/height mismatch). That
+    string is also produced when a camera simply doesn't support the
+    configured resolution — a permanent misconfiguration, not turbulence —
+    and `utils/errors.py::friendly_hint` already classifies it that way for
+    the operator. Folding it into this retryable set would make the two
+    classifiers disagree about the same string, and burn ~9s retrying a
+    failure that can't succeed (see PR #38 discussion) before showing the
+    operator the correct "click Auto" hint. Don't add it here without first
+    resolving that conflict in `friendly_hint` too.
     """
     low = msg.lower()
     return any(
         marker in low
         for marker in (
             "failed to set fps",
-            "failed to set capture_",
             "do not match configured",
             "timed out waiting for frame",
         )

--- a/makermodslab/utils/errors.py
+++ b/makermodslab/utils/errors.py
@@ -150,6 +150,15 @@ def friendly_hint(error_text: str | None) -> str | None:
         )
     if "failed to set capture_" in low or "actual_width" in low or "actual_height" in low:
         return "A camera doesn't support the configured resolution — open camera settings and click Auto."
+    # Same read-back failure as the resolution case above, from lerobot's fps
+    # negotiation step instead (_validate_fps). Both are driven by free-form
+    # numbers in the same camera-settings panel, so both can be a permanent
+    # "this device can't do that" rather than turbulence. Without this branch
+    # an unsupported fps was the one camera misconfiguration that got retried
+    # (record.py's _is_transient_camera_error matches it) and then surfaced
+    # with no guidance at all — strictly worse than the resolution case.
+    if "failed to set fps" in low or "actual_fps" in low:
+        return "A camera doesn't support the configured frame rate — open camera settings and click Auto."
     if "permission" in low and ("port" in low or "com" in low):
         return "Couldn't open the serial port — close anything else using it, or run `makermodslab --stop`."
     return None

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -345,16 +345,49 @@ def test_is_transient_camera_error_markers_pinned_against_lerobot_source() -> No
     assert "failed to set fps={self.fps} ({actual_fps=})" in source
     assert "do not match configured width={self.capture_width} or height={self.capture_height}" in source
     assert "Timed out waiting for frame from camera {self}" in source
+    assert "read thread is not running." in source
+
+
+def test_do_not_match_configured_is_unreachable_from_connect() -> None:
+    """Pins WHY "read thread is not running" has to be in the marker set.
+
+    The wrong-native-format error is raised by `_postprocess_image`, which is
+    called only from `_read_loop` — i.e. inside the camera's background
+    thread, where `connect()` can never see it. After 12 consecutive
+    mismatches that loop dies, and the next `async_read` raises "read thread
+    is not running" instead. If upstream ever moves the size check onto the
+    synchronous path, this test goes red and the docstring's "do not expect it
+    to fire" caveat (and this whole marker) should be revisited.
+    """
+    import inspect
+
+    from lerobot.cameras.opencv import camera_opencv
+
+    source = inspect.getsource(camera_opencv)
+    postprocess_callers = [
+        line.strip() for line in source.splitlines() if "_postprocess_image(" in line and "def " not in line
+    ]
+    assert len(postprocess_callers) == 1, postprocess_callers
+    # ...and that single call site is inside the background read loop.
+    read_loop = inspect.getsource(camera_opencv.OpenCVCamera._read_loop)
+    assert "_postprocess_image(" in read_loop
 
 
 def test_is_transient_camera_error_matches_existing_markers() -> None:
     from makermodslab.record import _is_transient_camera_error
 
     assert _is_transient_camera_error("OpenCVCamera(0) failed to set fps=30 (actual_fps=5.0).")
+    # 640x360 landed where 640x480 was configured — width differs, height
+    # doesn't (the previous ordering here had the two swapped).
     assert _is_transient_camera_error(
-        "OpenCVCamera(0) frame width=360 or height=640 do not match configured width=480 or height=640."
+        "OpenCVCamera(0) frame width=360 or height=480 do not match configured width=640 or height=480."
     )
-    assert _is_transient_camera_error("Timed out waiting for frame from camera OpenCVCamera(0) after 200 ms.")
+    assert _is_transient_camera_error(
+        "Timed out waiting for frame from camera OpenCVCamera(0) after 200 ms. Read thread alive: True."
+    )
+    # The frame-dead session once its background reader has given up — this is
+    # what the caller actually sees for the wrong-native-format case.
+    assert _is_transient_camera_error("OpenCVCamera(0) read thread is not running.")
 
 
 def test_is_transient_camera_error_false_for_unrelated_errors() -> None:
@@ -365,16 +398,37 @@ def test_is_transient_camera_error_false_for_unrelated_errors() -> None:
 
 
 def test_is_transient_camera_error_false_for_capture_size_mismatch() -> None:
-    """`friendly_hint()` (utils/errors.py) already classifies "failed to set
-    capture_" as a permanent misconfiguration ("camera doesn't support the
-    configured resolution — click Auto"). Retrying it wastes ~9s telling the
-    operator the same thing three times. Don't add this marker here without
-    reconciling the two classifiers first."""
+    """`friendly_hint()` (utils/errors.py) classifies "failed to set capture_"
+    as a permanent misconfiguration ("camera doesn't support the configured
+    resolution — click Auto"). Retrying it wastes the backoff telling the
+    operator the same thing three times."""
     from makermodslab.record import _is_transient_camera_error
 
     assert not _is_transient_camera_error(
         "OpenCVCamera(0) failed to set capture_width=640 (actual_width=1920, width_success=True)."
     )
+
+
+def test_every_retryable_camera_marker_that_can_be_permanent_has_a_hint() -> None:
+    """The invariant the two classifiers have to share.
+
+    A marker in `_is_transient_camera_error` that can ALSO be a permanent
+    misconfiguration costs the operator the full backoff before failing — so
+    the message they're finally shown must at least tell them what to do.
+    "failed to set fps" is exactly that case (an operator can type an fps the
+    device can't do, in the same settings panel as the resolution), and it
+    used to be the one camera misconfiguration that got retried and then
+    surfaced with no guidance at all."""
+    from makermodslab.utils.errors import friendly_hint
+
+    fps_hint = friendly_hint("OpenCVCamera(0) failed to set fps=60 (actual_fps=30.0).")
+    assert fps_hint is not None
+    assert "Auto" in fps_hint
+    # The resolution sibling still gets its own, distinct wording.
+    size_hint = friendly_hint(
+        "OpenCVCamera(0) failed to set capture_width=640 (actual_width=1920, width_success=True)."
+    )
+    assert size_hint is not None and size_hint != fps_hint
 
 
 def test_is_transient_camera_error_false_for_fourcc_mismatch() -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -326,28 +326,29 @@ def test_build_camera_configs_skips_non_opencv_type() -> None:
     assert configs == {}
 
 
-def test_is_transient_camera_error_matches_capture_width_mismatch() -> None:
-    """Real hardware regression: lerobot's OpenCVCamera raises "failed to set
-    capture_width=640 (actual_width=1920, width_success=True)." when a camera
-    comes up in a cold-open/turbulent state (e.g. right after a hot-unplug) —
-    the same class of transient failure "failed to set fps" already covers,
-    just from the width/height negotiation step instead of the fps step. Only
-    "do not match configured" (the later frame-size check) and "failed to set
-    fps" were recognized before; a capture_width/height failure fell through
-    to a terminal (non-retried) failure with no cleanup pass, reproduced twice
-    on the bench unplugging the wrist camera mid-connect."""
-    from makerlab.record import _is_transient_camera_error
+def test_is_transient_camera_error_markers_pinned_against_lerobot_source() -> None:
+    """Pins the marker set against lerobot's *actual* raise sites, not
+    hand-typed copies of them — a `str.__contains__` over a literal tuple
+    can't fail on its own, so the thing worth testing is whether upstream
+    still emits these strings, not whether the tuple matches itself. If
+    lerobot rewords one of these RuntimeErrors, this test goes red instead of
+    the retry silently stopping firing.
 
-    assert _is_transient_camera_error(
-        "OpenCVCamera(0) failed to set capture_width=640 (actual_width=1920, width_success=True)."
-    )
-    assert _is_transient_camera_error(
-        "OpenCVCamera(0) failed to set capture_height=480 (actual_height=1080, height_success=True)."
-    )
+    "failed to set capture_" is deliberately NOT pinned here — it's excluded
+    from `_is_transient_camera_error` on purpose (see its docstring)."""
+    import inspect
+
+    from lerobot.cameras.opencv import camera_opencv
+
+    source = inspect.getsource(camera_opencv)
+
+    assert "failed to set fps={self.fps} ({actual_fps=})" in source
+    assert "do not match configured width={self.capture_width} or height={self.capture_height}" in source
+    assert "Timed out waiting for frame from camera {self}" in source
 
 
 def test_is_transient_camera_error_matches_existing_markers() -> None:
-    from makerlab.record import _is_transient_camera_error
+    from makermodslab.record import _is_transient_camera_error
 
     assert _is_transient_camera_error("OpenCVCamera(0) failed to set fps=30 (actual_fps=5.0).")
     assert _is_transient_camera_error(
@@ -357,10 +358,36 @@ def test_is_transient_camera_error_matches_existing_markers() -> None:
 
 
 def test_is_transient_camera_error_false_for_unrelated_errors() -> None:
-    from makerlab.record import _is_transient_camera_error
+    from makermodslab.record import _is_transient_camera_error
 
     assert not _is_transient_camera_error("Could not connect on port '/dev/ttyUSB0'.")
     assert not _is_transient_camera_error("Failed to open OpenCVCamera(97).")
+
+
+def test_is_transient_camera_error_false_for_capture_size_mismatch() -> None:
+    """`friendly_hint()` (utils/errors.py) already classifies "failed to set
+    capture_" as a permanent misconfiguration ("camera doesn't support the
+    configured resolution — click Auto"). Retrying it wastes ~9s telling the
+    operator the same thing three times. Don't add this marker here without
+    reconciling the two classifiers first."""
+    from makermodslab.record import _is_transient_camera_error
+
+    assert not _is_transient_camera_error(
+        "OpenCVCamera(0) failed to set capture_width=640 (actual_width=1920, width_success=True)."
+    )
+
+
+def test_is_transient_camera_error_false_for_fourcc_mismatch() -> None:
+    """lerobot logs a fourcc mismatch as a warning (camera_opencv.py's
+    `_validate_fourcc`) rather than raising — it never reaches this
+    classifier as an exception message. Not retried, but for a different
+    reason than the negative cases above: excluded by construction, not by
+    policy."""
+    from makermodslab.record import _is_transient_camera_error
+
+    assert not _is_transient_camera_error(
+        "OpenCVCamera(0) failed to set fourcc=MJPG (actual=YUYV, success=False)."
+    )
 
 
 def _make_dataset_dir(cache, repo_id: str, total_episodes: int):

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -326,6 +326,43 @@ def test_build_camera_configs_skips_non_opencv_type() -> None:
     assert configs == {}
 
 
+def test_is_transient_camera_error_matches_capture_width_mismatch() -> None:
+    """Real hardware regression: lerobot's OpenCVCamera raises "failed to set
+    capture_width=640 (actual_width=1920, width_success=True)." when a camera
+    comes up in a cold-open/turbulent state (e.g. right after a hot-unplug) —
+    the same class of transient failure "failed to set fps" already covers,
+    just from the width/height negotiation step instead of the fps step. Only
+    "do not match configured" (the later frame-size check) and "failed to set
+    fps" were recognized before; a capture_width/height failure fell through
+    to a terminal (non-retried) failure with no cleanup pass, reproduced twice
+    on the bench unplugging the wrist camera mid-connect."""
+    from makerlab.record import _is_transient_camera_error
+
+    assert _is_transient_camera_error(
+        "OpenCVCamera(0) failed to set capture_width=640 (actual_width=1920, width_success=True)."
+    )
+    assert _is_transient_camera_error(
+        "OpenCVCamera(0) failed to set capture_height=480 (actual_height=1080, height_success=True)."
+    )
+
+
+def test_is_transient_camera_error_matches_existing_markers() -> None:
+    from makerlab.record import _is_transient_camera_error
+
+    assert _is_transient_camera_error("OpenCVCamera(0) failed to set fps=30 (actual_fps=5.0).")
+    assert _is_transient_camera_error(
+        "OpenCVCamera(0) frame width=360 or height=640 do not match configured width=480 or height=640."
+    )
+    assert _is_transient_camera_error("Timed out waiting for frame from camera OpenCVCamera(0) after 200 ms.")
+
+
+def test_is_transient_camera_error_false_for_unrelated_errors() -> None:
+    from makerlab.record import _is_transient_camera_error
+
+    assert not _is_transient_camera_error("Could not connect on port '/dev/ttyUSB0'.")
+    assert not _is_transient_camera_error("Failed to open OpenCVCamera(97).")
+
+
 def _make_dataset_dir(cache, repo_id: str, total_episodes: int):
     """Create a minimal on-disk LeRobot dataset dir (meta/info.json) under the
     tmp cache root, plus a fake video file so 'removed' is observable."""


### PR DESCRIPTION
## Scope

This is a refactor + a documented decision, not a behavior fix. The hot-unplug "camera comes back at the wrong resolution" failure reproduced on real hardware (below) is **not** cured by this PR — see "Known follow-ups."

## What changed

- Extracted the inline retry-marker check in the robot-connect loop into a standalone `_is_transient_camera_error()` (`makermodslab/record.py`), with a docstring explaining what each marker means and why.
- The three existing retryable markers (`"failed to set fps"`, `"do not match configured"`, `"timed out waiting for frame"`) are unchanged — no new markers were added.
- `"failed to set capture_"` (width/height mismatch) is explicitly **not** added to the retryable set, and the docstring documents why: that string is produced both by a genuine hot-unplug readback glitch and by a camera that simply doesn't support the configured resolution — a permanent misconfiguration that `utils/errors.py::friendly_hint` already classifies as a "click Auto" hint for the operator. Folding it into the retry set would make the two classifiers disagree about the same string, and would burn ~9s retrying a failure that can't succeed in the permanent-misconfiguration case.
- Added `test_is_transient_camera_error_markers_pinned_against_lerobot_source`, which pins the three retry markers against the actual raise sites in the pinned lerobot version (`camera_opencv.py`) via `inspect.getsource` — it goes red if upstream rewords an error string, instead of the retry silently dying. Also added direct-assertion tests for each marker, including one (`test_is_transient_camera_error_false_for_capture_size_mismatch`) that pins the capture_ exclusion.

## To test

Run `tests/test_record.py::test_is_transient_camera_error_*` — covers all three retryable markers, the capture_ exclusion, and the fourcc-mismatch non-issue (lerobot logs that as a warning, never raises, so it never reaches this classifier).

## Reproduced on real hardware

Reproduced twice on a real SO-101 rig by calling `/start-recording` and unplugging the wrist USB camera during the "Connecting arm & cameras…" phase. Both times the server logged:

```
failed to set capture_width=640 (actual_width=1920, width_success=True).
```

— which matches none of the retryable markers, so the session fails on the first attempt instead of retrying. This PR documents and pins that as a deliberate exclusion (see above); it does not change that behavior.

## Known follow-ups (not fixed by this PR)

GitHub Issues are disabled on this repo, so this section is the tracking surface until a follow-up branch picks it up:

1. **Hot-unplug capture_-mismatch case stays unretried.** The repro above still fails the recording session on the first attempt. Reconciling it needs a discriminator better than string-matching — e.g. checking the requested resolution against the camera's enumerated formats to tell "genuinely unsupported" apart from "transient readback glitch," or making `friendly_hint` retry-aware so the two classifiers can agree on one string. Worth its own branch.
