### PR TITLE
Invalidate the cached Hub-existence answer when a dataset is deleted

### DIFF
--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -1246,8 +1246,12 @@ def handle_delete_dataset(request: DatasetInfoRequest) -> dict[str, Any]:
         return {"success": False, "message": f"Failed to delete dataset: {e}"}
 
     # The listing just changed — drop the cached /datasets listing so the delete
-    # reflects immediately instead of after the TTL.
+    # reflects immediately instead of after the TTL. Also drop the cached
+    # Hub-existence answer: get_hub_status memoizes "local_only" (and "on_hub")
+    # for the process lifetime, so without this a dataset checked before the
+    # delete would keep reporting "local_only" forever instead of "absent".
     invalidate_dataset_listing_cache()
+    invalidate_hub_status(repo_id)
 
     logger.info(f"Deleted dataset directory {target}")
     return {"success": True, "message": f"Deleted {repo_id}"}

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1871,6 +1871,66 @@ def test_delete_dataset_refused_mid_upload(tmp_lerobot_home, monkeypatch: pytest
     assert (tmp_lerobot_home / repo_id).exists()
 
 
+def test_delete_dataset_invalidates_hub_status(tmp_lerobot_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful delete drops the cached Hub-existence answer too, not just
+    the listing cache — otherwise a dataset previously checked and cached as
+    "local_only" would keep reporting that forever after its local copy is
+    gone, instead of flipping to "absent"."""
+    import json
+    from unittest.mock import patch
+
+    from makermodslab.record import DatasetInfoRequest, handle_delete_dataset
+
+    # handle_delete_dataset resolves HF_LEROBOT_HOME via a lerobot constant
+    # that's frozen at first import, not re-read from the env var per call —
+    # tmp_lerobot_home's monkeypatch.setenv alone doesn't reach it, so point
+    # it at the tmp dir directly (test-only; not a production code path).
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", str(tmp_lerobot_home))
+
+    repo_id = "tester/to_delete"
+    meta = tmp_lerobot_home / repo_id / "meta"
+    meta.mkdir(parents=True)
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 1}))
+
+    with patch("makermodslab.record.invalidate_hub_status") as inval:
+        result = handle_delete_dataset(DatasetInfoRequest(dataset_repo_id=repo_id))
+
+    assert result["success"] is True
+    inval.assert_called_once_with(repo_id)
+    assert not (tmp_lerobot_home / repo_id).exists()
+
+
+def test_delete_dataset_clears_stale_local_only_hub_status(
+    tmp_lerobot_home, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end reproduction of the actual bug: a dataset checked once
+    (caching "local_only") and then deleted must report "absent" on the next
+    check — not keep serving the stale, now-wrong cached answer."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab import datasets as ds
+    from makermodslab.record import DatasetInfoRequest, handle_delete_dataset
+
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", str(tmp_lerobot_home))
+
+    repo_id = "tester/stale_check"
+    meta = tmp_lerobot_home / repo_id / "meta"
+    meta.mkdir(parents=True)
+    (meta / "info.json").write_text('{"total_episodes": 1}')
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False  # never uploaded
+    with ds._HUB_STATUS_LOCK:
+        ds._HUB_STATUS_CACHE.clear()
+    with patch("makermodslab.datasets.shared_hf_api", return_value=fake_api):
+        assert ds.get_hub_status(repo_id)["status"] == "local_only"
+
+        result = handle_delete_dataset(DatasetInfoRequest(dataset_repo_id=repo_id))
+        assert result["success"] is True
+
+        assert ds.get_hub_status(repo_id)["status"] == "absent"
+
+
 def test_delete_dataset_refused_mid_recording(tmp_lerobot_home, monkeypatch: pytest.MonkeyPatch) -> None:
     """Deleting a dataset an active recording session is writing is refused —
     the delete guard now runs the full _dataset_in_use check, not just the


### PR DESCRIPTION
## What this fixes
- After deleting a local dataset, the app could keep showing it as existing even though it's now gone
- This only shows up for a dataset that was checked (e.g. its info card was opened) before it was deleted, since that's what populates the stale **cached** answer.

## What changed
- Deleting a dataset now also clears its cached existence answer, alongside the listing-cache clear that already happened.
- Same root cause as the dataset-rename fix in #43 (a mutation not clearing a cached answer it invalidated), found while auditing for other instances of that bug after #43.
- If you try to delete a local + hub dataset, only the local copy is deleted. This is to not interact with the hub dataset after its been uploaded according to design doc

## To test
Against a local `makerlab` server, with a dataset that exists locally only (never uploaded), under `tester/pick` (swap in a real local dataset you're OK deleting):

```bash
# Check its status once — this is what populates the cache
curl -s "http://localhost:8000/datasets/hub-status?repo_id=tester/pick"
# -> {"repo_id": "tester/pick", "status": "local_only", "url": null}

# Delete it
curl -s -X POST http://localhost:8000/delete-dataset \
  -H "Content-Type: application/json" \
  -d '{"dataset_repo_id": "tester/pick"}'
# -> {"success": true, "message": "Deleted tester/pick"}

# Before this fix: still reports "local_only" for a dataset that's gone.
# After this fix: correctly reports "absent".
curl -s "http://localhost:8000/datasets/hub-status?repo_id=tester/pick"
# -> {"repo_id": "tester/pick", "status": "absent", "url": null}
```

Also covered by 2 new unit tests in `tests/test_record.py`: one asserting the cache-invalidation call directly, one reproducing the exact stale-answer bug end-to-end (cache a "local_only" answer, delete, assert the next check reports "absent" not the stale "local_only").

- [x] `pytest` (full suite, 901 passed on top of current main)
- [x] `ruff check` / `ruff format --check`
- [x] Manual curl repro above run against a real local dataset