### PR TITLE
Wait long enough for the browser's camera release to settle before recording

### DIFF
--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -51,6 +51,17 @@ import type { DatasetItem } from "@/lib/replayApi";
  * Every recording session creates a NEW dataset — recording on top of an
  * existing one was removed; merging datasets covers growing one.
  */
+
+// Releasing a browser getUserMedia stream (releaseStreamsRef.current(), just
+// below) only guarantees the *browser* has dropped it — the OS-level camera
+// release it triggers is asynchronous, the same class of turbulence the
+// backend already documents and works around with its own 2s settle sleep
+// after a failed connect (makerlab/record.py, "let the OS release settle
+// past the turbulence window before re-rolling the connect"). Wait that same
+// 2s here, before /start-recording asks cv2 to grab the device, so a cold
+// backend connect attempt isn't racing the browser's own teardown.
+const CAMERA_RELEASE_SETTLE_MS = 2000;
+
 const CollectPanel: React.FC = () => {
   const { auth } = useHfAuth();
   const { selectedRecord } = useRobots();
@@ -198,7 +209,7 @@ const CollectPanel: React.FC = () => {
         description: `Releasing ${cameras.length} camera stream(s) for recording...`,
       });
       releaseStreamsRef.current();
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, CAMERA_RELEASE_SETTLE_MS));
       toast({
         title: "Camera resources ready",
         description:


### PR DESCRIPTION
## What this fixes
- Right after closing a camera's live preview and starting a recording, the app sometimes failed to get exclusive access to that camera — it only waited 500ms after releasing the browser's preview before asking the backend to open the camera, which isn't always long enough for the camera to actually be free.

## What changed
- The wait between releasing the browser's camera preview and starting the recording is now 2 seconds instead of 500ms — matching the wait the backend itself already uses when recovering from the same kind of camera-release timing issue on its own side.

## To test
1. Open the recording setup, add a camera, and let its live preview load.
2. Start a recording session right away.
3. The camera should connect cleanly, without a stuck "connecting" state or a busy-device error.

## Note
Found while investigating a camera-still-held report on #37 (a raw wait of 500ms vs. the backend's own tuned 2s wait for the same class of problem was a clear inconsistency). This addresses a confirmed timing gap, not a guaranteed fix for that specific report — not yet verified on real hardware, opening as a draft for review first.
