### PR TITLE
Make the training form's optimizer controls real (route through the policy config)

### DIFF
--- a/frontend/src/components/training/config/AdvancedCard.tsx
+++ b/frontend/src/components/training/config/AdvancedCard.tsx
@@ -3,16 +3,9 @@ import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AdvancedSection } from "@/components/studio/panel/primitives";
 import { cn } from "@/lib/utils";
-import { ConfigComponentProps } from "../types";
+import { ConfigComponentProps, POLICY_TYPE_OPTIONS } from "../types";
 import { useApi } from "@/contexts/ApiContext";
 import { isValidTimeout } from "@/lib/jobTimeout";
 
@@ -46,6 +39,42 @@ const OPTIMIZER_LABELS: Record<string, string> = {
   sgd: "SGD",
   multi_adam: "Multi Adam",
 };
+
+type OptimizerKnob = "lr" | "weight_decay" | "grad_clip_norm";
+
+/**
+ * Which optimizer knobs each policy actually exposes — the mirror of
+ * `_POLICY_OPTIMIZER_FIELDS` in makermodslab/train.py. Keep the two in sync.
+ *
+ * Training always runs with the policy training preset on, so lerobot rebuilds
+ * the optimizer from the POLICY config's own `optimizer_*` fields and discards
+ * anything sent to the `--optimizer.*` namespace. The backend therefore emits
+ * `--policy.optimizer_<knob>`, and only for knobs the selected policy declares
+ * (an unknown one makes the CLI parser reject the run outright). A knob missing
+ * here would silently do nothing, so the input is hidden rather than shown as a
+ * control that can't take effect.
+ *
+ * This can NOT be derived from /policy-optimizer-defaults: that endpoint
+ * reports the preset OBJECT's fields, and both AdamW and Adam presets carry a
+ * grad_clip_norm regardless of whether the policy exposes a knob for it.
+ */
+const POLICY_OPTIMIZER_KNOBS: Record<string, readonly OptimizerKnob[]> = {
+  act: ["lr", "weight_decay"],
+  diffusion: ["lr", "weight_decay"],
+  pi0: ["lr", "weight_decay", "grad_clip_norm"],
+  smolvla: ["lr", "weight_decay", "grad_clip_norm"],
+  tdmpc: ["lr"],
+  vqbet: ["lr", "weight_decay"],
+  pi0_fast: ["lr", "weight_decay", "grad_clip_norm"],
+  // Its preset is a MultiAdam built from per-group settings — no scalar knobs.
+  gaussian_actor: [],
+};
+
+// Matches the backend's fallback for a policy type absent from the table.
+const DEFAULT_OPTIMIZER_KNOBS: readonly OptimizerKnob[] = ["lr"];
+
+const policyShortLabel = (value: string): string =>
+  POLICY_TYPE_OPTIONS.find((o) => o.value === value)?.label || value;
 
 /** Advanced-parameters section of the training form. Uses the shared
  * AdvancedSection, so its trigger is the same eyebrow-level control as the
@@ -91,6 +120,14 @@ const AdvancedCard: React.FC<ConfigComponentProps> = ({
   const defaultOptimizerLabel = d
     ? OPTIMIZER_LABELS[d.optimizer] ?? d.optimizer
     : null;
+
+  // The optimizer CLASS is fixed by the policy preset and cannot be overridden
+  // from the CLI, so it is shown, not chosen. Which scalar knobs remain
+  // adjustable is likewise a property of the policy.
+  const knobs =
+    POLICY_OPTIMIZER_KNOBS[config.policy_type] ?? DEFAULT_OPTIMIZER_KNOBS;
+  const has = (k: OptimizerKnob) => knobs.includes(k);
+  const policyLabel = policyShortLabel(config.policy_type);
 
   // Cloud-only "Job timeout": the raw string drives both the input and the
   // (mirror-of-backend) inline validity check. Blank = HF Jobs default (2h).
@@ -153,64 +190,74 @@ const AdvancedCard: React.FC<ConfigComponentProps> = ({
         <section className="space-y-3">
           <SectionHeading>Optimizer</SectionHeading>
           <div className="space-y-2">
-            <Label htmlFor="optimizer_type">Optimizer</Label>
-            <Select
-              value={config.optimizer_type || "adam"}
-              onValueChange={(value) => updateConfig("optimizer_type", value)}
-            >
-              <SelectTrigger id="optimizer_type">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="adam">Adam</SelectItem>
-                <SelectItem value="adamw">AdamW</SelectItem>
-                <SelectItem value="sgd">SGD</SelectItem>
-                <SelectItem value="multi_adam">Multi Adam</SelectItem>
-              </SelectContent>
-            </Select>
-            {defaultOptimizerLabel && (
-              <p className="text-xs text-muted-foreground">
-                Policy default: {defaultOptimizerLabel}
-              </p>
-            )}
+            <Label>Optimizer</Label>
+            <p className="text-sm">
+              {defaultOptimizerLabel ?? "Set by the policy preset"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {defaultOptimizerLabel
+                ? `Set by the ${policyLabel} policy preset — the optimizer class isn't adjustable.`
+                : "The policy preset picks the optimizer class; it isn't adjustable."}
+            </p>
           </div>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-            <div className="space-y-2">
-              <Label htmlFor="optimizer_lr">Learning rate</Label>
-              <NumberInput
-                id="optimizer_lr"
-                integer={false}
-                step="0.0001"
-                value={config.optimizer_lr}
-                onChange={(v) => updateConfig("optimizer_lr", v)}
-                placeholder={lrPlaceholder}
-              />
+          {knobs.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              The {policyLabel} preset builds its optimizer from per-parameter-group
+              settings, so there are no learning-rate or weight-decay knobs to set here.
+            </p>
+          ) : (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+              {has("lr") && (
+                <div className="space-y-2">
+                  <Label htmlFor="optimizer_lr">Learning rate</Label>
+                  <NumberInput
+                    id="optimizer_lr"
+                    integer={false}
+                    step="0.0001"
+                    value={config.optimizer_lr}
+                    onChange={(v) => updateConfig("optimizer_lr", v)}
+                    placeholder={lrPlaceholder}
+                  />
+                </div>
+              )}
+              {has("weight_decay") && (
+                <div className="space-y-2">
+                  <Label htmlFor="optimizer_weight_decay">Weight decay</Label>
+                  <NumberInput
+                    id="optimizer_weight_decay"
+                    integer={false}
+                    step="0.0001"
+                    value={config.optimizer_weight_decay}
+                    onChange={(v) => updateConfig("optimizer_weight_decay", v)}
+                    placeholder={wdPlaceholder}
+                  />
+                </div>
+              )}
+              {has("grad_clip_norm") && (
+                <div className="space-y-2">
+                  <Label htmlFor="optimizer_grad_clip_norm">
+                    Gradient clipping
+                  </Label>
+                  <NumberInput
+                    id="optimizer_grad_clip_norm"
+                    integer={false}
+                    step="0.0001"
+                    value={config.optimizer_grad_clip_norm}
+                    onChange={(v) =>
+                      updateConfig("optimizer_grad_clip_norm", v)
+                    }
+                    placeholder={gradPlaceholder}
+                  />
+                </div>
+              )}
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="optimizer_weight_decay">Weight decay</Label>
-              <NumberInput
-                id="optimizer_weight_decay"
-                integer={false}
-                step="0.0001"
-                value={config.optimizer_weight_decay}
-                onChange={(v) => updateConfig("optimizer_weight_decay", v)}
-                placeholder={wdPlaceholder}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="optimizer_grad_clip_norm">
-                Gradient clipping
-              </Label>
-              <NumberInput
-                id="optimizer_grad_clip_norm"
-                integer={false}
-                step="0.0001"
-                value={config.optimizer_grad_clip_norm}
-                onChange={(v) => updateConfig("optimizer_grad_clip_norm", v)}
-                placeholder={gradPlaceholder}
-              />
-            </div>
-          </div>
+          )}
+          {knobs.length > 0 && !has("grad_clip_norm") && (
+            <p className="text-xs text-muted-foreground">
+              The {policyLabel} policy exposes no gradient-clipping setting
+              {has("weight_decay") ? "" : " or weight decay"}.
+            </p>
+          )}
         </section>
 
         {/* Logging & Checkpointing */}

--- a/makermodslab/train.py
+++ b/makermodslab/train.py
@@ -80,6 +80,47 @@ def _policy_hub_flags() -> list[str]:
     return ["--policy.private", "false", "--policy.tags", tag_list]
 
 
+# Which optimizer knobs each policy type actually exposes on ITS OWN config.
+#
+# Why this exists: the form always runs with `use_policy_training_preset true`,
+# and lerobot's TrainPipelineConfig.validate() then REPLACES the whole optimizer
+# with `active_cfg.get_optimizer_preset()` (configs/train.py:249-253) on every
+# fresh run. So `--optimizer.*` flags are silently discarded — the only way to
+# influence the optimizer is to set the POLICY fields the preset is built from
+# (`ACTConfig.get_optimizer_preset()` -> `AdamWConfig(lr=self.optimizer_lr,
+# weight_decay=self.optimizer_weight_decay)`), i.e. `--policy.optimizer_lr`.
+#
+# Gating is load-bearing, not cosmetic: draccus fails at CLI PARSE time when
+# given a `--policy.<field>` the selected policy config doesn't declare, so
+# emitting an unsupported knob kills the run before training starts. And the
+# /policy-optimizer-defaults payload can NOT be used to derive this — both
+# AdamWConfig and AdamConfig carry a `grad_clip_norm` field regardless of
+# whether the policy exposes an `optimizer_grad_clip_norm` knob.
+#
+# Derived by dataclass introspection of the pinned lerobot (see the `lerobot`
+# commit pin in pyproject.toml): for each policy in the form's
+# POLICY_TYPE_OPTIONS, `dataclasses.fields(make_policy_config(<type>))`.
+# Re-verify after a pin bump. Unknown/absent policy types fall back to lr-only.
+#
+# Notable: `gaussian_actor` exposes NONE of the three (its preset is a
+# MultiAdamConfig built from per-group settings), so it gets an empty set.
+_POLICY_OPTIMIZER_FIELDS: dict[str, frozenset[str]] = {
+    "act": frozenset({"lr", "weight_decay"}),
+    "diffusion": frozenset({"lr", "weight_decay"}),
+    "pi0": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
+    "smolvla": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
+    "tdmpc": frozenset({"lr"}),
+    "vqbet": frozenset({"lr", "weight_decay"}),
+    "pi0_fast": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
+    "gaussian_actor": frozenset(),
+}
+
+# Conservative fallback for a policy type not in the table (e.g. one added to
+# the form ahead of this table, or an old persisted config). `optimizer_lr` is
+# the one knob every action policy in the pin declares.
+_DEFAULT_POLICY_OPTIMIZER_FIELDS = frozenset({"lr"})
+
+
 def _resolve_device(device: str | None) -> str:
     """Resolve the requested training device to a concrete backend.
 
@@ -222,6 +263,27 @@ class TrainingRequest(BaseModel):
         return text
 
 
+def _policy_optimizer_flags(request: "TrainingRequest") -> list[str]:
+    """`--policy.optimizer_*` flags for the knobs this policy actually exposes.
+
+    Fresh runs only — see `_POLICY_OPTIMIZER_FIELDS` above for why these replace
+    the inert `--optimizer.*` flags, and why unsupported knobs must be dropped
+    rather than passed through. A value the policy can't accept is silently
+    skipped: the user's stored config keeps it (so switching back to a policy
+    that does support it restores the value) but it never reaches argv.
+    """
+    supported = _POLICY_OPTIMIZER_FIELDS.get(request.policy_type, _DEFAULT_POLICY_OPTIMIZER_FIELDS)
+    flags: list[str] = []
+    for name, value in (
+        ("lr", request.optimizer_lr),
+        ("weight_decay", request.optimizer_weight_decay),
+        ("grad_clip_norm", request.optimizer_grad_clip_norm),
+    ):
+        if value is not None and name in supported:
+            flags.extend([f"--policy.optimizer_{name}", str(value)])
+    return flags
+
+
 def build_training_command(
     request: TrainingRequest, output_dir: str, python_executable: str = "python"
 ) -> list[str]:
@@ -349,15 +411,15 @@ def build_training_command(
     cmd.extend(["--eval.batch_size", str(request.eval_batch_size)])
     cmd.extend(["--eval.use_async_envs", "true" if request.eval_use_async_envs else "false"])
 
-    # Optimizer
-    if request.optimizer_type:
-        cmd.extend(["--optimizer.type", request.optimizer_type])
-    if request.optimizer_lr is not None:
-        cmd.extend(["--optimizer.lr", str(request.optimizer_lr)])
-    if request.optimizer_weight_decay is not None:
-        cmd.extend(["--optimizer.weight_decay", str(request.optimizer_weight_decay)])
-    if request.optimizer_grad_clip_norm is not None:
-        cmd.extend(["--optimizer.grad_clip_norm", str(request.optimizer_grad_clip_norm)])
+    # Optimizer. Routed through the POLICY config, never `--optimizer.*`: with
+    # the training preset on (always, below) lerobot overwrites the whole
+    # optimizer from `active_cfg.get_optimizer_preset()`, so every `--optimizer.*`
+    # flag is discarded before the first step. `request.optimizer_type` is
+    # deliberately NOT emitted — the optimizer CLASS is fixed by the policy's
+    # preset (AdamW for act/smolvla/pi0/pi0_fast, Adam for diffusion/vqbet/tdmpc)
+    # and is not overridable; the field survives on the request only because
+    # persisted job configs and the resume prefill read it. See MT43.
+    cmd.extend(_policy_optimizer_flags(request))
 
     # Advanced
     cmd.extend(["--use_policy_training_preset", "true" if request.use_policy_training_preset else "false"])

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -64,6 +64,10 @@ def test_resume_request_emits_minimal_argv() -> None:
     # Inherited from the checkpoint — must not be re-specified on the CLI.
     assert "--dataset.repo_id" not in cmd
     assert "--policy.type" not in cmd
+    assert "--optimizer.type" not in cmd
+    # Optimizer state comes from the checkpoint on a resume — see
+    # test_resume_emits_no_optimizer_flags for the full assertion.
+    assert not any(tok.startswith("--policy.optimizer_") for tok in cmd)
 
 
 def test_optional_dataset_fields_only_present_when_set() -> None:
@@ -227,6 +231,171 @@ def test_training_request_validates_required_field() -> None:
 
     with pytest.raises(ValidationError):
         TrainingRequest()  # dataset_repo_id is required
+
+
+# ---------------------------------------------------------------------------
+# Optimizer knobs. The form always runs with use_policy_training_preset true,
+# and lerobot then REPLACES the optimizer with the policy's preset
+# (TrainPipelineConfig.validate, configs/train.py:249-253), so `--optimizer.*`
+# is inert. The knobs must ride on the POLICY config the preset is built from,
+# and only where that policy actually declares them (draccus fails at CLI parse
+# on an unknown --policy.<field>). See MT43.
+# ---------------------------------------------------------------------------
+
+
+def test_optimizer_knobs_ride_on_policy_config() -> None:
+    """lr + weight_decay reach argv as --policy.optimizer_* for a policy (act)
+    that declares both."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    req = TrainingRequest(
+        dataset_repo_id="x",
+        policy_type="act",
+        optimizer_lr=1e-4,
+        optimizer_weight_decay=0.01,
+    )
+    cmd = build_training_command(req, "/tmp/out")
+
+    assert _arg_value(cmd, "--policy.optimizer_lr") == "0.0001"
+    assert _arg_value(cmd, "--policy.optimizer_weight_decay") == "0.01"
+
+
+def test_optimizer_knobs_absent_when_unset() -> None:
+    """A knob the user left blank must not be forced onto argv — the policy
+    preset's own default has to win."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(TrainingRequest(dataset_repo_id="x", policy_type="act"), "/tmp/out")
+
+    assert "--policy.optimizer_lr" not in cmd
+    assert "--policy.optimizer_weight_decay" not in cmd
+    assert "--policy.optimizer_grad_clip_norm" not in cmd
+
+
+def test_grad_clip_gated_on_policy_support() -> None:
+    """smolvla declares optimizer_grad_clip_norm; act does NOT. Passing it to
+    act would make draccus die at parse time, so it must be dropped even though
+    the user set a value."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    smolvla = build_training_command(
+        TrainingRequest(dataset_repo_id="x", policy_type="smolvla", optimizer_grad_clip_norm=5.0),
+        "/tmp/out",
+    )
+    assert _arg_value(smolvla, "--policy.optimizer_grad_clip_norm") == "5.0"
+
+    act = build_training_command(
+        TrainingRequest(dataset_repo_id="x", policy_type="act", optimizer_grad_clip_norm=5.0),
+        "/tmp/out",
+    )
+    assert "--policy.optimizer_grad_clip_norm" not in act
+    # ...and dropping it must not disturb the knobs act DOES support.
+    assert "--policy.type" in act
+
+
+def test_weight_decay_gated_for_tdmpc() -> None:
+    """tdmpc declares only optimizer_lr — weight_decay must be dropped."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(
+        TrainingRequest(
+            dataset_repo_id="x",
+            policy_type="tdmpc",
+            optimizer_lr=3e-4,
+            optimizer_weight_decay=0.01,
+            optimizer_grad_clip_norm=5.0,
+        ),
+        "/tmp/out",
+    )
+
+    assert _arg_value(cmd, "--policy.optimizer_lr") == "0.0003"
+    assert "--policy.optimizer_weight_decay" not in cmd
+    assert "--policy.optimizer_grad_clip_norm" not in cmd
+
+
+def test_gaussian_actor_takes_no_optimizer_knobs() -> None:
+    """gaussian_actor's preset is a MultiAdamConfig built from per-group
+    settings; its config declares none of the three scalar knobs."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(
+        TrainingRequest(
+            dataset_repo_id="x",
+            policy_type="gaussian_actor",
+            optimizer_lr=1e-4,
+            optimizer_weight_decay=0.01,
+            optimizer_grad_clip_norm=5.0,
+        ),
+        "/tmp/out",
+    )
+
+    assert not any(tok.startswith("--policy.optimizer_") for tok in cmd)
+
+
+def test_unknown_policy_type_falls_back_to_lr_only() -> None:
+    """A policy type absent from the capability table (form addition ahead of
+    the table, or an old persisted config) gets the conservative subset."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(
+        TrainingRequest(
+            dataset_repo_id="x",
+            policy_type="some_future_policy",
+            optimizer_lr=1e-4,
+            optimizer_weight_decay=0.01,
+            optimizer_grad_clip_norm=5.0,
+        ),
+        "/tmp/out",
+    )
+
+    assert _arg_value(cmd, "--policy.optimizer_lr") == "0.0001"
+    assert "--policy.optimizer_weight_decay" not in cmd
+    assert "--policy.optimizer_grad_clip_norm" not in cmd
+
+
+@pytest.mark.parametrize("policy_type", ["act", "diffusion", "pi0", "smolvla", "tdmpc", "vqbet", "pi0_fast"])
+def test_no_optimizer_namespace_flag_is_ever_emitted(policy_type: str) -> None:
+    """The `--optimizer.*` namespace is dead under the training preset. Nothing
+    the builder emits may land there — including the optimizer TYPE, which the
+    policy preset fixes and the CLI cannot override."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    req = TrainingRequest(
+        dataset_repo_id="x",
+        policy_type=policy_type,
+        optimizer_type="sgd",
+        optimizer_lr=1e-4,
+        optimizer_weight_decay=0.01,
+        optimizer_grad_clip_norm=5.0,
+    )
+    cmd = build_training_command(req, "/tmp/out")
+
+    assert not any(tok.startswith("--optimizer.") for tok in cmd)
+    assert "sgd" not in cmd
+    # The preset is what makes --optimizer.* inert; assert it's actually on.
+    assert _arg_value(cmd, "--use_policy_training_preset") == "true"
+
+
+def test_resume_emits_no_optimizer_flags() -> None:
+    """On resume lerobot SKIPS the preset overwrite (the `not self.resume`
+    guard) and restores optimizer state from the checkpoint. Re-specifying the
+    knobs would fight that, so neither namespace may appear."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    req = TrainingRequest(
+        dataset_repo_id="x",
+        policy_type="smolvla",
+        resume=True,
+        config_path="/runs/abc/checkpoints/5000/pretrained_model/train_config.json",
+        optimizer_type="sgd",
+        optimizer_lr=1e-4,
+        optimizer_weight_decay=0.01,
+        optimizer_grad_clip_norm=5.0,
+    )
+    cmd = build_training_command(req, "/tmp/new")
+
+    assert not any(tok.startswith("--optimizer.") for tok in cmd)
+    assert not any(tok.startswith("--policy.optimizer_") for tok in cmd)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The form's optimizer controls were display-only: with `--use_policy_training_preset true` always on, lerobot's `TrainPipelineConfig.validate()` replaces the whole optimizer with the policy's preset, so every `--optimizer.*` flag we emitted was silently discarded. Every run trained with the preset (AdamW for act/smolvla/pi0, Adam for diffusion/vqbet/tdmpc) regardless of what the user set — an editable "Adam" dropdown that never did anything.

- **Backend**: `_policy_optimizer_flags` routes lr / weight-decay / grad-clip through `--policy.optimizer_*` — the fields the preset actually builds from — gated by a per-policy capability table (weight_decay: all but tdmpc; grad_clip_norm: only smolvla/pi0/pi0_fast; a flag the policy config lacks fails at draccus parse). No `--optimizer.*` flag is emitted anywhere anymore.
- **Frontend** (`AdvancedCard`): the optimizer-type Select becomes an honest display of the policy's actual preset ("AdamW — set by the ACT policy preset", fed by the existing `/policy-optimizer-defaults` endpoint), and unsupported knobs are hidden rather than rendered as controls that can't take effect. Policies whose preset is built from per-parameter-group settings (gaussian_actor) show no scalar knobs at all.
- **Resume unchanged**: the resume branch still emits no optimizer flags — optimizer state comes from the checkpoint, and lerobot skips the preset overwrite on resume.

## Test plan

- [x] `pytest tests/test_train.py`: 54 passed — including new tests pinning: lr+weight-decay emitted when set (act), grad-clip emitted for smolvla but not act, weight-decay not emitted for tdmpc, no `--optimizer.*` token in any generated command, resume emits none of the new flags
- [x] `ruff check` clean on touched files
- [x] `npx tsc --noEmit` clean; eslint clean on `AdvancedCard.tsx`
- [x] Capability table cross-checked against the pinned lerobot's policy configs (`get_optimizer_preset` + `optimizer_*` fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)