### PR TITLE
Pause/resume during recording sessions

### DIFF
--- a/frontend/src/components/recording/RecordingSessionDialog.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.tsx
@@ -272,6 +272,16 @@ const RecordingSessionDialog: React.FC<{
         const currentOptimisticPaused = optimisticPausedRef.current;
         if (currentOptimisticPaused !== null && status.paused === currentOptimisticPaused) {
           setOptimisticPaused(null);
+        } else if (
+          currentOptimisticPaused !== null &&
+          status.current_phase !== "resetting"
+        ) {
+          // Second line of defense: pause/resume is only meaningful during
+          // the reset phase, so once the real phase has moved past it, no
+          // failure mode (refused request, missed poll, race with the phase
+          // ending) can leave optimisticPaused wedged for the rest of the
+          // session — clear it regardless of whether it was ever confirmed.
+          setOptimisticPaused(null);
         }
 
         const real = status.current_phase as Phase;
@@ -433,8 +443,13 @@ const RecordingSessionDialog: React.FC<{
         `${baseUrl}/recording-pause`,
         { method: "POST" }
       );
-      if (!response.ok) {
-        const data = await response.json();
+      const data = await response.json();
+      // The backend returns HTTP 200 with { success: false } for a
+      // legitimately refused pause (e.g. the reset phase ended just as the
+      // request landed — a real, expected race). Treat that the same as a
+      // network error: roll the optimistic state back so a refused request
+      // never wedges the button.
+      if (!response.ok || !data.success) {
         setOptimisticPaused(null);
         toast({
           title: "Error",
@@ -463,8 +478,10 @@ const RecordingSessionDialog: React.FC<{
         `${baseUrl}/recording-resume`,
         { method: "POST" }
       );
-      if (!response.ok) {
-        const data = await response.json();
+      const data = await response.json();
+      // See handlePauseRecording: a refused resume also comes back as HTTP
+      // 200 + { success: false }, not just a non-ok status.
+      if (!response.ok || !data.success) {
         setOptimisticPaused(null);
         toast({
           title: "Error",
@@ -828,14 +845,19 @@ const RecordingSessionDialog: React.FC<{
                       <Button
                         onClick={isRecordingPaused ? handleResumeRecording : handlePauseRecording}
                         disabled={
-                          isRecordingPaused
+                          (isRecordingPaused
                             ? !backendStatus.available_controls.resume_recording
-                            : !backendStatus.available_controls.pause_recording
+                            : !backendStatus.available_controls.pause_recording) ||
+                          optimisticPaused !== null
                         }
                         variant="outline"
                         className="py-6 text-lg font-semibold border-border bg-transparent text-foreground hover:bg-muted disabled:opacity-50"
                       >
-                        <Pause className="w-5 h-5 mr-2" />
+                        {isRecordingPaused ? (
+                          <Play className="w-5 h-5 mr-2" />
+                        ) : (
+                          <Pause className="w-5 h-5 mr-2" />
+                        )}
                         {isRecordingPaused ? "Resume" : "Pause"}
                       </Button>
                     )}

--- a/frontend/src/components/recording/RecordingSessionDialog.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.tsx
@@ -5,6 +5,7 @@ import {
   RotateCcw,
   SkipForward,
   Play,
+  Pause,
   Volume2,
   VolumeX,
 } from "lucide-react";
@@ -73,6 +74,10 @@ interface BackendStatus {
   session_elapsed_seconds?: number;
   session_ended?: boolean;
   dataset_repo_id?: string;
+  // True only during the reset phase, while a pause is active. Distinct from
+  // the unrelated `paused`/`streamsPaused` naming used by camera-preview
+  // components elsewhere — see CameraConfiguration.tsx.
+  paused?: boolean;
   // True when the session saved zero episodes and its dataset directory was
   // discarded (see record.py). The exit handoff shows a "nothing was saved"
   // variant when this is set.
@@ -88,6 +93,8 @@ interface BackendStatus {
     stop_recording: boolean;
     exit_early: boolean;
     rerecord_episode: boolean;
+    pause_recording: boolean;
+    resume_recording: boolean;
   };
 }
 
@@ -116,6 +123,7 @@ const RecordingSessionDialog: React.FC<{
   const [logs, setLogs] = useState("");
 
   const [optimisticPhase, setOptimisticPhase] = useState<Phase | null>(null);
+  const [optimisticPaused, setOptimisticPaused] = useState<boolean | null>(null);
   // The two explicit exits while a session is live: Done (finish + keep) and
   // Quit (end without saving / discard). Each gets its own confirm dialog.
   const [showDoneConfirm, setShowDoneConfirm] = useState(false);
@@ -214,6 +222,8 @@ const RecordingSessionDialog: React.FC<{
   // without tearing itself down on every state change.
   const optimisticPhaseRef = useRef(optimisticPhase);
   optimisticPhaseRef.current = optimisticPhase;
+  const optimisticPausedRef = useRef(optimisticPaused);
+  optimisticPausedRef.current = optimisticPaused;
   const rerecordTickRef = useRef(rerecordTick);
   rerecordTickRef.current = rerecordTick;
 
@@ -257,6 +267,11 @@ const RecordingSessionDialog: React.FC<{
         const currentOptimistic = optimisticPhaseRef.current;
         if (currentOptimistic && status.current_phase === currentOptimistic) {
           setOptimisticPhase(null);
+        }
+
+        const currentOptimisticPaused = optimisticPausedRef.current;
+        if (currentOptimisticPaused !== null && status.paused === currentOptimisticPaused) {
+          setOptimisticPaused(null);
         }
 
         const real = status.current_phase as Phase;
@@ -406,6 +421,66 @@ const RecordingSessionDialog: React.FC<{
       });
     }
   }, [backendStatus, optimisticPhase, baseUrl, fetchWithHeaders, toast]);
+
+  const handlePauseRecording = useCallback(async () => {
+    if (!backendStatus?.available_controls.pause_recording) return;
+    if (optimisticPaused !== null) return;
+
+    setOptimisticPaused(true);
+
+    try {
+      const response = await fetchWithHeaders(
+        `${baseUrl}/recording-pause`,
+        { method: "POST" }
+      );
+      if (!response.ok) {
+        const data = await response.json();
+        setOptimisticPaused(null);
+        toast({
+          title: "Error",
+          description: data.message,
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      setOptimisticPaused(null);
+      toast({
+        title: "Connection Error",
+        description: "Could not connect to the backend server.",
+        variant: "destructive",
+      });
+    }
+  }, [backendStatus, optimisticPaused, baseUrl, fetchWithHeaders, toast]);
+
+  const handleResumeRecording = useCallback(async () => {
+    if (!backendStatus?.available_controls.resume_recording) return;
+    if (optimisticPaused !== null) return;
+
+    setOptimisticPaused(false);
+
+    try {
+      const response = await fetchWithHeaders(
+        `${baseUrl}/recording-resume`,
+        { method: "POST" }
+      );
+      if (!response.ok) {
+        const data = await response.json();
+        setOptimisticPaused(null);
+        toast({
+          title: "Error",
+          description: data.message,
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      setOptimisticPaused(null);
+      toast({
+        title: "Connection Error",
+        description: "Could not connect to the backend server.",
+        variant: "destructive",
+      });
+    }
+  }, [backendStatus, optimisticPaused, baseUrl, fetchWithHeaders, toast]);
 
   const handleRerecordEpisode = useCallback(async () => {
     if (!backendStatus?.available_controls.rerecord_episode) return;
@@ -583,6 +658,9 @@ const RecordingSessionDialog: React.FC<{
 
   const realPhase = backendStatus?.current_phase as Phase;
   const currentPhase: Phase = optimisticPhase ?? realPhase;
+  const isRecordingPaused =
+    currentPhase === "resetting" &&
+    (optimisticPaused ?? backendStatus?.paused ?? false);
   const currentEpisode = backendStatus?.current_episode ?? 1;
   const totalEpisodes =
     backendStatus?.total_episodes ?? recordingConfig.num_episodes;
@@ -613,7 +691,7 @@ const RecordingSessionDialog: React.FC<{
 
   const getStatusText = () => {
     if (currentPhase === "recording") return `RECORDING EPISODE ${currentEpisode}`;
-    if (currentPhase === "resetting") return "RESET — GET READY";
+    if (currentPhase === "resetting") return isRecordingPaused ? "RESET PAUSED" : "RESET — GET READY";
     // Finer "preparing" substeps (and terminal states) the backend now reports
     // (record.py). These aren't in the Phase-narrowed set that drives the
     // recording/resetting colors, so read the raw backend string: they render
@@ -746,6 +824,21 @@ const RecordingSessionDialog: React.FC<{
                       item. Backspace mirrors the button (a deliberate delete
                       gesture — see the keydown handler note). */}
                   <div className="flex gap-3">
+                    {currentPhase === "resetting" && (
+                      <Button
+                        onClick={isRecordingPaused ? handleResumeRecording : handlePauseRecording}
+                        disabled={
+                          isRecordingPaused
+                            ? !backendStatus.available_controls.resume_recording
+                            : !backendStatus.available_controls.pause_recording
+                        }
+                        variant="outline"
+                        className="py-6 text-lg font-semibold border-border bg-transparent text-foreground hover:bg-muted disabled:opacity-50"
+                      >
+                        <Pause className="w-5 h-5 mr-2" />
+                        {isRecordingPaused ? "Resume" : "Pause"}
+                      </Button>
+                    )}
                     <Button
                       onClick={handleExitEarly}
                       disabled={

--- a/frontend/src/components/recording/RecordingSessionDialog.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.tsx
@@ -413,8 +413,11 @@ const RecordingSessionDialog: React.FC<{
         `${baseUrl}/recording-exit-early`,
         { method: "POST" }
       );
-      if (!response.ok) {
-        const data = await response.json();
+      const data = await response.json();
+      // See handlePauseRecording: a refused exit-early also comes back as
+      // HTTP 200 + { success: false } (e.g. the reset phase is currently
+      // paused), not just a non-ok status.
+      if (!response.ok || !data.success) {
         setOptimisticPhase(null);
         toast({
           title: "Error",

--- a/frontend/src/components/recording/RecordingSessionDialog.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.tsx
@@ -74,10 +74,15 @@ interface BackendStatus {
   session_elapsed_seconds?: number;
   session_ended?: boolean;
   dataset_repo_id?: string;
-  // True only during the reset phase, while a pause is active. Distinct from
-  // the unrelated `paused`/`streamsPaused` naming used by camera-preview
-  // components elsewhere — see CameraConfiguration.tsx.
+  // True only during the reset phase, while a pause is actively freezing it.
+  // Distinct from the unrelated `paused`/`streamsPaused` naming used by
+  // camera-preview components elsewhere — see CameraConfiguration.tsx.
   paused?: boolean;
+  // True whenever a pause is set at all, including one armed during the
+  // recording phase for the upcoming reset gap (not yet actually freezing
+  // anything). Drives the Pause/Resume toggle, which is available in both
+  // the recording and resetting phases.
+  pause_armed?: boolean;
   // True when the session saved zero episodes and its dataset directory was
   // discarded (see record.py). The exit handoff shows a "nothing was saved"
   // variant when this is set.
@@ -459,6 +464,16 @@ const RecordingSessionDialog: React.FC<{
           description: data.message,
           variant: "destructive",
         });
+      } else if ((optimisticPhase ?? backendStatus?.current_phase) === "recording") {
+        // Pausing mid-episode only arms the pause — it has no effect until
+        // the reset gap actually begins (see handle_pause_recording in
+        // record.py). Say so, since the button/status otherwise give no
+        // visible feedback during the recording phase.
+        toast({
+          title: "Pause armed",
+          description:
+            "The episode keeps recording. It'll pause once the reset phase starts.",
+        });
       }
     } catch (error) {
       setOptimisticPaused(null);
@@ -468,7 +483,7 @@ const RecordingSessionDialog: React.FC<{
         variant: "destructive",
       });
     }
-  }, [backendStatus, optimisticPaused, baseUrl, fetchWithHeaders, toast]);
+  }, [backendStatus, optimisticPaused, optimisticPhase, baseUrl, fetchWithHeaders, toast]);
 
   const handleResumeRecording = useCallback(async () => {
     if (!backendStatus?.available_controls.resume_recording) return;
@@ -501,6 +516,18 @@ const RecordingSessionDialog: React.FC<{
       });
     }
   }, [backendStatus, optimisticPaused, baseUrl, fetchWithHeaders, toast]);
+
+  // ENTER-key equivalent of the Pause/Resume button: toggles based on
+  // whichever of pause/resume is currently active, mirroring the button's
+  // own ternary so the keybind and click always agree.
+  const handleTogglePause = useCallback(() => {
+    const active = optimisticPaused ?? backendStatus?.pause_armed ?? false;
+    if (active) {
+      handleResumeRecording();
+    } else {
+      handlePauseRecording();
+    }
+  }, [optimisticPaused, backendStatus, handleResumeRecording, handlePauseRecording]);
 
   const handleRerecordEpisode = useCallback(async () => {
     if (!backendStatus?.available_controls.rerecord_episode) return;
@@ -621,15 +648,17 @@ const RecordingSessionDialog: React.FC<{
     onExitRef.current();
   }, [backendStatus, recordingConfig, baseUrl, fetchWithHeaders]);
 
-  // Re-record is keyboard-driven again, on BACKSPACE (explicit user request;
-  // the old ArrowLeft binding was removed because a back-gesture keystroke
-  // discarding the in-progress episode felt accidental — Backspace is a
-  // deliberate "delete" gesture, and the handler still preventDefaults so it
-  // can never double as browser back-navigation).
+  // Re-record is keyboard-driven on DELETE (and Backspace, for keyboards/
+  // muscle memory where Delete sends Backspace — explicit user request; the
+  // old ArrowLeft binding was removed because a back-gesture keystroke
+  // discarding the in-progress episode felt accidental — Delete/Backspace is
+  // a deliberate "delete" gesture, and the handler still preventDefaults so
+  // it can never double as browser back-navigation). ENTER toggles Pause/Resume.
   const anyExitDialogOpen = showDoneConfirm || showQuitConfirm;
   const handlersRef = useRef({
     handleExitEarly,
     handleRerecordEpisode,
+    handleTogglePause,
     requestDone,
     anyExitDialogOpen,
   });
@@ -637,6 +666,7 @@ const RecordingSessionDialog: React.FC<{
     handlersRef.current = {
       handleExitEarly,
       handleRerecordEpisode,
+      handleTogglePause,
       requestDone,
       anyExitDialogOpen,
     };
@@ -659,11 +689,14 @@ const RecordingSessionDialog: React.FC<{
       if (e.key === " " || e.code === "Space" || e.key === "ArrowRight") {
         e.preventDefault();
         handlersRef.current.handleExitEarly();
-      } else if (e.key === "Backspace") {
+      } else if (e.key === "Backspace" || e.key === "Delete") {
         // Deliberate delete gesture: discard and re-record the current episode.
         // preventDefault also guarantees it never acts as browser back-nav.
         e.preventDefault();
         handlersRef.current.handleRerecordEpisode();
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        handlersRef.current.handleTogglePause();
       } else if (e.key === "Escape") {
         if (handlersRef.current.anyExitDialogOpen) return;
         // Escape = finish & keep (the least destructive exit). Quit is an
@@ -678,9 +711,13 @@ const RecordingSessionDialog: React.FC<{
 
   const realPhase = backendStatus?.current_phase as Phase;
   const currentPhase: Phase = optimisticPhase ?? realPhase;
-  const isRecordingPaused =
-    currentPhase === "resetting" &&
-    (optimisticPaused ?? backendStatus?.paused ?? false);
+  // Phase-independent: true whether a pause is actively freezing the reset
+  // gap right now, or merely armed during the recording phase for the gap
+  // that follows. Drives the Pause/Resume button toggle in both phases.
+  const isPauseActive = optimisticPaused ?? backendStatus?.pause_armed ?? false;
+  // Narrower: true only while the reset gap is ACTUALLY frozen (used for
+  // the "RESET PAUSED" status text, which only makes sense during resetting).
+  const isRecordingPaused = currentPhase === "resetting" && isPauseActive;
   const currentEpisode = backendStatus?.current_episode ?? 1;
   const totalEpisodes =
     backendStatus?.total_episodes ?? recordingConfig.num_episodes;
@@ -839,31 +876,16 @@ const RecordingSessionDialog: React.FC<{
                     />
                   </div>
 
-                  {/* Primary advance + re-record side by side: retaking a bad take
-                      is a first-class action during collection, not a hidden menu
-                      item. Backspace mirrors the button (a deliberate delete
-                      gesture — see the keydown handler note). */}
-                  <div className="flex gap-3">
-                    {currentPhase === "resetting" && (
-                      <Button
-                        onClick={isRecordingPaused ? handleResumeRecording : handlePauseRecording}
-                        disabled={
-                          (isRecordingPaused
-                            ? !backendStatus.available_controls.resume_recording
-                            : !backendStatus.available_controls.pause_recording) ||
-                          optimisticPaused !== null
-                        }
-                        variant="outline"
-                        className="py-6 text-lg font-semibold border-border bg-transparent text-foreground hover:bg-muted disabled:opacity-50"
-                      >
-                        {isRecordingPaused ? (
-                          <Play className="w-5 h-5 mr-2" />
-                        ) : (
-                          <Pause className="w-5 h-5 mr-2" />
-                        )}
-                        {isRecordingPaused ? "Resume" : "Pause"}
-                      </Button>
-                    )}
+                  {/* Primary advance full-width on its own row, with Pause and
+                      Re-record sharing a secondary row below — keeps the row
+                      count fixed at two-per-line regardless of how many
+                      secondary controls are visible, so it can never overflow
+                      the dialog width the way a single three-across row did.
+                      Retaking a bad take is a first-class action during
+                      collection, not a hidden menu item; ENTER mirrors Pause,
+                      DELETE/Backspace mirrors Re-record (see the keydown
+                      handler note). */}
+                  <div className="flex flex-col gap-3">
                     <Button
                       onClick={handleExitEarly}
                       disabled={
@@ -871,7 +893,7 @@ const RecordingSessionDialog: React.FC<{
                         optimisticPhase !== null ||
                         currentPhase === "completed"
                       }
-                      className={`flex-1 text-white font-semibold py-6 text-lg disabled:opacity-50 ${phaseColor.button}`}
+                      className={`w-full text-white font-semibold py-6 text-lg disabled:opacity-50 ${phaseColor.button}`}
                     >
                       <PrimaryIcon className="w-5 h-5 mr-2" />
                       {primaryLabel}
@@ -879,16 +901,39 @@ const RecordingSessionDialog: React.FC<{
                         <span className="ml-3 px-2 py-0.5 rounded text-xs font-mono bg-white/20 text-white/90">SPACE / →</span>
                       )}
                     </Button>
-                    <Button
-                      onClick={handleRerecordEpisode}
-                      disabled={!backendStatus.available_controls.rerecord_episode}
-                      variant="outline"
-                      className="py-6 text-lg font-semibold border-border bg-transparent text-foreground hover:bg-muted disabled:opacity-50"
-                    >
-                      <RotateCcw className="w-5 h-5 mr-2" />
-                      Re-record
-                      <span className="ml-3 px-2 py-0.5 rounded text-xs font-mono bg-muted text-muted-foreground">⌫</span>
-                    </Button>
+                    <div className="flex gap-3">
+                      {(currentPhase === "recording" || currentPhase === "resetting") && (
+                        <Button
+                          onClick={isPauseActive ? handleResumeRecording : handlePauseRecording}
+                          disabled={
+                            (isPauseActive
+                              ? !backendStatus.available_controls.resume_recording
+                              : !backendStatus.available_controls.pause_recording) ||
+                            optimisticPaused !== null
+                          }
+                          variant="outline"
+                          className="flex-1 py-4 text-base font-semibold border-border bg-transparent text-foreground hover:bg-muted disabled:opacity-50"
+                        >
+                          {isPauseActive ? (
+                            <Play className="w-4 h-4 mr-2" />
+                          ) : (
+                            <Pause className="w-4 h-4 mr-2" />
+                          )}
+                          {isPauseActive ? "Resume" : "Pause"}
+                          <span className="ml-3 px-2 py-0.5 rounded text-xs font-mono bg-muted text-muted-foreground">ENTER</span>
+                        </Button>
+                      )}
+                      <Button
+                        onClick={handleRerecordEpisode}
+                        disabled={!backendStatus.available_controls.rerecord_episode}
+                        variant="outline"
+                        className="flex-1 py-4 text-base font-semibold border-border bg-transparent text-foreground hover:bg-muted disabled:opacity-50"
+                      >
+                        <RotateCcw className="w-4 h-4 mr-2" />
+                        Re-record
+                        <span className="ml-3 px-2 py-0.5 rounded text-xs font-mono bg-muted text-muted-foreground">DEL</span>
+                      </Button>
+                    </div>
                   </div>
                 </>
               )}

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -816,34 +816,45 @@ def handle_rerecord_episode() -> dict[str, Any]:
 
 
 def handle_pause_recording() -> dict[str, Any]:
-    """Pause the reset-phase gap between episodes. Freezes teleop passthrough
-    (the follower holds position and ignores the leader) and the reset
-    countdown until resumed. No-ops outside the reset phase and when already
-    paused, so a stray or duplicate request is always safe."""
+    """Pause the reset gap. Can be requested during the recording phase too —
+    that ARMS a pending pause: the current episode keeps recording
+    uninterrupted, and the reset phase that follows starts already paused
+    (teleop passthrough frozen, follower holds position, ignores the leader)
+    instead of needing a fresh click once resetting begins. Only takes
+    effect on the reset countdown once resetting actually starts (see the
+    reset-phase preamble in record_with_web_events, which seeds
+    pause_started_at at that point if arming already happened). No-ops
+    outside recording/resetting and when already paused/armed, so a stray or
+    duplicate request is always safe."""
     global pause_started_at
 
     if not recording_active or recording_events is None:
         return {"success": False, "message": "No recording session is active"}
-    if current_phase != "resetting":
-        return {"success": False, "message": "Pause is only available during the reset phase"}
+    if current_phase not in ("recording", "resetting"):
+        return {"success": False, "message": "Pause is only available while recording or during the reset gap"}
     if recording_events.get("paused", False):
         return {"success": True, "message": "Already paused", "events_state": dict(recording_events)}
 
     recording_events["paused"] = True
-    pause_started_at = time.time()
-    logger.info("Reset phase paused")
-    return {"success": True, "message": "Reset phase paused", "events_state": dict(recording_events)}
+    if current_phase == "resetting":
+        pause_started_at = time.time()
+    # else: armed during the recording phase — pause_started_at stays None
+    # until the reset phase actually begins, since the countdown that
+    # matters hasn't started yet.
+    logger.info("Pause requested (phase=%s)", current_phase)
+    return {"success": True, "message": "Pause set", "events_state": dict(recording_events)}
 
 
 def handle_resume_recording() -> dict[str, Any]:
-    """Resume a paused reset-phase gap. No-ops outside the reset phase and
-    when not currently paused."""
+    """Resume a paused reset gap, or cancel a pause armed during the
+    recording phase before the reset gap it targets even begins. No-ops
+    outside recording/resetting and when not currently paused/armed."""
     global paused_accum_seconds, pause_started_at
 
     if not recording_active or recording_events is None:
         return {"success": False, "message": "No recording session is active"}
-    if current_phase != "resetting":
-        return {"success": False, "message": "Resume is only available during the reset phase"}
+    if current_phase not in ("recording", "resetting"):
+        return {"success": False, "message": "Resume is only available while recording or during the reset gap"}
     if not recording_events.get("paused", False):
         return {"success": True, "message": "Not paused", "events_state": dict(recording_events)}
 
@@ -851,21 +862,40 @@ def handle_resume_recording() -> dict[str, Any]:
     if pause_started_at is not None:
         paused_accum_seconds += time.time() - pause_started_at
         pause_started_at = None
-    logger.info("Reset phase resumed")
-    return {"success": True, "message": "Reset phase resumed", "events_state": dict(recording_events)}
+    logger.info("Pause cleared (phase=%s)", current_phase)
+    return {"success": True, "message": "Pause cleared", "events_state": dict(recording_events)}
 
 
 def _reset_paused() -> bool:
     """True only while a live session is genuinely paused DURING THE RESET
-    PHASE. Phase-gated (not just an events-dict flag check) so a stale
-    paused=True left over from a reset loop that exited without clearing it
-    (e.g. via exit_early) can never leak into a later phase's
-    available_controls or status — see the loop-exit cleanup in
-    record_with_web_events, which is defense in depth on top of this gate,
-    not a substitute for it."""
+    PHASE — i.e. the pause is actually freezing the countdown/passthrough
+    right now, as opposed to merely being armed for an upcoming reset gap
+    while still in the recording phase. Phase-gated (not just an
+    events-dict flag check) so a stale paused=True left over from a reset
+    loop that exited without clearing it (e.g. via exit_early) can never
+    leak into a later phase's available_controls or status — see the
+    loop-exit cleanup in record_with_web_events, which is defense in depth
+    on top of this gate, not a substitute for it."""
     return bool(
         recording_events and current_phase == "resetting" and recording_events.get("paused", False)
     )
+
+
+def _pause_armed() -> bool:
+    """True whenever paused is set at all, regardless of phase — covers both
+    a live pause during the reset phase and a pause armed during the
+    recording phase for the upcoming reset gap. Used to gate
+    pause_recording/resume_recording's availability across both phases;
+    _reset_paused() remains the narrower, phase-gated predicate for anything
+    that must only react to an ACTIVE freeze (the exit_early guard, the
+    status `paused` field). Gated on recording_active, not just the
+    events-dict flag: a pause armed on an episode's recording phase can be
+    left stranded True if that episode turns out to be the session's last
+    (no reset phase follows to run the unconditional `paused = False`
+    cleanup in record_with_web_events) — without this gate, the stale flag
+    would keep reporting pause_armed=True in the completed/stopped status
+    until the next session's handle_start_recording rebuilds the dict."""
+    return bool(recording_active and recording_events and recording_events.get("paused", False))
 
 
 def handle_recording_status() -> dict[str, Any]:
@@ -892,20 +922,25 @@ def handle_recording_status() -> dict[str, Any]:
         # over but the arm is still energized and driving back to its
         # session-start pose before torque is released.
         "releasing": releasing,
-        # True only during the reset phase, and only while a pause is active —
-        # see handle_pause_recording/handle_resume_recording.
+        # True only during the reset phase, and only while a pause is
+        # actively freezing it — see handle_pause_recording/handle_resume_recording.
         "paused": _reset_paused(),
+        # True whenever paused is set at all, including a pause armed during
+        # the recording phase for the upcoming reset gap (not yet actually
+        # freezing anything). Drives the frontend's Pause/Resume toggle,
+        # which is available in both phases.
+        "pause_armed": _pause_armed(),
         "available_controls": {
             "stop_recording": recording_active,  # ESC key replacement
             "exit_early": recording_active and not _reset_paused(),  # Right arrow key replacement; disabled while paused
             "rerecord_episode": recording_active
             and current_phase == "recording",  # Only during recording phase
             "pause_recording": recording_active
-            and current_phase == "resetting"
-            and not _reset_paused(),
+            and current_phase in ("recording", "resetting")
+            and not _pause_armed(),
             "resume_recording": recording_active
-            and current_phase == "resetting"
-            and _reset_paused(),
+            and current_phase in ("recording", "resetting")
+            and _pause_armed(),
         },
         "message": "Recording session failed with error - check logs"
         if current_phase == "error"
@@ -1723,9 +1758,14 @@ def record_with_web_events(
 
                 log_say("Reset the environment", cfg.play_sounds)
 
-                # Reset exit_early/paused flags at the start of each phase
+                # Reset exit_early at the start of each phase. Don't clear
+                # `paused` unconditionally: an operator may have armed a
+                # pause during the just-finished recording phase for this
+                # exact reset gap (see handle_pause_recording) — preserve it
+                # and start its wall-clock accounting now that the countdown
+                # it affects has actually begun.
                 web_events["exit_early"] = False
-                web_events["paused"] = False
+                pause_started_at = time.time() if web_events.get("paused", False) else None
                 logger.info(f"Reset phase - calling reset loop with events: {web_events}")
 
                 _reset_loop_with_pause(
@@ -1798,9 +1838,14 @@ def record_with_web_events(
 
                 log_say("Reset the environment", cfg.play_sounds)
 
-                # Reset exit_early/paused flags at the start of each phase
+                # Reset exit_early at the start of each phase. Don't clear
+                # `paused` unconditionally: an operator may have armed a
+                # pause during the just-finished recording phase for this
+                # exact reset gap (see handle_pause_recording) — preserve it
+                # and start its wall-clock accounting now that the countdown
+                # it affects has actually begun.
                 web_events["exit_early"] = False
-                web_events["paused"] = False
+                pause_started_at = time.time() if web_events.get("paused", False) else None
                 logger.info(f"Reset phase - calling reset loop with events: {web_events}")
 
                 _reset_loop_with_pause(

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -838,6 +838,12 @@ def handle_resume_recording() -> dict[str, Any]:
     return {"success": True, "message": "Reset phase resumed", "events_state": dict(recording_events)}
 
 
+def _reset_paused() -> bool:
+    """True only while a live session is genuinely paused (defensive against
+    recording_events being None between sessions)."""
+    return bool(recording_events and recording_events.get("paused", False))
+
+
 def handle_recording_status() -> dict[str, Any]:
     """Handle recording status request"""
     # If recording is not active and phase is completed or error, indicate session has ended
@@ -862,11 +868,20 @@ def handle_recording_status() -> dict[str, Any]:
         # over but the arm is still energized and driving back to its
         # session-start pose before torque is released.
         "releasing": releasing,
+        # True only during the reset phase, and only while a pause is active —
+        # see handle_pause_recording/handle_resume_recording.
+        "paused": _reset_paused(),
         "available_controls": {
             "stop_recording": recording_active,  # ESC key replacement
-            "exit_early": recording_active,  # Right arrow key replacement
+            "exit_early": recording_active and not _reset_paused(),  # Right arrow key replacement; disabled while paused
             "rerecord_episode": recording_active
             and current_phase == "recording",  # Only during recording phase
+            "pause_recording": recording_active
+            and current_phase == "resetting"
+            and not _reset_paused(),
+            "resume_recording": recording_active
+            and current_phase == "resetting"
+            and _reset_paused(),
         },
         "message": "Recording session failed with error - check logs"
         if current_phase == "error"
@@ -922,7 +937,10 @@ def handle_recording_status() -> dict[str, Any]:
         # Add phase timing information
         if phase_start_time:
             status["phase_start_time"] = phase_start_time
-            status["phase_elapsed_seconds"] = int(time.time() - phase_start_time)
+            elapsed = time.time() - phase_start_time - paused_accum_seconds
+            if pause_started_at is not None:
+                elapsed -= time.time() - pause_started_at
+            status["phase_elapsed_seconds"] = int(elapsed)
 
             # Add phase time limits
             if current_phase == "recording":

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -193,9 +193,15 @@ saved_episodes = 0  # Track how many episodes have been saved
 current_phase = "preparing"  # Track current phase: "preparing", "recording", "resetting", "completed"
 phase_start_time = None  # Track when current phase started
 # Total time spent paused during the CURRENT reset phase, credited on resume
-# (see handle_resume_recording). Reset to 0.0 whenever a new reset phase
-# begins (both reset-phase call sites in record_with_web_events) so pause
-# time from an earlier episode's gap never leaks into a later one.
+# (see handle_resume_recording). Reset to 0.0 at the start of every new reset
+# phase (both reset-phase call sites in record_with_web_events) AND at the
+# following recording-phase entry (top of the while loop in
+# record_with_web_events), so a leftover value from a finished reset phase
+# never leaks into the next episode's phase_elapsed_seconds. Consumers
+# (handle_recording_status) must ALSO gate their use of this value on
+# current_phase == "resetting" — the two resets alone aren't sufficient,
+# since this is a stateless global any thread's status read can observe
+# between the reset-phase end and the next reset-phase start.
 paused_accum_seconds: float = 0.0
 # Wall-clock time.time() the current pause began; None while not paused. Kept
 # separate from the reset loop's own internal perf_counter()-based pacing —
@@ -770,6 +776,17 @@ def handle_exit_early() -> dict[str, Any]:
     """Handle exit early request - replaces right arrow key"""
     if not recording_active or recording_events is None:
         return {"success": False, "message": "No recording session is active"}
+    if _reset_paused():
+        # Design decision: skip-to-next-episode is disabled while paused (the
+        # operator must explicitly resume first). Enforced here, not just in
+        # the advertised available_controls.exit_early, since the frontend's
+        # gate is 1-second-stale via polling and this closes that race at
+        # its root.
+        return {
+            "success": False,
+            "message": "Cannot skip to next episode while the reset phase is paused",
+            "current_phase": current_phase,
+        }
     recording_events["exit_early"] = True
     # Tracking flag that record_loop won't reset, so the worker can tell
     # "user pressed skip" from "control_time_s elapsed naturally".
@@ -839,9 +856,16 @@ def handle_resume_recording() -> dict[str, Any]:
 
 
 def _reset_paused() -> bool:
-    """True only while a live session is genuinely paused (defensive against
-    recording_events being None between sessions)."""
-    return bool(recording_events and recording_events.get("paused", False))
+    """True only while a live session is genuinely paused DURING THE RESET
+    PHASE. Phase-gated (not just an events-dict flag check) so a stale
+    paused=True left over from a reset loop that exited without clearing it
+    (e.g. via exit_early) can never leak into a later phase's
+    available_controls or status — see the loop-exit cleanup in
+    record_with_web_events, which is defense in depth on top of this gate,
+    not a substitute for it."""
+    return bool(
+        recording_events and current_phase == "resetting" and recording_events.get("paused", False)
+    )
 
 
 def handle_recording_status() -> dict[str, Any]:
@@ -937,9 +961,16 @@ def handle_recording_status() -> dict[str, Any]:
         # Add phase timing information
         if phase_start_time:
             status["phase_start_time"] = phase_start_time
-            elapsed = time.time() - phase_start_time - paused_accum_seconds
-            if pause_started_at is not None:
-                elapsed -= time.time() - pause_started_at
+            elapsed = time.time() - phase_start_time
+            # Only the reset phase ever accumulates paused time; gate the
+            # adjustment on phase so a leftover paused_accum_seconds/
+            # pause_started_at from a finished reset phase (this is a
+            # stateless read of module globals, so it can race a phase
+            # transition) never corrupts the recording phase's countdown.
+            if current_phase == "resetting":
+                elapsed -= paused_accum_seconds
+                if pause_started_at is not None:
+                    elapsed -= time.time() - pause_started_at
             status["phase_elapsed_seconds"] = int(elapsed)
 
             # Add phase time limits
@@ -1287,10 +1318,12 @@ def _reset_loop_with_pause(
     this loop enforces no timeout of its own.
 
     Never blocks on an unbounded wait while paused: sleeps one control tick
-    at a time and rechecks events["exit_early"] every iteration BEFORE the
-    pause check (stop_recording also sets exit_early — see
-    handle_stop_recording), so Stop remains responsive within about one tick
-    even while paused.
+    at a time and rechecks events["exit_early"]/events["stop_recording"] every
+    iteration BEFORE the pause check, so Stop remains responsive within about
+    one tick even while paused. handle_stop_recording always sets both flags
+    together, so the stop_recording check is redundant in practice today —
+    it's here so this loop's own contract (matching the design spec: check
+    both every tick) doesn't depend on caller discipline.
     """
     from lerobot.utils.robot_utils import precise_sleep
 
@@ -1301,8 +1334,11 @@ def _reset_loop_with_pause(
     while timestamp < control_time_s:
         start_loop_t = time.perf_counter()
 
-        if events["exit_early"]:
+        if events.get("exit_early", False):
             events["exit_early"] = False
+            break
+
+        if events.get("stop_recording", False):
             break
 
         if events.get("paused", False):
@@ -1592,6 +1628,12 @@ def record_with_web_events(
             # RECORDING PHASE - with dataset (matches original record.py exactly)
             current_phase = "recording"
             phase_start_time = time.time()
+            # Defense in depth alongside the phase gate in handle_recording_status:
+            # a reset phase's pause bookkeeping must never survive into the
+            # recording phase that follows it, whether this is the very first
+            # recording phase of the session or the one after a reset gap.
+            paused_accum_seconds = 0.0
+            pause_started_at = None
             logger.info(f"Starting recording phase for episode {current_episode}")
             logger.info(f"Events state at start of recording phase: {web_events}")
             print(
@@ -1696,6 +1738,13 @@ def record_with_web_events(
                     control_time_s=cfg.dataset.reset_time_s,
                 )
 
+                # The loop may have exited (e.g. via exit_early/stop) while
+                # still paused. Clear the actual pause state here rather than
+                # relying solely on the phase-aware _reset_paused() gate, so a
+                # paused flag can never survive past this reset phase's end.
+                web_events["paused"] = False
+                pause_started_at = None
+
                 logger.info(f"Reset phase completed - events state: {web_events}")
 
                 # Check if reset was interrupted by exit_early
@@ -1763,6 +1812,13 @@ def record_with_web_events(
                     robot_action_processor=robot_action_processor,
                     control_time_s=cfg.dataset.reset_time_s,
                 )
+
+                # The loop may have exited (e.g. via exit_early/stop) while
+                # still paused. Clear the actual pause state here rather than
+                # relying solely on the phase-aware _reset_paused() gate, so a
+                # paused flag can never survive past this reset phase's end.
+                web_events["paused"] = False
+                pause_started_at = None
 
                 logger.info(f"Reset phase completed - events state: {web_events}")
 

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -1263,6 +1263,68 @@ def handle_upload_status() -> dict[str, Any]:
     return upload_manager.get_status()
 
 
+def _reset_loop_with_pause(
+    robot,
+    teleop,
+    events: dict,
+    fps: int,
+    teleop_action_processor,
+    robot_action_processor,
+    control_time_s: float,
+) -> None:
+    """Reset-phase tick loop: same per-tick shape as lerobot's record_loop
+    (lerobot.scripts.lerobot_record.record_loop) called with dataset=None —
+    read the leader, send it to the follower, no dataset write, no display —
+    but additionally checks events["paused"] every tick, which record_loop has
+    no primitive for and which can't be added without patching that vendored
+    dependency.
+
+    While paused: skips the leader-to-follower step entirely (the follower
+    holds its last commanded position and ignores the leader — "freeze
+    passthrough"), and holds the loop's own control_time_s budget rather than
+    spending it, so the operator gets the full reset_time_s of active gap
+    time regardless of how long they stayed paused. Pausing is indefinite —
+    this loop enforces no timeout of its own.
+
+    Never blocks on an unbounded wait while paused: sleeps one control tick
+    at a time and rechecks events["exit_early"] every iteration BEFORE the
+    pause check (stop_recording also sets exit_early — see
+    handle_stop_recording), so Stop remains responsive within about one tick
+    even while paused.
+    """
+    from lerobot.utils.robot_utils import precise_sleep
+
+    control_interval = 1 / fps
+    timestamp = 0.0
+    start_episode_t = time.perf_counter()
+
+    while timestamp < control_time_s:
+        start_loop_t = time.perf_counter()
+
+        if events["exit_early"]:
+            events["exit_early"] = False
+            break
+
+        if events.get("paused", False):
+            precise_sleep(control_interval)
+            # Paused time isn't spent from control_time_s: push the reference
+            # point forward by the tick we just spent paused.
+            start_episode_t += time.perf_counter() - start_loop_t
+            timestamp = time.perf_counter() - start_episode_t
+            continue
+
+        if teleop is not None:
+            obs = robot.get_observation()
+            act = teleop.get_action()
+            act_processed_teleop = teleop_action_processor((act, obs))
+            robot_action_to_send = robot_action_processor((act_processed_teleop, obs))
+            robot.send_action(robot_action_to_send)
+
+        dt_s = time.perf_counter() - start_loop_t
+        precise_sleep(max(control_interval - dt_s, 0.0))
+        timestamp = time.perf_counter() - start_episode_t
+
+
 def record_with_web_events(
     cfg: RecordConfig,
     web_events: dict,
@@ -1292,6 +1354,7 @@ def record_with_web_events(
 
     global current_phase, phase_start_time, current_episode, saved_episodes, releasing
     global identity_warnings
+    global paused_accum_seconds, pause_started_at
 
     robot = make_robot_from_config(cfg.robot)
     teleop = make_teleoperator_from_config(cfg.teleop) if cfg.teleop is not None else None
@@ -1610,29 +1673,27 @@ def record_with_web_events(
                 # RESET PHASE - without dataset (matches original record.py exactly)
                 current_phase = "resetting"
                 phase_start_time = time.time()
+                paused_accum_seconds = 0.0
+                pause_started_at = None
                 logger.info(f"Starting reset phase for re-record of episode {current_episode}")
                 logger.info(f"Events state at start of reset phase: {web_events}")
                 print(f"🔄 STATUS CHANGE: Starting reset phase for episode {current_episode}")
 
                 log_say("Reset the environment", cfg.play_sounds)
 
-                # Reset exit_early flag at the start of each phase
+                # Reset exit_early/paused flags at the start of each phase
                 web_events["exit_early"] = False
-                logger.info(f"Reset phase - calling record_loop with events: {web_events}")
+                web_events["paused"] = False
+                logger.info(f"Reset phase - calling reset loop with events: {web_events}")
 
-                record_loop(
+                _reset_loop_with_pause(
                     robot=robot,
+                    teleop=teleop,
                     events=web_events,
                     fps=cfg.dataset.fps,
                     teleop_action_processor=teleop_action_processor,
                     robot_action_processor=robot_action_processor,
-                    robot_observation_processor=robot_observation_processor,
-                    teleop=teleop,
-                    # NOTE: NO dataset parameter here - matches LeRobot CLI exactly
-                    # This means NO recording happens during reset phase
                     control_time_s=cfg.dataset.reset_time_s,
-                    single_task=cfg.dataset.single_task,
-                    display_data=cfg.display_data,
                 )
 
                 logger.info(f"Reset phase completed - events state: {web_events}")
@@ -1680,29 +1741,27 @@ def record_with_web_events(
                 # RESET PHASE - without dataset (matches original record.py exactly)
                 current_phase = "resetting"
                 phase_start_time = time.time()
+                paused_accum_seconds = 0.0
+                pause_started_at = None
                 logger.info(f"Starting reset phase for next episode {current_episode}")
                 logger.info(f"Events state at start of reset phase: {web_events}")
                 print(f"🔄 STATUS CHANGE: Starting reset phase for episode {current_episode}")
 
                 log_say("Reset the environment", cfg.play_sounds)
 
-                # Reset exit_early flag at the start of each phase
+                # Reset exit_early/paused flags at the start of each phase
                 web_events["exit_early"] = False
-                logger.info(f"Reset phase - calling record_loop with events: {web_events}")
+                web_events["paused"] = False
+                logger.info(f"Reset phase - calling reset loop with events: {web_events}")
 
-                record_loop(
+                _reset_loop_with_pause(
                     robot=robot,
+                    teleop=teleop,
                     events=web_events,
                     fps=cfg.dataset.fps,
                     teleop_action_processor=teleop_action_processor,
                     robot_action_processor=robot_action_processor,
-                    robot_observation_processor=robot_observation_processor,
-                    teleop=teleop,
-                    # NOTE: NO dataset parameter here - matches LeRobot CLI exactly
-                    # This means NO recording happens during reset phase
                     control_time_s=cfg.dataset.reset_time_s,
-                    single_task=cfg.dataset.single_task,
-                    display_data=cfg.display_data,
                 )
 
                 logger.info(f"Reset phase completed - events state: {web_events}")

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -192,6 +192,16 @@ current_episode = 1  # Track current episode number
 saved_episodes = 0  # Track how many episodes have been saved
 current_phase = "preparing"  # Track current phase: "preparing", "recording", "resetting", "completed"
 phase_start_time = None  # Track when current phase started
+# Total time spent paused during the CURRENT reset phase, credited on resume
+# (see handle_resume_recording). Reset to 0.0 whenever a new reset phase
+# begins (both reset-phase call sites in record_with_web_events) so pause
+# time from an earlier episode's gap never leaks into a later one.
+paused_accum_seconds: float = 0.0
+# Wall-clock time.time() the current pause began; None while not paused. Kept
+# separate from the reset loop's own internal perf_counter()-based pacing —
+# this pair exists purely so handle_recording_status can freeze the
+# frontend-facing countdown, independent of how the tick loop paces itself.
+pause_started_at: float | None = None
 # True when the most recent session saved zero episodes and its (freshly
 # created) dataset directory was discarded. Surfaced in the session-end status
 # so the frontend can tell the user nothing was kept (see Upload.tsx).
@@ -563,6 +573,7 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
             "exit_early": False,  # Right arrow key -> "Skip to next episode" button
             "stop_recording": False,  # ESC key -> "Stop recording" button
             "rerecord_episode": False,  # Left arrow key -> "Re-record episode" button
+            "paused": False,  # Reset-phase pause/resume (mouse-only, no keyboard shortcut)
         }
 
         record_config = create_record_config(request)
@@ -578,10 +589,14 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
                 saved_episodes, \
                 last_session_discarded_empty, \
                 last_session_outcome, \
-                last_session_error
+                last_session_error, \
+                paused_accum_seconds, \
+                pause_started_at
             recording_start_time = time.time()
             current_episode = 1
             saved_episodes = 0
+            paused_accum_seconds = 0.0
+            pause_started_at = None
 
             try:
                 logger.info(
@@ -781,6 +796,46 @@ def handle_rerecord_episode() -> dict[str, Any]:
         "message": "Re-record episode requested successfully",
         "events_state": dict(recording_events),
     }
+
+
+def handle_pause_recording() -> dict[str, Any]:
+    """Pause the reset-phase gap between episodes. Freezes teleop passthrough
+    (the follower holds position and ignores the leader) and the reset
+    countdown until resumed. No-ops outside the reset phase and when already
+    paused, so a stray or duplicate request is always safe."""
+    global pause_started_at
+
+    if not recording_active or recording_events is None:
+        return {"success": False, "message": "No recording session is active"}
+    if current_phase != "resetting":
+        return {"success": False, "message": "Pause is only available during the reset phase"}
+    if recording_events.get("paused", False):
+        return {"success": True, "message": "Already paused", "events_state": dict(recording_events)}
+
+    recording_events["paused"] = True
+    pause_started_at = time.time()
+    logger.info("Reset phase paused")
+    return {"success": True, "message": "Reset phase paused", "events_state": dict(recording_events)}
+
+
+def handle_resume_recording() -> dict[str, Any]:
+    """Resume a paused reset-phase gap. No-ops outside the reset phase and
+    when not currently paused."""
+    global paused_accum_seconds, pause_started_at
+
+    if not recording_active or recording_events is None:
+        return {"success": False, "message": "No recording session is active"}
+    if current_phase != "resetting":
+        return {"success": False, "message": "Resume is only available during the reset phase"}
+    if not recording_events.get("paused", False):
+        return {"success": True, "message": "Not paused", "events_state": dict(recording_events)}
+
+    recording_events["paused"] = False
+    if pause_started_at is not None:
+        paused_accum_seconds += time.time() - pause_started_at
+        pause_started_at = None
+    logger.info("Reset phase resumed")
+    return {"success": True, "message": "Reset phase resumed", "events_state": dict(recording_events)}
 
 
 def handle_recording_status() -> dict[str, Any]:

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -84,9 +84,11 @@ from .record import (
     UploadRequest,
     handle_delete_dataset,
     handle_exit_early,
+    handle_pause_recording,
     handle_recording_log,
     handle_recording_status,
     handle_rerecord_episode,
+    handle_resume_recording,
     handle_start_recording,
     handle_stop_recording,
     handle_upload_dataset,
@@ -918,6 +920,20 @@ def recording_exit_early():
 def recording_rerecord_episode():
     """Re-record current episode (replaces left arrow key)"""
     return handle_rerecord_episode()
+
+
+@app.post("/recording-pause")
+def recording_pause():
+    """Pause the reset-phase gap between episodes (mouse-only, no keyboard
+    shortcut). No-ops outside the reset phase — see handle_pause_recording."""
+    return handle_pause_recording()
+
+
+@app.post("/recording-resume")
+def recording_resume():
+    """Resume a paused reset-phase gap. No-ops if not currently paused —
+    see handle_resume_recording."""
+    return handle_resume_recording()
 
 
 @app.post("/upload-dataset")

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -921,6 +921,9 @@ def _run_record_session(
     raise_in_loop: bool = False,
     preset_release_now: bool = False,
     repo_id: str = "tester/ds",
+    num_episodes: int = 1,
+    reset_time_s: int = 10,
+    record_loop_side_effect=None,
 ):
     """Drive record_with_web_events with every lerobot dependency mocked so no
     real hardware, dataset, or record_loop runs. Returns the spy call log for
@@ -964,7 +967,11 @@ def _run_record_session(
         if raise_in_loop:
             raise RuntimeError("bus died mid-episode")
         events = kwargs.get("events")
-        if events is not None and kwargs.get("dataset") is not None:
+        if events is None or kwargs.get("dataset") is None:
+            return
+        if record_loop_side_effect is not None:
+            record_loop_side_effect(events)
+        else:
             events.update(stop_events or {"stop_recording": True, "_exit_early_triggered": True})
 
     monkeypatch.setattr("lerobot.scripts.lerobot_record.record_loop", _fake_record_loop, raising=False)
@@ -1006,7 +1013,8 @@ def _run_record_session(
             follower_config="follower",
             dataset_repo_id=repo_id,
             single_task="pick",
-            num_episodes=1,
+            num_episodes=num_episodes,
+            reset_time_s=reset_time_s,
             video=False,
         )
     )
@@ -1020,6 +1028,64 @@ def _run_record_session(
     except Exception as e:  # the error-path test expects this
         error = e
     return return_calls, robot, error, dataset_calls
+
+
+def test_reset_phase_globals_reset_on_both_call_sites(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """paused_accum_seconds/pause_started_at must be freshly reset at the
+    START of every reset phase — both the re-record call site and the normal
+    inter-episode call site — not just one of them. Verified by spying on
+    _reset_loop_with_pause: the spy snapshots the globals on each call (which
+    should always read as freshly reset, since record_with_web_events resets
+    them immediately before calling it), then pollutes them, so the SECOND
+    snapshot only reads clean if the SECOND call site independently reset
+    them rather than inheriting the first call's pollution."""
+    import makermodslab.record as record
+
+    calls: list[dict] = []
+
+    def _spy_reset_loop(**kwargs):
+        calls.append(
+            {
+                "paused_accum_seconds": record.paused_accum_seconds,
+                "pause_started_at": record.pause_started_at,
+            }
+        )
+        if len(calls) == 1:
+            record.paused_accum_seconds = 7.5
+            record.pause_started_at = 555.0
+
+    monkeypatch.setattr(record, "_reset_loop_with_pause", _spy_reset_loop)
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+
+    call_count = [0]
+
+    def _record_loop_side_effect(events: dict) -> None:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # Episode 1, first take: trigger a re-record (RE-RECORD call site).
+            events.update({"rerecord_episode": True, "_exit_early_triggered": True})
+        else:
+            # Episode 1's re-take, then episode 2: normal skip-to-next
+            # (NORMAL call site after episode 1; session completes after 2).
+            events.update({"rerecord_episode": False, "_exit_early_triggered": True})
+
+    robot = _RecRobot(_RecReturnBus())
+    _run_record_session(
+        monkeypatch,
+        robot,
+        num_episodes=2,
+        record_loop_side_effect=_record_loop_side_effect,
+    )
+
+    assert len(calls) == 2
+    assert calls[0] == {"paused_accum_seconds": 0.0, "pause_started_at": None}
+    # The second call site must have reset the polluted values, not inherited them.
+    assert calls[1] == {"paused_accum_seconds": 0.0, "pause_started_at": None}
 
 
 def test_record_accepts_bare_repo_id(monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -671,6 +671,119 @@ def test_recording_status_never_exposes_pause_during_recording_phase(
     assert status["available_controls"]["resume_recording"] is False
 
 
+class _FakePauseTeleop:
+    def __init__(self) -> None:
+        self.get_action_calls = 0
+
+    def get_action(self) -> dict:
+        self.get_action_calls += 1
+        return {"shoulder_pan.pos": 1.0}
+
+
+class _FakePauseRobot:
+    def __init__(self) -> None:
+        self.send_action_calls = 0
+
+    def get_observation(self) -> dict:
+        return {"shoulder_pan.pos": 0.5}
+
+    def send_action(self, action: dict) -> dict:
+        self.send_action_calls += 1
+        return action
+
+
+def _identity(pair):
+    return pair[0]
+
+
+def test_reset_loop_freezes_passthrough_while_paused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """While paused, the loop must never read the leader or send to the
+    follower, and must not exit on its own (freeze = indefinite, no
+    auto-timeout) — it only exits here because the fake sleep flips
+    exit_early after a few ticks, standing in for a real Stop request."""
+    from makermodslab import record
+
+    robot = _FakePauseRobot()
+    teleop = _FakePauseTeleop()
+    events = {"exit_early": False, "paused": True}
+    sleep_calls: list[float] = []
+
+    def _fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 3:
+            events["exit_early"] = True
+
+    monkeypatch.setattr("lerobot.utils.robot_utils.precise_sleep", _fake_sleep, raising=False)
+
+    record._reset_loop_with_pause(
+        robot=robot,
+        teleop=teleop,
+        events=events,
+        fps=30,
+        teleop_action_processor=_identity,
+        robot_action_processor=_identity,
+        control_time_s=10.0,
+    )
+
+    assert teleop.get_action_calls == 0
+    assert robot.send_action_calls == 0
+    assert len(sleep_calls) == 3
+
+
+def test_reset_loop_drives_passthrough_when_not_paused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unpaused, the loop behaves like the original record_loop: reads the
+    leader and sends to the follower every tick until control_time_s elapses."""
+    from makermodslab import record
+
+    robot = _FakePauseRobot()
+    teleop = _FakePauseTeleop()
+    events = {"exit_early": False, "paused": False}
+
+    monkeypatch.setattr("lerobot.utils.robot_utils.precise_sleep", lambda seconds: None, raising=False)
+
+    record._reset_loop_with_pause(
+        robot=robot,
+        teleop=teleop,
+        events=events,
+        fps=30,
+        teleop_action_processor=_identity,
+        robot_action_processor=_identity,
+        control_time_s=0.02,
+    )
+
+    assert teleop.get_action_calls > 0
+    assert robot.send_action_calls == teleop.get_action_calls
+
+
+def test_reset_loop_exit_early_stops_promptly_even_while_paused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop (which sets exit_early — see handle_stop_recording) must win
+    immediately even if the loop is paused when it's requested; it must not
+    be deferred until a resume."""
+    from makermodslab import record
+
+    robot = _FakePauseRobot()
+    teleop = _FakePauseTeleop()
+    events = {"exit_early": True, "paused": True}
+
+    def _fail_sleep(seconds: float) -> None:
+        raise AssertionError("must not sleep at all — exit_early is already set")
+
+    monkeypatch.setattr("lerobot.utils.robot_utils.precise_sleep", _fail_sleep, raising=False)
+
+    record._reset_loop_with_pause(
+        robot=robot,
+        teleop=teleop,
+        events=events,
+        fps=30,
+        teleop_action_processor=_identity,
+        robot_action_processor=_identity,
+        control_time_s=10.0,
+    )
+
+    assert events["exit_early"] is False  # consumed, matching record_loop's own convention
+    assert teleop.get_action_calls == 0
+
+
 def test_worker_quit_discards_fresh_dataset_with_saved_episodes(
     monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
 ) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -508,20 +508,66 @@ def test_handle_pause_recording_sets_flag_during_reset_phase(monkeypatch: pytest
     assert record.pause_started_at == 12345.0
 
 
-def test_handle_pause_recording_ignored_outside_reset_phase(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Pausing mid-episode (or any phase other than resetting) is refused and
-    never arms the paused flag."""
+def test_handle_pause_recording_ignored_outside_recording_or_resetting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pausing is only meaningful while recording (arms it for the next reset
+    gap) or resetting (freezes it live) — any other phase (preparing,
+    connecting_*, stopping, completed, error) is refused and never arms the
+    paused flag."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "preparing")
+
+    result = record.handle_pause_recording()
+
+    assert result["success"] is False
+    assert events["paused"] is False
+
+
+def test_handle_pause_recording_arms_during_recording_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pausing during the recording phase arms a pending pause for the
+    upcoming reset gap: the flag is set, but pause_started_at stays None
+    since the countdown it will freeze hasn't started yet — the reset-phase
+    preamble seeds it once resetting actually begins."""
     import makermodslab.record as record
 
     events = {"stop_recording": False, "exit_early": False, "paused": False}
     monkeypatch.setattr(record, "recording_active", True)
     monkeypatch.setattr(record, "recording_events", events)
     monkeypatch.setattr(record, "current_phase", "recording")
+    monkeypatch.setattr(record, "pause_started_at", None)
 
     result = record.handle_pause_recording()
 
-    assert result["success"] is False
+    assert result["success"] is True
+    assert events["paused"] is True
+    assert record.pause_started_at is None
+
+
+def test_handle_resume_recording_cancels_pause_armed_during_recording(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resuming during the recording phase cancels a pending arm before the
+    reset gap it targets ever begins. No elapsed time is credited since
+    pause_started_at was never set for an armed-but-not-yet-active pause."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": True}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "recording")
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+
+    result = record.handle_resume_recording()
+
+    assert result["success"] is True
     assert events["paused"] is False
+    assert record.paused_accum_seconds == 0.0
 
 
 def test_handle_pause_recording_idempotent_when_already_paused(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -648,15 +694,42 @@ def test_recording_status_exposes_pause_recording_when_resetting_and_unpaused(
     assert status["available_controls"]["exit_early"] is True
 
 
-def test_recording_status_never_exposes_pause_during_recording_phase(
+def test_recording_status_exposes_pause_recording_during_recording_phase(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pause controls must be structurally impossible outside the reset
-    phase — this is the gate that keeps pause off mid-episode."""
+    """Pause is available during the recording phase too (arms it for the
+    upcoming reset gap — the episode itself keeps recording uninterrupted),
+    not just during resetting. `paused` itself stays False since nothing is
+    actively frozen yet."""
     import makermodslab.record as record
 
     monkeypatch.setattr(record, "recording_active", True)
     monkeypatch.setattr(record, "current_phase", "recording")
+    monkeypatch.setattr(record, "phase_start_time", None)
+    monkeypatch.setattr(record, "recording_config", None)
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(
+        record, "recording_events", {"paused": False, "exit_early": False, "stop_recording": False}
+    )
+
+    status = record.handle_recording_status()
+
+    assert status["paused"] is False
+    assert status["pause_armed"] is False
+    assert status["available_controls"]["pause_recording"] is True
+    assert status["available_controls"]["resume_recording"] is False
+
+
+def test_recording_status_never_exposes_pause_outside_recording_or_resetting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pause controls must be structurally impossible outside the recording
+    and resetting phases (e.g. while preparing/connecting/stopping)."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "current_phase", "preparing")
     monkeypatch.setattr(record, "phase_start_time", None)
     monkeypatch.setattr(record, "recording_config", None)
     monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
@@ -708,12 +781,14 @@ def test_recording_status_does_not_leak_paused_time_into_recording_phase(
     assert status["phase_elapsed_seconds"] == 10
 
 
-def test_recording_status_paused_predicate_is_phase_gated(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A stale paused=True left in recording_events (e.g. a reset loop that
-    exited via exit_early without clearing it) must not leak past the reset
-    phase: both `paused` and the pause-related available_controls must read
-    as unpaused once current_phase has moved on, even with the dict flag
-    still stale-True."""
+def test_recording_status_armed_pause_during_recording_does_not_block_exit_early(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """paused=True during the recording phase (armed for the next reset gap,
+    or a stale flag a reset loop failed to clear) must read as `paused: False`
+    — nothing is actively frozen yet/anymore — and must NOT block ending the
+    current episode: only an ACTIVELY frozen reset phase disables exit_early.
+    resume_recording IS available, though, so the operator can cancel the arm."""
     import makermodslab.record as record
 
     monkeypatch.setattr(record, "recording_active", True)
@@ -729,9 +804,38 @@ def test_recording_status_paused_predicate_is_phase_gated(monkeypatch: pytest.Mo
     status = record.handle_recording_status()
 
     assert status["paused"] is False
+    assert status["pause_armed"] is True
     assert status["available_controls"]["exit_early"] is True
     assert status["available_controls"]["pause_recording"] is False
-    assert status["available_controls"]["resume_recording"] is False
+    assert status["available_controls"]["resume_recording"] is True
+
+
+def test_recording_status_pause_armed_false_after_session_ends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pause armed on an episode's recording phase is only cleared by the
+    reset-phase cleanup in record_with_web_events — which never runs if that
+    episode turns out to be the session's last (no reset gap follows) or the
+    session is stopped before reaching one. Once the session has actually
+    ended (recording_active False), the stale `paused=True` left in the dead
+    events dict must not resurface as pause_armed=True in the completed/
+    stopped status — the frontend has nothing to resume and no reset gap is
+    coming."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr(record, "current_phase", "completed")
+    monkeypatch.setattr(record, "phase_start_time", None)
+    monkeypatch.setattr(record, "recording_config", None)
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(
+        record, "recording_events", {"paused": True, "exit_early": False, "stop_recording": False}
+    )
+
+    status = record.handle_recording_status()
+
+    assert status["pause_armed"] is False
 
 
 def test_handle_exit_early_refused_while_paused_in_reset_phase(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1190,6 +1294,55 @@ def test_reset_phase_globals_reset_on_both_call_sites(
     assert calls[0] == {"paused_accum_seconds": 0.0, "pause_started_at": None}
     # The second call site must have reset the polluted values, not inherited them.
     assert calls[1] == {"paused_accum_seconds": 0.0, "pause_started_at": None}
+
+
+def test_reset_phase_preamble_preserves_pause_armed_during_recording(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """A pause armed during the recording phase (operator clicks Pause
+    mid-episode) must survive into the reset phase that follows: `paused`
+    stays True and pause_started_at gets seeded the moment resetting
+    actually begins, rather than being unconditionally wiped. Verified by
+    spying on _reset_loop_with_pause and arming the pause from within the
+    fake recording-phase call, mirroring how handle_pause_recording flips
+    the flag mid-episode in production."""
+    import makermodslab.record as record
+
+    calls: list[dict] = []
+
+    def _spy_reset_loop(**kwargs):
+        calls.append(
+            {
+                "paused": kwargs["events"].get("paused"),
+                "pause_started_at": record.pause_started_at,
+            }
+        )
+        kwargs["events"]["exit_early"] = True
+
+    monkeypatch.setattr(record, "_reset_loop_with_pause", _spy_reset_loop)
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+    monkeypatch.setattr(record.time, "time", lambda: 42.0)
+
+    def _record_loop_side_effect(events: dict) -> None:
+        # Simulate the operator clicking Pause mid-episode — arms it exactly
+        # like handle_pause_recording does when current_phase == "recording".
+        events["paused"] = True
+        events.update({"rerecord_episode": False, "_exit_early_triggered": True})
+
+    robot = _RecRobot(_RecReturnBus())
+    _run_record_session(
+        monkeypatch,
+        robot,
+        num_episodes=2,
+        record_loop_side_effect=_record_loop_side_effect,
+    )
+
+    assert len(calls) == 1  # the spy ends the session after the one reset phase it reaches
+    assert calls[0]["paused"] is True
+    assert calls[0]["pause_started_at"] == 42.0
 
 
 def test_record_accepts_bare_repo_id(monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -592,6 +592,85 @@ def test_handle_pause_recording_refused_when_idle(monkeypatch: pytest.MonkeyPatc
     assert result["success"] is False
 
 
+def test_recording_status_freezes_elapsed_time_while_paused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """phase_elapsed_seconds must stop advancing while paused, accounting for
+    the in-progress pause (not just previously-completed ones)."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record.time, "time", lambda: 1000.0)
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+    monkeypatch.setattr(record, "phase_start_time", 990.0)  # phase began 10s ago
+    monkeypatch.setattr(record, "recording_start_time", 900.0)
+    monkeypatch.setattr(record, "current_episode", 2)
+    monkeypatch.setattr(record, "saved_episodes", 1)
+    monkeypatch.setattr(
+        record,
+        "recording_config",
+        type("Cfg", (), {"dataset_repo_id": "tester/ds", "num_episodes": 2, "reset_time_s": 20})(),
+    )
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+    monkeypatch.setattr(record, "pause_started_at", 995.0)  # paused for the last 5s
+    monkeypatch.setattr(
+        record, "recording_events", {"paused": True, "exit_early": False, "stop_recording": False}
+    )
+
+    status = record.handle_recording_status()
+
+    assert status["paused"] is True
+    # 10s since phase start, minus the 5s currently paused = 5s.
+    assert status["phase_elapsed_seconds"] == 5
+    assert status["available_controls"]["pause_recording"] is False
+    assert status["available_controls"]["resume_recording"] is True
+    assert status["available_controls"]["exit_early"] is False
+
+
+def test_recording_status_exposes_pause_recording_when_resetting_and_unpaused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+    monkeypatch.setattr(record, "phase_start_time", None)
+    monkeypatch.setattr(record, "recording_config", None)
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(
+        record, "recording_events", {"paused": False, "exit_early": False, "stop_recording": False}
+    )
+
+    status = record.handle_recording_status()
+
+    assert status["paused"] is False
+    assert status["available_controls"]["pause_recording"] is True
+    assert status["available_controls"]["resume_recording"] is False
+    assert status["available_controls"]["exit_early"] is True
+
+
+def test_recording_status_never_exposes_pause_during_recording_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pause controls must be structurally impossible outside the reset
+    phase — this is the gate that keeps pause off mid-episode."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "current_phase", "recording")
+    monkeypatch.setattr(record, "phase_start_time", None)
+    monkeypatch.setattr(record, "recording_config", None)
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(
+        record, "recording_events", {"paused": False, "exit_early": False, "stop_recording": False}
+    )
+
+    status = record.handle_recording_status()
+
+    assert status["available_controls"]["pause_recording"] is False
+    assert status["available_controls"]["resume_recording"] is False
+
+
 def test_worker_quit_discards_fresh_dataset_with_saved_episodes(
     monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
 ) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -489,6 +489,109 @@ def test_handle_stop_recording_discard_ignored_when_idle(monkeypatch: pytest.Mon
     assert record.discard_requested is False
 
 
+def test_handle_pause_recording_sets_flag_during_reset_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pause only takes effect during the reset phase, and records a wall-clock
+    pause-start timestamp for the status handler to use."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(record.time, "time", lambda: 12345.0)
+
+    result = record.handle_pause_recording()
+
+    assert result["success"] is True
+    assert events["paused"] is True
+    assert record.pause_started_at == 12345.0
+
+
+def test_handle_pause_recording_ignored_outside_reset_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pausing mid-episode (or any phase other than resetting) is refused and
+    never arms the paused flag."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "recording")
+
+    result = record.handle_pause_recording()
+
+    assert result["success"] is False
+    assert events["paused"] is False
+
+
+def test_handle_pause_recording_idempotent_when_already_paused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A duplicate pause request (e.g. a double-click) is a safe no-op, not a
+    second timestamp overwrite that would lose accounted pause time."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": True}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+    monkeypatch.setattr(record, "pause_started_at", 999.0)
+
+    result = record.handle_pause_recording()
+
+    assert result["success"] is True
+    assert record.pause_started_at == 999.0  # unchanged
+
+
+def test_handle_resume_recording_credits_paused_duration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resuming clears the paused flag and folds the just-finished pause
+    interval into the running total, so status can freeze-then-continue the
+    countdown correctly."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": True}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+    monkeypatch.setattr(record, "pause_started_at", 100.0)
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+    monkeypatch.setattr(record.time, "time", lambda: 106.0)
+
+    result = record.handle_resume_recording()
+
+    assert result["success"] is True
+    assert events["paused"] is False
+    assert record.pause_started_at is None
+    assert record.paused_accum_seconds == 6.0
+
+
+def test_handle_resume_recording_ignored_when_not_paused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resuming when nothing is paused is a safe no-op — it must not credit
+    bogus paused time."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(record, "paused_accum_seconds", 3.0)
+
+    result = record.handle_resume_recording()
+
+    assert result["success"] is True
+    assert record.paused_accum_seconds == 3.0  # unchanged
+
+
+def test_handle_pause_recording_refused_when_idle(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr(record, "recording_events", None)
+
+    result = record.handle_pause_recording()
+
+    assert result["success"] is False
+
+
 def test_worker_quit_discards_fresh_dataset_with_saved_episodes(
     monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
 ) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -671,6 +671,105 @@ def test_recording_status_never_exposes_pause_during_recording_phase(
     assert status["available_controls"]["resume_recording"] is False
 
 
+def test_recording_status_does_not_leak_paused_time_into_recording_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for the Critical leak: a leftover paused_accum_seconds
+    from a finished reset phase must NOT reduce phase_elapsed_seconds once
+    current_phase has moved on to "recording" — this is the test that would
+    have caught the bug where the subtraction applied unconditionally to
+    every phase instead of being gated on current_phase == "resetting"."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record.time, "time", lambda: 1000.0)
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "current_phase", "recording")
+    monkeypatch.setattr(record, "phase_start_time", 990.0)  # phase began 10s ago
+    monkeypatch.setattr(record, "recording_start_time", 900.0)
+    monkeypatch.setattr(record, "current_episode", 2)
+    monkeypatch.setattr(record, "saved_episodes", 1)
+    monkeypatch.setattr(
+        record,
+        "recording_config",
+        type("Cfg", (), {"dataset_repo_id": "tester/ds", "num_episodes": 2, "episode_time_s": 60})(),
+    )
+    # Leftover from the reset phase that just ended, not yet cleared —
+    # exactly the pre-fix world this test guards against.
+    monkeypatch.setattr(record, "paused_accum_seconds", 4.0)
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(
+        record, "recording_events", {"paused": False, "exit_early": False, "stop_recording": False}
+    )
+
+    status = record.handle_recording_status()
+
+    # 10s since phase start; the leftover 4s must NOT be subtracted now that
+    # current_phase is "recording" (pre-fix this would have read 6).
+    assert status["phase_elapsed_seconds"] == 10
+
+
+def test_recording_status_paused_predicate_is_phase_gated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale paused=True left in recording_events (e.g. a reset loop that
+    exited via exit_early without clearing it) must not leak past the reset
+    phase: both `paused` and the pause-related available_controls must read
+    as unpaused once current_phase has moved on, even with the dict flag
+    still stale-True."""
+    import makermodslab.record as record
+
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "current_phase", "recording")
+    monkeypatch.setattr(record, "phase_start_time", None)
+    monkeypatch.setattr(record, "recording_config", None)
+    monkeypatch.setattr(record, "paused_accum_seconds", 0.0)
+    monkeypatch.setattr(record, "pause_started_at", None)
+    monkeypatch.setattr(
+        record, "recording_events", {"paused": True, "exit_early": False, "stop_recording": False}
+    )
+
+    status = record.handle_recording_status()
+
+    assert status["paused"] is False
+    assert status["available_controls"]["exit_early"] is True
+    assert status["available_controls"]["pause_recording"] is False
+    assert status["available_controls"]["resume_recording"] is False
+
+
+def test_handle_exit_early_refused_while_paused_in_reset_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip-to-next-episode must be refused server-side while the reset phase
+    is paused (design decision: skip is disabled while paused) — this closes
+    the race at its root rather than relying only on the advisory frontend
+    available_controls gate, which is up to 1s stale via polling."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": True}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+
+    result = record.handle_exit_early()
+
+    assert result["success"] is False
+    assert events["exit_early"] is False
+
+
+def test_handle_exit_early_allowed_when_resetting_and_not_paused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity check: the new pause guard on handle_exit_early must not block
+    the ordinary skip-to-next-episode path when nothing is paused."""
+    import makermodslab.record as record
+
+    events = {"stop_recording": False, "exit_early": False, "paused": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "current_phase", "resetting")
+
+    result = record.handle_exit_early()
+
+    assert result["success"] is True
+    assert events["exit_early"] is True
+
+
 class _FakePauseTeleop:
     def __init__(self) -> None:
         self.get_action_calls = 0
@@ -1021,7 +1120,12 @@ def _run_record_session(
     # No teleop device: keep the return path follower-only and simple.
     cfg.teleop = None
 
-    web_events = {"exit_early": False, "stop_recording": False, "rerecord_episode": False}
+    web_events = {
+        "exit_early": False,
+        "stop_recording": False,
+        "rerecord_episode": False,
+        "paused": False,
+    }
     error: Exception | None = None
     try:
         record.record_with_web_events(cfg, web_events)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1062,3 +1062,39 @@ def test_delete_local_job_records_no_dismissal(
     resp = client.delete("/jobs/some-local-run")
     assert resp.status_code == 204
     assert cfg.get_dismissed_hub_jobs() == set()
+
+
+def test_recording_pause_route_calls_handler(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    import makermodslab.server as server_mod
+
+    called = {}
+
+    def _fake_handle_pause_recording():
+        called["hit"] = True
+        return {"success": True, "message": "Reset phase paused"}
+
+    monkeypatch.setattr(server_mod, "handle_pause_recording", _fake_handle_pause_recording)
+
+    response = client.post("/recording-pause")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert called.get("hit") is True
+
+
+def test_recording_resume_route_calls_handler(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    import makermodslab.server as server_mod
+
+    called = {}
+
+    def _fake_handle_resume_recording():
+        called["hit"] = True
+        return {"success": True, "message": "Reset phase resumed"}
+
+    monkeypatch.setattr(server_mod, "handle_resume_recording", _fake_handle_resume_recording)
+
+    response = client.post("/recording-resume")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert called.get("hit") is True


### PR DESCRIPTION
## Summary

- Adds Pause/Resume to the recording flow: available during the reset gap between episodes (freezes the countdown and teleop passthrough) and, as of the latest commits, during the recording phase itself — pressing Pause mid-episode arms a pending pause that takes effect once the reset gap starts, without interrupting the episode currently being recorded.
- The dataset-writing recording loop never inspects the pause flag, so no frame is ever skipped or duplicated by pausing, whether armed mid-episode or actively frozen during the reset gap — recording continuity matches the existing reset-phase behavior exactly.
- Fixes a status-leak bug: `pause_armed` is now gated on `recording_active`, so a pause armed on a session's last episode (or one ended by Stop before reaching a reset gap) no longer keeps reporting `pause_armed: true` after the session has already ended.
- Frontend: Pause/Resume renders in both phases, toggled by the same button and an ENTER shortcut; pressing Pause during the recording phase now shows a toast confirming it's armed for the upcoming reset gap.

## Screenshot(s)

Pause button available during an active episode:

![Pause button during recording](https://raw.githubusercontent.com/makermods-robotics/makermodslab/assets/pr-45-screenshots/pr-45-pause-button.png)

Toast shown when pause is armed mid-episode:

![Pause armed toast](https://raw.githubusercontent.com/makermods-robotics/makermodslab/assets/pr-45-screenshots/pr-45-pause-toast.png)

## Test plan

- [x] `pytest tests/test_record.py tests/test_server.py` — 155 passed
- [x] `ruff check` — clean
- [x] `npx tsc --noEmit` / `npx eslint` on the changed frontend file — clean
- [x] Manual hardware verification (pause during an active episode and during the reset gap, on real SO-101 arms)
