### PR TITLE
Add PI0.5 policy support

### DIFF
--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -640,6 +640,18 @@ const JobCard: React.FC<Props> = ({
           >
             {isImported ? "\u200e" + subtitle : subtitle}
           </div>
+          {/* Why it failed, on the card itself. The reason was already on the
+              record but only the job dialog rendered it, so a run that died on
+              something actionable (out of memory) looked, from the list the
+              user actually lands on, like it had failed for no reason. */}
+          {job.state === "failed" && job.error_message ? (
+            <div
+              className="text-destructive mt-0.5 line-clamp-2 text-[11px]"
+              title={job.error_message}
+            >
+              {job.error_message}
+            </div>
+          ) : null}
         </div>
         <MetaRows rows={metaRows} />
         {showProgressBar ? (

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -816,6 +816,7 @@ const JobCard: React.FC<Props> = ({
           packageName={missingExtra.packageName}
           installTarget={missingExtra.installTarget}
           installHint={missingExtra.installHint}
+          purpose="training"
         />
       ) : null}
     </Card>

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -45,6 +45,7 @@ import DisplayName from "@/components/library/DisplayName";
 import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
 import ModelsLibrary from "@/components/jobs/ModelsLibrary";
 import ImportModelModal from "@/components/jobs/ImportModelModal";
+import PolicyExtraDialog from "@/components/training/PolicyExtraDialog";
 import {
   AdvancedSection,
   FormSection,
@@ -217,6 +218,13 @@ const DeployPanel: React.FC = () => {
   const [policyConfigError, setPolicyConfigError] = useState<string | null>(
     null,
   );
+  const [policyExtra, setPolicyExtra] = useState<{
+    policyType: string;
+    packageName: string;
+    installTarget: string;
+    installHint: string;
+  } | null>(null);
+  const [checkingExtra, setCheckingExtra] = useState(false);
 
   // Per camera DISPLAY name → the NAME of one of the selected robot's cameras.
   // Keyed by the stripped display name (== requestKey), and sent verbatim as
@@ -569,6 +577,7 @@ const DeployPanel: React.FC = () => {
     allCamerasBound &&
     !temporalEnsembleInvalid &&
     !submitting &&
+    !checkingExtra &&
     !inferenceActive;
 
   const handleStart = async () => {
@@ -579,6 +588,38 @@ const DeployPanel: React.FC = () => {
       !policyConfig
     )
       return;
+
+    // Pre-flight: pi0/pi0_fast/pi05/smolvla/diffusion need an optional
+    // package installed locally. The rollout subprocess runs against this
+    // machine's own environment (it drives the physically-connected robot),
+    // so catch a missing extra here with a one-click installer instead of a
+    // buried ImportError after the rollout has already claimed the cameras.
+    if (policyConfig.policy_type) {
+      setCheckingExtra(true);
+      try {
+        const r = await fetchWithHeaders(
+          `${baseUrl}/system/policy-extra/${policyConfig.policy_type}`,
+        );
+        if (r.ok) {
+          const extra = await r.json();
+          if (extra.needs_extra && !extra.available) {
+            setPolicyExtra({
+              policyType: policyConfig.policy_type,
+              packageName: extra.package,
+              installTarget: extra.install_target,
+              installHint: extra.install_hint,
+            });
+            return;
+          }
+        }
+      } catch {
+        // Check failed (offline / older backend) — fall through and let the
+        // rollout report any problem itself.
+      } finally {
+        setCheckingExtra(false);
+      }
+    }
+
     // Drops every CameraThumbnail's browser stream so the rollout subprocess can
     // open the same camera index via OpenCV without colliding on the device.
     setSubmitting(true);
@@ -1102,9 +1143,11 @@ const DeployPanel: React.FC = () => {
           <Play className="h-4 w-4" />
           {submitting
             ? "Starting…"
-            : evalEpisodes > 1
-              ? `Start evaluation (${evalEpisodes})`
-              : "Start inference"}
+            : checkingExtra
+              ? "Checking…"
+              : evalEpisodes > 1
+                ? `Start evaluation (${evalEpisodes})`
+                : "Start inference"}
         </Button>
         <Button
           onClick={handleStop}
@@ -1130,6 +1173,18 @@ const DeployPanel: React.FC = () => {
           }}
         />
       </LibrarySection>
+
+      {policyExtra && (
+        <PolicyExtraDialog
+          open={!!policyExtra}
+          onOpenChange={(o) => !o && setPolicyExtra(null)}
+          policyType={policyExtra.policyType}
+          packageName={policyExtra.packageName}
+          installTarget={policyExtra.installTarget}
+          installHint={policyExtra.installHint}
+          purpose="inference"
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/training/PolicyExtraDialog.tsx
+++ b/frontend/src/components/training/PolicyExtraDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useInstallExtra } from "@/hooks/useInstallExtra";
+import { policyTypeShortLabel } from "./types";
 import {
   InstallProgress,
   InstallTitleIcon,
@@ -21,11 +22,18 @@ interface Props {
   packageName: string; // the probed module, e.g. "transformers"
   installTarget: string; // e.g. "lerobot[smolvla]"
   installHint: string; // e.g. "pip install 'lerobot[smolvla]'"
+  purpose: "training" | "inference"; // what the caller was about to do
 }
 
+const PURPOSE_COPY: Record<Props["purpose"], { verb: string; noun: string }> = {
+  training: { verb: "Training", noun: "training" },
+  inference: { verb: "Running", noun: "inference" },
+};
+
 // Some policies (smolvla, pi0, pi0_fast, diffusion) need an optional LeRobot
-// extra. This catches the missing package before training starts and offers a
-// one-click install, instead of the run dying with a buried ImportError.
+// extra. This catches the missing package before training/inference starts
+// and offers a one-click install, instead of the run dying with a buried
+// ImportError.
 const PolicyExtraDialog: React.FC<Props> = ({
   open,
   onOpenChange,
@@ -33,9 +41,12 @@ const PolicyExtraDialog: React.FC<Props> = ({
   packageName,
   installTarget,
   installHint,
+  purpose,
 }) => {
   const install = useInstallExtra(`system/policy-extra/${policyType}`, open);
-  const title = `${policyType.toUpperCase()} needs an extra package`;
+  const shortLabel = policyTypeShortLabel(policyType);
+  const title = `${shortLabel} needs an extra package`;
+  const { verb, noun } = PURPOSE_COPY[purpose];
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -46,7 +57,7 @@ const PolicyExtraDialog: React.FC<Props> = ({
             {installTitle(install.state, title)}
           </DialogTitle>
           <DialogDescription className="sr-only">
-            Install {installTarget} to train {policyType}.
+            Install {installTarget} for {noun} with {shortLabel}.
           </DialogDescription>
         </DialogHeader>
 
@@ -63,14 +74,14 @@ const PolicyExtraDialog: React.FC<Props> = ({
             idleTitle={title}
             idleDescription={
               <>
-                Training a <span className="font-semibold">{policyType}</span> policy needs the{" "}
+                {verb} a <span className="font-semibold">{shortLabel}</span> policy needs the{" "}
                 <code className="px-1 py-0.5 rounded bg-muted text-info">{packageName}</code>{" "}
                 package (installed via{" "}
                 <code className="px-1 py-0.5 rounded bg-muted text-info">{installTarget}</code>),
-                which isn't in this environment yet. Install it to train this policy.
+                which isn't in this environment yet. Install it to {purpose === "training" ? "train" : "run"} this policy.
               </>
             }
-            doneDescription={<ReadyInstructions purpose={`${policyType} training`} />}
+            doneDescription={<ReadyInstructions purpose={`${shortLabel} ${noun}`} />}
           />
         </div>
       </DialogContent>

--- a/frontend/src/components/training/PolicyExtraDialog.tsx
+++ b/frontend/src/components/training/PolicyExtraDialog.tsx
@@ -30,10 +30,10 @@ const PURPOSE_COPY: Record<Props["purpose"], { verb: string; noun: string }> = {
   inference: { verb: "Running", noun: "inference" },
 };
 
-// Some policies (smolvla, pi0, pi0_fast, diffusion) need an optional LeRobot
-// extra. This catches the missing package before training/inference starts
-// and offers a one-click install, instead of the run dying with a buried
-// ImportError.
+// Some policies (smolvla, pi0, pi0_fast, pi05, diffusion) need an optional
+// LeRobot extra. This catches the missing package before training/inference
+// starts and offers a one-click install, instead of the run dying with a
+// buried ImportError.
 const PolicyExtraDialog: React.FC<Props> = ({
   open,
   onOpenChange,

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -504,8 +504,8 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
       return;
     }
 
-    // Pre-flight: smolvla/pi0/diffusion need an optional package installed
-    // locally. Catch it here with a one-click installer instead of a buried
+    // Pre-flight: smolvla/pi0/pi0_fast/pi05/diffusion need an optional package
+    // installed locally. Catch it here with a one-click installer instead of a buried
     // ImportError after the job has already started. Cloud jobs run in their
     // own environment, so the local package is irrelevant — skip the check.
     if (config.target.runner === "local") {

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -108,6 +108,15 @@ interface TrainingConfiguratorProps {
   actionsContainer?: HTMLElement | null;
 }
 
+// PI0.5 is a 4B-parameter VLA — a real cloud run OOM'd an 80GB A100 on step 1
+// at the standard batch_size=8 in full precision. Every other policy keeps the
+// historical off default; only PI0.5 needs mixed precision to fit.
+const POLICY_DEFAULT_USE_AMP: Record<string, boolean> = {
+  pi05: true,
+};
+const defaultUseAmp = (policyType: string): boolean =>
+  POLICY_DEFAULT_USE_AMP[policyType] ?? false;
+
 function configToRequest(
   c: TrainingConfig,
   needsCheckpointUpload: boolean,
@@ -243,7 +252,9 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     wandb_mode: "online",
     wandb_disable_artifact: false,
     policy_device: resumeSeed?.policyDevice ?? "auto",
-    policy_use_amp: resumeSeed?.policyUseAmp ?? false,
+    // A resume prefills the parent run's own AMP setting (it may not match
+    // today's per-policy default); a fresh run gets the per-policy default.
+    policy_use_amp: resumeSeed?.policyUseAmp ?? defaultUseAmp(policyType),
     optimizer_type: resumeSeed?.optimizerType ?? "adam",
     optimizer_lr: resumeSeed?.optimizerLr,
     optimizer_weight_decay: resumeSeed?.optimizerWeightDecay,
@@ -290,6 +301,29 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
   const [hardwareLoading, setHardwareLoading] = useState(true);
   // HF_HUB_OFFLINE on the backend: Hub writes (incl. dataset upload) disabled.
   const [offline, setOffline] = useState<boolean>(false);
+
+  // Whether the user has hand-toggled the AMP switch this session — once they
+  // have, their choice wins over the per-policy default below, same as any
+  // other form field the policy dropdown doesn't reset.
+  const ampTouchedRef = useRef(false);
+
+  // The policy dropdown lives inside this same mounted form (PolicyField ->
+  // updateConfig("policy_type", ...) -> onPolicyTypeChange), so switching
+  // architecture does not remount the component or re-run the useState
+  // initializer above. Re-apply the per-policy AMP default whenever the
+  // selection changes, unless the user already touched the switch by hand.
+  // A resumeSeed's policyType is locked (see policyLocked below), so this
+  // never fires from a real dropdown change during a resume — but effects
+  // still run once on mount, which would otherwise stomp the parent run's own
+  // prefilled AMP value with today's per-policy default the instant the form
+  // opens. Skip entirely when resuming.
+  useEffect(() => {
+    if (ampTouchedRef.current || resumeSeed) return;
+    setTrainingConfig((prev) => ({
+      ...prev,
+      policy_use_amp: defaultUseAmp(policyType),
+    }));
+  }, [policyType, resumeSeed]);
 
   useEffect(() => {
     fetchWithHeaders(`${baseUrl}/system/training-extra`)
@@ -344,6 +378,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
       return;
     }
     if (key === "dataset_repo_id") return;
+    if (key === "policy_use_amp") ampTouchedRef.current = true;
     setTrainingConfig((prev) => ({ ...prev, [key]: value }));
   };
 

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -742,6 +742,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
           packageName={policyExtra.packageName}
           installTarget={policyExtra.installTarget}
           installHint={policyExtra.installHint}
+          purpose="training"
         />
       )}
     </div>

--- a/frontend/src/components/training/config/TargetCard.tsx
+++ b/frontend/src/components/training/config/TargetCard.tsx
@@ -22,8 +22,16 @@ const formatHourly = (unitCostUsd: number, unitLabel: string): string => {
   return `$${hourly.toFixed(2)}/hr`;
 };
 
+// VRAM is included because it is the one spec that decides whether a run
+// starts at all: the big VLA policies OOM on a small card at the standard
+// batch size, and the failure lands on the first training step, minutes after
+// the user has already paid for the box.
 const formatFlavorLine = (f: RunnerFlavor): string => {
-  const accel = f.accelerator ? f.accelerator : f.cpu;
+  const accel = f.accelerator
+    ? f.vram
+      ? `${f.accelerator} · ${f.vram} VRAM`
+      : f.accelerator
+    : f.cpu;
   return `${f.pretty_name} · ${accel} · ${formatHourly(f.unit_cost_usd, f.unit_label)}`;
 };
 

--- a/frontend/src/components/training/types.ts
+++ b/frontend/src/components/training/types.ts
@@ -73,6 +73,7 @@ export const POLICY_TYPE_OPTIONS: {
   },
   { value: "diffusion", label: "Diffusion", display: "Diffusion Policy" },
   { value: "pi0", label: "PI0", display: "PI0" },
+  { value: "pi05", label: "PI0.5", display: "PI0.5" },
   { value: "smolvla", label: "SmolVLA", display: "SmolVLA" },
   { value: "tdmpc", label: "TD-MPC", display: "TD-MPC" },
   { value: "vqbet", label: "VQ-BeT", display: "VQ-BeT" },

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -296,7 +296,13 @@ export interface RunnerFlavor {
   pretty_name: string;
   cpu: string;
   ram: string;
+  // Flattened by the backend from huggingface_hub's JobAccelerator object —
+  // "Nvidia T4", "4× Nvidia A100". Null on the cpu-* flavors.
   accelerator: string | null;
+  // GPU memory as the Hub words it ("16 GB", "80 GB"), null on cpu-* flavors
+  // and on an older backend that didn't send the field. This is the number
+  // that decides whether a policy fits, so it gets its own line in the picker.
+  vram?: string | null;
   unit_cost_usd: number;
   unit_label: string;
 }

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -43,6 +43,7 @@ from tqdm.auto import tqdm as _base_tqdm
 from .datasets import CAMERA_FEATURE_PREFIX, read_dataset_features
 from .train import TrainingRequest
 from .utils.config import is_valid_robot_name
+from .utils.errors import is_out_of_memory
 from .utils.hf_auth import LOGIN_COMMAND, cached_whoami, hf_hub_offline, shared_hf_api
 from .utils.naming import (
     dedupe_display_names,
@@ -2278,6 +2279,87 @@ def _job_meta_path(output_root: Path, job_id: str) -> Path:
     return _job_dir(output_root, job_id) / "job.json"
 
 
+# How much of log.jsonl the post-mortem below reads. A verbose training log
+# runs to many MB; the cause is always in the last handful of lines, so we
+# decode a fixed tail rather than materializing the file.
+_LOG_TAIL_BYTES = 64 * 1024
+_LOG_TAIL_LINES = 80
+
+# Exit codes that mean the OS killed the trainer rather than the trainer
+# raising: SIGKILL is what the Linux OOM killer sends when the HOST (not the
+# GPU) runs out of memory, and it leaves nothing at all in the log. Popen
+# reports it as -9; a shell-wrapped process reports 128+9.
+_SIGKILL_EXIT_CODES = frozenset({-9, 137})
+
+_GPU_OOM_MESSAGE = (
+    "Out of memory — the training process ran out of GPU memory. "
+    "Turn on mixed precision (AMP), lower the batch size, or use a larger GPU."
+)
+_HOST_OOM_MESSAGE = (
+    "Killed by the operating system — almost always the host running out of RAM. "
+    "Lower the batch size or the number of dataloader workers."
+)
+
+
+def _read_log_tail_messages(log_path: Path) -> builtins.list[str]:
+    """The `message` field of the last few log.jsonl lines, oldest first.
+
+    Both runners write the same JSON-lines format (LocalJobRunner from the
+    subprocess's stdout, HfCloudJobRunner from the HF Jobs log stream), so one
+    reader covers local and cloud runs alike. Unreadable file → empty list; a
+    malformed line is skipped rather than raising, exactly as
+    read_persisted_logs does.
+    """
+    try:
+        with log_path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - _LOG_TAIL_BYTES))
+            data = fh.read()
+    except OSError:
+        return []
+    lines = data.decode("utf-8", errors="replace").splitlines()
+    # Seeking into the middle of the file lands inside a line; drop that
+    # fragment so json.loads isn't handed half a record.
+    if size > _LOG_TAIL_BYTES and lines:
+        lines = lines[1:]
+    out: builtins.list[str] = []
+    for raw in lines[-_LOG_TAIL_LINES:]:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            message = json.loads(raw).get("message")
+        except (ValueError, AttributeError):
+            continue
+        if isinstance(message, str):
+            out.append(message)
+    return out
+
+
+def _oom_failure_reason(log_path: Path, rc: int | None) -> str | None:
+    """Ran-out-of-memory, as a sentence, or None when that isn't what happened.
+
+    Subprocess/container forensics, the same shape rollout.py uses: the trainer
+    is not in this process, so its log is the only evidence. Without this an
+    OOM finalises as the synthetic "Subprocess exited with code 1" — HF Jobs
+    reports a crashed container as a bare stage change and carries no reason of
+    its own — which is how an intensive policy (PI0.5 dying on step 1) came
+    back from the cloud looking like it had failed for no reason at all.
+
+    The whole tail window is matched, not just the last line: torch prints the
+    "CUDA out of memory" body BELOW the exception line, and the trainer usually
+    logs a few more lines on its way down.
+    """
+    if is_out_of_memory("\n".join(_read_log_tail_messages(log_path))):
+        return _GPU_OOM_MESSAGE
+    # No traceback at all + a SIGKILL exit is the host-RAM OOM killer, which
+    # never gets the chance to print anything.
+    if rc in _SIGKILL_EXIT_CODES:
+        return _HOST_OOM_MESSAGE
+    return None
+
+
 class JobAlreadyRunningError(Exception):
     """Raised when start() is called while another local job is running."""
 
@@ -3784,6 +3866,9 @@ class JobRegistry:
 
             # Subprocess exited since the last tick. Finalise.
             rc = runner.returncode()
+            # Mine the log for an out-of-memory death BEFORE taking the lock —
+            # it reads a 64 KB tail off disk, and rc is all it needs.
+            oom_reason = _oom_failure_reason(_job_log_path(self._output_root, jid), rc) if rc else None
             # A stop counts only if we asked for it AND the runner didn't tell
             # us it never got to signal anything (already-dead process). A
             # runner that can't answer abstains rather than vetoing.
@@ -3831,8 +3916,12 @@ class JobRegistry:
                     elif state == "failed":
                         # Prefer a runner-supplied reason (e.g. HF Jobs'
                         # 'Job timeout') over the synthetic exit-code message.
+                        # An OOM found in the log outranks both: HF Jobs' own
+                        # message for a crashed container is generic where it
+                        # exists at all, and "exited with code 1" tells the
+                        # user nothing they can act on.
                         reason = _runner_hook(runner, "terminal_message")
-                        record.error_message = reason or f"Subprocess exited with code {rc}"
+                        record.error_message = oom_reason or reason or f"Subprocess exited with code {rc}"
                 self._runners.pop(jid, None)
                 self._stop_requested.discard(jid)
             self._persist(record, force=True)

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -431,6 +431,7 @@ _POLICY_TYPE_TO_LEROBOT = {
     "act": "act",
     "diffusion": "diffusion",
     "pi0": "pi0",
+    "pi05": "pi05",
     "smolvla": "smolvla",
     "tdmpc": "tdmpc",
     "vqbet": "vqbet",

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -1784,6 +1784,31 @@ def delete_job(job_id: str):
         add_dismissed_hub_job(record.hf_job_id)
 
 
+def _format_accelerator(accelerator) -> str | None:
+    """Render a JobHardwareInfo's accelerator as a label — 2× Nvidia A100 —
+    or None on a CPU flavor.
+
+    huggingface_hub returns this field as a JobAccelerator OBJECT (type, model,
+    quantity, vram, manufacturer), not a string. Forwarding it raw put a nested
+    dict on the wire under a field the frontend types as `string`, which the
+    hardware dropdown then interpolated into its label as "[object Object]".
+    Flattened here rather than in the frontend so `vram` — the one number that
+    says whether a policy will fit — survives as its own field instead of being
+    buried in a shape nothing declared.
+    """
+    if accelerator is None:
+        return None
+    quantity = str(getattr(accelerator, "quantity", "") or "").strip()
+    model = str(getattr(accelerator, "model", "") or "").strip()
+    manufacturer = str(getattr(accelerator, "manufacturer", "") or "").strip()
+    name = " ".join(part for part in (manufacturer, model) if part)
+    if not name:
+        # A future hub version could rename the fields out from under us; a
+        # plain str() still beats a dict the UI would render as [object Object].
+        return str(accelerator)
+    return f"{quantity}× {name}" if quantity and quantity != "1" else name
+
+
 @app.get("/jobs/runners/hardware")
 def get_runners_hardware():
     """Return HF Jobs flavor catalog + auth state for the TargetCard.
@@ -1815,7 +1840,8 @@ def get_runners_hardware():
                 "pretty_name": h.pretty_name,
                 "cpu": h.cpu,
                 "ram": h.ram,
-                "accelerator": h.accelerator,
+                "accelerator": _format_accelerator(h.accelerator),
+                "vram": getattr(h.accelerator, "vram", None),
                 "unit_cost_usd": h.unit_cost_usd,
                 "unit_label": h.unit_label,
             }

--- a/makermodslab/train.py
+++ b/makermodslab/train.py
@@ -112,6 +112,10 @@ _POLICY_OPTIMIZER_FIELDS: dict[str, frozenset[str]] = {
     "tdmpc": frozenset({"lr"}),
     "vqbet": frozenset({"lr", "weight_decay"}),
     "pi0_fast": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
+    # Same PreTrainedConfig shape as pi0 (verified by dataclass introspection
+    # against the pinned lerobot: identical optimizer_lr/betas/eps/
+    # weight_decay/grad_clip_norm/scheduler_* fields and defaults).
+    "pi05": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
     "gaussian_actor": frozenset(),
 }
 

--- a/makermodslab/utils/errors.py
+++ b/makermodslab/utils/errors.py
@@ -21,7 +21,9 @@ Deliberately free of any rollout/recording/teleop specifics: the input is just
 text, so every feature can reuse it regardless of where the text came from.
 Rollout mines it out of a failed subprocess's log tail (see rollout.py);
 recording/teleop run in-process and will pass the message of a caught exception
-(`str(exc)`) instead — same functions, different source.
+(`str(exc)`) instead — same functions, different source. Training is a third
+source: jobs.py mines a finished run's log the same way rollout does, local and
+cloud alike (see is_out_of_memory).
 """
 
 from __future__ import annotations
@@ -43,6 +45,36 @@ def is_cleanup_error(error_text: str | None) -> bool:
         return False
     low = error_text.lower()
     return any(marker in low for marker in CLEANUP_MARKERS)
+
+
+# An allocator running out of memory, keyed on what each backend actually
+# prints: PyTorch's CUDA allocator raises "torch.OutOfMemoryError: CUDA out of
+# memory", ROCm and MPS have their own wording, and a host-RAM allocation
+# failure surfaces through DefaultCPUAllocator. Deliberately NOT keyed on a
+# bare "killed": the Linux OOM killer's SIGKILL leaves no text in the log at
+# all, so that case is recognised from the exit code by the caller.
+OOM_MARKERS: tuple[str, ...] = (
+    "cuda out of memory",
+    "hip out of memory",
+    "mps backend out of memory",
+    "outofmemoryerror",
+    "cuda error: out of memory",
+    "defaultcpuallocator: can't allocate memory",
+)
+
+
+def is_out_of_memory(error_text: str | None) -> bool:
+    """True when the error text is an allocator running out of memory (see
+    OOM_MARKERS). Case-insensitive; None/empty text is False.
+
+    Training's most common hard failure and, until this existed, its most
+    silent one: the trainer dies on the first step, the platform reports only
+    that the process exited non-zero, and the actual cause sits in a log the
+    user has to go find and read."""
+    if not error_text:
+        return False
+    low = error_text.lower()
+    return any(marker in low for marker in OOM_MARKERS)
 
 
 def format_exception(exc: BaseException, limit: int = 500) -> str:
@@ -78,14 +110,22 @@ def classify_outcome(work_completed: bool, error_text: str | None) -> str:
 
 
 def friendly_hint(error_text: str | None) -> str | None:
-    """A plain-language, actionable headline for the common SO-101 failures,
-    or None when the text doesn't match a known pattern.
+    """A plain-language, actionable headline for the common SO-101 and
+    training failures, or None when the text doesn't match a known pattern.
 
     Pure text → hint: pass a subprocess log-tail snippet or the message of a
     caught exception — nothing here is coupled to how the text was obtained."""
     if not error_text:
         return None
     low = error_text.lower()
+    # Checked first: an OOM traceback often carries a device/allocator string
+    # that would otherwise trip one of the connection branches below, and it
+    # is unambiguous when it matches.
+    if is_out_of_memory(error_text):
+        return (
+            "The GPU ran out of memory. Turn on mixed precision (AMP), lower the batch size, "
+            "or run on a larger GPU."
+        )
     if "overload" in low or "torque_enable" in low:
         return (
             "A motor overloaded — usually the gripper holding an object too hard. Release the object / "

--- a/makermodslab/utils/system.py
+++ b/makermodslab/utils/system.py
@@ -247,6 +247,7 @@ POLICY_EXTRAS: dict[str, tuple[str, str]] = {
     "smolvla": ("transformers", "lerobot[smolvla]"),
     "pi0": ("transformers", "lerobot[pi]"),
     "pi0_fast": ("transformers", "lerobot[pi]"),
+    "pi05": ("transformers", "lerobot[pi]"),
     "diffusion": ("diffusers", "lerobot[diffusion]"),
 }
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4418,3 +4418,84 @@ def test_boot_reattach_stays_interrupted_when_no_exit_status_file(tmp_path) -> N
     record = reg.get("job-1")
     assert record.state == "interrupted"
     assert record.exit_code is None
+def _write_log(path: Path, messages: list[str]) -> Path:
+    """Write messages in the log.jsonl shape both runners produce."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(_json.dumps({"timestamp": 1.0, "message": m}) for m in messages) + "\n")
+    return path
+
+
+def test_oom_failure_reason_names_the_gpu_oom(tmp_path) -> None:
+    """The whole point: a run that died on CUDA OOM must finalise with a reason
+    the user can act on, not "Subprocess exited with code 1"."""
+    from makermodslab.jobs import _oom_failure_reason
+
+    log = _write_log(
+        tmp_path / "log.jsonl",
+        [
+            "INFO 2026-08-07 10:31:02 train.py:243 step:1 loss:2.104",
+            'File "/app/lerobot/policies/pi05/modeling_pi05.py", line 612, in forward',
+            "torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 4.20 GiB. GPU 0 has a total "
+            "capacity of 79.14 GiB of which 1.88 GiB is free.",
+            "[wrapper] trainer exited with rc=1",
+        ],
+    )
+    reason = _oom_failure_reason(log, 1)
+    assert reason is not None
+    assert "memory" in reason.lower()
+    assert "batch size" in reason.lower()
+
+
+def test_oom_failure_reason_reads_past_the_last_line(tmp_path) -> None:
+    """torch prints the OOM body BELOW the exception line and the trainer keeps
+    logging on its way down, so matching only the final line would miss it."""
+    from makermodslab.jobs import _oom_failure_reason
+
+    log = _write_log(
+        tmp_path / "log.jsonl",
+        ["torch.OutOfMemoryError: CUDA out of memory."]
+        + [f"[wrapper] scanning checkpoints {i}" for i in range(30)],
+    )
+    assert _oom_failure_reason(log, 1) is not None
+
+
+def test_oom_failure_reason_is_silent_on_an_ordinary_failure(tmp_path) -> None:
+    """No OOM evidence ⇒ None, so the caller keeps its existing message rather
+    than mislabelling every failure as out of memory."""
+    from makermodslab.jobs import _oom_failure_reason
+
+    log = _write_log(tmp_path / "log.jsonl", ["ValueError: expected 6-dim action, got 12"])
+    assert _oom_failure_reason(log, 1) is None
+    assert _oom_failure_reason(tmp_path / "missing.jsonl", 1) is None
+
+
+def test_oom_failure_reason_recognises_a_sigkill_with_an_empty_log(tmp_path) -> None:
+    """The host OOM killer sends SIGKILL and the process prints nothing, so the
+    exit code is the only evidence there is."""
+    from makermodslab.jobs import _oom_failure_reason
+
+    log = _write_log(tmp_path / "log.jsonl", ["INFO step:120 loss:0.8"])
+    for rc in (-9, 137):
+        reason = _oom_failure_reason(log, rc)
+        assert reason is not None and "ram" in reason.lower()
+    assert _oom_failure_reason(log, 1) is None
+
+
+def test_read_log_tail_messages_survives_a_mid_line_seek(tmp_path) -> None:
+    """The reader seeks to a fixed byte offset, which lands inside a record;
+    the fragment must be dropped, not fed to json.loads as a whole line."""
+    from makermodslab.jobs import _LOG_TAIL_BYTES, _read_log_tail_messages
+
+    filler = ["x" * 200 for _ in range(_LOG_TAIL_BYTES // 200 + 40)]
+    log = _write_log(tmp_path / "log.jsonl", [*filler, "torch.OutOfMemoryError: CUDA out of memory."])
+    messages = _read_log_tail_messages(log)
+    assert messages  # the fragment didn't take the whole window with it
+    assert messages[-1] == "torch.OutOfMemoryError: CUDA out of memory."
+
+
+def test_read_log_tail_messages_skips_malformed_lines(tmp_path) -> None:
+    from makermodslab.jobs import _read_log_tail_messages
+
+    path = tmp_path / "log.jsonl"
+    path.write_text('{"timestamp": 1.0, "message": "ok"}\nnot json at all\n{"timestamp": 2.0}\n')
+    assert _read_log_tail_messages(path) == ["ok"]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4418,6 +4418,8 @@ def test_boot_reattach_stays_interrupted_when_no_exit_status_file(tmp_path) -> N
     record = reg.get("job-1")
     assert record.state == "interrupted"
     assert record.exit_code is None
+
+
 def _write_log(path: Path, messages: list[str]) -> Path:
     """Write messages in the log.jsonl shape both runners produce."""
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -1639,6 +1639,42 @@ def test_friendly_hint_maps_common_failures() -> None:
     assert friendly_hint(None) is None
 
 
+def test_is_out_of_memory_matches_every_allocator_backend() -> None:
+    """The wording differs per backend, so each one is keyed separately."""
+    from makermodslab.utils.errors import is_out_of_memory
+
+    for text in (
+        "torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 GiB",
+        "RuntimeError: HIP out of memory. Tried to allocate 512.00 MiB",
+        "RuntimeError: MPS backend out of memory (MPS allocated: 9.06 GB)",
+        "RuntimeError: CUDA error: out of memory",
+        "RuntimeError: [enforce fail] DefaultCPUAllocator: can't allocate memory: you tried to allocate",
+    ):
+        assert is_out_of_memory(text), text
+    assert not is_out_of_memory("RuntimeError: shape mismatch")
+    assert not is_out_of_memory("")
+    assert not is_out_of_memory(None)
+
+
+def test_is_out_of_memory_ignores_a_bare_killed() -> None:
+    """ "Killed" alone is not evidence: the host OOM killer prints nothing, and
+    plenty of benign lines contain the word. That case is recognised from the
+    exit code instead (see jobs._oom_failure_reason)."""
+    from makermodslab.utils.errors import is_out_of_memory
+
+    assert not is_out_of_memory("Killed")
+    assert not is_out_of_memory("stop requested: killed the training subprocess")
+
+
+def test_friendly_hint_names_the_three_oom_remedies() -> None:
+    from makermodslab.utils.errors import friendly_hint
+
+    hint = (friendly_hint("torch.OutOfMemoryError: CUDA out of memory.") or "").lower()
+    assert "mixed precision" in hint
+    assert "batch size" in hint
+    assert "larger gpu" in hint
+
+
 def test_friendly_hint_servo_bus_error_is_not_a_download_failure() -> None:
     """A servo that stops answering must read as an ARM problem.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1297,3 +1297,36 @@ def test_recording_resume_route_calls_handler(client: TestClient, monkeypatch: p
     assert response.status_code == 200
     assert response.json()["success"] is True
     assert called.get("hit") is True
+
+
+def test_format_accelerator_flattens_the_hub_object() -> None:
+    """huggingface_hub hands us a JobAccelerator OBJECT here, not a string.
+
+    Forwarding it raw put a nested dict on the wire under a field the frontend
+    types as `string`, so the hardware picker rendered "[object Object]" for
+    every GPU flavor.
+    """
+    from huggingface_hub._jobs_api import JobAccelerator
+
+    from makermodslab.server import _format_accelerator
+
+    single = JobAccelerator(type="gpu", model="T4", quantity="1", vram="16 GB", manufacturer="Nvidia")
+    assert _format_accelerator(single) == "Nvidia T4"
+
+    multi = JobAccelerator(type="gpu", model="A100", quantity="4", vram="320 GB", manufacturer="Nvidia")
+    assert _format_accelerator(multi) == "4× Nvidia A100"
+
+    # cpu-* flavors carry no accelerator; the caller falls back to `cpu`.
+    assert _format_accelerator(None) is None
+
+
+def test_format_accelerator_survives_a_renamed_hub_field() -> None:
+    """A future hub version could rename the fields out from under us. Any
+    string still beats a dict the UI would render as [object Object]."""
+    from makermodslab.server import _format_accelerator
+
+    class _Unknown:
+        def __str__(self) -> str:
+            return "some-future-accelerator"
+
+    assert _format_accelerator(_Unknown()) == "some-future-accelerator"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -428,6 +428,7 @@ def test_policy_optimizer_defaults_reports_availability(client: TestClient) -> N
     assert data["available"]["act"] is True
     assert data["defaults"]["act"] is not None
     assert data["available"]["pi0_fast"] is True
+    assert data["available"]["pi05"] is True
     assert data["available"]["reward_classifier"] is False
     assert data["defaults"]["reward_classifier"] is None
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -306,6 +306,28 @@ def test_grad_clip_gated_on_policy_support() -> None:
     assert "--policy.type" in act
 
 
+def test_grad_clip_and_weight_decay_supported_for_pi05() -> None:
+    """pi05's PreTrainedConfig declares the same optimizer_lr/weight_decay/
+    grad_clip_norm trio as pi0 (verified by dataclass introspection against the
+    pinned lerobot) — it must not be treated more restrictively than pi0."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(
+        TrainingRequest(
+            dataset_repo_id="x",
+            policy_type="pi05",
+            optimizer_lr=2.5e-5,
+            optimizer_weight_decay=0.01,
+            optimizer_grad_clip_norm=1.0,
+        ),
+        "/tmp/out",
+    )
+
+    assert _arg_value(cmd, "--policy.optimizer_lr") == "2.5e-05"
+    assert _arg_value(cmd, "--policy.optimizer_weight_decay") == "0.01"
+    assert _arg_value(cmd, "--policy.optimizer_grad_clip_norm") == "1.0"
+
+
 def test_weight_decay_gated_for_tdmpc() -> None:
     """tdmpc declares only optimizer_lr — weight_decay must be dropped."""
     from makermodslab.train import TrainingRequest, build_training_command
@@ -366,7 +388,9 @@ def test_unknown_policy_type_falls_back_to_lr_only() -> None:
     assert "--policy.optimizer_grad_clip_norm" not in cmd
 
 
-@pytest.mark.parametrize("policy_type", ["act", "diffusion", "pi0", "smolvla", "tdmpc", "vqbet", "pi0_fast"])
+@pytest.mark.parametrize(
+    "policy_type", ["act", "diffusion", "pi0", "smolvla", "tdmpc", "vqbet", "pi0_fast", "pi05"]
+)
 def test_no_optimizer_namespace_flag_is_ever_emitted(policy_type: str) -> None:
     """The `--optimizer.*` namespace is dead under the training preset. Nothing
     the builder emits may land there — including the optimizer TYPE, which the

--- a/tests/test_utils_system.py
+++ b/tests/test_utils_system.py
@@ -132,9 +132,10 @@ def test_policy_extra_maps_policies_to_install_targets() -> None:
     assert smol["install_target"] == "lerobot[smolvla]"
     assert "lerobot[smolvla]" in smol["install_hint"]
 
-    # pi0 and pi0_fast share the lerobot[pi] extra; diffusion uses diffusers.
+    # pi0, pi0_fast, and pi05 share the lerobot[pi] extra; diffusion uses diffusers.
     assert handle_get_policy_extra("pi0")["install_target"] == "lerobot[pi]"
     assert handle_get_policy_extra("pi0_fast")["install_target"] == "lerobot[pi]"
+    assert handle_get_policy_extra("pi05")["install_target"] == "lerobot[pi]"
     assert handle_get_policy_extra("diffusion")["package"] == "diffusers"
     assert handle_get_policy_extra("diffusion")["install_target"] == "lerobot[diffusion]"
 


### PR DESCRIPTION
## What this fixes
- The app couldn't train or run inference with Physical Intelligence's PI0.5 model — it wasn't offered as a choice anywhere, even though the underlying LeRobot library already supports it.

## What changed
- PI0.5 is now a selectable policy on the "Create a model" page, alongside PI0, PI0 Fast, and SmolVLA.
- If the package PI0.5 needs isn't installed yet, starting training or inference now shows the same "needs an extra package" install popup that local training already had for SmolVLA. Previously that check only ran before training started, so a missing package on inference just failed with a confusing error partway through.

## To test
Backend:
```
GET /policy-optimizer-defaults
  -> available.pi05 == true, with real optimizer defaults (lr, weight_decay, etc.)

GET /system/policy-extra/pi05
  -> needs_extra: true, install_target: "lerobot[pi]"
     (verified against a local install missing `transformers`, which
     correctly reports available: false — the exact condition that
     triggers the install popup)
```
Both verified directly against the FastAPI app this session; `pytest` (950 passed, 1 pre-existing unrelated failure on `main` too), `ruff check`, `tsc --noEmit`, and `npm run lint` all clean.

Frontend (manual check needed — not verified in a browser this session):
1. Open the landing page's "Create a model" card — PI0.5 should appear next to PI0 / PI0 Fast / SmolVLA.
2. Start local training, or inference on a PI0.5 checkpoint, on a machine missing `transformers` — the "PI0.5 needs an extra package" dialog should appear with a one-click install button, same as SmolVLA's.
3. Manual Test: Have tried it, adjusted default settings to match PI's default settings.