### PR TITLE
Rename a dataset's Hub copy along with its local directory

### DIFF
--- a/frontend/src/components/landing/DatasetInfoCard.tsx
+++ b/frontend/src/components/landing/DatasetInfoCard.tsx
@@ -670,7 +670,22 @@ const RenameDatasetDialog: React.FC<{
     setError(null);
     try {
       const res = await renameDataset(baseUrl, fetchWithHeaders, repoId, next);
-      toast({ title: "Dataset renamed", description: res.repo_id });
+      /* The dialog has closed by the time the toast shows, so it's the only
+       * place the user learns whether the Hub copy moved — never claim a Hub
+       * rename on "skipped" (offline / logged out / unwritable namespace). */
+      if (res.hub === "renamed") {
+        toast({
+          title: "Dataset renamed",
+          description: `${res.repo_id} — the Hub copy was renamed too.`,
+        });
+      } else if (res.hub === "skipped") {
+        toast({
+          title: "Dataset renamed locally",
+          description: `${res.repo_id} — any copy on the Hub still has the old name.`,
+        });
+      } else {
+        toast({ title: "Dataset renamed", description: res.repo_id });
+      }
       onOpenChange(false);
       onRenamed(res.repo_id);
     } catch (e) {

--- a/frontend/src/components/landing/DatasetInfoCard.tsx
+++ b/frontend/src/components/landing/DatasetInfoCard.tsx
@@ -601,7 +601,8 @@ const HubSyncRow: React.FC<{ repoId: string }> = ({ repoId }) => {
  * Rename dialog for a local dataset (mirrors JobCard's rename UI). The namespace
  * prefix is fixed — the user edits only the name segment, shown after a static
  * "namespace/" prefix. A dataset's repo id IS its directory path, so this moves
- * the directory; the Hub copy (if any) keeps its old name, called out below.
+ * the directory; if a copy also exists on the Hub, the server renames that too
+ * so the two stay in sync.
  */
 const RenameDatasetDialog: React.FC<{
   open: boolean;
@@ -669,8 +670,8 @@ const RenameDatasetDialog: React.FC<{
         <DialogHeader>
           <DialogTitle>Rename dataset</DialogTitle>
           <DialogDescription className="text-muted-foreground">
-            Renames the local dataset directory. If this dataset has a copy on
-            the Hub, the Hub copy keeps its old name.
+            Renames the local dataset directory. If this dataset also has a
+            copy on the Hub, it's renamed there too.
           </DialogDescription>
         </DialogHeader>
         <div className="flex items-center gap-1">

--- a/frontend/src/components/landing/DatasetInfoCard.tsx
+++ b/frontend/src/components/landing/DatasetInfoCard.tsx
@@ -140,6 +140,28 @@ const useCanEditHub = (repoId: string): boolean => {
   );
 };
 
+/** True when Rename should be offered for `repoId`.
+ *
+ * Rename is an identity mutation the backend refuses outside a namespace the
+ * user can write to, so a downloaded third-party dataset (`lerobot/pusht`)
+ * shouldn't show the button at all — mirroring how the delete flow offers
+ * remove-local-copy for third-party content rather than an identity change.
+ *
+ * Unlike `useCanEditHub` this defaults to TRUE while loading or unauthenticated:
+ * with no Hub identity the namespace can't be judged, and the backend does a
+ * purely local rename in that case, so hiding the button would break renaming
+ * a never-uploaded dataset while logged out. A bare id has no namespace to
+ * disown — it lives under the user's own account. */
+const useCanRename = (repoId: string): boolean => {
+  const { auth } = useHfAuth();
+  if (auth.status !== "authenticated") return true;
+  if (!repoId.includes("/")) return true;
+  const ns = repoId.split("/")[0];
+  return auth.writableNamespaces.some(
+    (n) => n.toLowerCase() === ns.toLowerCase(),
+  );
+};
+
 /** Org/required tags the backend's `with_makermodslab_tag` always re-adds on save, so
  * they can't actually be dropped. Shown as locked, non-removable chips so the
  * UI never implies the user can remove them. Matched case-insensitively. */
@@ -915,6 +937,7 @@ const DatasetInfoCard: React.FC<DatasetInfoCardProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<{ notLocal: boolean } | null>(null);
   const [renameOpen, setRenameOpen] = useState(false);
+  const canRename = useCanRename(repoId);
   // Bumped when a Hub-only dataset finishes downloading, to re-run the info
   // fetch (now that the dataset is local, /datasets/info succeeds and the card
   // flips from the Hub-only fallback to the full local detail view).
@@ -994,8 +1017,9 @@ const DatasetInfoCard: React.FC<DatasetInfoCardProps> = ({
                 </div>
                 <div className="-mr-1 -mt-0.5 flex shrink-0 items-center gap-0.5">
                   {/* Rename moves the local directory — meaningless for a
-                      hub-only summary. */}
-                  {!isHubOnly && (
+                      hub-only summary, and refused by the backend outside a
+                      namespace the user owns (see useCanRename). */}
+                  {!isHubOnly && canRename && (
                     <button
                       type="button"
                       onClick={() => setRenameOpen(true)}

--- a/frontend/src/lib/replayApi.ts
+++ b/frontend/src/lib/replayApi.ts
@@ -388,18 +388,28 @@ export async function deleteDataset(
   });
 }
 
+/** What happened to the dataset's Hub copy during a rename: "renamed" — the
+ * Hub copy was moved to match; "none" — the Hub was reachable and confirmed
+ * it has no copy; "skipped" — the Hub step didn't run (offline, logged out,
+ * or a namespace this account can't write to), so a Hub copy, if any, KEPT
+ * ITS OLD NAME. The local rename always happens regardless. */
+export type DatasetRenameHubResult = "renamed" | "none" | "skipped";
+
 /**
  * Rename a locally-cached dataset by moving its directory. `newName` is the
  * NAME PART ONLY — the namespace prefix stays fixed (so `ns/old` -> `ns/new`).
- * Returns the new repo_id. Throws ApiError on a rejected rename (invalid name,
- * target exists, dataset in use), with the backend's message in `.detail`.
+ * Returns the new repo_id plus `hub`, which reports whether the Hub copy was
+ * renamed too — the caller must surface it rather than claim a Hub rename
+ * happened unconditionally (a "skipped" Hub copy is still live under the old
+ * name). Throws ApiError on a rejected rename (invalid name, target exists,
+ * dataset in use), with the backend's message in `.detail`.
  */
 export async function renameDataset(
   baseUrl: string,
   fetcher: Fetcher,
   repoId: string,
   newName: string,
-): Promise<{ success: boolean; repo_id: string }> {
+): Promise<{ success: boolean; repo_id: string; hub: DatasetRenameHubResult }> {
   return apiRequest(baseUrl, fetcher, "/datasets/rename", {
     method: "POST",
     body: { repo_id: repoId, new_name: newName },

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -1081,6 +1081,17 @@ def _dataset_in_use(repo_id: str) -> str | None:
     return None
 
 
+def _invalidate_rename_caches(*ids: str | None) -> None:
+    """Drop every cached Hub-existence answer a rename could have touched,
+    plus the dataset listing. Called on BOTH the success path and the
+    failure path of rename_local_dataset — a half-completed rename (Hub
+    moved, local move failed, rollback may or may not have landed) is
+    precisely when the cache is most likely to be wrong."""
+    for stale in set(ids) - {None}:
+        invalidate_hub_status(stale)
+    invalidate_dataset_listing_cache()
+
+
 def rename_local_dataset(repo_id: str, new_name: str) -> dict[str, Any]:
     """Rename a locally-cached dataset by moving its directory, and its Hub
     copy (if any) to match.
@@ -1288,15 +1299,15 @@ def rename_local_dataset(repo_id: str, new_name: str) -> dict[str, Any]:
                 )
         else:
             logger.error("Failed to rename dataset %s -> %s: %s", repo_id, new_repo_id, exc)
+        # Invalidate on the way out too. Whatever just happened — a landed Hub
+        # move, a rollback, or a hub-status poll that raced the move window and
+        # cached the new id as "on_hub" — the cached answers can no longer be
+        # trusted, and a stale "on_hub" surviving for the process lifetime would
+        # point the info card at a URL that now 404s.
+        _invalidate_rename_caches(repo_id, new_repo_id, hub_repo_id, hub_new_repo_id)
         raise DatasetRenameError(500, f"Failed to rename dataset: {exc}") from exc
 
-    # The old id no longer exists and the new id now does — drop both cached
-    # Hub-existence answers so the next hub-status check re-queries. The
-    # qualified Hub ids are invalidated too when they differ from the bare ones,
-    # since hub-status may have cached its answer under either spelling.
-    for stale in {repo_id, new_repo_id, hub_repo_id, hub_new_repo_id} - {None}:
-        invalidate_hub_status(stale)
-    invalidate_dataset_listing_cache()
+    _invalidate_rename_caches(repo_id, new_repo_id, hub_repo_id, hub_new_repo_id)
 
     logger.info("Renamed dataset directory %s -> %s (hub: %s)", src, dst, hub_state)
     return {"repo_id": new_repo_id, "hub": hub_state}

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -1173,9 +1173,9 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
         logger.warning("rename: whoami() failed: %s", exc)
         raise DatasetRenameError(
             502,
-            "Couldn't confirm your Hub identity to check dataset ownership. "
-            "Check your connection and try again, or set HF_HUB_OFFLINE=1 to "
-            "rename the local copy without contacting the Hub.",
+            "Couldn't confirm your Hub identity to check dataset ownership, so nothing "
+            "was renamed. Check your connection and try again. Setting HF_HUB_OFFLINE=1 "
+            "renames the local copy only and leaves any Hub copy under the old name.",
         ) from exc
     hub_repo_id: str | None = None
     hub_new_repo_id: str | None = None
@@ -1208,9 +1208,9 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
             logger.warning("rename: repo_exists(%s) failed: %s", hub_repo_id, exc)
             raise DatasetRenameError(
                 502,
-                "Couldn't confirm whether this dataset also exists on the Hub. "
-                "Check your connection and try again, or set HF_HUB_OFFLINE=1 to "
-                "rename the local copy without contacting the Hub.",
+                "Couldn't confirm whether this dataset also exists on the Hub, so nothing "
+                "was renamed. Check your connection and try again. Setting HF_HUB_OFFLINE=1 "
+                "renames the local copy only and leaves any Hub copy under the old name.",
             ) from exc
 
     if hub_repo_exists:
@@ -1220,9 +1220,9 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
             logger.warning("rename: repo_exists(%s) failed: %s", hub_new_repo_id, exc)
             raise DatasetRenameError(
                 502,
-                "Couldn't confirm whether the new name is free on the Hub. "
-                "Check your connection and try again, or set HF_HUB_OFFLINE=1 to "
-                "rename the local copy without contacting the Hub.",
+                "Couldn't confirm whether the new name is free on the Hub, so nothing was "
+                "renamed. Check your connection and try again. Setting HF_HUB_OFFLINE=1 "
+                "renames the local copy only and leaves the Hub copy under the old name.",
             ) from exc
         if new_taken:
             raise DatasetRenameError(409, f"A dataset named '{hub_new_repo_id}' already exists on the Hub.")

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -1127,7 +1127,7 @@ def rename_local_dataset(repo_id: str, new_name: str) -> dict[str, Any]:
     a best-effort basis.
 
     Raises DatasetRenameError (with an HTTP status + message) on: a bad
-    new_name, a source that isn't a local dataset, a target that already
+    repo_id or new_name, a source that isn't a local dataset, a target that already
     exists (locally or on the Hub), a failed attempt to confirm the user's Hub
     identity while a token IS present (the unauthenticated case above is
     distinct and never errors), the dataset being actively used (recording /
@@ -1135,6 +1135,13 @@ def rename_local_dataset(repo_id: str, new_name: str) -> dict[str, Any]:
     Hub-existence answer for BOTH ids so the info card re-checks after the
     move.
     """
+    # Validate the SOURCE id too, the way record and merge do at creation.
+    # Without this a malformed id (`a/b/c`) is a fully valid local directory
+    # path and would rename to an equally malformed one, silently.
+    ok, reason = validate_dataset_repo_id(repo_id)
+    if not ok:
+        raise DatasetRenameError(400, reason)
+
     ok, reason = validate_dataset_name(new_name)
     if not ok:
         raise DatasetRenameError(400, reason)

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -257,11 +257,24 @@ class DatasetHubEditError(Exception):
         self.docs_url = docs_url
 
 
+def _hub_status_code(exc: Exception) -> int | None:
+    """HTTP status carried by a huggingface_hub exception, or None if it isn't
+    an HTTP error. `HfHubHTTPError` keeps the `requests.Response` around; read
+    the real status from it rather than pattern-matching the message text,
+    which could also match a "409" that happens to appear in a repo name."""
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
 def _hub_edit_error(exc: Exception) -> DatasetHubEditError:
-    """Map a huggingface_hub exception raised by a visibility/tags mutation to a
-    DatasetHubEditError with a legible message. A 401/auth failure or a 403
-    permission failure becomes a clear "you can't edit this" message; anything
-    else degrades to a generic Hub-failure 502."""
+    """Map a huggingface_hub exception raised by a visibility/tags/rename
+    mutation to a DatasetHubEditError with a legible message. A 401/auth
+    failure or a 403 permission failure becomes a clear "you can't edit this"
+    message; a 409 is a name race (the target was free at the pre-check and
+    taken before the write landed) and gets the same "already exists" a
+    caller's own pre-check would report; anything else degrades to a generic
+    Hub-failure 502."""
     from .record import _upload_auth_error
 
     auth = _upload_auth_error(exc)
@@ -274,6 +287,13 @@ def _hub_edit_error(exc: Exception) -> DatasetHubEditError:
             403,
             "You don't have permission to change this dataset on the Hub. "
             "You can only edit datasets in a namespace you can write to.",
+        )
+    status = _hub_status_code(exc)
+    if status == 409 or (status is None and "conflict" in err_text):
+        return DatasetHubEditError(
+            409,
+            "The Hub already has a dataset with that name — it was taken while this "
+            "change was in flight. Pick a different name and try again.",
         )
     return DatasetHubEditError(502, f"The Hub rejected the change: {exc}")
 

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -41,7 +41,7 @@ from .utils.config import (
     validate_dataset_repo_id,
     with_makermodslab_tag,
 )
-from .utils.hf_auth import cached_whoami, hf_hub_offline, owns_namespace, shared_hf_api
+from .utils.hf_auth import cached_whoami, canonical_writable_namespace, hf_hub_offline, shared_hf_api
 
 logger = logging.getLogger(__name__)
 
@@ -1107,10 +1107,12 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
 
     Raises DatasetRenameError (with an HTTP status + message) on: a bad
     new_name, a source that isn't a local dataset, a target that already
-    exists (locally or on the Hub), a namespace the user doesn't own, the
-    dataset being actively used (recording / merge / local training), or a Hub
-    rename failure. Invalidates the cached Hub-existence answer for BOTH ids
-    so the info card re-checks after the move.
+    exists (locally or on the Hub), a namespace the user doesn't own, a failed
+    attempt to confirm the user's Hub identity while a token IS present (the
+    unauthenticated case above is distinct and never errors), the dataset
+    being actively used (recording / merge / local training), or a Hub rename
+    failure. Invalidates the cached Hub-existence answer for BOTH ids so the
+    info card re-checks after the move.
     """
     ok, reason = validate_dataset_name(new_name)
     if not ok:
@@ -1129,6 +1131,7 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
 
     # The namespace prefix is fixed — swap only the final path segment.
     namespace = repo_id.rsplit("/", 1)[0] if "/" in repo_id else None
+    local_name = repo_id.rsplit("/", 1)[1] if namespace else repo_id
     new_repo_id = f"{namespace}/{new_name}" if namespace else new_name
     if new_repo_id == repo_id:
         return repo_id  # no-op
@@ -1159,19 +1162,37 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
     # Hub-name bug this whole change exists to fix. The LOCAL path and the
     # RETURNED id stay bare either way: qualifying is a Hub-side concern only.
     api = shared_hf_api()
-    whoami_info = cached_whoami()
+    # cached_whoami() collapses "no token" and "token present but whoami
+    # failed" into the same None. fail_on_error=True re-raises the second
+    # case instead, so a transient whoami failure fails closed like the
+    # repo_exists checks below do, rather than silently falling through to
+    # a local-only rename that leaves a stale Hub copy under the old name.
+    try:
+        whoami_info = cached_whoami(fail_on_error=True)
+    except Exception as exc:
+        logger.warning("rename: whoami() failed: %s", exc)
+        raise DatasetRenameError(
+            502,
+            "Couldn't confirm your Hub identity to check dataset ownership. "
+            "Check your connection and try again, or set HF_HUB_OFFLINE=1 to "
+            "rename the local copy without contacting the Hub.",
+        ) from exc
     hub_repo_id: str | None = None
     hub_new_repo_id: str | None = None
     if whoami_info is not None:
-        hub_namespace = namespace or whoami_info["name"]
-        if not owns_namespace(whoami_info, hub_namespace):
+        requested_namespace = namespace or whoami_info["name"]
+        # Resolve to whoami's own spelling, not the local directory's — a
+        # locally-recorded "MyOrg/foo" would otherwise hit the Hub as
+        # "MyOrg" instead of the canonical "myorg" the account actually owns.
+        hub_namespace = canonical_writable_namespace(whoami_info, requested_namespace)
+        if hub_namespace is None:
             raise DatasetRenameError(
                 403,
-                f"This dataset belongs to '{hub_namespace}' on the Hub — you can only "
+                f"This dataset belongs to '{requested_namespace}' on the Hub — you can only "
                 "rename datasets in your own namespace. Delete your local copy instead, "
                 "or upload it under your own account to get a renameable copy.",
             )
-        hub_repo_id = repo_id if namespace else f"{hub_namespace}/{repo_id}"
+        hub_repo_id = f"{hub_namespace}/{local_name}"
         hub_new_repo_id = f"{hub_namespace}/{new_name}"
 
     # Unauthenticated (no token): there's no Hub identity to resolve ownership

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -1081,38 +1081,48 @@ def _dataset_in_use(repo_id: str) -> str | None:
     return None
 
 
-def rename_local_dataset(repo_id: str, new_name: str) -> str:
+def rename_local_dataset(repo_id: str, new_name: str) -> dict[str, Any]:
     """Rename a locally-cached dataset by moving its directory, and its Hub
     copy (if any) to match.
 
     A dataset's repo id *is* its path under the cache root, so a rename is a
     directory move. `new_name` is the NAME PART ONLY — the namespace prefix is
     fixed, so ``ns/old`` renamed to ``new`` becomes ``ns/new`` and a bare
-    ``old`` becomes ``new``. Returns the new repo id.
+    ``old`` becomes ``new``.
 
-    Renaming is only offered for datasets the user OWNS: the namespace must be
-    one they can write to (their account or a write-role org). A downloaded
-    third-party dataset is refused with a 403 before any Hub call, since moving
-    a repo in someone else's namespace can never succeed. A bare id is treated
-    as living under the user's own account for the Hub-side check and move.
+    Returns ``{"repo_id": <new id>, "hub": "renamed" | "none" | "skipped"}``:
+
+      * ``renamed`` — a Hub copy existed and was moved to match,
+      * ``none``    — the Hub was reachable and confirmed it has no copy,
+      * ``skipped`` — the Hub step didn't run (``HF_HUB_OFFLINE``, no token, or
+        a namespace this account can't write to), so a Hub copy, if one
+        exists, KEPT ITS OLD NAME.
+
+    The local rename always happens; the tri-state exists so a caller can say
+    which of those it was instead of reporting a flat success for a rename
+    that only did half the job.
+
+    A bare id is treated as living under the user's own account for the
+    Hub-side check and move. A downloaded third-party dataset
+    (``lerobot/pusht``) still renames locally — the directory is the user's
+    own and moving it needs no Hub permission — but its Hub step is skipped,
+    since moving a repo in someone else's namespace can never succeed.
 
     If `repo_id` also exists on the Hub, it's moved there FIRST via
     ``HfApi().move_repo`` — before the local directory is touched — so a Hub
     failure (offline, no permission, name taken) leaves both copies untouched
     instead of renaming only the local one and leaving a stale Hub entry under
     the old name. If the LOCAL move then fails, the Hub move is rolled back on
-    a best-effort basis. Skipped entirely when ``HF_HUB_OFFLINE`` is set or no
-    HF token is present, same as the rest of the app's Hub mutations degrade —
-    a purely local (never-uploaded) dataset still renames fine in that case.
+    a best-effort basis.
 
     Raises DatasetRenameError (with an HTTP status + message) on: a bad
     new_name, a source that isn't a local dataset, a target that already
-    exists (locally or on the Hub), a namespace the user doesn't own, a failed
-    attempt to confirm the user's Hub identity while a token IS present (the
-    unauthenticated case above is distinct and never errors), the dataset
-    being actively used (recording / merge / local training), or a Hub rename
-    failure. Invalidates the cached Hub-existence answer for BOTH ids so the
-    info card re-checks after the move.
+    exists (locally or on the Hub), a failed attempt to confirm the user's Hub
+    identity while a token IS present (the unauthenticated case above is
+    distinct and never errors), the dataset being actively used (recording /
+    merge / local training), or a Hub rename failure. Invalidates the cached
+    Hub-existence answer for BOTH ids so the info card re-checks after the
+    move.
     """
     ok, reason = validate_dataset_name(new_name)
     if not ok:
@@ -1134,7 +1144,8 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
     local_name = repo_id.rsplit("/", 1)[1] if namespace else repo_id
     new_repo_id = f"{namespace}/{new_name}" if namespace else new_name
     if new_repo_id == repo_id:
-        return repo_id  # no-op
+        # No-op: nothing moved anywhere, so no Hub copy went stale.
+        return {"repo_id": repo_id, "hub": "none"}
 
     dst = src.parent / new_name
     if dst.exists():
@@ -1144,15 +1155,17 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
     if in_use is not None:
         raise DatasetRenameError(409, in_use)
 
-    # Which ids this rename would use ON THE HUB, and whether we're allowed to.
+    # Which ids this rename would use ON THE HUB, and whether the Hub step
+    # runs at all — see the docstring for what each `hub_state` means.
     #
-    # A rename is an identity mutation, so it only makes sense for a dataset in
-    # a namespace the user can write to. The card offers Rename for anything
-    # with a local copy, which includes DOWNLOADED THIRD-PARTY datasets
-    # (lerobot/pusht): repo_exists says True, and the move_repo that follows
-    # targets someone else's namespace, where it can never succeed. Refusing
-    # here makes that a deliberate, legible 403 instead of a Hub 403 surfacing
-    # from a button the UI happily offered.
+    # The card offers Rename for anything with a local copy, which includes
+    # DOWNLOADED THIRD-PARTY datasets (lerobot/pusht): repo_exists says True,
+    # and a move_repo there would target someone else's namespace, where it
+    # can never succeed. But the local DIRECTORY is the user's own and moving
+    # it needs no Hub permission at all — so a namespace this account can't
+    # write to gates the HUB STEP, not the whole rename. Refusing the whole
+    # operation would take away a working local capability over something the
+    # Hub was never going to allow anyway.
     #
     # A bare id (a locally-recorded dataset with no "owner/" prefix) lives under
     # the user's own account on the Hub, so it's qualified to "<username>/<name>"
@@ -1177,6 +1190,7 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
             "was renamed. Check your connection and try again. Setting HF_HUB_OFFLINE=1 "
             "renames the local copy only and leaves any Hub copy under the old name.",
         ) from exc
+    hub_state = "skipped"
     hub_repo_id: str | None = None
     hub_new_repo_id: str | None = None
     if whoami_info is not None:
@@ -1186,14 +1200,19 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
         # "MyOrg" instead of the canonical "myorg" the account actually owns.
         hub_namespace = canonical_writable_namespace(whoami_info, requested_namespace)
         if hub_namespace is None:
-            raise DatasetRenameError(
-                403,
-                f"This dataset belongs to '{requested_namespace}' on the Hub — you can only "
-                "rename datasets in your own namespace. Delete your local copy instead, "
-                "or upload it under your own account to get a renameable copy.",
+            # Someone else's namespace (a downloaded third-party dataset, or
+            # an org this token doesn't have write access to). move_repo there
+            # can never succeed, so the Hub step is skipped — hub_state stays
+            # "skipped" — but the local rename below still goes ahead.
+            logger.info(
+                "rename: '%s' belongs to '%s' on the Hub, which this account can't write to "
+                "— renaming the local copy only",
+                repo_id,
+                requested_namespace,
             )
-        hub_repo_id = f"{hub_namespace}/{local_name}"
-        hub_new_repo_id = f"{hub_namespace}/{new_name}"
+        else:
+            hub_repo_id = f"{hub_namespace}/{local_name}"
+            hub_new_repo_id = f"{hub_namespace}/{new_name}"
 
     # Unauthenticated (no token): there's no Hub identity to resolve ownership
     # against and no credential to move a repo with, so skip the Hub entirely
@@ -1201,7 +1220,9 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
     # would break renaming a never-uploaded dataset while logged out, which is
     # the case least deserving of a Hub error.
     hub_repo_exists = False
-    if hub_repo_id is not None and not hf_hub_offline():
+    if hub_repo_id is not None and hf_hub_offline():
+        logger.info("rename: HF_HUB_OFFLINE is set — renaming %s locally only", repo_id)
+    elif hub_repo_id is not None:
         try:
             hub_repo_exists = api.repo_exists(hub_repo_id, repo_type="dataset")
         except Exception as exc:
@@ -1212,6 +1233,8 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
                 "was renamed. Check your connection and try again. Setting HF_HUB_OFFLINE=1 "
                 "renames the local copy only and leaves any Hub copy under the old name.",
             ) from exc
+        if not hub_repo_exists:
+            hub_state = "none"
 
     if hub_repo_exists:
         try:
@@ -1233,6 +1256,7 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
             logger.info("move_repo(%s -> %s) failed: %s", hub_repo_id, hub_new_repo_id, exc)
             hub_err = _hub_edit_error(exc)
             raise DatasetRenameError(hub_err.status, hub_err.message) from exc
+        hub_state = "renamed"
         logger.info("Renamed Hub dataset %s -> %s", hub_repo_id, hub_new_repo_id)
 
     try:
@@ -1274,8 +1298,8 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
         invalidate_hub_status(stale)
     invalidate_dataset_listing_cache()
 
-    logger.info("Renamed dataset directory %s -> %s", src, dst)
-    return new_repo_id
+    logger.info("Renamed dataset directory %s -> %s (hub: %s)", src, dst, hub_state)
+    return {"repo_id": new_repo_id, "hub": hub_state}
 
 
 def list_user_datasets() -> list[dict[str, Any]]:

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -41,7 +41,7 @@ from .utils.config import (
     validate_dataset_repo_id,
     with_makermodslab_tag,
 )
-from .utils.hf_auth import cached_whoami, hf_hub_offline, shared_hf_api
+from .utils.hf_auth import cached_whoami, hf_hub_offline, owns_namespace, shared_hf_api
 
 logger = logging.getLogger(__name__)
 
@@ -1090,20 +1090,27 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
     fixed, so ``ns/old`` renamed to ``new`` becomes ``ns/new`` and a bare
     ``old`` becomes ``new``. Returns the new repo id.
 
+    Renaming is only offered for datasets the user OWNS: the namespace must be
+    one they can write to (their account or a write-role org). A downloaded
+    third-party dataset is refused with a 403 before any Hub call, since moving
+    a repo in someone else's namespace can never succeed. A bare id is treated
+    as living under the user's own account for the Hub-side check and move.
+
     If `repo_id` also exists on the Hub, it's moved there FIRST via
     ``HfApi().move_repo`` — before the local directory is touched — so a Hub
     failure (offline, no permission, name taken) leaves both copies untouched
     instead of renaming only the local one and leaving a stale Hub entry under
-    the old name. Skipped entirely when ``HF_HUB_OFFLINE`` is set, same as the
-    rest of the app's Hub mutations degrade when explicitly offline — a purely
-    local (never-uploaded) dataset still renames fine in that case.
+    the old name. If the LOCAL move then fails, the Hub move is rolled back on
+    a best-effort basis. Skipped entirely when ``HF_HUB_OFFLINE`` is set or no
+    HF token is present, same as the rest of the app's Hub mutations degrade —
+    a purely local (never-uploaded) dataset still renames fine in that case.
 
     Raises DatasetRenameError (with an HTTP status + message) on: a bad
     new_name, a source that isn't a local dataset, a target that already
-    exists (locally or on the Hub), the dataset being actively used
-    (recording / merge / local training), or a Hub rename failure. Invalidates
-    the cached Hub-existence answer for BOTH ids so the info card re-checks
-    after the move.
+    exists (locally or on the Hub), a namespace the user doesn't own, the
+    dataset being actively used (recording / merge / local training), or a Hub
+    rename failure. Invalidates the cached Hub-existence answer for BOTH ids
+    so the info card re-checks after the move.
     """
     ok, reason = validate_dataset_name(new_name)
     if not ok:
@@ -1134,59 +1141,116 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
     if in_use is not None:
         raise DatasetRenameError(409, in_use)
 
+    # Which ids this rename would use ON THE HUB, and whether we're allowed to.
+    #
+    # A rename is an identity mutation, so it only makes sense for a dataset in
+    # a namespace the user can write to. The card offers Rename for anything
+    # with a local copy, which includes DOWNLOADED THIRD-PARTY datasets
+    # (lerobot/pusht): repo_exists says True, and the move_repo that follows
+    # targets someone else's namespace, where it can never succeed. Refusing
+    # here makes that a deliberate, legible 403 instead of a Hub 403 surfacing
+    # from a button the UI happily offered.
+    #
+    # A bare id (a locally-recorded dataset with no "owner/" prefix) lives under
+    # the user's own account on the Hub, so it's qualified to "<username>/<name>"
+    # for the Hub check and move — the same bare-id semantics #55/#56 establish
+    # for upload and hub-status. Without that, a recorded-then-uploaded dataset
+    # (the common case) would skip Hub sync entirely and recreate the stale-
+    # Hub-name bug this whole change exists to fix. The LOCAL path and the
+    # RETURNED id stay bare either way: qualifying is a Hub-side concern only.
     api = shared_hf_api()
+    whoami_info = cached_whoami()
+    hub_repo_id: str | None = None
+    hub_new_repo_id: str | None = None
+    if whoami_info is not None:
+        hub_namespace = namespace or whoami_info["name"]
+        if not owns_namespace(whoami_info, hub_namespace):
+            raise DatasetRenameError(
+                403,
+                f"This dataset belongs to '{hub_namespace}' on the Hub — you can only "
+                "rename datasets in your own namespace. Delete your local copy instead, "
+                "or upload it under your own account to get a renameable copy.",
+            )
+        hub_repo_id = repo_id if namespace else f"{hub_namespace}/{repo_id}"
+        hub_new_repo_id = f"{hub_namespace}/{new_name}"
+
+    # Unauthenticated (no token): there's no Hub identity to resolve ownership
+    # against and no credential to move a repo with, so skip the Hub entirely
+    # and do the local-only rename this function has always done. Failing shut
+    # would break renaming a never-uploaded dataset while logged out, which is
+    # the case least deserving of a Hub error.
     hub_repo_exists = False
-    if not hf_hub_offline():
+    if hub_repo_id is not None and not hf_hub_offline():
         try:
-            hub_repo_exists = api.repo_exists(repo_id, repo_type="dataset")
+            hub_repo_exists = api.repo_exists(hub_repo_id, repo_type="dataset")
         except Exception as exc:
-            logger.info("rename: repo_exists(%s) failed: %s", repo_id, exc)
+            logger.warning("rename: repo_exists(%s) failed: %s", hub_repo_id, exc)
             raise DatasetRenameError(
                 502,
                 "Couldn't confirm whether this dataset also exists on the Hub. "
-                "Check your connection and try again.",
+                "Check your connection and try again, or set HF_HUB_OFFLINE=1 to "
+                "rename the local copy without contacting the Hub.",
             ) from exc
 
     if hub_repo_exists:
         try:
-            new_taken = api.repo_exists(new_repo_id, repo_type="dataset")
+            new_taken = api.repo_exists(hub_new_repo_id, repo_type="dataset")
         except Exception as exc:
-            logger.info("rename: repo_exists(%s) failed: %s", new_repo_id, exc)
+            logger.warning("rename: repo_exists(%s) failed: %s", hub_new_repo_id, exc)
             raise DatasetRenameError(
                 502,
                 "Couldn't confirm whether the new name is free on the Hub. "
-                "Check your connection and try again.",
+                "Check your connection and try again, or set HF_HUB_OFFLINE=1 to "
+                "rename the local copy without contacting the Hub.",
             ) from exc
         if new_taken:
-            raise DatasetRenameError(409, f"A dataset named '{new_repo_id}' already exists on the Hub.")
+            raise DatasetRenameError(409, f"A dataset named '{hub_new_repo_id}' already exists on the Hub.")
 
         try:
-            api.move_repo(repo_id, new_repo_id, repo_type="dataset")
+            api.move_repo(hub_repo_id, hub_new_repo_id, repo_type="dataset")
         except Exception as exc:
-            logger.info("move_repo(%s -> %s) failed: %s", repo_id, new_repo_id, exc)
+            logger.info("move_repo(%s -> %s) failed: %s", hub_repo_id, hub_new_repo_id, exc)
             hub_err = _hub_edit_error(exc)
             raise DatasetRenameError(hub_err.status, hub_err.message) from exc
-        logger.info("Renamed Hub dataset %s -> %s", repo_id, new_repo_id)
+        logger.info("Renamed Hub dataset %s -> %s", hub_repo_id, hub_new_repo_id)
 
     try:
         os.rename(src, dst)
     except OSError as exc:
         if hub_repo_exists:
-            logger.error(
-                "Renamed dataset on the Hub (%s -> %s) but failed to rename the local "
-                "directory: %s. The local and Hub copies are now out of sync.",
-                repo_id,
-                new_repo_id,
-                exc,
-            )
+            # The Hub already moved, so the two copies have diverged. Try to put
+            # the Hub back rather than leaving the user with a dataset renamed
+            # in one place only — a best-effort undo of the one step that did
+            # land. If the rollback ALSO fails there's nothing left to try, so
+            # log the divergence loudly for whoever has to reconcile it by hand.
+            try:
+                api.move_repo(hub_new_repo_id, hub_repo_id, repo_type="dataset")
+                logger.warning(
+                    "Local rename of %s failed (%s); rolled the Hub copy back to %s.",
+                    repo_id,
+                    exc,
+                    hub_repo_id,
+                )
+            except Exception as rollback_exc:
+                logger.error(
+                    "Renamed dataset on the Hub (%s -> %s) but failed to rename the local "
+                    "directory: %s. Rolling the Hub copy back also failed: %s. The local "
+                    "and Hub copies are now out of sync.",
+                    hub_repo_id,
+                    hub_new_repo_id,
+                    exc,
+                    rollback_exc,
+                )
         else:
             logger.error("Failed to rename dataset %s -> %s: %s", repo_id, new_repo_id, exc)
         raise DatasetRenameError(500, f"Failed to rename dataset: {exc}") from exc
 
     # The old id no longer exists and the new id now does — drop both cached
-    # Hub-existence answers so the next hub-status check re-queries.
-    invalidate_hub_status(repo_id)
-    invalidate_hub_status(new_repo_id)
+    # Hub-existence answers so the next hub-status check re-queries. The
+    # qualified Hub ids are invalidated too when they differ from the bare ones,
+    # since hub-status may have cached its answer under either spelling.
+    for stale in {repo_id, new_repo_id, hub_repo_id, hub_new_repo_id} - {None}:
+        invalidate_hub_status(stale)
     invalidate_dataset_listing_cache()
 
     logger.info("Renamed dataset directory %s -> %s", src, dst)

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -1082,18 +1082,28 @@ def _dataset_in_use(repo_id: str) -> str | None:
 
 
 def rename_local_dataset(repo_id: str, new_name: str) -> str:
-    """Rename a locally-cached dataset by moving its directory.
+    """Rename a locally-cached dataset by moving its directory, and its Hub
+    copy (if any) to match.
 
     A dataset's repo id *is* its path under the cache root, so a rename is a
     directory move. `new_name` is the NAME PART ONLY — the namespace prefix is
     fixed, so ``ns/old`` renamed to ``new`` becomes ``ns/new`` and a bare
     ``old`` becomes ``new``. Returns the new repo id.
 
+    If `repo_id` also exists on the Hub, it's moved there FIRST via
+    ``HfApi().move_repo`` — before the local directory is touched — so a Hub
+    failure (offline, no permission, name taken) leaves both copies untouched
+    instead of renaming only the local one and leaving a stale Hub entry under
+    the old name. Skipped entirely when ``HF_HUB_OFFLINE`` is set, same as the
+    rest of the app's Hub mutations degrade when explicitly offline — a purely
+    local (never-uploaded) dataset still renames fine in that case.
+
     Raises DatasetRenameError (with an HTTP status + message) on: a bad
     new_name, a source that isn't a local dataset, a target that already
-    exists, or the dataset being actively used (recording / merge / local
-    training). Invalidates the cached Hub-existence answer for BOTH ids so the
-    info card re-checks after the move.
+    exists (locally or on the Hub), the dataset being actively used
+    (recording / merge / local training), or a Hub rename failure. Invalidates
+    the cached Hub-existence answer for BOTH ids so the info card re-checks
+    after the move.
     """
     ok, reason = validate_dataset_name(new_name)
     if not ok:
@@ -1124,10 +1134,53 @@ def rename_local_dataset(repo_id: str, new_name: str) -> str:
     if in_use is not None:
         raise DatasetRenameError(409, in_use)
 
+    api = shared_hf_api()
+    hub_repo_exists = False
+    if not hf_hub_offline():
+        try:
+            hub_repo_exists = api.repo_exists(repo_id, repo_type="dataset")
+        except Exception as exc:
+            logger.info("rename: repo_exists(%s) failed: %s", repo_id, exc)
+            raise DatasetRenameError(
+                502,
+                "Couldn't confirm whether this dataset also exists on the Hub. "
+                "Check your connection and try again.",
+            ) from exc
+
+    if hub_repo_exists:
+        try:
+            new_taken = api.repo_exists(new_repo_id, repo_type="dataset")
+        except Exception as exc:
+            logger.info("rename: repo_exists(%s) failed: %s", new_repo_id, exc)
+            raise DatasetRenameError(
+                502,
+                "Couldn't confirm whether the new name is free on the Hub. "
+                "Check your connection and try again.",
+            ) from exc
+        if new_taken:
+            raise DatasetRenameError(409, f"A dataset named '{new_repo_id}' already exists on the Hub.")
+
+        try:
+            api.move_repo(repo_id, new_repo_id, repo_type="dataset")
+        except Exception as exc:
+            logger.info("move_repo(%s -> %s) failed: %s", repo_id, new_repo_id, exc)
+            hub_err = _hub_edit_error(exc)
+            raise DatasetRenameError(hub_err.status, hub_err.message) from exc
+        logger.info("Renamed Hub dataset %s -> %s", repo_id, new_repo_id)
+
     try:
         os.rename(src, dst)
     except OSError as exc:
-        logger.error("Failed to rename dataset %s -> %s: %s", repo_id, new_repo_id, exc)
+        if hub_repo_exists:
+            logger.error(
+                "Renamed dataset on the Hub (%s -> %s) but failed to rename the local "
+                "directory: %s. The local and Hub copies are now out of sync.",
+                repo_id,
+                new_repo_id,
+                exc,
+            )
+        else:
+            logger.error("Failed to rename dataset %s -> %s: %s", repo_id, new_repo_id, exc)
         raise DatasetRenameError(500, f"Failed to rename dataset: {exc}") from exc
 
     # The old id no longer exists and the new id now does — drop both cached

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -717,13 +717,19 @@ def datasets_rename(body: DatasetRenameBody):
     `new_name` is the NAME PART ONLY — the namespace prefix stays fixed, so
     `ns/old` renamed to `new` becomes `ns/new`. Refuses (409) if the dataset is
     being recorded, merged, or trained on locally, or if the new name is
-    already taken (locally or on the Hub). Returns the new repo_id.
+    already taken (locally or on the Hub).
+
+    Returns `{success, repo_id, hub}`, where `hub` is `"renamed"` (the Hub copy
+    moved too), `"none"` (the Hub has no copy of this dataset), or `"skipped"`
+    (the Hub step didn't run — offline, logged out, or someone else's
+    namespace — so a Hub copy, if any, kept its old name). The caller needs
+    that distinction to avoid claiming a Hub rename that didn't happen.
     """
     try:
-        new_repo_id = dataset_browser.rename_local_dataset(body.repo_id, body.new_name)
+        result = dataset_browser.rename_local_dataset(body.repo_id, body.new_name)
     except dataset_browser.DatasetRenameError as exc:
         raise HTTPException(status_code=exc.status, detail=exc.message) from exc
-    return {"success": True, "repo_id": new_repo_id}
+    return {"success": True, **result}
 
 
 class CustomDatasetRequest(BaseModel):

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -711,11 +711,13 @@ class DatasetRenameBody(BaseModel):
 
 @app.post("/datasets/rename")
 def datasets_rename(body: DatasetRenameBody):
-    """Rename a locally-cached dataset by moving its directory.
+    """Rename a locally-cached dataset by moving its directory, and its Hub
+    copy (if any) to match.
 
     `new_name` is the NAME PART ONLY — the namespace prefix stays fixed, so
     `ns/old` renamed to `new` becomes `ns/new`. Refuses (409) if the dataset is
-    being recorded, merged, or trained on locally. Returns the new repo_id.
+    being recorded, merged, or trained on locally, or if the new name is
+    already taken (locally or on the Hub). Returns the new repo_id.
     """
     try:
         new_repo_id = dataset_browser.rename_local_dataset(body.repo_id, body.new_name)

--- a/makermodslab/utils/hf_auth.py
+++ b/makermodslab/utils/hf_auth.py
@@ -71,11 +71,18 @@ def _whoami_default_cache(self, token=None, *, cache=True):
 _WHOAMI_API.whoami = types.MethodType(_whoami_default_cache, _WHOAMI_API)
 
 
-def cached_whoami() -> dict | None:
+def cached_whoami(*, fail_on_error: bool = False) -> dict | None:
     """Return cached whoami() for the active HF token, or None if no token.
 
-    Swallows transport errors and returns None — callers treat that as
-    "unauthenticated" so the UI degrades gracefully instead of 500ing.
+    Swallows transport errors and returns None by default — callers treat
+    that as "unauthenticated" so the UI degrades gracefully instead of
+    500ing. That collapses two different situations into the same None,
+    though: no token, and a token that failed to validate (network blip,
+    cold cache). Pass fail_on_error=True to tell them apart — a token
+    present but the whoami call failing then raises instead, so a caller
+    gating a Hub mutation on identity can fail closed on the transient case
+    like its other Hub calls do, rather than silently treating it as
+    logged-out.
     """
     token = get_token()
     if not token:
@@ -84,6 +91,8 @@ def cached_whoami() -> dict | None:
         return _WHOAMI_API.whoami(token=token, cache=True)
     except Exception as exc:
         logger.info("whoami failed: %s", exc)
+        if fail_on_error:
+            raise
         return None
 
 
@@ -112,12 +121,19 @@ def writable_namespaces(info: dict) -> list[str]:
     return [info["name"]] + [o["name"] for o in info.get("orgs", []) if o.get("roleInGroup") in WRITE_ROLES]
 
 
-def owns_namespace(info: dict, namespace: str) -> bool:
-    """True when `namespace` is one the user can write to. Case-insensitive:
-    Hub namespaces are compared case-insensitively, and the id a caller passes
-    in comes from a local directory name that may not match whoami's casing."""
+def canonical_writable_namespace(info: dict, namespace: str) -> str | None:
+    """The entry from `writable_namespaces` matching `namespace`, or None if
+    the user can't write to it. Matches case-insensitively — the namespace a
+    caller passes in typically comes from a local directory name, which may
+    not match whoami's casing (a locally-recorded "MyOrg/foo" vs. the Hub's
+    canonical "myorg") — but returns whoami's own spelling, since Hub calls
+    built from the mismatched local casing risk a 404/502 against a
+    namespace the user does in fact own."""
     ns = namespace.lower()
-    return any(n.lower() == ns for n in writable_namespaces(info))
+    for candidate in writable_namespaces(info):
+        if candidate.lower() == ns:
+            return candidate
+    return None
 
 
 def handle_hf_auth_status() -> dict:

--- a/makermodslab/utils/hf_auth.py
+++ b/makermodslab/utils/hf_auth.py
@@ -100,6 +100,26 @@ def invalidate_whoami_cache() -> None:
     _WHOAMI_API._whoami_cache.clear()
 
 
+def writable_namespaces(info: dict) -> list[str]:
+    """Namespaces the `whoami` payload's user can push a NEW repo to: their own
+    account plus every org whose role grants write access.
+
+    The single source of truth for that set. `/hf-auth-status` ships it to the
+    frontend to gate buttons, and the server-side ownership gates resolve
+    against the same helper — computing it twice is how a button that the
+    backend refuses ends up rendered anyway.
+    """
+    return [info["name"]] + [o["name"] for o in info.get("orgs", []) if o.get("roleInGroup") in WRITE_ROLES]
+
+
+def owns_namespace(info: dict, namespace: str) -> bool:
+    """True when `namespace` is one the user can write to. Case-insensitive:
+    Hub namespaces are compared case-insensitively, and the id a caller passes
+    in comes from a local directory name that may not match whoami's casing."""
+    ns = namespace.lower()
+    return any(n.lower() == ns for n in writable_namespaces(info))
+
+
 def handle_hf_auth_status() -> dict:
     try:
         info = whoami()
@@ -111,8 +131,7 @@ def handle_hf_auth_status() -> dict:
             # Namespaces the user can push a NEW dataset to: their own account
             # plus any org where their role grants write access. Consumed by the
             # frontend to gate each dataset row's "Upload to Hub" button.
-            "writable_namespaces": [info["name"]]
-            + [o["name"] for o in orgs if o.get("roleInGroup") in WRITE_ROLES],
+            "writable_namespaces": writable_namespaces(info),
             "login_command": LOGIN_COMMAND,
         }
     except (LocalTokenNotFoundError, HfHubHTTPError, OSError) as e:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -505,9 +505,9 @@ def test_rename_local_dataset_moves_directory(tmp_lerobot_home: Path) -> None:
         _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        new_id = rename_local_dataset("makermods/old_name", "new_name")
+        result = rename_local_dataset("makermods/old_name", "new_name")
 
-    assert new_id == "makermods/new_name"
+    assert result == {"repo_id": "makermods/new_name", "hub": "none"}
     assert not (tmp_lerobot_home / "makermods" / "old_name").exists()
     assert (tmp_lerobot_home / "makermods" / "new_name" / "meta" / "info.json").is_file()
     fake_api.move_repo.assert_not_called()
@@ -533,7 +533,7 @@ def test_rename_endpoint_old_id_404s_new_id_resolves(client: TestClient, tmp_ler
             json={"repo_id": "makermods/pick", "new_name": "place"},
         )
     assert resp.status_code == 200
-    assert resp.json() == {"success": True, "repo_id": "makermods/place"}
+    assert resp.json() == {"success": True, "repo_id": "makermods/place", "hub": "none"}
 
     old = client.get("/datasets/info", params={"repo_id": "makermods/pick"})
     assert old.status_code == 404
@@ -553,7 +553,7 @@ def test_rename_bare_dataset_keeps_no_namespace(tmp_lerobot_home: Path) -> None:
         _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("solo", "solo2") == "solo2"
+        assert rename_local_dataset("solo", "solo2") == {"repo_id": "solo2", "hub": "none"}
     assert (tmp_lerobot_home / "solo2" / "meta" / "info.json").is_file()
 
 
@@ -561,7 +561,7 @@ def test_rename_same_name_is_noop(tmp_lerobot_home: Path) -> None:
     from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "makermods/keep", episodes=1)
-    assert rename_local_dataset("makermods/keep", "keep") == "makermods/keep"
+    assert rename_local_dataset("makermods/keep", "keep") == {"repo_id": "makermods/keep", "hub": "none"}
 
 
 def test_rename_rejects_invalid_name(tmp_lerobot_home: Path) -> None:
@@ -726,9 +726,9 @@ def test_rename_moves_hub_repo_when_dataset_is_on_hub(tmp_lerobot_home: Path) ->
         _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        new_id = rename_local_dataset("makermods/old_name", "new_name")
+        result = rename_local_dataset("makermods/old_name", "new_name")
 
-    assert new_id == "makermods/new_name"
+    assert result == {"repo_id": "makermods/new_name", "hub": "renamed"}
     fake_api.move_repo.assert_called_once_with(
         "makermods/old_name", "makermods/new_name", repo_type="dataset"
     )
@@ -782,7 +782,9 @@ def test_rename_hub_failure_blocks_local_rename(tmp_lerobot_home: Path) -> None:
 
 def test_rename_skips_hub_check_when_offline(tmp_lerobot_home: Path) -> None:
     """Explicit HF_HUB_OFFLINE skips the Hub check entirely — a never-uploaded
-    dataset still renames locally without a network call."""
+    dataset still renames locally without a network call. Because the Hub
+    wasn't consulted at all, a copy there (if any) keeps its old name, so this
+    is "skipped" rather than "none"."""
     from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
@@ -793,9 +795,9 @@ def test_rename_skips_hub_check_when_offline(tmp_lerobot_home: Path) -> None:
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
         patch("makermodslab.datasets.hf_hub_offline", return_value=True),
     ):
-        new_id = rename_local_dataset("makermods/old_name", "new_name")
+        result = rename_local_dataset("makermods/old_name", "new_name")
 
-    assert new_id == "makermods/new_name"
+    assert result == {"repo_id": "makermods/new_name", "hub": "skipped"}
     fake_api.repo_exists.assert_not_called()
     fake_api.move_repo.assert_not_called()
 
@@ -859,16 +861,19 @@ def test_rename_new_name_hub_check_failure_502s(tmp_lerobot_home: Path) -> None:
 # --- Rename: ownership gate ---------------------------------------------
 
 
-def test_rename_third_party_dataset_403s_without_touching_the_hub(
+def test_rename_third_party_dataset_renames_locally_and_skips_the_hub(
     tmp_lerobot_home: Path,
 ) -> None:
     """THE REGRESSION TEST for the case the Hub-sync change let through: a
     downloaded third-party dataset (`lerobot/pusht`) has a local copy, so the
     card offers Rename, and repo_exists would say True — but move_repo in
-    someone else's namespace can never succeed. Refuse it up front with a clean
-    403 and no Hub round-trips at all, rather than dying on the Hub's own 403.
-    """
-    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+    someone else's namespace can never succeed. That has to gate the HUB STEP,
+    not the whole rename: the local directory is the user's own and moving it
+    needs no Hub permission at all. Refusing outright would take away a local
+    capability that works today, and with the frontend hiding the button for
+    an unowned namespace the user would have no recourse. "skipped" is how the
+    caller knows not to claim the Hub copy moved too."""
+    from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "lerobot/pusht", episodes=1)
 
@@ -876,16 +881,15 @@ def test_rename_third_party_dataset_403s_without_touching_the_hub(
     with (
         _signed_in_as("makermods"),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
-        pytest.raises(DatasetRenameError) as exc,
     ):
-        rename_local_dataset("lerobot/pusht", "mine")
+        result = rename_local_dataset("lerobot/pusht", "mine")
 
-    assert exc.value.status == 403
-    assert "lerobot" in exc.value.message
+    assert result == {"repo_id": "lerobot/mine", "hub": "skipped"}
+    # No Hub round-trips at all: the answer is knowable from whoami alone.
     fake_api.repo_exists.assert_not_called()
     fake_api.move_repo.assert_not_called()
-    assert (tmp_lerobot_home / "lerobot" / "pusht").exists()
-    assert not (tmp_lerobot_home / "lerobot" / "mine").exists()
+    assert not (tmp_lerobot_home / "lerobot" / "pusht").exists()
+    assert (tmp_lerobot_home / "lerobot" / "mine" / "meta" / "info.json").is_file()
 
 
 def test_rename_allows_write_role_org_namespace(tmp_lerobot_home: Path) -> None:
@@ -901,17 +905,19 @@ def test_rename_allows_write_role_org_namespace(tmp_lerobot_home: Path) -> None:
         _signed_in_as("makermods", orgs=[("myorg", "write")]),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("myorg/pick", "place") == "myorg/place"
+        result = rename_local_dataset("myorg/pick", "place")
 
+    assert result == {"repo_id": "myorg/place", "hub": "renamed"}
     fake_api.move_repo.assert_called_once_with("myorg/pick", "myorg/place", repo_type="dataset")
 
 
-def test_rename_refuses_read_only_org_namespace(tmp_lerobot_home: Path) -> None:
-    """A read-role org is NOT writable, so the Hub move would 403. Refuse it in
-    the same clean way as a third-party namespace — and refuse it identically
-    to how the frontend's writable-namespace gate hides the button, so the UI
-    and the backend can't disagree about what's renameable."""
-    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+def test_rename_read_only_org_namespace_skips_the_hub(tmp_lerobot_home: Path) -> None:
+    """A read-role org is NOT writable, so the Hub move would 403 -- gate the
+    Hub step exactly as for a third-party namespace, not the local rename.
+    This is also where token scope bites: a fine-grained token that doesn't
+    enumerate an org makes it look unwritable, and locking a legitimate
+    member out of a purely local move over that would be indefensible."""
+    from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "readonlyorg/pick", episodes=1)
 
@@ -919,12 +925,13 @@ def test_rename_refuses_read_only_org_namespace(tmp_lerobot_home: Path) -> None:
     with (
         _signed_in_as("makermods", orgs=[("readonlyorg", "read")]),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
-        pytest.raises(DatasetRenameError) as exc,
     ):
-        rename_local_dataset("readonlyorg/pick", "place")
+        result = rename_local_dataset("readonlyorg/pick", "place")
 
-    assert exc.value.status == 403
+    assert result == {"repo_id": "readonlyorg/place", "hub": "skipped"}
     fake_api.repo_exists.assert_not_called()
+    fake_api.move_repo.assert_not_called()
+    assert (tmp_lerobot_home / "readonlyorg" / "place" / "meta" / "info.json").is_file()
 
 
 def test_rename_namespace_ownership_is_case_insensitive(tmp_lerobot_home: Path) -> None:
@@ -940,7 +947,7 @@ def test_rename_namespace_ownership_is_case_insensitive(tmp_lerobot_home: Path) 
         _signed_in_as("makermods"),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("MakerMods/pick", "place") == "MakerMods/place"
+        assert rename_local_dataset("MakerMods/pick", "place") == {"repo_id": "MakerMods/place", "hub": "none"}
 
 
 def test_rename_qualifies_hub_calls_with_canonical_namespace_casing(tmp_lerobot_home: Path) -> None:
@@ -960,7 +967,7 @@ def test_rename_qualifies_hub_calls_with_canonical_namespace_casing(tmp_lerobot_
         _signed_in_as("makermods", orgs=[("myorg", "write")]),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("MyOrg/pick", "place") == "MyOrg/place"
+        assert rename_local_dataset("MyOrg/pick", "place") == {"repo_id": "MyOrg/place", "hub": "renamed"}
 
     fake_api.move_repo.assert_called_once_with("myorg/pick", "myorg/place", repo_type="dataset")
     assert (tmp_lerobot_home / "MyOrg" / "place" / "meta" / "info.json").is_file()
@@ -984,7 +991,7 @@ def test_rename_bare_id_syncs_hub_copy_under_the_users_namespace(
         _signed_in_as("makermods"),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("pick", "place") == "place"
+        assert rename_local_dataset("pick", "place") == {"repo_id": "place", "hub": "renamed"}
 
     fake_api.move_repo.assert_called_once_with("makermods/pick", "makermods/place", repo_type="dataset")
     assert (tmp_lerobot_home / "place" / "meta" / "info.json").is_file()
@@ -1007,8 +1014,9 @@ def test_rename_without_a_token_skips_the_hub_and_renames_locally(
         patch("makermodslab.datasets.cached_whoami", return_value=None),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("makermods/old_name", "new_name") == "makermods/new_name"
+        result = rename_local_dataset("makermods/old_name", "new_name")
 
+    assert result == {"repo_id": "makermods/new_name", "hub": "skipped"}
     fake_api.repo_exists.assert_not_called()
     fake_api.move_repo.assert_not_called()
     assert (tmp_lerobot_home / "makermods" / "new_name" / "meta" / "info.json").is_file()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -911,6 +911,29 @@ def test_rename_namespace_ownership_is_case_insensitive(tmp_lerobot_home: Path) 
         assert rename_local_dataset("MakerMods/pick", "place") == "MakerMods/place"
 
 
+def test_rename_qualifies_hub_calls_with_canonical_namespace_casing(tmp_lerobot_home: Path) -> None:
+    """Ownership matches namespace case-insensitively, but the Hub calls that
+    follow must use whoami's own spelling, not the local directory's — a local
+    dir named `MyOrg/foo` clearing the gate and then hitting the Hub as
+    `MyOrg` instead of the canonical `myorg` risks a 404/502 on a namespace the
+    user does in fact own. The local path and returned id stay bare/original-
+    cased either way: qualifying is a Hub-side concern only."""
+    from makermodslab.datasets import rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "MyOrg/pick", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "myorg/pick"
+    with (
+        _signed_in_as("makermods", orgs=[("myorg", "write")]),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
+        assert rename_local_dataset("MyOrg/pick", "place") == "MyOrg/place"
+
+    fake_api.move_repo.assert_called_once_with("myorg/pick", "myorg/place", repo_type="dataset")
+    assert (tmp_lerobot_home / "MyOrg" / "place" / "meta" / "info.json").is_file()
+
+
 def test_rename_bare_id_syncs_hub_copy_under_the_users_namespace(
     tmp_lerobot_home: Path,
 ) -> None:
@@ -957,6 +980,33 @@ def test_rename_without_a_token_skips_the_hub_and_renames_locally(
     fake_api.repo_exists.assert_not_called()
     fake_api.move_repo.assert_not_called()
     assert (tmp_lerobot_home / "makermods" / "new_name" / "meta" / "info.json").is_file()
+
+
+def test_rename_whoami_failure_with_token_502s(tmp_lerobot_home: Path) -> None:
+    """A token IS present but the whoami call itself fails (network blip, cold
+    whoami cache) — cached_whoami() collapses that into the same None as "no
+    token", so without the fail_on_error split this used to fall through to a
+    local-only rename that leaves a stale Hub copy under the old name. It must
+    fail closed instead, like the neighboring repo_exists checks."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    with (
+        patch("makermodslab.datasets.cached_whoami", side_effect=RuntimeError("whoami failed")),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert exc.value.status == 502
+    # The escape hatch has to be discoverable from the error itself — a user in
+    # the field with a flaky connection can't act on "try again" alone.
+    assert "HF_HUB_OFFLINE" in exc.value.message
+    fake_api.repo_exists.assert_not_called()
+    fake_api.move_repo.assert_not_called()
+    assert (tmp_lerobot_home / "makermods" / "old_name").exists()
 
 
 # --- Rename: local-failure rollback -------------------------------------

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -782,6 +782,38 @@ def test_rename_new_name_taken_on_hub_409s_before_any_move(tmp_lerobot_home: Pat
     assert (tmp_lerobot_home / "makermods" / "old_name").exists()
 
 
+def test_rename_hub_409_is_reported_as_a_name_conflict(tmp_lerobot_home: Path) -> None:
+    """The target was free when the pre-check ran and got taken before the
+    write landed -- a genuine race, distinct from test_rename_new_name_taken_
+    on_hub_409s_before_any_move above. A 409 raised by move_repo itself has to
+    stay a 409: "already exists" tells the user to pick another name, while
+    the generic 502 "the Hub rejected the change" tells them to file a bug."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    # The status is read from the exception's response rather than pattern-
+    # matched out of its text, so this message deliberately spells out neither
+    # "409" nor "conflict": text-matching alone would fall through to the 502.
+    race = Exception("Repository already exists on the Hub")
+    race.response = MagicMock(status_code=409)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
+    fake_api.move_repo.side_effect = race
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert exc.value.status == 409
+    # The Hub move never landed, so the local copy must not move either.
+    assert (tmp_lerobot_home / "makermods" / "old_name").exists()
+    assert not (tmp_lerobot_home / "makermods" / "new_name").exists()
+
+
 def test_rename_hub_failure_blocks_local_rename(tmp_lerobot_home: Path) -> None:
     """A Hub-side rename failure (e.g. no write permission) aborts the whole
     operation — the local directory is left untouched rather than diverging

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -579,6 +579,31 @@ def test_rename_rejects_invalid_name(tmp_lerobot_home: Path) -> None:
     assert (tmp_lerobot_home / "makermods" / "src").exists()
 
 
+def test_rename_rejects_malformed_source_repo_id(tmp_lerobot_home: Path) -> None:
+    """The SOURCE id is validated too, the same way record and merge validate
+    at creation (validate_dataset_repo_id). A nested id like `a/b/c` is not a
+    Hub id at all -- reject it on shape before doing anything else, rather
+    than silently renaming it to another equally malformed local path."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "a/b/c", episodes=1)
+
+    fake_api = MagicMock()
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("a/b/c", "d")
+
+    # 400, not 404: the id is rejected on its shape, before the cache is even
+    # consulted — and no Hub round-trip is spent on an id the Hub can't hold.
+    assert exc.value.status == 400
+    fake_api.repo_exists.assert_not_called()
+    fake_api.move_repo.assert_not_called()
+    assert (tmp_lerobot_home / "a" / "b" / "c").exists()
+
+
 def test_rename_missing_source_404s(tmp_lerobot_home: Path) -> None:
     from makermodslab.datasets import DatasetRenameError, rename_local_dataset
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -820,8 +820,40 @@ def test_rename_hub_status_check_failure_502s(tmp_lerobot_home: Path) -> None:
     assert exc.value.status == 502
     assert (tmp_lerobot_home / "makermods" / "old_name").exists()
     # The escape hatch has to be discoverable from the error itself — a user in
-    # the field with a flaky connection can't act on "try again" alone.
+    # the field with a flaky connection can't act on "try again" alone. But it
+    # must not be presented as a free equivalent: HF_HUB_OFFLINE=1 skips the
+    # Hub move it's suggested as an alternative to, so a user who follows the
+    # hint on a dataset that IS on the Hub reproduces the exact stale-name bug
+    # this whole change exists to prevent. The message has to say so.
     assert "HF_HUB_OFFLINE" in exc.value.message
+    assert "local copy only" in exc.value.message
+    assert "old name" in exc.value.message
+
+
+def test_rename_new_name_hub_check_failure_502s(tmp_lerobot_home: Path) -> None:
+    """Same as test_rename_hub_status_check_failure_502s, but the transient
+    failure is on the second repo_exists call (checking whether the new name
+    is free on the Hub) rather than the first (checking whether the dataset
+    itself is on the Hub) -- a distinct code path with its own message."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = [True, OSError("no network")]
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert exc.value.status == 502
+    assert (tmp_lerobot_home / "makermods" / "old_name").exists()
+    fake_api.move_repo.assert_not_called()
+    assert "HF_HUB_OFFLINE" in exc.value.message
+    assert "local copy only" in exc.value.message
+    assert "old name" in exc.value.message
 
 
 # --- Rename: ownership gate ---------------------------------------------
@@ -1001,9 +1033,12 @@ def test_rename_whoami_failure_with_token_502s(tmp_lerobot_home: Path) -> None:
         rename_local_dataset("makermods/old_name", "new_name")
 
     assert exc.value.status == 502
-    # The escape hatch has to be discoverable from the error itself — a user in
-    # the field with a flaky connection can't act on "try again" alone.
+    # Same disclosure requirement as the repo_exists failures below: the hint
+    # must not read as a free equivalent when it silently leaves a Hub copy
+    # under the old name.
     assert "HF_HUB_OFFLINE" in exc.value.message
+    assert "local copy only" in exc.value.message
+    assert "old name" in exc.value.message
     fake_api.repo_exists.assert_not_called()
     fake_api.move_repo.assert_not_called()
     assert (tmp_lerobot_home / "makermods" / "old_name").exists()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1082,6 +1082,34 @@ def test_rename_rolls_the_hub_back_when_the_local_move_fails(
     ]
 
 
+def test_rename_invalidates_hub_status_when_the_local_move_fails(
+    tmp_lerobot_home: Path,
+) -> None:
+    """The Hub move can land before the local move fails (whether or not the
+    best-effort rollback then succeeds) -- that's exactly when the cached
+    Hub-existence answer is most wrong, so it has to be dropped on the failure
+    path too, not just after a full success. A stale on_hub cached for the old
+    id would otherwise survive for the process lifetime and point the info
+    card at a URL that 404s."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.os.rename", side_effect=OSError("disk full")),
+        patch("makermodslab.datasets.invalidate_hub_status") as inval,
+        pytest.raises(DatasetRenameError),
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    called = {c.args[0] for c in inval.call_args_list}
+    assert called == {"makermods/old_name", "makermods/new_name"}
+
+
 def test_rename_logs_divergence_when_the_hub_rollback_also_fails(
     tmp_lerobot_home: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -543,18 +543,31 @@ def test_rename_endpoint_old_id_404s_new_id_resolves(client: TestClient, tmp_ler
 
 
 def test_rename_bare_dataset_keeps_no_namespace(tmp_lerobot_home: Path) -> None:
-    """A dataset with no namespace renames to a bare name (no prefix invented)."""
+    """A dataset with no namespace renames to a bare name (no prefix invented)
+    LOCALLY, while the Hub side is qualified to the user's own account.
+
+    repo_exists here models what the real Hub answers: the canonical `solo`
+    (unqualified) is absent, and `makermods/solo` -- where push_to_hub
+    actually put it -- is present. A blanket-False stub would let a rename
+    that never qualifies the id pass this test just as easily as a correct
+    one, which is exactly how the original bare-id bug went unnoticed."""
     from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "solo", episodes=1)
     fake_api = MagicMock()
-    fake_api.repo_exists.return_value = False
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/solo"
     with (
         _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("solo", "solo2") == {"repo_id": "solo2", "hub": "none"}
+        result = rename_local_dataset("solo", "solo2")
+
+    assert result == {"repo_id": "solo2", "hub": "renamed"}
+    # Qualifying is a Hub-side concern only: the local path and the returned
+    # id stay bare, while move_repo gets the ids the Hub actually uses.
+    fake_api.move_repo.assert_called_once_with("makermods/solo", "makermods/solo2", repo_type="dataset")
     assert (tmp_lerobot_home / "solo2" / "meta" / "info.json").is_file()
+    assert not (tmp_lerobot_home / "solo").exists()
 
 
 def test_rename_same_name_is_noop(tmp_lerobot_home: Path) -> None:
@@ -993,18 +1006,27 @@ def test_rename_read_only_org_namespace_skips_the_hub(tmp_lerobot_home: Path) ->
 
 def test_rename_namespace_ownership_is_case_insensitive(tmp_lerobot_home: Path) -> None:
     """The namespace comes from a local directory name, whoami's casing is the
-    Hub's — comparing them case-sensitively would refuse the user's own data."""
+    Hub's — comparing them case-sensitively would refuse the user's own data.
+
+    The dataset is ON the Hub here so move_repo is actually reached: with a
+    blanket-False repo_exists the ownership comparison this test is named for
+    could be case-sensitive (silently skipping the Hub) or case-insensitive
+    (checking and finding nothing) and this test wouldn't tell them apart."""
     from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "MakerMods/pick", episodes=1)
 
     fake_api = MagicMock()
-    fake_api.repo_exists.return_value = False
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/pick"
     with (
         _signed_in_as("makermods"),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
     ):
-        assert rename_local_dataset("MakerMods/pick", "place") == {"repo_id": "MakerMods/place", "hub": "none"}
+        result = rename_local_dataset("MakerMods/pick", "place")
+
+    assert result == {"repo_id": "MakerMods/place", "hub": "renamed"}
+    # The id keeps the local directory's casing — the Hub resolves it either way.
+    fake_api.move_repo.assert_called_once_with("makermods/pick", "makermods/place", repo_type="dataset")
 
 
 def test_rename_qualifies_hub_calls_with_canonical_namespace_casing(tmp_lerobot_home: Path) -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -21,7 +21,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -474,6 +474,23 @@ def test_hub_status_endpoint(client: TestClient) -> None:
 # --- Rename -----------------------------------------------------------------
 
 
+def _whoami(name: str, orgs: list[tuple[str, str]] | None = None) -> dict:
+    """A whoami payload. `orgs` entries are ``(name, roleInGroup)`` — the role
+    is what decides whether the org counts as a writable namespace."""
+    return {"name": name, "orgs": [{"name": n, "roleInGroup": r} for n, r in (orgs or [])]}
+
+
+def _signed_in_as(name: str = "makermods", orgs: list[tuple[str, str]] | None = None):
+    """Pin the Hub identity the rename path resolves ownership against.
+
+    Rename gates on cached_whoami, so every rename test states its identity
+    rather than inheriting whatever HF token the machine running the suite
+    happens to have — otherwise the ownership branch taken would vary by
+    developer laptop.
+    """
+    return patch("makermodslab.datasets.cached_whoami", return_value=_whoami(name, orgs))
+
+
 def test_rename_local_dataset_moves_directory(tmp_lerobot_home: Path) -> None:
     """Happy path: the directory moves, only the name segment changes, and the
     returned repo id carries the fixed namespace prefix. Not on the Hub, so no
@@ -484,7 +501,10 @@ def test_rename_local_dataset_moves_directory(tmp_lerobot_home: Path) -> None:
 
     fake_api = MagicMock()
     fake_api.repo_exists.return_value = False
-    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
         new_id = rename_local_dataset("makermods/old_name", "new_name")
 
     assert new_id == "makermods/new_name"
@@ -504,7 +524,10 @@ def test_rename_endpoint_old_id_404s_new_id_resolves(client: TestClient, tmp_ler
 
     fake_api = MagicMock()
     fake_api.repo_exists.return_value = False
-    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
         resp = client.post(
             "/datasets/rename",
             json={"repo_id": "makermods/pick", "new_name": "place"},
@@ -526,7 +549,10 @@ def test_rename_bare_dataset_keeps_no_namespace(tmp_lerobot_home: Path) -> None:
     _make_dataset(tmp_lerobot_home, "solo", episodes=1)
     fake_api = MagicMock()
     fake_api.repo_exists.return_value = False
-    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
         assert rename_local_dataset("solo", "solo2") == "solo2"
     assert (tmp_lerobot_home / "solo2" / "meta" / "info.json").is_file()
 
@@ -674,6 +700,7 @@ def test_rename_invalidates_hub_status_for_both_ids(tmp_lerobot_home: Path) -> N
     fake_api = MagicMock()
     fake_api.repo_exists.return_value = False
     with (
+        _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
         patch("makermodslab.datasets.invalidate_hub_status") as inval,
     ):
@@ -695,7 +722,10 @@ def test_rename_moves_hub_repo_when_dataset_is_on_hub(tmp_lerobot_home: Path) ->
 
     fake_api = MagicMock()
     fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
-    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
         new_id = rename_local_dataset("makermods/old_name", "new_name")
 
     assert new_id == "makermods/new_name"
@@ -716,6 +746,7 @@ def test_rename_new_name_taken_on_hub_409s_before_any_move(tmp_lerobot_home: Pat
     fake_api = MagicMock()
     fake_api.repo_exists.return_value = True  # both old and new names exist on the Hub
     with (
+        _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
         pytest.raises(DatasetRenameError) as exc,
     ):
@@ -738,6 +769,7 @@ def test_rename_hub_failure_blocks_local_rename(tmp_lerobot_home: Path) -> None:
     fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
     fake_api.move_repo.side_effect = Exception("403 Forbidden: no write access")
     with (
+        _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
         pytest.raises(DatasetRenameError) as exc,
     ):
@@ -757,6 +789,7 @@ def test_rename_skips_hub_check_when_offline(tmp_lerobot_home: Path) -> None:
 
     fake_api = MagicMock()
     with (
+        _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
         patch("makermodslab.datasets.hf_hub_offline", return_value=True),
     ):
@@ -778,6 +811,7 @@ def test_rename_hub_status_check_failure_502s(tmp_lerobot_home: Path) -> None:
     fake_api = MagicMock()
     fake_api.repo_exists.side_effect = OSError("no network")
     with (
+        _signed_in_as(),
         patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
         pytest.raises(DatasetRenameError) as exc,
     ):
@@ -785,6 +819,199 @@ def test_rename_hub_status_check_failure_502s(tmp_lerobot_home: Path) -> None:
 
     assert exc.value.status == 502
     assert (tmp_lerobot_home / "makermods" / "old_name").exists()
+    # The escape hatch has to be discoverable from the error itself — a user in
+    # the field with a flaky connection can't act on "try again" alone.
+    assert "HF_HUB_OFFLINE" in exc.value.message
+
+
+# --- Rename: ownership gate ---------------------------------------------
+
+
+def test_rename_third_party_dataset_403s_without_touching_the_hub(
+    tmp_lerobot_home: Path,
+) -> None:
+    """THE REGRESSION TEST for the case the Hub-sync change let through: a
+    downloaded third-party dataset (`lerobot/pusht`) has a local copy, so the
+    card offers Rename, and repo_exists would say True — but move_repo in
+    someone else's namespace can never succeed. Refuse it up front with a clean
+    403 and no Hub round-trips at all, rather than dying on the Hub's own 403.
+    """
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "lerobot/pusht", episodes=1)
+
+    fake_api = MagicMock()
+    with (
+        _signed_in_as("makermods"),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("lerobot/pusht", "mine")
+
+    assert exc.value.status == 403
+    assert "lerobot" in exc.value.message
+    fake_api.repo_exists.assert_not_called()
+    fake_api.move_repo.assert_not_called()
+    assert (tmp_lerobot_home / "lerobot" / "pusht").exists()
+    assert not (tmp_lerobot_home / "lerobot" / "mine").exists()
+
+
+def test_rename_allows_write_role_org_namespace(tmp_lerobot_home: Path) -> None:
+    """Ownership isn't just the username: an org the user has write access to
+    is renameable, and its Hub copy moves like any other."""
+    from makermodslab.datasets import rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "myorg/pick", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "myorg/pick"
+    with (
+        _signed_in_as("makermods", orgs=[("myorg", "write")]),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
+        assert rename_local_dataset("myorg/pick", "place") == "myorg/place"
+
+    fake_api.move_repo.assert_called_once_with("myorg/pick", "myorg/place", repo_type="dataset")
+
+
+def test_rename_refuses_read_only_org_namespace(tmp_lerobot_home: Path) -> None:
+    """A read-role org is NOT writable, so the Hub move would 403. Refuse it in
+    the same clean way as a third-party namespace — and refuse it identically
+    to how the frontend's writable-namespace gate hides the button, so the UI
+    and the backend can't disagree about what's renameable."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "readonlyorg/pick", episodes=1)
+
+    fake_api = MagicMock()
+    with (
+        _signed_in_as("makermods", orgs=[("readonlyorg", "read")]),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("readonlyorg/pick", "place")
+
+    assert exc.value.status == 403
+    fake_api.repo_exists.assert_not_called()
+
+
+def test_rename_namespace_ownership_is_case_insensitive(tmp_lerobot_home: Path) -> None:
+    """The namespace comes from a local directory name, whoami's casing is the
+    Hub's — comparing them case-sensitively would refuse the user's own data."""
+    from makermodslab.datasets import rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "MakerMods/pick", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False
+    with (
+        _signed_in_as("makermods"),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
+        assert rename_local_dataset("MakerMods/pick", "place") == "MakerMods/place"
+
+
+def test_rename_bare_id_syncs_hub_copy_under_the_users_namespace(
+    tmp_lerobot_home: Path,
+) -> None:
+    """A locally-RECORDED dataset has a bare id, but its uploaded Hub copy lives
+    at `<username>/<name>`. Qualifying the bare id for the Hub check and move is
+    what keeps the recorded-then-uploaded dataset — the common case — from
+    skipping Hub sync and recreating the stale-Hub-name bug. The local path and
+    the returned id stay bare."""
+    from makermodslab.datasets import rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "pick", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/pick"
+    with (
+        _signed_in_as("makermods"),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
+        assert rename_local_dataset("pick", "place") == "place"
+
+    fake_api.move_repo.assert_called_once_with("makermods/pick", "makermods/place", repo_type="dataset")
+    assert (tmp_lerobot_home / "place" / "meta" / "info.json").is_file()
+    assert not (tmp_lerobot_home / "pick").exists()
+
+
+def test_rename_without_a_token_skips_the_hub_and_renames_locally(
+    tmp_lerobot_home: Path,
+) -> None:
+    """No HF token: there's no identity to resolve ownership against and no
+    credential to move a repo with, so the Hub is skipped entirely and the
+    local rename still works — the logged-out, never-uploaded case must not
+    start failing on a Hub error it can do nothing about."""
+    from makermodslab.datasets import rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    with (
+        patch("makermodslab.datasets.cached_whoami", return_value=None),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+    ):
+        assert rename_local_dataset("makermods/old_name", "new_name") == "makermods/new_name"
+
+    fake_api.repo_exists.assert_not_called()
+    fake_api.move_repo.assert_not_called()
+    assert (tmp_lerobot_home / "makermods" / "new_name" / "meta" / "info.json").is_file()
+
+
+# --- Rename: local-failure rollback -------------------------------------
+
+
+def test_rename_rolls_the_hub_back_when_the_local_move_fails(
+    tmp_lerobot_home: Path,
+) -> None:
+    """The Hub moves first, so a failing os.rename leaves the two copies
+    diverged. Undo the one step that landed: a best-effort reverse move_repo
+    restores sync instead of stranding the user mid-rename."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.os.rename", side_effect=OSError("disk full")),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert exc.value.status == 500
+    assert fake_api.move_repo.call_args_list == [
+        call("makermods/old_name", "makermods/new_name", repo_type="dataset"),
+        call("makermods/new_name", "makermods/old_name", repo_type="dataset"),
+    ]
+
+
+def test_rename_logs_divergence_when_the_hub_rollback_also_fails(
+    tmp_lerobot_home: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the rollback itself fails there's nothing left to try, so the
+    divergence has to be loud — someone has to reconcile it by hand."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
+    fake_api.move_repo.side_effect = [None, Exception("hub down")]
+    with (
+        _signed_in_as(),
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.os.rename", side_effect=OSError("disk full")),
+        caplog.at_level(logging.ERROR, logger="makermodslab.datasets"),
+        pytest.raises(DatasetRenameError),
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert "out of sync" in caplog.text
 
 
 # --- Hub visibility / tags editing (post-upload) ----------------------------

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -476,16 +476,21 @@ def test_hub_status_endpoint(client: TestClient) -> None:
 
 def test_rename_local_dataset_moves_directory(tmp_lerobot_home: Path) -> None:
     """Happy path: the directory moves, only the name segment changes, and the
-    returned repo id carries the fixed namespace prefix."""
+    returned repo id carries the fixed namespace prefix. Not on the Hub, so no
+    HfApi mutation call is made."""
     from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=3)
 
-    new_id = rename_local_dataset("makermods/old_name", "new_name")
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False
+    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+        new_id = rename_local_dataset("makermods/old_name", "new_name")
 
     assert new_id == "makermods/new_name"
     assert not (tmp_lerobot_home / "makermods" / "old_name").exists()
     assert (tmp_lerobot_home / "makermods" / "new_name" / "meta" / "info.json").is_file()
+    fake_api.move_repo.assert_not_called()
 
 
 def test_rename_endpoint_old_id_404s_new_id_resolves(client: TestClient, tmp_lerobot_home: Path) -> None:
@@ -497,10 +502,13 @@ def test_rename_endpoint_old_id_404s_new_id_resolves(client: TestClient, tmp_ler
         {"total_episodes": 3, "total_frames": 900, "fps": 30, "features": {}},
     )
 
-    resp = client.post(
-        "/datasets/rename",
-        json={"repo_id": "makermods/pick", "new_name": "place"},
-    )
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False
+    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+        resp = client.post(
+            "/datasets/rename",
+            json={"repo_id": "makermods/pick", "new_name": "place"},
+        )
     assert resp.status_code == 200
     assert resp.json() == {"success": True, "repo_id": "makermods/place"}
 
@@ -516,7 +524,10 @@ def test_rename_bare_dataset_keeps_no_namespace(tmp_lerobot_home: Path) -> None:
     from makermodslab.datasets import rename_local_dataset
 
     _make_dataset(tmp_lerobot_home, "solo", episodes=1)
-    assert rename_local_dataset("solo", "solo2") == "solo2"
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False
+    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+        assert rename_local_dataset("solo", "solo2") == "solo2"
     assert (tmp_lerobot_home / "solo2" / "meta" / "info.json").is_file()
 
 
@@ -660,11 +671,120 @@ def test_rename_invalidates_hub_status_for_both_ids(tmp_lerobot_home: Path) -> N
 
     _make_dataset(tmp_lerobot_home, "makermods/before", episodes=1)
 
-    with patch("makermodslab.datasets.invalidate_hub_status") as inval:
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.invalidate_hub_status") as inval,
+    ):
         ds.rename_local_dataset("makermods/before", "after")
 
     called = {c.args[0] for c in inval.call_args_list}
     assert called == {"makermods/before", "makermods/after"}
+
+
+# --- Rename: Hub sync ---------------------------------------------------
+
+
+def test_rename_moves_hub_repo_when_dataset_is_on_hub(tmp_lerobot_home: Path) -> None:
+    """When the dataset also exists on the Hub, the Hub repo is moved (via
+    HfApi.move_repo) in addition to the local directory."""
+    from makermodslab.datasets import rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
+    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+        new_id = rename_local_dataset("makermods/old_name", "new_name")
+
+    assert new_id == "makermods/new_name"
+    fake_api.move_repo.assert_called_once_with(
+        "makermods/old_name", "makermods/new_name", repo_type="dataset"
+    )
+    assert not (tmp_lerobot_home / "makermods" / "old_name").exists()
+    assert (tmp_lerobot_home / "makermods" / "new_name" / "meta" / "info.json").is_file()
+
+
+def test_rename_new_name_taken_on_hub_409s_before_any_move(tmp_lerobot_home: Path) -> None:
+    """If the new name is already used on the Hub, the rename is refused before
+    touching either the Hub repo or the local directory."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = True  # both old and new names exist on the Hub
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert exc.value.status == 409
+    fake_api.move_repo.assert_not_called()
+    assert (tmp_lerobot_home / "makermods" / "old_name").exists()
+
+
+def test_rename_hub_failure_blocks_local_rename(tmp_lerobot_home: Path) -> None:
+    """A Hub-side rename failure (e.g. no write permission) aborts the whole
+    operation — the local directory is left untouched rather than diverging
+    from the (unrenamed) Hub copy."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda repo_id, repo_type: repo_id == "makermods/old_name"
+    fake_api.move_repo.side_effect = Exception("403 Forbidden: no write access")
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert exc.value.status == 403
+    assert (tmp_lerobot_home / "makermods" / "old_name").exists()
+    assert not (tmp_lerobot_home / "makermods" / "new_name").exists()
+
+
+def test_rename_skips_hub_check_when_offline(tmp_lerobot_home: Path) -> None:
+    """Explicit HF_HUB_OFFLINE skips the Hub check entirely — a never-uploaded
+    dataset still renames locally without a network call."""
+    from makermodslab.datasets import rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.hf_hub_offline", return_value=True),
+    ):
+        new_id = rename_local_dataset("makermods/old_name", "new_name")
+
+    assert new_id == "makermods/new_name"
+    fake_api.repo_exists.assert_not_called()
+    fake_api.move_repo.assert_not_called()
+
+
+def test_rename_hub_status_check_failure_502s(tmp_lerobot_home: Path) -> None:
+    """A transient error while checking Hub status (offline/rate-limited)
+    blocks the rename rather than silently doing a local-only rename that
+    could leave a stale Hub copy under the old name."""
+    from makermodslab.datasets import DatasetRenameError, rename_local_dataset
+
+    _make_dataset(tmp_lerobot_home, "makermods/old_name", episodes=1)
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = OSError("no network")
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        pytest.raises(DatasetRenameError) as exc,
+    ):
+        rename_local_dataset("makermods/old_name", "new_name")
+
+    assert exc.value.status == 502
+    assert (tmp_lerobot_home / "makermods" / "old_name").exists()
 
 
 # --- Hub visibility / tags editing (post-upload) ----------------------------

--- a/tests/test_utils_hf_auth.py
+++ b/tests/test_utils_hf_auth.py
@@ -50,6 +50,61 @@ def test_invalidate_whoami_cache_clears_cached_value() -> None:
         assert spy.call_count == 2
 
 
+def test_cached_whoami_fail_on_error_swallows_by_default() -> None:
+    from makermodslab.utils import hf_auth
+
+    with (
+        patch("makermodslab.utils.hf_auth.get_token", return_value="hf_fake_token"),
+        patch.object(hf_auth._WHOAMI_API, "whoami", side_effect=RuntimeError("boom")),
+    ):
+        assert hf_auth.cached_whoami() is None
+
+
+def test_cached_whoami_fail_on_error_true_reraises_when_token_present() -> None:
+    """A token IS present but the whoami call fails — fail_on_error=True must
+    surface that as an exception instead of collapsing it into the same None
+    as "no token", so a caller gating a Hub mutation on identity can fail
+    closed on the transient case rather than treating it as logged-out."""
+    from makermodslab.utils import hf_auth
+
+    with (
+        patch("makermodslab.utils.hf_auth.get_token", return_value="hf_fake_token"),
+        patch.object(hf_auth._WHOAMI_API, "whoami", side_effect=RuntimeError("boom")),
+    ):
+        try:
+            hf_auth.cached_whoami(fail_on_error=True)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("expected cached_whoami(fail_on_error=True) to re-raise")
+
+
+def test_cached_whoami_fail_on_error_true_still_returns_none_without_a_token() -> None:
+    """No token is the genuinely unauthenticated case — fail_on_error must not
+    turn that into an error too, or a logged-out, never-uploaded rename would
+    start failing on a Hub error it can do nothing about."""
+    from makermodslab.utils import hf_auth
+
+    with patch("makermodslab.utils.hf_auth.get_token", return_value=None):
+        assert hf_auth.cached_whoami(fail_on_error=True) is None
+
+
+def test_canonical_writable_namespace_matches_case_insensitively() -> None:
+    from makermodslab.utils import hf_auth
+
+    info = {"name": "makermods", "orgs": [{"name": "myorg", "roleInGroup": "write"}]}
+    assert hf_auth.canonical_writable_namespace(info, "MyOrg") == "myorg"
+    assert hf_auth.canonical_writable_namespace(info, "MAKERMODS") == "makermods"
+
+
+def test_canonical_writable_namespace_returns_none_when_not_writable() -> None:
+    from makermodslab.utils import hf_auth
+
+    info = {"name": "makermods", "orgs": [{"name": "readonlyorg", "roleInGroup": "read"}]}
+    assert hf_auth.canonical_writable_namespace(info, "readonlyorg") is None
+    assert hf_auth.canonical_writable_namespace(info, "lerobot") is None
+
+
 def test_handle_hf_auth_status_returns_dict() -> None:
     from makermodslab.utils import hf_auth
 


### PR DESCRIPTION
## Summary
Renaming a dataset previously renamed only the local copy, so a copy on the Hub kept its old name (creates duplicates of job cards where videos are the exact same but with different names). This PR moves the Hub copy along with the local rename, still allows renaming datasets in a namespace the user doesn't own (skipping just the Hub step, since it can never succeed there), and tells the UI honestly whether the Hub copy actually moved.

## Before
```bash
curl -s "http://localhost:8000/datasets/hub-status?repo_id=makermods/pick"
# -> {"repo_id": "makermods/pick", "status": "on_hub", "url": "https://huggingface.co/datasets/makermods/pick"}

curl -s -X POST http://localhost:8000/datasets/rename \
  -H "Content-Type: application/json" \
  -d '{"repo_id": "makermods/pick", "new_name": "place"}'
# -> {"success": true, "repo_id": "makermods/place"}

curl -s "http://localhost:8000/datasets/hub-status?repo_id=makermods/pick"
# -> {"repo_id": "makermods/pick", "status": "on_hub", "url": "https://huggingface.co/datasets/makermods/pick"}
# (stale — the Hub copy never moved, still live under the old name)
```

## After
```bash
curl -s -X POST http://localhost:8000/datasets/rename \
  -H "Content-Type: application/json" \
  -d '{"repo_id": "makermods/pick", "new_name": "place"}'
# -> {"success": true, "repo_id": "makermods/place", "hub": "renamed"}

curl -s "http://localhost:8000/datasets/hub-status?repo_id=makermods/pick"
# -> {"repo_id": "makermods/pick", "status": "absent", "url": null}

curl -s "http://localhost:8000/datasets/hub-status?repo_id=makermods/place"
# -> {"repo_id": "makermods/place", "status": "on_hub", "url": "https://huggingface.co/datasets/makermods/place"}
```

A rename in a namespace the account can't write to (a downloaded third-party dataset, or a read-only org) now still renames the local copy and reports it honestly:
```bash
curl -s -X POST http://localhost:8000/datasets/rename \
  -H "Content-Type: application/json" \
  -d '{"repo_id": "lerobot/pusht", "new_name": "mine"}'
# -> {"success": true, "repo_id": "lerobot/mine", "hub": "skipped"}
```

## Commits
1. Move the dataset's Hub copy along with its local directory during rename, so the two never diverge.
2. Scope the ownership gate to the Hub step, not the whole rename — a namespace the account can't write to still renames locally; only the Hub move is skipped.
3. Fail closed when the Hub identity check itself fails, and fix a namespace-casing mismatch that could misjudge ownership.
4. State the `HF_HUB_OFFLINE=1` hint's real cost in the 502 messages (it leaves any Hub copy under the old name) instead of presenting it as an equivalent workaround.
5. Return `hub: "renamed" | "none" | "skipped"` from `/datasets/rename` and drive the frontend toast off it, so "the Hub copy was renamed too" is only ever claimed when it happened.
6. Invalidate the Hub-status cache on the local-move failure path too, not just on success.
7. Validate the source `repo_id`'s shape, the same way `record` and `merge` already do at creation.
8. Map a genuine Hub 409 name-collision race to 409 ("pick another name") instead of a generic 502 ("file a bug").
9. Strengthen two tests that stubbed `repo_exists` to a blanket `False`, so each can actually fail for the scenario it's named for.

## Sensitive changes
None — this touches dataset metadata and Hub sync logic only; no deletion, no data corruption/override, or hardware-control code.
