### PR TITLE
fix(cameras): bind previews and roles by device identity, not browser deviceId

### DIFF
--- a/frontend/src/components/BackendCameraStream.tsx
+++ b/frontend/src/components/BackendCameraStream.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { VideoOff, RefreshCw } from "lucide-react";
+import { useApi } from "@/contexts/ApiContext";
+import { cn } from "@/lib/utils";
+
+interface BackendCameraStreamProps {
+  /** cv2 camera index on the server (CameraConfig.camera_index). */
+  cameraIndex: number;
+  /** Stable device identity (CameraConfig.unique_id). When set, the server
+   * re-anchors the index to this physical device before opening — its cv2
+   * resolves indices against a startup snapshot that drifts from the fresh
+   * enumeration after a replug, so index alone can open the wrong camera. */
+  uniqueId?: string;
+  className?: string;
+}
+
+// Retry backoff for a failed stream: quick first attempts (a session just
+// released the camera), settling to a slow poll (camera unplugged, server
+// down). Preview failures are usually TRANSIENT — a recording session holding
+// the cameras, a restarting server — so the tile must keep trying instead of
+// latching into a dead "Preview failed" state until the modal is reopened.
+const RETRY_BASE_MS = 2000;
+const RETRY_MAX_MS = 12000;
+
+/**
+ * MJPEG `<img>` stream of a camera attached to the *server* machine
+ * (GET /camera-preview/{index}).
+ *
+ * Fallback for headless deployments (e.g. a Jetson on the LAN): the browser's
+ * getUserMedia only sees the viewing machine's cameras, so a camera plugged
+ * into the server has no matching deviceId — this streams it from the backend
+ * instead. Owns its whole failure lifecycle: on stream error it asks the
+ * endpoint WHY (the 409/503 detail — "recording is using the cameras" etc.),
+ * shows that on the tile, and retries with capped backoff; clicking the tile
+ * retries immediately. Parents should render it whenever a cameraIndex is
+ * known and unmount it to pause/release (unmount cleanup clears the img src
+ * so the browser drops the HTTP connection and the server releases the
+ * shared capture).
+ */
+const BackendCameraStream: React.FC<BackendCameraStreamProps> = ({
+  cameraIndex,
+  uniqueId,
+  className,
+}) => {
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const imgRef = useRef<HTMLImageElement>(null);
+  const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptRef = useRef(0);
+  // Bumping remounts the <img> with a cache-busted URL — a clean retry.
+  const [attempt, setAttempt] = useState(0);
+  const [down, setDown] = useState(false);
+  const [reason, setReason] = useState<string | null>(null);
+  const uniqueIdQuery = uniqueId
+    ? `?unique_id=${encodeURIComponent(uniqueId)}`
+    : "";
+
+  // A new index or identity is a new stream — forget the previous one's
+  // failure state.
+  useEffect(() => {
+    attemptRef.current = 0;
+    setAttempt(0);
+    setDown(false);
+    setReason(null);
+  }, [cameraIndex, uniqueId]);
+
+  useEffect(() => {
+    const img = imgRef.current;
+    return () => {
+      if (retryTimer.current) clearTimeout(retryTimer.current);
+      // Detaching an <img> doesn't reliably abort its in-flight request;
+      // clearing src does, which is what lets the backend release the camera.
+      if (img) img.src = "";
+    };
+  }, []);
+
+  const scheduleRetry = useCallback(() => {
+    if (retryTimer.current) clearTimeout(retryTimer.current);
+    const delay = Math.min(
+      RETRY_BASE_MS * 2 ** Math.min(attemptRef.current, 5),
+      RETRY_MAX_MS
+    );
+    retryTimer.current = setTimeout(() => {
+      attemptRef.current += 1;
+      setAttempt((a) => a + 1);
+      setDown(false);
+    }, delay);
+  }, []);
+
+  const handleError = useCallback(() => {
+    setDown(true);
+    // The <img> can't see WHY the stream died — probe the endpoint once for
+    // the status detail so the tile can say "recording is using the cameras"
+    // instead of a generic failure. Best-effort: any probe error is itself
+    // a reason ("server unreachable").
+    fetchWithHeaders(`${baseUrl}/camera-preview/${cameraIndex}${uniqueIdQuery}`, {
+      method: "GET",
+      headers: { Range: "bytes=0-0" },
+    })
+      .then(async (r) => {
+        if (r.ok) {
+          // Endpoint is fine again — the stream just dropped; retry sooner.
+          r.body?.cancel?.();
+          setReason(null);
+          return;
+        }
+        const data = await r.json().catch(() => ({}));
+        setReason(
+          typeof data.detail === "string"
+            ? data.detail
+            : `camera preview unavailable (${r.status})`
+        );
+      })
+      .catch(() => setReason("server unreachable"))
+      .finally(scheduleRetry);
+  }, [baseUrl, fetchWithHeaders, cameraIndex, uniqueIdQuery, scheduleRetry]);
+
+  const retryNow = useCallback(() => {
+    if (retryTimer.current) clearTimeout(retryTimer.current);
+    attemptRef.current += 1;
+    setAttempt((a) => a + 1);
+    setDown(false);
+  }, []);
+
+  if (down) {
+    return (
+      <button
+        type="button"
+        onClick={retryNow}
+        className={cn(
+          className,
+          "flex cursor-pointer flex-col items-center justify-center gap-1 bg-muted text-muted-foreground"
+        )}
+        title="Click to retry now"
+      >
+        <VideoOff className="h-5 w-5" />
+        <span className="px-1 text-center text-[10px] leading-tight">
+          {reason ?? "Preview failed"}
+        </span>
+        <span className="flex items-center gap-1 text-[10px] text-muted-foreground/70">
+          <RefreshCw className="h-3 w-3" /> retrying...
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <img
+      key={attempt}
+      ref={imgRef}
+      src={`${baseUrl}/camera-preview/${cameraIndex}?r=${attempt}${
+        uniqueId ? `&unique_id=${encodeURIComponent(uniqueId)}` : ""
+      }`}
+      onError={handleError}
+      className={className}
+      alt="Server camera preview"
+    />
+  );
+};
+
+export default BackendCameraStream;

--- a/frontend/src/components/control/CameraFeed.tsx
+++ b/frontend/src/components/control/CameraFeed.tsx
@@ -1,35 +1,43 @@
 import React from "react";
 import { VideoOff } from "lucide-react";
-import { useCameraStream } from "@/hooks/useCameraStream";
+import BackendCameraStream from "@/components/BackendCameraStream";
 
 interface CameraFeedProps {
-  /** Browser deviceId to stream. Empty string renders the "no camera" state. */
-  deviceId: string;
+  /** cv2 index on the server. Undefined renders the "no camera" state. */
+  cameraIndex?: number;
+  /** Stable device identity, so the server re-anchors the index across replugs. */
+  uniqueId?: string;
   /** Optional caption shown under the feed. */
   label?: string;
 }
 
-/** Live browser-camera feed bound to a deviceId via getUserMedia. */
-const CameraFeed: React.FC<CameraFeedProps> = ({ deviceId, label }) => {
-  const { videoRef, hasError } = useCameraStream(deviceId, false);
-  const showVideo = deviceId && !hasError;
-
+/** Live camera feed streamed from the *server* by cv2 index.
+ *
+ * Previously bound to a browser deviceId via getUserMedia. That deviceId was
+ * matched to a cv2 index by localizedName, so two cameras of the same model
+ * paired arbitrarily and a feed could be captioned with the other camera's
+ * name. Streaming by index removes the ambiguity — the caption and the footage
+ * now come from the same identity. Teleoperation opens no cv2 cameras, so
+ * these previews never contend with it. */
+const CameraFeed: React.FC<CameraFeedProps> = ({
+  cameraIndex,
+  uniqueId,
+  label,
+}) => {
   return (
     <div className="bg-card rounded-lg border border-border overflow-hidden">
       <div className="aspect-[4/3] bg-muted relative">
-        {showVideo ? (
-          <video
-            ref={videoRef}
-            autoPlay
-            muted
-            playsInline
+        {cameraIndex !== undefined ? (
+          <BackendCameraStream
+            cameraIndex={cameraIndex}
+            uniqueId={uniqueId}
             className="w-full h-full object-cover"
           />
         ) : (
           <div className="w-full h-full flex flex-col items-center justify-center">
             <VideoOff className="w-8 h-8 text-muted-foreground mb-2" />
             <span className="text-muted-foreground text-sm">
-              {deviceId ? "Preview failed" : "No camera selected"}
+              No camera selected
             </span>
           </div>
         )}

--- a/frontend/src/components/control/TeleopCameraPanel.tsx
+++ b/frontend/src/components/control/TeleopCameraPanel.tsx
@@ -24,15 +24,17 @@ const TeleopCameraPanel: React.FC = () => {
   const [reloadKey, setReloadKey] = useState(0);
   const { selectedRecord, isLoading: robotsLoading } = useRobots();
 
-  // Feeds come solely from the robot's configured cameras; each carries a stored
-  // browser device_id we stream directly. A configured camera whose device is
-  // currently absent still shows (name + failed-preview placeholder), so the
-  // user can tell it's expected but not detected.
+  // Feeds come solely from the robot's configured cameras, streamed from the
+  // backend by cv2 index (+ unique_id so the server re-anchors it across
+  // replugs). A configured camera whose device is currently absent still shows
+  // (name + failed-preview placeholder), so the user can tell it's expected but
+  // not detected.
   const configured = selectedRecord?.cameras ?? [];
   const feeds = configured.map((c) => ({
     key: c.id,
     name: c.name,
-    deviceId: c.device_id,
+    cameraIndex: c.camera_index,
+    uniqueId: c.unique_id,
   }));
 
   return (
@@ -70,7 +72,8 @@ const TeleopCameraPanel: React.FC = () => {
             {feeds.map((feed) => (
               <CameraFeed
                 key={`${feed.key}:${reloadKey}`}
-                deviceId={feed.deviceId}
+                cameraIndex={feed.cameraIndex}
+                uniqueId={feed.uniqueId}
                 label={feed.name}
               />
             ))}

--- a/frontend/src/components/landing/InferenceModal.tsx
+++ b/frontend/src/components/landing/InferenceModal.tsx
@@ -35,7 +35,7 @@ import {
   AvailableCamera,
   useAvailableCameras,
 } from "@/hooks/useAvailableCameras";
-import { useCameraStream } from "@/hooks/useCameraStream";
+import BackendCameraStream from "@/components/BackendCameraStream";
 
 interface Props {
   open: boolean;
@@ -49,15 +49,19 @@ const DEFAULT_FPS = 30;
 
 const cameraKey = (cam: AvailableCamera) => String(cam.index);
 
-/** Small getUserMedia preview for verifying which physical camera a role binds
- * to. `paused` drops the browser stream so the rollout subprocess can open the
- * same device via OpenCV without contending. */
-const CameraThumbnail: React.FC<{ deviceId: string; paused: boolean }> = ({
-  deviceId,
-  paused,
-}) => {
-  const { videoRef, hasError } = useCameraStream(deviceId, paused);
-  if (paused || hasError || !deviceId) {
+/** Small preview for verifying which physical camera a role binds to.
+ *
+ * Streams from the backend by cv2 index — the live feed at exactly the index
+ * the rollout will open, independent of any browser deviceId match. That match
+ * was by localizedName, so twin cameras ("KD-USB Cameras" x2) paired
+ * arbitrarily and the front/wrist tiles swapped footage between refreshes.
+ * `paused` unmounts the stream so the rollout subprocess can claim the device. */
+const CameraThumbnail: React.FC<{
+  cameraIndex?: number;
+  uniqueId?: string;
+  paused: boolean;
+}> = ({ cameraIndex, uniqueId, paused }) => {
+  if (paused || cameraIndex === undefined) {
     return (
       <div className="w-32 h-24 bg-muted rounded border border-border flex flex-col items-center justify-center">
         <VideoOff className="w-5 h-5 text-muted-foreground mb-1" />
@@ -67,12 +71,11 @@ const CameraThumbnail: React.FC<{ deviceId: string; paused: boolean }> = ({
       </div>
     );
   }
+  // BackendCameraStream owns its own failure/retry UI.
   return (
-    <video
-      ref={videoRef}
-      autoPlay
-      muted
-      playsInline
+    <BackendCameraStream
+      cameraIndex={cameraIndex}
+      uniqueId={uniqueId}
       className="w-32 h-24 object-cover rounded border border-border bg-muted"
     />
   );
@@ -286,9 +289,18 @@ const InferenceModal: React.FC<Props> = ({
           (c) => c.name.toLowerCase() === m.display.toLowerCase(),
         );
         if (!robotCam) continue;
-        const live = robotCam.device_id
-          ? availableCameras.find((c) => c.deviceId === robotCam.device_id)
-          : availableCameras.find((c) => c.index === robotCam.camera_index);
+        // Resolve by unique_id first: it names the physical device exactly.
+        // device_id is a coin flip when two cameras share a name (the browser
+        // match is by localizedName), and camera_index goes stale on replug —
+        // both are fallbacks for records saved before unique_id was stored.
+        const live =
+          (robotCam.unique_id
+            ? availableCameras.find((c) => c.uniqueId === robotCam.unique_id)
+            : undefined) ??
+          (robotCam.device_id
+            ? availableCameras.find((c) => c.deviceId === robotCam.device_id)
+            : undefined) ??
+          availableCameras.find((c) => c.index === robotCam.camera_index);
         if (live) {
           next[m.requestKey] = cameraKey(live);
           changed = true;
@@ -637,10 +649,11 @@ const InferenceModal: React.FC<Props> = ({
                           )}
                         </SelectContent>
                       </Select>
-                      {/* getUserMedia preview so the user can verify which
-                          physical camera this role binds to. */}
+                      {/* Backend preview at the exact cv2 index this role
+                          binds to, so the tile can't disagree with the run. */}
                       <CameraThumbnail
-                        deviceId={selectedCamera?.deviceId ?? ""}
+                        cameraIndex={selectedCamera?.index}
+                        uniqueId={selectedCamera?.uniqueId}
                         paused={submitting}
                       />
                     </div>

--- a/frontend/src/components/recording/CameraConfiguration.tsx
+++ b/frontend/src/components/recording/CameraConfiguration.tsx
@@ -18,7 +18,8 @@ import {
 } from "@/components/ui/collapsible";
 import { useToast } from "@/hooks/use-toast";
 import { useAvailableCameras } from "@/hooks/useAvailableCameras";
-import { useCameraStream } from "@/hooks/useCameraStream";
+import BackendCameraStream from "@/components/BackendCameraStream";
+import { isCameraConnected } from "@/lib/cameraResolve";
 
 // Sentinels distinguish "leave unset" (auto-detect / platform default) from an
 // explicit choice. Radix Select disallows an empty-string value, so we map these
@@ -43,6 +44,10 @@ export interface CameraConfig {
   type: string;
   camera_index?: number; // cv2 index — what the recorder opens
   device_id: string; // Browser deviceId matched to the cv2 index by AVFoundation localizedName
+  // Stable OS device identity (AVFoundation uniqueID). The authoritative link
+  // to the physical camera: cv2 indices shift on replug and device names can
+  // collide (two "KD-USB Cameras"), but this survives both.
+  unique_id?: string;
   width: number;
   height: number;
   fps?: number;
@@ -86,16 +91,28 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
     : undefined;
 
   // cv2's AVFoundation order is uniqueID-sorted, so plugging/unplugging a
-  // device between sessions shifts indices. The browser device_id stays
-  // stable per-origin, so use it to refresh each seeded camera's
-  // camera_index — otherwise the recorder opens the wrong physical device
-  // and the dropdown's "already added" check guards a stale index.
+  // device between sessions shifts indices. Refresh each seeded camera's
+  // camera_index by unique_id (exact physical identity) when the record has
+  // one, falling back to the browser device_id for older records — otherwise
+  // the recorder opens the wrong physical device and the dropdown's "already
+  // added" check guards a stale index.
+  //
+  // device_id alone is a COIN FLIP when two cameras share a name (twin
+  // "KD-USB Cameras"): the deviceId↔index pairing is decided by
+  // enumerateDevices() order, which is unrelated to the uniqueID sort and not
+  // stable across refreshes. Anchoring on unique_id is what stops this effect
+  // from silently rewriting the recorder's index to the other camera.
   useEffect(() => {
     if (availableCameras.length === 0 || cameras.length === 0) return;
     let changed = false;
     const refreshed = cameras.map((cam) => {
-      if (!cam.device_id) return cam;
-      const match = availableCameras.find((m) => m.deviceId === cam.device_id);
+      const match =
+        (cam.unique_id
+          ? availableCameras.find((m) => m.uniqueId === cam.unique_id)
+          : undefined) ??
+        (cam.device_id
+          ? availableCameras.find((m) => m.deviceId === cam.device_id)
+          : undefined);
       if (match && match.index !== cam.camera_index) {
         changed = true;
         return { ...cam, camera_index: match.index };
@@ -135,11 +152,13 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
       return;
     }
 
-    // Block duplicates by either cv2 index or browser deviceId — a stale
+    // Block duplicates by unique_id, cv2 index, or browser deviceId — a stale
     // camera_index in a seeded camera can otherwise let the same physical
-    // device sneak in under a different index.
+    // device sneak in under a different index. unique_id is checked first
+    // because it's the only one that can't alias between twin cameras.
     const isDuplicate = cameras.some(
       (cam) =>
+        (selectedCamera.uniqueId && cam.unique_id === selectedCamera.uniqueId) ||
         cam.camera_index === selectedCamera.index ||
         (selectedCamera.deviceId && cam.device_id === selectedCamera.deviceId),
     );
@@ -158,6 +177,7 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
       type: "opencv",
       camera_index: selectedCamera.index,
       device_id: selectedCamera.deviceId,
+      unique_id: selectedCamera.uniqueId,
       width: 640,
       height: 480,
       fps: 30,
@@ -281,7 +301,8 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="bg-card rounded-lg border border-border overflow-hidden">
               <CameraStreamBox
-                deviceId={selectedCamera.deviceId}
+                cameraIndex={selectedCamera.index}
+                uniqueId={selectedCamera.uniqueId}
                 paused={streamsPaused}
               />
             </div>
@@ -331,6 +352,7 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
               <CameraPreview
                 key={camera.id}
                 camera={camera}
+                connected={isCameraConnected(camera, availableCameras)}
                 paused={streamsPaused}
                 onRemove={() => removeCamera(camera.id)}
                 onUpdate={(updates) => updateCamera(camera.id, updates)}
@@ -351,43 +373,47 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
 };
 
 interface CameraStreamBoxProps {
-  deviceId: string;
+  cameraIndex?: number;
+  uniqueId?: string;
   paused: boolean;
+  /** Shown when there's no index to stream. Distinguishes "nothing picked yet"
+   * (dropdown preview) from "this configured camera is gone" (camera card). */
+  emptyLabel?: string;
 }
 
 /** Live preview for a camera. Used both for the pre-add preview (as soon as
  * a camera is picked in the dropdown) and for each configured camera's card.
- * A camera with a browser deviceId match streams via getUserMedia (the hook
- * stops the stream on deviceId change and on unmount); a camera without a
- * browser match shows the "No browser match" placeholder. Pausing (recording
- * start / modal close) drops the getUserMedia stream so cv2 can grab the
- * device. */
+ *
+ * Streams from the BACKEND by cv2 index (GET /camera-preview/{index}), not via
+ * getUserMedia. The browser identifies cameras by deviceId, which the frontend
+ * could only map to a cv2 index by localizedName — and two cameras of the same
+ * model share that name, so the mapping was a coin flip that swapped between
+ * refreshes. Streaming by index shows exactly the device the recorder will
+ * open, and is the only preview that works when makerlab runs on a headless
+ * host. `uniqueId` re-anchors the index server-side across replugs.
+ *
+ * Pausing (recording start / modal close) unmounts the stream so cv2 can grab
+ * the device; the backend also force-releases previews on the record path. */
 const CameraStreamBox: React.FC<CameraStreamBoxProps> = ({
-  deviceId,
+  cameraIndex,
+  uniqueId,
   paused,
+  emptyLabel = "No camera selected",
 }) => {
-  const { videoRef, hasError: streamError } = useCameraStream(deviceId, paused);
-
-  const showVideo = !paused && deviceId && !streamError;
+  const showStream = !paused && cameraIndex !== undefined;
   return (
     <div className="aspect-[4/3] bg-muted relative">
-      {showVideo ? (
-        <video
-          ref={videoRef}
-          autoPlay
-          muted
-          playsInline
+      {showStream ? (
+        <BackendCameraStream
+          cameraIndex={cameraIndex}
+          uniqueId={uniqueId}
           className="w-full h-full object-cover"
         />
       ) : (
         <div className="w-full h-full flex flex-col items-center justify-center">
           <VideoOff className="w-8 h-8 text-muted-foreground mb-2" />
           <span className="text-muted-foreground text-sm">
-            {paused
-              ? "Preview paused"
-              : deviceId
-              ? "Preview failed"
-              : "No browser match"}
+            {paused ? "Preview paused" : emptyLabel}
           </span>
         </div>
       )}
@@ -397,6 +423,10 @@ const CameraStreamBox: React.FC<CameraStreamBoxProps> = ({
 
 interface CameraPreviewProps {
   camera: CameraConfig;
+  /** False when this camera's unique_id is verifiably absent from the current
+   * enumeration — the tile must show "disconnected", never a wrong device: a
+   * stale camera_index now points at whatever took its place. */
+  connected: boolean;
   paused: boolean;
   onRemove: () => void;
   onUpdate: (updates: Partial<CameraConfig>) => void;
@@ -404,6 +434,7 @@ interface CameraPreviewProps {
 
 const CameraPreview: React.FC<CameraPreviewProps> = ({
   camera,
+  connected,
   paused,
   onRemove,
   onUpdate,
@@ -411,8 +442,10 @@ const CameraPreview: React.FC<CameraPreviewProps> = ({
   return (
     <div className="bg-card rounded-lg border border-border overflow-hidden">
       <CameraStreamBox
-        deviceId={camera.device_id}
+        cameraIndex={connected ? camera.camera_index : undefined}
+        uniqueId={camera.unique_id}
         paused={paused}
+        emptyLabel="Camera disconnected — reconnect it or rescan"
       />
 
       {/* Camera Info */}

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -48,7 +48,7 @@ import {
   AvailableCamera,
   useAvailableCameras,
 } from "@/hooks/useAvailableCameras";
-import { useCameraStream } from "@/hooks/useCameraStream";
+import BackendCameraStream from "@/components/BackendCameraStream";
 
 /**
  * Studio panel 3 · Deploy — run a skill (local trained checkpoint or an
@@ -70,15 +70,20 @@ const JOB_SCAN_LIMIT = 200;
 
 const cameraKey = (cam: AvailableCamera) => String(cam.index);
 
-/** Small getUserMedia preview for verifying which physical camera a role binds
- * to. `paused` drops the browser stream so the rollout subprocess can open the
- * same device via OpenCV without contending. (Ported from InferenceModal.) */
-const CameraThumbnail: React.FC<{ deviceId: string; paused: boolean }> = ({
-  deviceId,
-  paused,
-}) => {
-  const { videoRef, hasError } = useCameraStream(deviceId, paused);
-  if (paused || hasError || !deviceId) {
+/** Small preview for verifying which physical camera a role binds to.
+ *
+ * Streams from the backend by cv2 index — the live feed at exactly the index
+ * the rollout will open, independent of any browser deviceId match. That match
+ * was by localizedName, so twin cameras ("KD-USB Cameras" x2) paired
+ * arbitrarily and the tiles swapped footage between refreshes.
+ * `paused` unmounts the stream so the rollout subprocess can claim the device.
+ * (Ported from InferenceModal.) */
+const CameraThumbnail: React.FC<{
+  cameraIndex?: number;
+  uniqueId?: string;
+  paused: boolean;
+}> = ({ cameraIndex, uniqueId, paused }) => {
+  if (paused || cameraIndex === undefined) {
     return (
       <div className="flex h-24 w-32 flex-col items-center justify-center rounded border border-border bg-muted">
         <VideoOff className="mb-1 h-5 w-5 text-muted-foreground" />
@@ -88,12 +93,11 @@ const CameraThumbnail: React.FC<{ deviceId: string; paused: boolean }> = ({
       </div>
     );
   }
+  // BackendCameraStream owns its own failure/retry UI.
   return (
-    <video
-      ref={videoRef}
-      autoPlay
-      muted
-      playsInline
+    <BackendCameraStream
+      cameraIndex={cameraIndex}
+      uniqueId={uniqueId}
       className="h-24 w-32 rounded border border-border bg-muted object-cover"
     />
   );
@@ -400,9 +404,18 @@ const DeployPanel: React.FC = () => {
           (c) => c.name.toLowerCase() === m.display.toLowerCase(),
         );
         if (!robotCam) continue;
-        const live = robotCam.device_id
-          ? availableCameras.find((c) => c.deviceId === robotCam.device_id)
-          : availableCameras.find((c) => c.index === robotCam.camera_index);
+        // Resolve by unique_id first: it names the physical device exactly.
+        // device_id is a coin flip when two cameras share a name (the browser
+        // match is by localizedName), and camera_index goes stale on replug —
+        // both are fallbacks for records saved before unique_id was stored.
+        const live =
+          (robotCam.unique_id
+            ? availableCameras.find((c) => c.uniqueId === robotCam.unique_id)
+            : undefined) ??
+          (robotCam.device_id
+            ? availableCameras.find((c) => c.deviceId === robotCam.device_id)
+            : undefined) ??
+          availableCameras.find((c) => c.index === robotCam.camera_index);
         if (live) {
           next[m.requestKey] = cameraKey(live);
           changed = true;
@@ -829,7 +842,8 @@ const DeployPanel: React.FC = () => {
                           </SelectContent>
                         </Select>
                         <CameraThumbnail
-                          deviceId={selectedCamera?.deviceId ?? ""}
+                          cameraIndex={selectedCamera?.index}
+                          uniqueId={selectedCamera?.uniqueId}
                           paused={submitting || inferenceActive}
                         />
                       </div>

--- a/frontend/src/hooks/useAvailableCameras.ts
+++ b/frontend/src/hooks/useAvailableCameras.ts
@@ -6,6 +6,9 @@ export interface AvailableCamera {
   name: string;
   deviceId: string;
   available: boolean;
+  /** Stable OS-level device identity (AVFoundation uniqueID on macOS).
+   * Unlike the cv2 index, it survives replugs and identically-named devices. */
+  uniqueId?: string;
 }
 
 const norm = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
@@ -13,6 +16,10 @@ const norm = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
 interface UseAvailableCamerasOptions {
   /** When false, do nothing. Use to gate on modal open. */
   enabled?: boolean;
+  /** When false, skip browser device matching entirely (no getUserMedia
+   * permission probe, deviceId stays ""). Previews that stream from the
+   * backend by cv2 index don't need a browser match at all. */
+  matchBrowser?: boolean;
 }
 
 /**
@@ -23,6 +30,7 @@ interface UseAvailableCamerasOptions {
  */
 export function useAvailableCameras({
   enabled = true,
+  matchBrowser = true,
 }: UseAvailableCamerasOptions = {}) {
   const { baseUrl, fetchWithHeaders } = useApi();
   const [cameras, setCameras] = useState<AvailableCamera[]>([]);
@@ -50,7 +58,7 @@ export function useAvailableCameras({
       // still list and recording works, there are just no live previews.
       let browserDevices: { deviceId: string; label: string }[] = [];
       const md = navigator.mediaDevices;
-      if (md) {
+      if (md && matchBrowser) {
         let devices = await md.enumerateDevices();
         const hasLabels = devices.some((d) => d.kind === "videoinput" && d.label);
         // Only open a real stream if labels are still hidden (permission not yet
@@ -81,6 +89,7 @@ export function useAvailableCameras({
         index: number;
         name?: string;
         available: boolean;
+        unique_id?: string;
       }[] = data.cameras ?? [];
 
       // Browser's MediaDeviceInfo.label starts with AVFoundation's localizedName
@@ -105,6 +114,7 @@ export function useAvailableCameras({
           name: label,
           deviceId: match?.deviceId ?? "",
           available: cam.available,
+          uniqueId: cam.unique_id,
         };
       });
       setCameras(merged);
@@ -118,7 +128,7 @@ export function useAvailableCameras({
       setIsLoading(false);
       refreshingRef.current = false;
     }
-  }, [baseUrl, fetchWithHeaders]);
+  }, [baseUrl, fetchWithHeaders, matchBrowser]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/frontend/src/lib/cameraResolve.ts
+++ b/frontend/src/lib/cameraResolve.ts
@@ -1,0 +1,35 @@
+import type { AvailableCamera } from "@/hooks/useAvailableCameras";
+import type { CameraConfig } from "@/components/recording/CameraConfiguration";
+
+// A stored camera_index is only a position in cv2's device list — it silently
+// rebinds to a different physical camera when devices come and go (a robot cam
+// unplugging can leave its index pointing at the laptop's built-in camera).
+// These helpers re-anchor a configured camera to its stable unique_id against
+// a fresh /available-cameras enumeration before the index is trusted.
+//
+// Verification is only possible when the record stores a unique_id AND the
+// enumeration reports uniqueIds (macOS). Otherwise fall back to legacy
+// trust-the-stored-index behavior rather than falsely flagging disconnects.
+
+const canVerify = (cam: CameraConfig, available: AvailableCamera[]) =>
+  Boolean(cam.unique_id) && available.some((m) => m.uniqueId);
+
+/** True when `cam` is verifiably attached, or when we can't verify. */
+export function isCameraConnected(
+  cam: CameraConfig,
+  available: AvailableCamera[],
+): boolean {
+  if (!canVerify(cam, available)) return true;
+  return available.some((m) => m.uniqueId === cam.unique_id);
+}
+
+/** The cv2 index to open for `cam` right now: the enumerated index of its
+ * unique_id when verifiable (stored indices go stale on replug), undefined
+ * when the camera is verifiably disconnected, else the stored index. */
+export function resolveCameraIndex(
+  cam: CameraConfig,
+  available: AvailableCamera[],
+): number | undefined {
+  if (!canVerify(cam, available)) return cam.camera_index;
+  return available.find((m) => m.uniqueId === cam.unique_id)?.index;
+}

--- a/makerlab/camera_identity.py
+++ b/makerlab/camera_identity.py
@@ -1,0 +1,123 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Camera identity → cv2 index translation for THIS process (macOS).
+
+``cv2.VideoCapture(index)`` resolves the index against AVFoundation's
+*in-process* device list, which is snapshotted the first time this process
+touches AVFoundation and never refreshes — device-connection notifications
+are delivered on a thread that needs an active NSRunLoop, which uvicorn
+doesn't run. ``/available-cameras`` therefore enumerates in a *fresh
+subprocess* (see server._avfoundation_cameras_in_cv2_order), but that yields
+indices in the fresh device order, which diverges from this process's order
+whenever cameras were plugged/unplugged after startup. Opening by such an
+index then silently hits the wrong physical device — e.g. the built-in
+webcam instead of a robot camera, poisoning previews AND recordings.
+
+The stable link between the two index spaces is AVFoundation's ``uniqueID``.
+:func:`resolve_cv2_index` maps a camera's uniqueID to the index cv2 will
+actually open *in this process*, by walking the same in-process device list
+cv2 walks (video + muxed devices, uniqueID-sorted — mirrors OpenCV's
+cap_avfoundation_mac.mm). A device attached after startup is invisible to
+in-process AVFoundation entirely; for that case resolution returns None and
+callers must fail loudly (telling the user to restart makerlab) rather than
+open whatever now sits at the stale index.
+"""
+
+import logging
+import platform
+
+logger = logging.getLogger(__name__)
+
+_AVF_DEVICE_TYPE_NAMES = (
+    "AVCaptureDeviceTypeBuiltInWideAngleCamera",
+    "AVCaptureDeviceTypeExternalUnknown",  # macOS < 14
+    "AVCaptureDeviceTypeExternal",  # macOS >= 14
+    "AVCaptureDeviceTypeContinuityCamera",  # macOS >= 14
+    "AVCaptureDeviceTypeDeskViewCamera",  # macOS >= 13
+)
+
+
+def list_cameras_in_process() -> list[dict] | None:
+    """This process's camera list, in cv2 open order.
+
+    Returns ``[{"index", "name", "unique_id"}, ...]`` reflecting the same
+    (possibly stale) AVFoundation state cv2.VideoCapture resolves indices
+    against, or None when identity can't be established (non-macOS, PyObjC
+    unavailable, AVFoundation query failure).
+    """
+    if platform.system() != "Darwin":
+        return None
+    try:
+        import objc
+        from Foundation import NSBundle
+
+        bundle = NSBundle.bundleWithPath_("/System/Library/Frameworks/AVFoundation.framework")
+        bundle.load()
+        types = []
+        for name in _AVF_DEVICE_TYPE_NAMES:
+            loaded = {}
+            try:
+                objc.loadBundleVariables(bundle, loaded, [(name, b"@")])
+            except objc.error:
+                continue
+            if loaded.get(name) is not None:
+                types.append(loaded[name])
+        cls = objc.lookUpClass("AVCaptureDeviceDiscoverySession")
+        devs = []
+        for media_type in ("vide", "muxx"):
+            session = cls.discoverySessionWithDeviceTypes_mediaType_position_(types, media_type, 0)
+            devs.extend(session.devices() or [])
+        devs.sort(key=lambda d: d.uniqueID())
+        return [
+            {"index": i, "name": str(d.localizedName()), "unique_id": str(d.uniqueID())}
+            for i, d in enumerate(devs)
+        ]
+    except Exception as e:
+        logger.warning("In-process AVFoundation enumeration failed: %s", e)
+        return None
+
+
+def resolve_cv2_index(unique_id: str | None, fallback_index: int) -> int | None:
+    """The index THIS process's cv2 opens for ``unique_id``.
+
+    - No unique_id, or identity unavailable (non-macOS / query failure):
+      ``fallback_index`` — legacy trust-the-index behavior.
+    - unique_id found in the in-process list: its position there (which can
+      differ from the fresh-subprocess enumeration index the caller has).
+    - unique_id verifiably absent: None — the device attached after this
+      process started; only a restart makes it reachable. Callers must error
+      out instead of opening a different physical camera.
+    """
+    if not unique_id:
+        return fallback_index
+    cameras = list_cameras_in_process()
+    if cameras is None:
+        return fallback_index
+    for cam in cameras:
+        if cam["unique_id"] == unique_id:
+            if cam["index"] != fallback_index:
+                logger.info(
+                    "Camera %s: in-process cv2 index %d differs from enumerated index %d "
+                    "(device set changed since makerlab started)",
+                    unique_id,
+                    cam["index"],
+                    fallback_index,
+                )
+            return cam["index"]
+    logger.warning(
+        "Camera %s is not visible to this process (attached after makerlab started?) — "
+        "restart makerlab to use it.",
+        unique_id,
+    )
+    return None

--- a/makerlab/camera_preview.py
+++ b/makerlab/camera_preview.py
@@ -1,0 +1,204 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend MJPEG camera previews for headless deployments.
+
+The frontend's preview tiles normally use getUserMedia, which only sees the
+*viewing* machine's cameras. When makerlab runs on a headless host (e.g. a Jetson)
+with the cameras plugged into the server, no browser deviceId ever matches, so
+the tiles would show "No camera selected" forever. This module streams the
+backend's cv2 cameras as multipart/x-mixed-replace MJPEG (GET
+/camera-preview/{index}) so the tiles can fall back to an ``<img>``.
+"""
+
+import logging
+import platform
+import threading
+import time
+
+import cv2
+
+logger = logging.getLogger(__name__)
+
+# A preview is a thumbnail, not a recording: ~15 fps at JPEG quality 70 keeps
+# per-client bandwidth modest without visible stutter.
+TARGET_FPS = 15.0
+JPEG_QUALITY = 70
+
+# Same per-platform backend pin as recording (record._platform_backend) and the
+# /available-cameras enumeration: CAP_ANY can pick different backends across
+# calls on macOS, silently reordering indices, so a preview could show a
+# different physical device than the one the recorder will open.
+_CV2_BACKEND = {
+    "Darwin": cv2.CAP_AVFOUNDATION,
+    "Linux": cv2.CAP_V4L2,
+    "Windows": cv2.CAP_DSHOW,
+}.get(platform.system(), cv2.CAP_ANY)
+
+
+class CameraOpenError(RuntimeError):
+    """The camera at the requested index could not be opened."""
+
+
+class _SharedCapture:
+    """One refcounted cv2.VideoCapture, shared by every client of an index."""
+
+    def __init__(self, index: int) -> None:
+        self.index = index
+        self.cap: cv2.VideoCapture | None = None
+        self.refcount = 0
+        # Held around every cap.read() AND every cap.release(): cv2 segfaults
+        # if a capture is released while another thread is inside read(), so a
+        # release must never happen outside this lock.
+        self.lock = threading.Lock()
+        # Set by stop_all() so every client generator exits promptly instead of
+        # grabbing another frame.
+        self.stop = threading.Event()
+
+
+class CameraPreviewManager:
+    """Refcounted, shared MJPEG streaming of the backend's cv2 cameras.
+
+    One cv2.VideoCapture per camera index, shared across all connected preview
+    clients; the last client detaching releases the device. Recording and
+    teleoperation always win: their start paths call :meth:`stop_all`, which
+    tells every client generator to exit and force-releases any capture a
+    stalled client would otherwise keep holding.
+    """
+
+    def __init__(self) -> None:
+        self._captures: dict[int, _SharedCapture] = {}
+        # Guards the registry dict and the refcounts; never held during device
+        # I/O (open/read/release happen under the per-index lock instead).
+        self._registry_lock = threading.Lock()
+
+    def open_stream(self, index: int):
+        """Open (or share) the capture for ``index`` and return a frame generator.
+
+        Raises :class:`CameraOpenError` when the device can't be opened. The
+        generator yields ``multipart/x-mixed-replace`` JPEG parts (boundary
+        ``frame``) at ~TARGET_FPS and drops its reference on exit — client
+        disconnect, :meth:`stop_all`, or the device dying mid-stream.
+        """
+        entry = self._acquire(index)
+        return self._frames(entry)
+
+    def stop_all(self, timeout: float = 1.0) -> None:
+        """Stop every preview stream and release every capture.
+
+        Sets each capture's stop event so client generators exit on their next
+        frame, waits up to ``timeout`` seconds for them to detach, then
+        force-releases anything still held — a client stalled mid-yield on a
+        dead connection must not keep the device away from recording/teleop.
+        The force-release happens under the per-index lock, so it can never
+        pull the capture out from under a thread inside cap.read().
+        """
+        with self._registry_lock:
+            entries = list(self._captures.values())
+        if not entries:
+            return
+        for entry in entries:
+            entry.stop.set()
+        deadline = time.monotonic() + timeout
+        for entry in entries:
+            while time.monotonic() < deadline:
+                with self._registry_lock:
+                    detached = self._captures.get(entry.index) is not entry
+                if detached:
+                    break
+                time.sleep(0.02)
+            with entry.lock:
+                if entry.cap is not None:
+                    logger.warning(
+                        "Force-releasing camera %d preview capture (a client is still attached)",
+                        entry.index,
+                    )
+                    entry.cap.release()
+                    entry.cap = None
+            # Deregister so a lagging client's _release becomes a no-op and a
+            # future preview starts from a fresh entry (fresh stop event).
+            with self._registry_lock:
+                if self._captures.get(entry.index) is entry:
+                    del self._captures[entry.index]
+
+    def _acquire(self, index: int) -> _SharedCapture:
+        with self._registry_lock:
+            entry = self._captures.get(index)
+            if entry is None:
+                entry = _SharedCapture(index)
+                self._captures[index] = entry
+            entry.refcount += 1
+        try:
+            with entry.lock:
+                if entry.cap is None:
+                    cap = cv2.VideoCapture(index, _CV2_BACKEND)
+                    if not cap.isOpened():
+                        cap.release()
+                        raise CameraOpenError(
+                            f"Camera {index} could not be opened — it may be unplugged or in use "
+                            "by another application."
+                        )
+                    entry.cap = cap
+        except Exception:
+            self._release(entry)
+            raise
+        return entry
+
+    def _release(self, entry: _SharedCapture) -> None:
+        with self._registry_lock:
+            entry.refcount -= 1
+            if entry.refcount > 0:
+                return
+            # Last client: deregister before the (slow) device release so a new
+            # client never latches onto a capture that is being torn down.
+            if self._captures.get(entry.index) is entry:
+                del self._captures[entry.index]
+        with entry.lock:
+            if entry.cap is not None:
+                entry.cap.release()
+                entry.cap = None
+                logger.info("Released camera %d preview capture (last client detached)", entry.index)
+
+    def _frames(self, entry: _SharedCapture):
+        """Yield multipart JPEG parts from a shared capture until stopped."""
+        interval = 1.0 / TARGET_FPS
+        try:
+            while not entry.stop.is_set():
+                started = time.monotonic()
+                with entry.lock:
+                    if entry.cap is None:  # force-released by stop_all
+                        break
+                    ok, frame = entry.cap.read()
+                if not ok:
+                    logger.warning("Camera %d stopped producing frames; ending preview", entry.index)
+                    break
+                ok, jpeg = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, JPEG_QUALITY])
+                if not ok:
+                    continue
+                data = jpeg.tobytes()
+                yield (
+                    b"--frame\r\nContent-Type: image/jpeg\r\n"
+                    + f"Content-Length: {len(data)}\r\n\r\n".encode()
+                    + data
+                    + b"\r\n"
+                )
+                # Pace to ~TARGET_FPS. Waiting on the stop event (not a plain
+                # sleep) lets stop_all cut the frame interval short.
+                remaining = interval - (time.monotonic() - started)
+                if remaining > 0 and entry.stop.wait(remaining):
+                    break
+        finally:
+            self._release(entry)
+
+
+camera_preview_manager = CameraPreviewManager()

--- a/makerlab/record.py
+++ b/makerlab/record.py
@@ -33,6 +33,7 @@ from lerobot.motors.motors_bus import MotorsBus
 from lerobot.scripts.lerobot_record import RecordConfig
 
 from .arm_identity import ArmIdentityError, verify_devices
+from .camera_preview import camera_preview_manager
 from .datasets import (
     _lerobot_cache_root,
     invalidate_dataset_listing_cache,
@@ -518,6 +519,14 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
         # lock that claims the active flag (mirrors the _release_now reset), so a
         # stale flag can never make this fresh session delete its own dataset.
         discard_requested = False
+
+    # Backend camera previews hold the cv2 devices; hand them over before we open
+    # the same indices. Ordered deliberately: `recording_active` is already True
+    # (set under the lock above), so /camera-preview now 409s and no client can
+    # re-acquire a device in the gap between this release and the recorder's
+    # open. Doing it the other way round leaves that race open, and a preview
+    # still holding index 0 starves the recorder (OpenCVCamera(0) actual_fps=5.0).
+    camera_preview_manager.stop_all()
 
     # Start capturing this session's logs into a fresh bounded ring buffer so the
     # Record page can display them (detaches any previous session's handler).

--- a/makerlab/rollout.py
+++ b/makerlab/rollout.py
@@ -42,6 +42,7 @@ from tqdm.auto import tqdm as _base_tqdm
 from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 
 from .arm_identity import ArmIdentityError, ArmSlot, verify_devices
+from .camera_preview import camera_preview_manager
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .record import _DEFAULT_FOURCC
 from .utils.config import (
@@ -996,6 +997,12 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
             "status_code": 400,
             "message": f"Unrecognised policy ref: {request.policy_ref!r}",
         }
+
+    # Backend camera previews hold the cv2 devices the rollout subprocess is about
+    # to open. Released here — after the cheap guards above, so a rejected request
+    # doesn't needlessly kill the modal's previews, and while `inference_active`
+    # is already True so /camera-preview 409s instead of re-acquiring a device.
+    camera_preview_manager.stop_all()
 
     # Everything heavy (download, preflight, spawn) runs off the request thread.
     # Tracked so a later start can tell whether a stopped session's worker is

--- a/makerlab/server.py
+++ b/makerlab/server.py
@@ -33,7 +33,7 @@ from typing import Any, Literal
 import httpx
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from huggingface_hub.errors import HfHubHTTPError
 from pydantic import BaseModel
@@ -50,6 +50,8 @@ from lerobot.policies.factory import make_policy_config
 from . import (
     datasets as dataset_browser,
     models as model_browser,
+    record as record_state,
+    rollout as rollout_state,
 )
 
 # Import our custom calibration functionality
@@ -60,6 +62,8 @@ from .auto_calibrate import (
     auto_calibration_manager,
 )
 from .calibrate import CalibrationRequest, calibration_manager
+from .camera_identity import resolve_cv2_index
+from .camera_preview import CameraOpenError, camera_preview_manager
 from .identify import identify_arm_by_motion
 from .jobs import (
     DatasetNotOnHubError,
@@ -2385,6 +2389,53 @@ def get_available_cameras():
     except Exception as e:
         logger.error(f"Error detecting cameras: {e}")
         return {"status": "error", "message": str(e), "cameras": []}
+
+
+@app.get("/camera-preview/{index}")
+def camera_preview_stream(index: int, unique_id: str | None = None):
+    """MJPEG preview stream of a camera attached to the *server* machine.
+
+    The browser's getUserMedia only sees the *viewing* machine's cameras, and
+    it identifies them by ``deviceId`` — which the frontend can only match to a
+    cv2 index by localizedName. Two cameras of the same model share that name,
+    so the match is a coin flip and the preview can show the wrong device (and
+    swap between refreshes). Streaming from the backend by cv2 index removes
+    the browser from the loop: the tile shows exactly what the recorder will
+    open. It is also the only preview that works at all on a headless host.
+
+    ``unique_id`` (AVFoundation uniqueID, from /available-cameras) re-anchors
+    the index to the physical device before opening: cv2 resolves indices
+    against this process's startup device snapshot, which diverges from the
+    fresh-subprocess enumeration after a replug — without the re-anchor the
+    stream can silently show a different camera (see makerlab/camera_identity.py).
+
+    Returns 409 while recording or inference is active (they own the cv2
+    devices) and 503 when the camera can't be opened. Teleoperation drives the
+    serial bus and opens no cv2 cameras, so a preview during teleop does not
+    contend — it is allowed.
+    """
+    if record_state.recording_active:
+        raise HTTPException(
+            status_code=409,
+            detail="Recording is active — the cameras are in use. Stop recording to preview them.",
+        )
+    if rollout_state.inference_active:
+        raise HTTPException(
+            status_code=409,
+            detail="Inference is active — the cameras are in use. Stop the run to preview them.",
+        )
+    resolved = resolve_cv2_index(unique_id, index)
+    if resolved is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Camera not visible to the server — it was plugged in after makerlab "
+            "started. Restart makerlab to use it.",
+        )
+    try:
+        stream = camera_preview_manager.open_stream(resolved)
+    except CameraOpenError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return StreamingResponse(stream, media_type="multipart/x-mixed-replace; boundary=frame")
 
 
 RobotSideLiteral = Literal["leader", "follower"]

--- a/tests/test_camera_preview.py
+++ b/tests/test_camera_preview.py
@@ -1,0 +1,310 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for makerlab.camera_preview — shared MJPEG previews of backend cameras.
+
+Everything runs against a fake cv2.VideoCapture: no real camera is ever opened
+(on macOS a real open would pop a permission dialog and stall the run).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+import makerlab.camera_preview as camera_preview
+import makerlab.record as record
+import makerlab.rollout as rollout
+import makerlab.server as server_mod
+import makerlab.teleoperate as teleoperate
+from makerlab.camera_preview import CameraOpenError, CameraPreviewManager
+
+
+class FakeVideoCapture:
+    """cv2.VideoCapture double: serves synthetic frames, records release()."""
+
+    def __init__(self, index: int, backend: int | None = None) -> None:
+        self.index = index
+        self.backend = backend
+        self.opened = True
+        self.released = False
+
+    def isOpened(self) -> bool:  # noqa: N802 — cv2's camelCase API
+        return self.opened
+
+    def read(self):
+        if not self.opened:
+            return False, None
+        return True, np.zeros((8, 8, 3), dtype=np.uint8)
+
+    def release(self) -> None:
+        self.released = True
+        self.opened = False
+
+
+class FailingVideoCapture(FakeVideoCapture):
+    """A capture whose device can't be opened (unplugged / held elsewhere)."""
+
+    def __init__(self, index: int, backend: int | None = None) -> None:
+        super().__init__(index, backend)
+        self.opened = False
+
+
+@pytest.fixture
+def fake_captures(monkeypatch: pytest.MonkeyPatch) -> list[FakeVideoCapture]:
+    """Patch cv2.VideoCapture (as seen by makerlab.camera_preview) with a fake
+    factory; returns the list of instances it constructed."""
+    instances: list[FakeVideoCapture] = []
+
+    def factory(index: int, backend: int | None = None) -> FakeVideoCapture:
+        cap = FakeVideoCapture(index, backend)
+        instances.append(cap)
+        return cap
+
+    monkeypatch.setattr(camera_preview.cv2, "VideoCapture", factory)
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# CameraPreviewManager — refcounting, stop_all, generator lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_two_clients_share_one_capture_last_release_frees_it(
+    fake_captures: list[FakeVideoCapture],
+) -> None:
+    manager = CameraPreviewManager()
+    gen_a = manager.open_stream(0)
+    gen_b = manager.open_stream(0)
+
+    # Both clients stream frames from ONE underlying device.
+    assert b"--frame" in next(gen_a)
+    assert b"Content-Type: image/jpeg" in next(gen_b)
+    assert len(fake_captures) == 1
+
+    # First client detaching must NOT release the shared capture...
+    gen_a.close()
+    assert not fake_captures[0].released
+
+    # ...but the last one must, and the registry entry goes with it.
+    gen_b.close()
+    assert fake_captures[0].released
+    assert manager._captures == {}
+
+
+def test_distinct_indices_get_distinct_captures(fake_captures: list[FakeVideoCapture]) -> None:
+    manager = CameraPreviewManager()
+    gen_a = manager.open_stream(0)
+    gen_b = manager.open_stream(1)
+    next(gen_a)
+    next(gen_b)
+    assert [cap.index for cap in fake_captures] == [0, 1]
+    gen_a.close()
+    gen_b.close()
+    assert all(cap.released for cap in fake_captures)
+
+
+def test_open_failure_raises_and_leaks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    instances: list[FakeVideoCapture] = []
+
+    def factory(index: int, backend: int | None = None) -> FakeVideoCapture:
+        cap = FailingVideoCapture(index, backend)
+        instances.append(cap)
+        return cap
+
+    monkeypatch.setattr(camera_preview.cv2, "VideoCapture", factory)
+    manager = CameraPreviewManager()
+
+    with pytest.raises(CameraOpenError):
+        manager.open_stream(3)
+
+    # The failed capture was released and no registry entry was left behind.
+    assert instances[0].released
+    assert manager._captures == {}
+
+
+def test_generator_exits_when_device_stops_producing(
+    fake_captures: list[FakeVideoCapture],
+) -> None:
+    manager = CameraPreviewManager()
+    gen = manager.open_stream(0)
+    next(gen)
+    fake_captures[0].opened = False  # camera unplugged mid-stream
+    with pytest.raises(StopIteration):
+        next(gen)
+    assert fake_captures[0].released
+    assert manager._captures == {}
+
+
+def test_stop_all_force_releases_a_stalled_client(fake_captures: list[FakeVideoCapture]) -> None:
+    """A generator suspended mid-yield (a stalled/dead client) can't detach on
+    its own; stop_all must force-release the device after the brief wait, and
+    the generator must exit — not re-grab the camera — when it resumes."""
+    manager = CameraPreviewManager()
+    gen = manager.open_stream(0)
+    next(gen)  # suspended at yield, refcount still held
+
+    manager.stop_all(timeout=0.05)
+
+    assert fake_captures[0].released
+    assert manager._captures == {}
+    # The lagging client's next pull ends the stream (release is a no-op).
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_stop_all_without_streams_is_a_noop(fake_captures: list[FakeVideoCapture]) -> None:
+    manager = CameraPreviewManager()
+    manager.stop_all(timeout=0.05)
+    assert fake_captures == []
+
+
+def test_stream_after_stop_all_reopens_the_camera(fake_captures: list[FakeVideoCapture]) -> None:
+    """stop_all must not poison the index: a later preview gets a fresh capture."""
+    manager = CameraPreviewManager()
+    gen = manager.open_stream(0)
+    next(gen)
+    manager.stop_all(timeout=0.05)
+
+    gen2 = manager.open_stream(0)
+    assert b"--frame" in next(gen2)
+    assert len(fake_captures) == 2
+    gen2.close()
+    assert fake_captures[1].released
+    gen.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /camera-preview/{index} — status codes and exclusivity
+# ---------------------------------------------------------------------------
+
+
+def test_camera_preview_409_while_recording(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(record, "recording_active", True)
+    response = client.get("/camera-preview/0")
+    assert response.status_code == 409
+    assert "Recording" in response.json()["detail"]
+
+
+def test_camera_preview_allowed_while_teleoperating(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Teleop drives the serial bus and opens no cv2 cameras, so a preview during
+    teleop does not contend — it must NOT 409. (The manager is patched to a
+    finite stream so the TestClient request completes.)"""
+
+    def finite_stream(index: int):
+        yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\nfake-jpeg\r\n"
+
+    monkeypatch.setattr(teleoperate, "teleoperation_active", True)
+    monkeypatch.setattr(server_mod.camera_preview_manager, "open_stream", finite_stream)
+    response = client.get("/camera-preview/0")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("multipart/x-mixed-replace")
+
+
+def test_camera_preview_503_when_camera_cannot_open(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(camera_preview.cv2, "VideoCapture", FailingVideoCapture)
+    response = client.get("/camera-preview/9")
+    assert response.status_code == 503
+    assert "could not be opened" in response.json()["detail"]
+
+
+def test_camera_preview_streams_multipart_mjpeg(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path: 200 + the multipart media type, with the manager patched to
+    a FINITE stream so the TestClient request completes (the real generator is
+    endless by design; its behavior is covered by the manager tests above)."""
+
+    def finite_stream(index: int):
+        yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\nfake-jpeg\r\n"
+
+    monkeypatch.setattr(server_mod.camera_preview_manager, "open_stream", finite_stream)
+    response = client.get("/camera-preview/0")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("multipart/x-mixed-replace")
+    assert b"--frame" in response.content
+
+
+# ---------------------------------------------------------------------------
+# Exclusivity wiring — recording/teleop start paths stop the previews
+# ---------------------------------------------------------------------------
+
+
+def test_start_recording_stops_camera_previews(monkeypatch: pytest.MonkeyPatch) -> None:
+    """handle_start_recording force-releases the previews before any
+    robot/camera construction (create_record_config is made to fail right
+    after, so no worker or hardware is ever touched)."""
+    calls: list[str] = []
+    monkeypatch.setattr(record.camera_preview_manager, "stop_all", lambda: calls.append("stop_all"))
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr(record, "recording_thread", None)
+    monkeypatch.setattr(teleoperate, "teleoperation_active", False)
+    monkeypatch.setattr(teleoperate, "teleoperation_thread", None)
+
+    def _boom(request):
+        raise RuntimeError("stop before hardware")
+
+    monkeypatch.setattr(record, "create_record_config", _boom)
+
+    result = record.handle_start_recording(
+        record.RecordingRequest(
+            leader_port="COM_LEADER",
+            follower_port="COM_FOLLOWER",
+            leader_config="leader",
+            follower_config="follower",
+            dataset_repo_id="tester/dataset",
+            single_task="pick",
+        )
+    )
+
+    assert result["success"] is False
+    assert calls == ["stop_all"]
+    assert record.recording_active is False
+
+
+def test_start_inference_stops_camera_previews(monkeypatch: pytest.MonkeyPatch) -> None:
+    """handle_start_inference force-releases the previews before spawning the
+    rollout subprocess, which opens the same cv2 indices. The startup thread is
+    stubbed so no hardware is touched."""
+    calls: list[str] = []
+    monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: calls.append("stop_all"))
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(rollout, "_run_inference_startup", lambda request, cancel: None)
+    # Neutralise the cheap pre-flight guards so this test isolates the preview
+    # release; they run BEFORE it and would otherwise early-return.
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
+    monkeypatch.setattr(rollout, "_arm_count_mismatch", lambda mode, dim: None)
+
+    result = rollout.handle_start_inference(
+        rollout.InferenceRequest(
+            follower_port="COM_FOLLOWER",
+            follower_config="follower",
+            policy_ref="tester/policy",
+            duration_s=10,
+        )
+    )
+
+    assert result["success"] is True
+    assert calls == ["stop_all"]
+    rollout.inference_active = False
+
+
+def test_teleoperation_does_not_touch_camera_previews(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Teleoperation opens NO cv2 cameras in this architecture (robot_factory
+    passes cameras=None), so it must leave previews alone — killing them would
+    blank the user's tiles for no reason. Guards the /camera-preview endpoint's
+    "allowed while teleoperating" contract from the other side."""
+    assert not hasattr(teleoperate, "camera_preview_manager")


### PR DESCRIPTION
## The problem

With two cameras of the **same model** assigned to different roles, the preview tiles continuously swap footage while their labels stay put. Assign front → `#0 KD-USB Cameras` and wrist → `#1 KD-USB Cameras`, and after a few seconds the front tile is showing the wrist camera, then it swaps back.

Replacing one of them with a *different* model makes it stop. One "new" + one "old" camera is fine; two of the same model — any model — breaks.

This is **not** cosmetic. Two code paths turn that same ambiguous pairing into a real cv2 index:

- `CameraConfiguration` re-synced `camera_index` — explicitly commented as *"cv2 index — what the recorder opens"* — from the stored `device_id` on **every** enumeration refresh.
- The inference auto-bind resolved `device_id` → index and sent that index to the rollout.

So a dataset could be recorded, or a policy driven, with `front` and `wrist` transposed — silently, looking like a bad checkpoint rather than a wiring bug.

## Why it happens

`useAvailableCameras` paired each backend cv2 index with a browser `deviceId` by matching on **name**, first-unused-wins:

```ts
const used = new Set<string>();
const candidates = browserDevices.filter(d => !used.has(d.deviceId) && d.label);
const match =
  candidates.find(d => norm(d.label) === target) ||
  candidates.find(d => norm(d.label).startsWith(target)) || ...
```

Two identical cameras report the *same* AVFoundation `localizedName`, so both satisfy the first predicate. Which browser device lands on index 0 versus index 1 is decided purely by `enumerateDevices()` iteration order — which has no relationship to the uniqueID sort cv2 uses, and is not guaranteed stable across calls.

Every `refresh()` re-rolls that pairing, and `refresh()` runs on every `devicechange` (debounced 500ms). An iPhone Continuity Camera waking or sleeping is enough to fire it. Hence the periodic back-and-forth.

With distinct model names the exact-name match is unambiguous, the pairing is fixed, and the symptom disappears — which is exactly the reported behaviour.

`deviceId` was the only identity carried forward: `/available-cameras` already returned AVFoundation's `unique_id`, but the frontend dropped it on the floor (zero occurrences of `unique_id`/`uniqueId` in the shipped bundle).

### Two things ruled out

- **Not** a uniqueID collision. The two cameras have distinct location-based IDs (`0x1310002c7f4a60` / `0x1323002c7f4a60`).
- **Not** an index-space mismatch. OpenCV sorts its AVFoundation device array by uniqueID internally (`sortedArrayUsingComparator` + `uniqueID` in the binary), matching what `/available-cameras` reports. Measured against the running rig with one camera physically covered, MakerLab's ordering predicted the correct physical device **30/30** opens. The backend index space was already correct and stable.

### Prior art

This was diagnosed and fixed once before, in `c4e5198`. The code carried the exact failure mode in a comment:

> `device_id` alone is a coin flip when two cameras share a name (twin "USB Camera"s), which is why `unique_id` wins when present.

Two days later `9e18b27` — a 327-file, +40,573/−15,080 single snapshot commit that rebuilt the branch on the older `min_stable` backend — deleted `camera_identity.py`, `camera_preview.py`, `cameraResolve.ts`, `BackendCameraStream.tsx`, and `test_camera_preview.py`. No merge conflict, no review signal. This PR restores that work, hand-ported to the current architecture rather than reverted.

## The fix

Two halves, because each covers the other's gap.

**1. Identity.** Carry `unique_id` through as `uniqueId`, persist it on the robot record, and resolve `unique_id` → `device_id` → `camera_index` everywhere. The ambiguous key survives only as a fallback for records saved before this change.

**2. Previews.** Stream from the backend by cv2 index (`GET /camera-preview/{index}`) instead of `getUserMedia`, so a tile shows *exactly* the device the recorder will open and cannot disagree with the run. This is also the only preview that works when makerlab runs on a headless host — the browser only ever sees the *viewing* machine's cameras. `camera_identity.resolve_cv2_index` re-anchors the index server-side, since cv2 resolves indices against a process-startup snapshot that drifts after a replug.

Fixing only identity would leave the preview still lying and still swapping — and create a worse failure mode, where correct data sits under a misleading tile. Fixing only previews would leave stored indices unanchored across replugs.

**Device contention.** Recording and inference force-release previews on their start paths, ordered deliberately *after* the active flag is claimed so nothing can re-acquire a device in the gap; the endpoint 409s while either is running. There's a known failure if this is skipped — a preview holding index 0 starves the recorder to `actual_fps=5.0`.

**Teleoperation is deliberately exempt.** It opens no cv2 cameras here (`robot_factory` passes `cameras=None`), so previews never contend with it and killing them would blank the tiles for nothing. This differs from `c4e5198`, where teleop *did* open cameras; the test asserting teleop releases previews was replaced with one asserting the current contract.

## What changed

**Restored** (deleted by `9e18b27`): `makerlab/camera_identity.py`, `makerlab/camera_preview.py`, `frontend/src/lib/cameraResolve.ts`, `frontend/src/components/BackendCameraStream.tsx`, `tests/test_camera_preview.py`

**Backend**
- `server.py` — `/camera-preview/{index}` endpoint, guarding on **both** `recording_active` and `inference_active` (`rollout.py` postdates `c4e5198`, so the inference guard is new)
- `record.py`, `rollout.py` — `camera_preview_manager.stop_all()` on the start paths

**Frontend**
- `useAvailableCameras.ts` — carries `uniqueId`; adds `matchBrowser`
- `CameraConfiguration.tsx` — identity-first re-sync, persists `unique_id`, identity-aware duplicate check, backend previews, and a disconnected camera now renders a placeholder instead of streaming a stale index that points at whatever replaced it
- `InferenceModal.tsx` — same resolution chain, backend previews
- `DeployPanel.tsx`, `CameraFeed.tsx` + `TeleopCameraPanel.tsx` — carried copies of the same binding logic; fixed identically

## Verification

Measured on a rig with two `KD-USB Cameras`, one physically covered.

**Before:** the dark feed migrated between the front and wrist tiles while the dropdowns still read `#0` / `#1`.

**After**, sampling frames straight from the endpoint:

```
#0: 8/8 rounds dark -> COVERED
      index vs index+unique_id disagreements: 0/8
#1: 0/8 rounds dark -> uncovered
RESULT: STABLE — each index stayed on one physical camera.
```

32 stream opens across two independent runs, zero drift.

| check | result |
|---|---|
| `pytest` | 899 passed |
| `pytest tests/test_camera_preview.py` | 14 passed |
| `ruff check` (changed files) | clean |
| `tsc --noEmit` | exit 0 |
| `npm run lint` (changed files) | clean |
| `npm run build` | succeeds |

Pre-existing and untouched: `ruff format` on `rollout.py`, and 3 eslint errors in `ui/command.tsx` / `tailwind.config.ts` — all present on pristine `main`.

## Notes for reviewers

- **`frontend/dist` is intentionally not in this PR** — CI rebuilds it on `main`. The build was run only to verify it compiles and that the bundle contains the fix.
- **Existing robot records have `unique_id: null`** and will fall back to `device_id` until their cameras are re-added. Worth calling out in release notes; a migration that back-fills by index on first successful enumeration would be a reasonable follow-up.
- **`unique_id` is macOS-only.** `_windows_cameras()` and `_linux_cameras()` return index + name only, so on Linux/Windows this degrades to the previous `device_id` behaviour. Twin-camera rigs on the Jetson would still be exposed; adding identity there (e.g. `/dev/v4l/by-id`) is follow-up work.
- **`unique_id` is location-based** and changes when a camera moves to a different USB port — observed during testing. That's why `device_id` and `camera_index` are retained as fallbacks and why `isCameraConnected` surfaces a "reconnect it or rescan" state rather than silently opening the wrong device.
