### PR TITLE
ci: gate the frontend build on every PR, add upstream tracking

### DIFF
--- a/.claude/commands/review-upstream.md
+++ b/.claude/commands/review-upstream.md
@@ -85,6 +85,7 @@ Give every subagent this instruction verbatim, with its own batch substituted in
 > you took in your report.
 >
 > For each commit in your batch:
+>
 > 1. Read the full upstream diff: `git show <sha>`.
 > 2. Find our corresponding code. Upstream `lelab/<x>.py` maps to `makermodslab/<x>.py`,
 >    but the contents frequently differ — read our file, do not assume.

--- a/.claude/commands/review-upstream.md
+++ b/.claude/commands/review-upstream.md
@@ -1,0 +1,126 @@
+---
+description: Review new upstream (huggingface/leLab) commits for knowledge, bugs, and features worth bringing into MakerMods Lab
+argument-hint: "[optional: an upstream commit range to review instead of the ledger cursor]"
+---
+
+# Review upstream (leLab)
+
+MakerMods Lab began as a fork of [huggingface/leLab](https://github.com/huggingface/leLab)
+and has diverged substantially — different package name (`lelab/` → `makermodslab/`),
+different feature set, far higher change velocity. Git-level integration with upstream
+is no longer possible, so we track them deliberately instead: once a week, someone runs
+this command, reads what upstream has learned, and decides what is worth having here.
+
+The most valuable thing upstream produces for us is usually **not their code** — it is
+knowledge about the shared substrate we both sit on: lerobot's APIs, SO-101 hardware
+behaviour, the Hugging Face Hub. A twelve-line fix can encode a fact that cost them a
+debugging session with real arms. Capture the fact even when we decline the patch.
+
+Both repositories are Apache-2.0. Record the upstream SHA for anything we port, and when
+we fix something that also affects their code, consider sending it back.
+
+## Ground rules
+
+- **Never `git merge`, `git rebase`, or `git cherry-pick` from `upstream`.** The rename
+  means upstream commits touch paths that do not exist here; every backend file would
+  conflict. Ports are deliberate re-implementations against our code, done separately
+  from this review.
+- **This command changes no application code.** It reads, classifies, and writes a report
+  plus proposed ledger rows. Nothing under `makermodslab/`, `frontend/src/`, or `tests/`
+  may be edited by this command or its subagents.
+- **Do not commit, push, or open a PR.** Leave the report and ledger edits as local
+  changes for the person who ran the command to review.
+- **Path mapping:** upstream `lelab/<x>.py` corresponds to our `makermodslab/<x>.py`,
+  but the contents often differ heavily. Always read our actual file before judging
+  whether an upstream change applies — never assume the mapping implies similarity.
+- **"We already solved this, differently" is a real verdict, and often the correct one.**
+  Some of our code is ahead of upstream's. Recommending a downgrade is worse than
+  recommending nothing.
+
+## Steps
+
+### 1. Set up and fetch
+
+Teammates cloning fresh will not have the remote. Ensure it, then fetch:
+
+```bash
+git remote get-url upstream >/dev/null 2>&1 || \
+  git remote add upstream https://github.com/huggingface/leLab.git
+git fetch upstream
+```
+
+### 2. Determine the review range
+
+Read `docs/upstream/ledger.md` and take the SHA from its `cursor:` line. That is the
+last upstream commit already reviewed.
+
+```bash
+git log --oneline --no-merges <cursor>..upstream/main
+```
+
+If the user passed an explicit range as an argument, use that instead of the cursor.
+
+Skip any SHA that already appears in the ledger — it has a recorded verdict and must not
+be re-litigated. If the range is empty, say so and stop; there is nothing to review.
+
+### 3. Fan out subagents
+
+Group the commits into batches of at most 6, keeping related commits together (same
+subsystem, or an original plus its follow-up review fixes — upstream often ships
+"Address review feedback" commits separately). Run at most 6 subagents concurrently,
+launched in a single message.
+
+Give every subagent this instruction verbatim, with its own batch substituted in:
+
+> You are reviewing commits from `huggingface/leLab`, the upstream project that
+> MakerMods Lab forked from and has since diverged from substantially. Your job is to
+> decide what, if anything, we should learn or take from each commit. You are read-only:
+> do not edit any file.
+>
+> Prefer running the analysis through codex if it is available on this machine
+> (`command -v codex`), since a second model reads our code without the biases of the
+> one that wrote it:
+> `codex exec -s read-only --skip-git-repo-check "<self-contained prompt>"`.
+> If codex is not installed, or it errors, do the analysis yourself and say which path
+> you took in your report.
+>
+> For each commit in your batch:
+> 1. Read the full upstream diff: `git show <sha>`.
+> 2. Find our corresponding code. Upstream `lelab/<x>.py` maps to `makermodslab/<x>.py`,
+>    but the contents frequently differ — read our file, do not assume.
+> 3. Classify it into exactly one bucket:
+>    - **knowledge** — teaches a fact about lerobot, SO-101 hardware, or the HF Hub that
+>      is worth knowing even if we never take a line of their code
+>    - **bug** — a defect that plausibly also exists in our diverged copy
+>    - **feature** — functionality worth having in MakerMods Lab
+>    - **already-have** — we solved this; note whether our approach differs and why
+>    - **n/a** — leLab-specific, or against code we have deleted or rewritten past
+>      applicability
+> 4. For `bug` and `feature`, estimate porting effort as **small** (isolated, new files,
+>    little conflict surface), **medium**, or **large** (touches files we have
+>    substantially rewritten), and name the files a port would touch.
+>
+> Ground every claim in evidence: cite our `file.py:line` for anything you assert about
+> our code. If you could not verify a claim, mark it explicitly as unverified rather than
+> stating it. Never recommend replacing our implementation with upstream's unless you
+> have read both and can say concretely why theirs is better.
+>
+> Return, for each commit: SHA, subject, bucket, effort (if applicable), affected files,
+> the knowledge or defect in one or two sentences, and your recommendation.
+
+### 4. Write the report
+
+Write the findings to `docs/upstream/reviews/<YYYY-MM-DD>.md` (use `date +%F`), ordered
+by bucket: `bug`, then `knowledge`, then `feature`, then `already-have`, then `n/a`.
+Include the range reviewed and the commit count.
+
+Then summarize in chat: the counts per bucket, and the two or three items that actually
+deserve someone's attention this week. Do not restate the whole report.
+
+### 5. Propose the ledger update
+
+Append one row per reviewed commit to the table in `docs/upstream/ledger.md`, and move
+the `cursor:` line to the newest reviewed upstream SHA.
+
+Leave every edit uncommitted. Tell the user which files changed and that the port work
+itself is a separate task.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,77 @@
+# Builds the frontend on every pull request, so a lockfile or source change that
+# breaks the build is caught *before* it reaches main.
+#
+# Why this exists: build_frontend.yml only runs on push to main, so until this
+# workflow the first thing to run `npm ci` on Linux was the job that fires after
+# a merge. Its failure is silent — frontend/dist just never gets rebuilt and prod
+# keeps serving the previous bundle. That has bitten us three times (e345e61,
+# 944cb05, c18d42c), each a different flavour of the same root cause: a lockfile
+# generated on a developer's machine that ubuntu-latest cannot install.
+#
+# `npm ci` is the real check here. It is the identical command build_frontend.yml
+# runs, on the identical runner, so green here means green there. It fails when
+# the lockfile is out of sync with package.json, when platform-specific optional
+# deps (esbuild, rollup, @emnapi/*) were pruned by an `npm install` on macOS, and
+# when a dependency simply cannot be fetched.
+#
+# Deliberately NOT path-filtered. Two reasons:
+#   1. A required status check that is path-filtered never reports on PRs that
+#      skip it, and GitHub blocks the merge waiting for a check that will never
+#      arrive.
+#   2. Lockfile churn most often arrives as an accident inside an unrelated PR —
+#      c18d42c was a rename commit that swept up local npm churn. Running on
+#      every PR is what catches that.
+
+name: Frontend
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
+        with:
+          # Must match build_frontend.yml. Vite 8 requires ^20.19.0 or >=22.12.0;
+          # on Node 18 `npm run build` fails and dist silently stops updating.
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      # The load-bearing step. If the lockfile is broken, this is where it shows.
+      - name: Install (npm ci)
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      # Non-blocking: `npm run lint` currently reports 3 pre-existing errors, all
+      # `require()`-style imports in tailwind.config.ts, plus 24 warnings. Per
+      # CLAUDE.md we do not fix pre-existing lint unrelated to a change, so this
+      # surfaces regressions in the log without failing the gate on day one.
+      # Clear the tailwind.config.ts errors and this can become blocking.
+      - name: Lint (non-blocking)
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -60,12 +60,19 @@ yarn-error.log*
 *.sqlite3
 
 # Local dev / tool state
-.claude/
+# .claude/ is personal (settings.local.json, agent worktrees) except the shared
+# slash commands, which the whole team runs and reviews like any other source.
+.claude/*
+!.claude/commands/
 .playwright-mcp/
 .superpowers/
 .worktrees/
 outputs/
-docs/
+# docs/ is local scratch (design notes, specs) except the upstream-tracking
+# ledger and review reports, which are the team's shared record of what we have
+# and have not taken from leLab.
+docs/*
+!docs/upstream/
 PHONE_CAMERA_SETUP.md
 HTTPS_SETUP.md
 JETSON_SETUP.md
@@ -83,3 +90,8 @@ reference-design/
 # setup notes. Machine-specific to the Jetson box, not part of the wheel or the
 # app, so it lives locally rather than in the repo.
 jetson/
+
+# Waitlist / marketing contact exports pulled from the Web3Forms Submissions
+# API. Contains personal data (emails, IPs) and an API key — local only, never
+# committed.
+waitlist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,31 @@ MakerMods Lab is a FastAPI + React web interface wrapping the [LeRobot](https://
 
 The frontend (React + Vite) lives in [`frontend/`](frontend/). The built bundle in `frontend/dist/` is committed and shipped inside the Python wheel as package data (`frontend.__init__.py` makes setuptools treat it as a package); [`makermodslab/server.py`](makermodslab/server.py) mounts it as `StaticFiles` at `/` so a single `makermodslab` process serves both API and UI on `:8000`.
 
+## Upstream (leLab)
+
+We forked leLab and have diverged past the point where git-level integration works.
+
+**Never `git merge`, `git rebase`, or `git cherry-pick` from `upstream`.** Anything we take from leLab is a deliberate re-implementation against our code. Upstream `lelab/<x>.py` maps to our `makermodslab/<x>.py`, but the contents usually differ heavily — read our file before assuming an upstream change applies. Upstream commits often arrive with tests; the `tests/` policy below still governs which of those we keep.
+
+The `upstream` remote is not in a fresh clone. Add it when you need it:
+
+```bash
+git remote add upstream https://github.com/huggingface/leLab.git
+```
+
+Run `/review-upstream` ([`.claude/commands/review-upstream.md`](.claude/commands/review-upstream.md)) weekly to triage what they have shipped. It writes a report under `docs/upstream/reviews/` and updates [`docs/upstream/ledger.md`](docs/upstream/ledger.md), the record of every upstream commit we have judged and why. **Read the ledger before porting anything** — some rows are `rejected` because our implementation is already ahead of theirs, and re-porting those is a regression.
+
+Both projects are Apache-2.0. Credit ports with the upstream SHA, and send fixes back when they apply to code we still share.
+
 ## Common commands
 
 Install and run: see [README.md](README.md) Quick Start (uv editable install; `makermodslab` / `makermodslab --dev`). Requires Python ≥3.12. Use the repo `.venv` — pytest fails to collect under other interpreters because of the pinned lerobot.
 
-`lerobot` is pinned to a specific commit on `huggingface/lerobot` `main` (see [pyproject.toml](pyproject.toml)) — no PyPI release yet exposes the `lerobot-rollout` script that [makermodslab/rollout.py](makermodslab/rollout.py) shells out to. Bump the SHA when you want newer upstream changes; expect import-path drift and adjust call sites.
+`lerobot` is pinned to the `v0.6.0` **release tag** on `huggingface/lerobot` (see [pyproject.toml](pyproject.toml)); that release exposes the `lerobot-rollout` script [makermodslab/rollout.py](makermodslab/rollout.py) shells out to. Track lerobot's releases, not its `main` branch — a moving pin makes every unrelated failure a bisect. lerobot is the one dependency the app cannot run without, so treat a bump as a real change: expect import-path drift, adjust call sites, and exercise a rollout end-to-end before landing it.
 
 When `frontend/**` (excluding `frontend/dist/**`) changes on `main`, [`.github/workflows/build_frontend.yml`](.github/workflows/build_frontend.yml) auto-rebuilds `frontend/dist/` and commits it back — don't rebuild it by hand for a PR. `makermodslab --dev` serves from Vite, no rebuild needed.
+
+**`frontend/package-lock.json` is the most fragile file in the repo** — it has broken CI three times (`e345e61`, `944cb05`, `c18d42c`). npm records platform-specific optional dependencies (esbuild, rollup, the `@emnapi/*` wasm shims) in it, so a lockfile written by `npm install` on macOS can fail `npm ci` on the Linux runner. Never hand-edit it; regenerate it on Linux or in a container when it genuinely needs regenerating; and treat an unexplained `package-lock.json` diff in an otherwise-unrelated PR as stray local churn to drop, not a change to keep. [`.github/workflows/frontend.yml`](.github/workflows/frontend.yml) runs `npm ci` + `npx tsc --noEmit` + `npm run build` on every PR so this is caught before merge rather than after.
 
 Test with `pytest` (install `.[test]`), lint with `ruff check` / `ruff format` (config for both in [pyproject.toml](pyproject.toml)). Tests in [tests/](tests/) cover request schemas, pure helpers, and idle/mutex branches; subprocess/thread happy paths and HF Jobs integration are **deliberately** not unit-tested — don't add coverage there. There is no Python build step; for end-to-end validation, run `makermodslab` and exercise endpoints.
 
@@ -123,10 +141,6 @@ All under `~/.cache/huggingface/lerobot/` (managed in [utils/config.py](makermod
 ## Frontend layout (`frontend/src/`)
 
 React + Vite + TypeScript with shadcn/radix primitives. Four pages (`Launchpad`, `Teleoperation`, `Training`, `NotFound`); ~100 components grouped by feature area (`calibration/`, `control/`, `dialogs/`, `studio/`, `library/`, `recording/`, `jobs/`, `launchpad/`, … plus shared `ui/`); state via React contexts (`ApiContext`, `StudioContext`, `InferenceSessionContext`, `UrdfContext`, …) and ~19 data/session hooks (`useRobots`, `useDatasets`, `useRealTimeJoints`, …). No Redux/Zustand.
-
-## UI verification scope
-
-The UI is verified in **light mode only** and is a desktop tool driven from a laptop next to the arms — **skip mobile/responsive-breakpoint checks**. Caveat: `ThemeProvider` defaults to `system`, so OS-dark users do get the `dark` class with unaudited styling; don't polish dark mode unless asked.
 
 ## Hardware target
 

--- a/docs/upstream/ledger.md
+++ b/docs/upstream/ledger.md
@@ -1,0 +1,44 @@
+# Upstream ledger — huggingface/leLab
+
+MakerMods Lab forked from [leLab](https://github.com/huggingface/leLab) and has diverged
+past the point where git-level integration works: the package rename (`lelab/` →
+`makermodslab/`) means upstream commits touch paths that no longer exist here, and our
+change volume is roughly twenty times theirs. We do not merge from upstream. We read it.
+
+This file is the record of that reading. Every upstream commit we have looked at gets a
+row and a verdict, so that:
+
+- "have we already considered this?" is a `grep`, not a conversation;
+- a settled **rejected** decision stays settled, instead of being rediscovered every
+  few months by whoever next reads upstream's log;
+- anything we port carries the upstream SHA, which is both good provenance and what
+  Apache-2.0 attribution looks like in practice.
+
+Update it by running `/review-upstream` — weekly is the intended cadence. Do not edit the
+cursor by hand unless you are deliberately re-reviewing a range.
+
+```
+cursor: 8f8a50f
+```
+
+The cursor is the newest upstream commit that has been reviewed. `8f8a50f`
+("Force-release camera/serial resources when a device disconnect fails", 2026-06-24) is
+the last commit our history and upstream's share, so the first run reviews everything
+they have shipped since the fork diverged in earnest.
+
+## Verdicts
+
+| Verdict | Meaning |
+|---|---|
+| `ported` | Re-implemented here. Note the PR or commit that did it. |
+| `knowledge` | We took the lesson, not the code. Note where the lesson landed (CLAUDE.md, a code comment, a test). |
+| `already-have` | We had solved it. Note if our approach differs, so nobody "fixes" it back. |
+| `rejected` | Considered and declined. **The reason is the point of the row.** |
+| `n/a` | Does not apply to our fork — leLab-specific, or against code we have rewritten. |
+| `todo` | Worth having, not yet done. Should have a tracking issue. |
+
+## Log
+
+| Upstream SHA | Date | Subject | Verdict | Notes |
+|---|---|---|---|---|
+| `12ad202` | 2026-07-17 | fix(security): remediate workflow vulnerability in build_frontend.yml | `rejected` | Their vuln was a token interpolated into a push URL. We never had it — `build_frontend.yml` mints a short-lived GitHub App token, hands it to `actions/checkout` with `persist-credentials`, and pushes with a bare `git push origin`, so the token never reaches a command string. Their fix (`gh auth login --with-token`) also broke their dist push and was partly reverted in `a654148`. **Do not port; it would be a downgrade.** |

--- a/docs/upstream/ledger.md
+++ b/docs/upstream/ledger.md
@@ -28,17 +28,17 @@ they have shipped since the fork diverged in earnest.
 
 ## Verdicts
 
-| Verdict | Meaning |
-|---|---|
-| `ported` | Re-implemented here. Note the PR or commit that did it. |
-| `knowledge` | We took the lesson, not the code. Note where the lesson landed (CLAUDE.md, a code comment, a test). |
-| `already-have` | We had solved it. Note if our approach differs, so nobody "fixes" it back. |
-| `rejected` | Considered and declined. **The reason is the point of the row.** |
-| `n/a` | Does not apply to our fork — leLab-specific, or against code we have rewritten. |
-| `todo` | Worth having, not yet done. Should have a tracking issue. |
+| Verdict        | Meaning                                                                                             |
+| -------------- | --------------------------------------------------------------------------------------------------- |
+| `ported`       | Re-implemented here. Note the PR or commit that did it.                                             |
+| `knowledge`    | We took the lesson, not the code. Note where the lesson landed (CLAUDE.md, a code comment, a test). |
+| `already-have` | We had solved it. Note if our approach differs, so nobody "fixes" it back.                          |
+| `rejected`     | Considered and declined. **The reason is the point of the row.**                                    |
+| `n/a`          | Does not apply to our fork — leLab-specific, or against code we have rewritten.                     |
+| `todo`         | Worth having, not yet done. Should have a tracking issue.                                           |
 
 ## Log
 
-| Upstream SHA | Date | Subject | Verdict | Notes |
-|---|---|---|---|---|
-| `12ad202` | 2026-07-17 | fix(security): remediate workflow vulnerability in build_frontend.yml | `rejected` | Their vuln was a token interpolated into a push URL. We never had it — `build_frontend.yml` mints a short-lived GitHub App token, hands it to `actions/checkout` with `persist-credentials`, and pushes with a bare `git push origin`, so the token never reaches a command string. Their fix (`gh auth login --with-token`) also broke their dist push and was partly reverted in `a654148`. **Do not port; it would be a downgrade.** |
+| Upstream SHA | Date       | Subject                                                               | Verdict    | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------ | ---------- | --------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `12ad202`    | 2026-07-17 | fix(security): remediate workflow vulnerability in build_frontend.yml | `rejected` | Their vuln was a token interpolated into a push URL. We never had it — `build_frontend.yml` mints a short-lived GitHub App token, hands it to `actions/checkout` with `persist-credentials`, and pushes with a bare `git push origin`, so the token never reaches a command string. Their fix (`gh auth login --with-token`) also broke their dist push and was partly reverted in `a654148`. **Do not port; it would be a downgrade.** |


### PR DESCRIPTION
## Why

Nothing built the frontend before merge. `tests.yml` is path-filtered to Python, `quality.yml` is pre-commit only, and `build_frontend.yml` runs on push to `main` — so the first thing to run `npm ci` on Linux was the job that fires **after** the merge. Its failure is silent: `frontend/dist` never rebuilds and prod keeps serving the previous bundle.

That has broken three times, three different flavours of the same root cause (a lockfile generated on a dev machine that `ubuntu-latest` can't install):

| Commit | Flavour |
|---|---|
| `e345e61` | lockfile pinned to the internal HF npm mirror → `npm ci` hangs ~8 min, crashes |
| `944cb05` | lockfile generated on macOS → regenerated on Linux to unbreak `npm ci` |
| `c18d42c` | lockfile out of sync with package.json (`@emnapi/*`) → dist never rebuilt for the rename |

## What

**`.github/workflows/frontend.yml`** — `npm ci` → `npx tsc --noEmit` → `npm run lint` → `npm run build`, on `ubuntu-latest` / Node 22, matching `build_frontend.yml` exactly so green here means green there.

Two decisions worth reviewing:

- **Not path-filtered.** A path-filtered *required* check never reports on PRs that skip it, and GitHub blocks the merge waiting for a status that never arrives. Separately, lockfile churn usually arrives inside an unrelated PR — `c18d42c` was a rename commit that swept up local `npm install` churn — so running on every PR is what catches it. Cost is ~1-2 min with the npm cache.
- **Lint is non-blocking.** `npm run lint` reports 3 pre-existing errors (`require()`-style imports in `tailwind.config.ts`) plus 24 warnings. Per CLAUDE.md we don't fix pre-existing lint, so it logs without gating. `tsc` is clean today (0 errors), so that one blocks. Clear the tailwind errors and lint can be promoted.

**Upstream tracking** — `/review-upstream` plus `docs/upstream/ledger.md`. We've diverged far enough from leLab that merges are dead (the `lelab/` → `makermodslab/` rename means every backend commit conflicts), so the ledger records which of their commits we've judged and why. It's seeded with one row: `12ad202`, their workflow "security fix", marked `rejected` — our `build_frontend.yml` never had that vuln and their fix broke their own dist push. Without the row, someone re-finds it and opens a PR downgrading us.

**`.gitignore`** — `.claude/` and `docs/` become allowlists so the command and ledger are shareable; everything else there stays local. Also picks up `waitlist/` (personal data + an API key).

**CLAUDE.md** — new Upstream section, the package-lock fragility rule, and a fix to the lerobot pin description: it claimed a commit on `main`, but `pyproject.toml` pins the `v0.6.0` release tag and that release does expose `lerobot-rollout`.

## Follow-up (not in this PR)

Branch protection needs `Frontend / Build` added as a required check — repo setting, not a file. Note `Tests / Pytest` and `Lockfile registry guard / check` are path-filtered and would hang if made required as-is.