### PR TITLE
fix(datasets): qualify bare repo_id with namespace in hub-status check

### DIFF
--- a/frontend/src/components/landing/DatasetInfoCard.tsx
+++ b/frontend/src/components/landing/DatasetInfoCard.tsx
@@ -468,6 +468,9 @@ const HubSyncRow: React.FC<{ repoId: string }> = ({ repoId }) => {
   const { toast } = useToast();
   const [status, setStatus] = useState<HubStatusValue>("unknown");
   const [hubUrl, setHubUrl] = useState<string | null>(null);
+  // A Hub repo of this name exists but holds different data than the local
+  // copy, so it is NOT a backup of it — see HubStatus.local_differs.
+  const [localDiffers, setLocalDiffers] = useState(false);
   // Bumped after a visibility/tags edit to re-run the status fetch (the backend
   // invalidates its hub-status cache on a change, so this re-reads fresh).
   const [refreshKey, setRefreshKey] = useState(0);
@@ -478,6 +481,8 @@ const HubSyncRow: React.FC<{ repoId: string }> = ({ repoId }) => {
     onDone: (url) => {
       setStatus("on_hub");
       setHubUrl(url);
+      // The push just made the Hub copy match the local one.
+      setLocalDiffers(false);
       toast({
         title: "Uploaded to Hub",
         description: (
@@ -522,10 +527,12 @@ const HubSyncRow: React.FC<{ repoId: string }> = ({ repoId }) => {
     const controller = new AbortController();
     setStatus("unknown");
     setHubUrl(null);
+    setLocalDiffers(false);
     getDatasetHubStatus(baseUrl, fetchWithHeaders, repoId, controller.signal)
       .then((data) => {
         setStatus(data.status);
         setHubUrl(data.url);
+        setLocalDiffers(data.local_differs === true);
       })
       .catch(() => {
         // Degrade silently to "unknown" — no error spam on the card.
@@ -539,6 +546,49 @@ const HubSyncRow: React.FC<{ repoId: string }> = ({ repoId }) => {
       <div className="flex items-center gap-1.5 text-muted-foreground">
         <Loader2 className="h-3 w-3 animate-spin" />
         <span>Uploading to Hub…</span>
+      </div>
+    );
+  }
+
+  // A Hub repo of this name exists, but it holds different data than the local
+  // copy — so it is NOT a backup of it. Say so instead of "Uploaded to
+  // HuggingFace" (which invites deleting a local copy that was never pushed)
+  // and keep offering the upload, warned that it merges into that repo.
+  if (status === "on_hub" && localDiffers) {
+    return (
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-1.5 text-amber-700 dark:text-amber-400">
+          On Hub, but the local copy differs
+          {hubUrl && (
+            <a
+              href={hubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-0.5 hover:text-foreground"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </span>
+        <UploadDatasetDialog
+          repoId={repoId}
+          start={start}
+          warning={
+            <>
+              A dataset named {repoId} is already on the Hub with different
+              contents. Uploading pushes this local copy into that same repo.
+            </>
+          }
+        >
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-6 gap-1 border-amber-500/50 px-2 text-xs text-amber-700 dark:text-amber-300 hover:bg-amber-500/10"
+          >
+            <UploadIcon className="h-3 w-3" />
+            Upload to Hub
+          </Button>
+        </UploadDatasetDialog>
       </div>
     );
   }

--- a/frontend/src/components/landing/UploadDatasetDialog.tsx
+++ b/frontend/src/components/landing/UploadDatasetDialog.tsx
@@ -32,7 +32,11 @@ const UploadDatasetDialog: React.FC<{
   /** Popover trigger element (a button/icon). */
   children: React.ReactNode;
   align?: "start" | "center" | "end";
-}> = ({ repoId, start, children, align = "end" }) => {
+  /** Shown above the form when the upload needs a caveat — e.g. a Hub repo of
+   * this name already exists and holds different data, so this push merges
+   * into it rather than creating a fresh repo. */
+  warning?: React.ReactNode;
+}> = ({ repoId, start, children, align = "end", warning }) => {
   const { toast } = useToast();
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isPrivate, setIsPrivate] = useState(false);
@@ -87,6 +91,11 @@ const UploadDatasetDialog: React.FC<{
         onPointerDown={(e) => e.stopPropagation()}
       >
         <div className="space-y-3">
+          {warning && (
+            <p className="leading-snug text-amber-700 dark:text-amber-400">
+              {warning}
+            </p>
+          )}
           <div className="space-y-1.5">
             <Label
               id={`hub-upload-visibility-${repoId}`}

--- a/frontend/src/lib/replayApi.ts
+++ b/frontend/src/lib/replayApi.ts
@@ -249,6 +249,13 @@ export interface HubStatus {
   repo_id: string;
   status: HubStatusValue;
   url: string | null;
+  /** Qualifies "on_hub": a locally-recorded dataset is matched to a Hub repo by
+   * NAME, and a name match is not an identity match (a local rename frees the
+   * name while the old repo keeps it; recording more episodes diverges the
+   * copies). True = a local copy exists and disagrees with that repo, so it is
+   * NOT backed up by it. null = no claim (not on_hub, no local copy, or the
+   * comparison couldn't be made). */
+  local_differs: boolean | null;
 }
 
 /** Hub existence check, fetched lazily/separately so it never blocks the

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -95,14 +95,26 @@ _HUB_FANOUT_MAX_WORKERS = 8
 # fast and degrades to "whatever the finished authors returned".
 _HUB_FANOUT_TIMEOUT_S = 5.0
 
-# In-process cache of Hub existence checks, keyed by the repo_id the caller
-# passed in (bare local id or already-namespaced) -> (status, url). /whoami-v2
-# and repo-existence lookups hit the network, so the info card fetches this
-# lazily and we memoize the "on Hub" answer for the process lifetime. A
-# successful upload invalidates the entry (see invalidate_hub_status), so the
-# card can flip Local only -> On Hub without waiting for a cache expiry.
-# "unknown" (the offline/unauthenticated/error degrade) is never cached, so
-# connectivity returning is picked up on the next check.
+# In-process cache of Hub existence checks, keyed by the id actually LOOKED UP
+# on the Hub (see _resolve_hub_repo_id: a bare local id resolved against the
+# logged-in namespace, or an already-namespaced id as-is) -> (status, url).
+# /whoami-v2 and repo-existence lookups hit the network, so the info card
+# fetches this lazily and we memoize the "on Hub" answer for the process
+# lifetime. A successful upload invalidates the entry (see
+# invalidate_hub_status), so the card can flip Local only -> On Hub without
+# waiting for a cache expiry. "unknown" (the offline/unauthenticated/error
+# degrade) is never cached, so connectivity returning is picked up on the next
+# check.
+#
+# Keying by the RESOLVED id (not the caller's bare id) is load-bearing: the
+# answer for a bare id depends on who is logged in, and the token can change
+# mid-process (the UI has an in-app login — see handle_hf_login). Keying by the
+# bare id alone would pin the first answer to that repo id forever: a status
+# fetched before login (unauthenticated → literal bare lookup → "local_only")
+# would survive the login and keep an already-uploaded dataset reading "Local
+# only" (re-offering upload, and making the cloud-training preflight in
+# jobs.start refuse it) for the process lifetime, and a login as a different
+# account would keep serving the previous account's on_hub answer and url.
 _HUB_STATUS_CACHE: dict[str, tuple[str, str | None]] = {}
 _HUB_STATUS_LOCK = threading.Lock()
 
@@ -110,9 +122,20 @@ _HUB_STATUS_LOCK = threading.Lock()
 def invalidate_hub_status(repo_id: str) -> None:
     """Drop the cached Hub-existence answer for `repo_id`. Called after a
     successful upload so the next /datasets/hub-status re-checks (and sees
-    the freshly pushed repo)."""
+    the freshly pushed repo).
+
+    Callers pass the id they hold — a bare local id, or a namespaced one. The
+    cache is keyed by the RESOLVED lookup id, so a bare id also drops every
+    "<namespace>/<repo_id>" entry (whichever namespace was logged in when the
+    answer was cached). Dropping a same-named entry of some other namespace is
+    harmless: it just forces one re-check.
+    """
     with _HUB_STATUS_LOCK:
         _HUB_STATUS_CACHE.pop(repo_id, None)
+        if "/" not in repo_id:
+            suffix = f"/{repo_id}"
+            for key in [k for k in _HUB_STATUS_CACHE if k.endswith(suffix)]:
+                del _HUB_STATUS_CACHE[key]
 
 
 # Short-TTL cache of the merged /datasets listing. Startup + navigation re-hit
@@ -188,6 +211,29 @@ def _fan_out_hub_authors(authors: list[str], call: Callable[[str], Any]) -> list
     return [r for r in results if r is not None]
 
 
+def _resolve_hub_repo_id(repo_id: str) -> str:
+    """The id to address `repo_id` by on the Hub.
+
+    A locally-recorded dataset's repo_id is bare (no "namespace/" prefix) —
+    that's the only form the app naturally has for it, since local dataset
+    directories aren't namespaced. Some Hub APIs resolve a bare id to the
+    caller's own namespace (``create_repo``, ``delete_repo``) and some do a
+    literal lookup that 404s on it (``repo_exists``, ``dataset_info``,
+    ``update_repo_settings``, ``snapshot_download``); qualifying up front makes
+    every call agree on one repo.
+
+    Returns the id unchanged when it is already namespaced, or when there's no
+    token to resolve a namespace from — callers must degrade gracefully rather
+    than raise on the unauthenticated case.
+    """
+    if "/" in repo_id:
+        return repo_id
+    who = cached_whoami()
+    if who is None:
+        return repo_id
+    return f"{who['name']}/{repo_id}"
+
+
 def get_hub_status(repo_id: str) -> dict[str, Any]:
     """Where a dataset repo with this id lives.
 
@@ -216,26 +262,23 @@ def get_hub_status(repo_id: str) -> dict[str, Any]:
     that's the only form the app naturally has for it. Unlike
     ``HfApi.create_repo()``, ``HfApi.repo_exists()`` does a literal lookup and
     does NOT resolve a bare id to the caller's own namespace, so a bare id is
-    qualified with the caller's namespace for the existence check (and for the
-    returned ``url``) when authenticated. The public contract is unchanged:
-    the returned ``repo_id`` is always exactly what was passed in, and the
-    cache stays keyed by that same string, matching the bare id every
-    ``invalidate_hub_status()`` caller already uses.
+    qualified with the caller's namespace (``_resolve_hub_repo_id``) for the
+    existence check and for the returned ``url``. Unauthenticated, there's no
+    namespace to qualify with, so it degrades to the literal bare-id lookup
+    rather than raising. The public contract is unchanged: the returned
+    ``repo_id`` is always exactly what was passed in.
     """
+    hub_repo_id = _resolve_hub_repo_id(repo_id)
+
+    # Keyed by the RESOLVED id, so an answer never outlives the auth state it
+    # was derived from — a later login (or a switch to another account) misses
+    # the cache and re-checks instead of serving the previous namespace's
+    # answer. See _HUB_STATUS_CACHE.
     with _HUB_STATUS_LOCK:
-        cached = _HUB_STATUS_CACHE.get(repo_id)
+        cached = _HUB_STATUS_CACHE.get(hub_repo_id)
     if cached is not None:
         cached_status, cached_url = cached
         return {"repo_id": repo_id, "status": cached_status, "url": cached_url}
-
-    hub_repo_id = repo_id
-    if "/" not in hub_repo_id:
-        who = cached_whoami()
-        if who is not None:
-            hub_repo_id = f"{who['name']}/{hub_repo_id}"
-        # else: no auth — fall back to the literal bare-id lookup below rather
-        # than raising; get_hub_status is documented to never raise, and an
-        # unauthenticated caller has no namespace to qualify with anyway.
 
     api = shared_hf_api()
     try:
@@ -264,7 +307,7 @@ def get_hub_status(repo_id: str) -> dict[str, Any]:
         # Cache only the definitive, stable answers; "absent" can flip to local
         # without a hub-status invalidation, so leave it uncached (like "unknown").
         if status in ("on_hub", "local_only"):
-            _HUB_STATUS_CACHE[repo_id] = (status, url)
+            _HUB_STATUS_CACHE[hub_repo_id] = (status, url)
     return {"repo_id": repo_id, "status": status, "url": url}
 
 

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -234,11 +234,47 @@ def _resolve_hub_repo_id(repo_id: str) -> str:
     return f"{who['name']}/{repo_id}"
 
 
+def _local_copy_differs_from_hub(repo_id: str) -> bool | None:
+    """Whether a FLAT-layout local copy of `repo_id` disagrees with the Hub repo
+    of the same name — i.e. "on the Hub" is NOT proof this local data is backed
+    up.
+
+    A bare id is matched to a Hub repo by NAME (``<namespace>/<repo_id>``), and
+    a name match is not an identity match. rename_local_dataset only moves the
+    local directory — the Hub repo keeps its old name — so a name freed locally
+    can be reused by a completely different recording while the old repo still
+    answers to it. Recording more episodes into an already-uploaded dataset
+    diverges the same way. Both render as "Uploaded to HuggingFace" with no
+    upload affordance, which invites deleting a local copy that was never
+    backed up.
+
+    Compares ``meta/info.json`` episode/frame counts (the Hub side reuses the
+    cached summary the info card already fetches). Returns None — "no claim" —
+    when there's no local copy to protect, or when the Hub summary can't be
+    read (offline / transport error): a degraded read must not manufacture a
+    mismatch warning.
+    """
+    local_info_path = _lerobot_cache_root() / repo_id / "meta" / "info.json"
+    try:
+        local = json.loads(local_info_path.read_text())
+    except (OSError, ValueError):
+        return None
+
+    hub = get_hub_dataset_info(repo_id)
+    if hub is None:
+        return None
+
+    return (int(local.get("total_episodes") or 0), int(local.get("total_frames") or 0)) != (
+        hub["total_episodes"],
+        hub["total_frames"],
+    )
+
+
 def get_hub_status(repo_id: str) -> dict[str, Any]:
     """Where a dataset repo with this id lives.
 
     Returns ``{"repo_id": ..., "status": "on_hub" | "local_only" | "absent" |
-    "unknown", "url": <hub url> | None}``:
+    "unknown", "url": <hub url> | None, "local_differs": bool | None}``:
 
     * ``on_hub``     — the repo exists on the Hub.
     * ``local_only`` — NOT on the Hub, but a usable local copy exists (a
@@ -252,11 +288,20 @@ def get_hub_status(repo_id: str) -> dict[str, Any]:
       distinct status lets the card say "not found" instead.
     * ``unknown``    — offline / unauthenticated / any transport error.
 
+    ``local_differs`` qualifies ``on_hub``: True when a local copy exists but
+    disagrees with the same-named Hub repo, so the card must not present it as
+    a backup (see _local_copy_differs_from_hub). None means "no claim" — not
+    ``on_hub``, no local copy, or the comparison couldn't be made.
+
     Never raises. Definitive Hub answers (``on_hub`` / ``local_only``) are
     memoized per repo_id for the process lifetime; ``"unknown"`` and ``"absent"``
     are NOT cached (a later record/merge/download can make an ``absent`` dataset
     appear locally without a hub-status invalidation, and a transient failure
-    should self-heal) so both re-check on the next call.
+    should self-heal) so both re-check on the next call. ``local_differs`` is
+    deliberately NOT cached alongside them: it tracks LOCAL content, which
+    changes (another recording session appends episodes) without any
+    hub-status invalidation. It re-reads a small local file and the already
+    cached Hub summary, so recomputing it per call is cheap.
 
     A locally-recorded dataset's repo_id is bare (no "namespace/" prefix) —
     that's the only form the app naturally has for it. Unlike
@@ -278,7 +323,12 @@ def get_hub_status(repo_id: str) -> dict[str, Any]:
         cached = _HUB_STATUS_CACHE.get(hub_repo_id)
     if cached is not None:
         cached_status, cached_url = cached
-        return {"repo_id": repo_id, "status": cached_status, "url": cached_url}
+        return {
+            "repo_id": repo_id,
+            "status": cached_status,
+            "url": cached_url,
+            "local_differs": (_local_copy_differs_from_hub(repo_id) if cached_status == "on_hub" else None),
+        }
 
     api = shared_hf_api()
     try:
@@ -287,7 +337,7 @@ def get_hub_status(repo_id: str) -> dict[str, Any]:
         # Offline / rate-limited / any other transport error: degrade to
         # "unknown" without caching so it re-checks once connectivity returns.
         logger.info("hub-status repo_exists(%s) failed: %s", hub_repo_id, exc)
-        return {"repo_id": repo_id, "status": "unknown", "url": None}
+        return {"repo_id": repo_id, "status": "unknown", "url": None, "local_differs": None}
 
     if exists:
         status = "on_hub"
@@ -308,7 +358,12 @@ def get_hub_status(repo_id: str) -> dict[str, Any]:
         # without a hub-status invalidation, so leave it uncached (like "unknown").
         if status in ("on_hub", "local_only"):
             _HUB_STATUS_CACHE[hub_repo_id] = (status, url)
-    return {"repo_id": repo_id, "status": status, "url": url}
+    return {
+        "repo_id": repo_id,
+        "status": status,
+        "url": url,
+        "local_differs": _local_copy_differs_from_hub(repo_id) if exists else None,
+    }
 
 
 class DatasetHubEditError(Exception):

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -95,14 +95,15 @@ _HUB_FANOUT_MAX_WORKERS = 8
 # fast and degrades to "whatever the finished authors returned".
 _HUB_FANOUT_TIMEOUT_S = 5.0
 
-# In-process cache of Hub existence checks, keyed by repo_id. /whoami-v2 and
-# repo-existence lookups hit the network, so the info card fetches this lazily
-# and we memoize the "on Hub" answer for the process lifetime. A successful
-# upload invalidates the entry (see invalidate_hub_status), so the card can
-# flip Local only -> On Hub without waiting for a cache expiry. "unknown" (the
-# offline/unauthenticated/error degrade) is never cached, so connectivity
-# returning is picked up on the next check.
-_HUB_STATUS_CACHE: dict[str, str] = {}
+# In-process cache of Hub existence checks, keyed by the repo_id the caller
+# passed in (bare local id or already-namespaced) -> (status, url). /whoami-v2
+# and repo-existence lookups hit the network, so the info card fetches this
+# lazily and we memoize the "on Hub" answer for the process lifetime. A
+# successful upload invalidates the entry (see invalidate_hub_status), so the
+# card can flip Local only -> On Hub without waiting for a cache expiry.
+# "unknown" (the offline/unauthenticated/error degrade) is never cached, so
+# connectivity returning is picked up on the next check.
+_HUB_STATUS_CACHE: dict[str, tuple[str, str | None]] = {}
 _HUB_STATUS_LOCK = threading.Lock()
 
 
@@ -210,38 +211,61 @@ def get_hub_status(repo_id: str) -> dict[str, Any]:
     are NOT cached (a later record/merge/download can make an ``absent`` dataset
     appear locally without a hub-status invalidation, and a transient failure
     should self-heal) so both re-check on the next call.
-    """
-    url = f"https://huggingface.co/datasets/{repo_id}"
 
+    A locally-recorded dataset's repo_id is bare (no "namespace/" prefix) —
+    that's the only form the app naturally has for it. Unlike
+    ``HfApi.create_repo()``, ``HfApi.repo_exists()`` does a literal lookup and
+    does NOT resolve a bare id to the caller's own namespace, so a bare id is
+    qualified with the caller's namespace for the existence check (and for the
+    returned ``url``) when authenticated. The public contract is unchanged:
+    the returned ``repo_id`` is always exactly what was passed in, and the
+    cache stays keyed by that same string, matching the bare id every
+    ``invalidate_hub_status()`` caller already uses.
+    """
     with _HUB_STATUS_LOCK:
         cached = _HUB_STATUS_CACHE.get(repo_id)
     if cached is not None:
-        return {"repo_id": repo_id, "status": cached, "url": url if cached == "on_hub" else None}
+        cached_status, cached_url = cached
+        return {"repo_id": repo_id, "status": cached_status, "url": cached_url}
+
+    hub_repo_id = repo_id
+    if "/" not in hub_repo_id:
+        who = cached_whoami()
+        if who is not None:
+            hub_repo_id = f"{who['name']}/{hub_repo_id}"
+        # else: no auth — fall back to the literal bare-id lookup below rather
+        # than raising; get_hub_status is documented to never raise, and an
+        # unauthenticated caller has no namespace to qualify with anyway.
 
     api = shared_hf_api()
     try:
-        exists = api.repo_exists(repo_id, repo_type="dataset")
+        exists = api.repo_exists(hub_repo_id, repo_type="dataset")
     except Exception as exc:
         # Offline / rate-limited / any other transport error: degrade to
         # "unknown" without caching so it re-checks once connectivity returns.
-        logger.info("hub-status repo_exists(%s) failed: %s", repo_id, exc)
+        logger.info("hub-status repo_exists(%s) failed: %s", hub_repo_id, exc)
         return {"repo_id": repo_id, "status": "unknown", "url": None}
 
     if exists:
         status = "on_hub"
+        # Use the resolved/namespaced id so the URL is one the Hub actually
+        # serves — building it from a bare repo_id would 404.
+        url = f"https://huggingface.co/datasets/{hub_repo_id}"
     elif is_dataset_available_locally(repo_id):
         # Not on the Hub, but a usable local copy exists — genuinely local-only.
         status = "local_only"
+        url = None
     else:
         # Neither on the Hub nor local: don't mislabel this "local_only".
         status = "absent"
+        url = None
 
     with _HUB_STATUS_LOCK:
         # Cache only the definitive, stable answers; "absent" can flip to local
         # without a hub-status invalidation, so leave it uncached (like "unknown").
         if status in ("on_hub", "local_only"):
-            _HUB_STATUS_CACHE[repo_id] = status
-    return {"repo_id": repo_id, "status": status, "url": url if exists else None}
+            _HUB_STATUS_CACHE[repo_id] = (status, url)
+    return {"repo_id": repo_id, "status": status, "url": url}
 
 
 class DatasetHubEditError(Exception):

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -354,14 +354,20 @@ def get_hub_settings(repo_id: str) -> dict[str, Any]:
     read reliably) or on a Hub failure so the route can surface a clear error.
     Tags come from the dataset card metadata (``dataset_info(...).tags``); the
     REQUIRED_HUB_TAGS are not stripped here — the card shows exactly what's live.
+
+    A bare (locally-recorded) repo_id is qualified with the caller's namespace
+    first — ``dataset_info`` does a literal lookup, so the bare id 404s even
+    when the dataset is on the Hub. The editor is offered exactly when
+    get_hub_status says ``on_hub``, which resolves the same way.
     """
     if hf_hub_offline():
         raise DatasetHubEditError(400, "The Hub is offline — dataset settings can't be read right now.")
+    hub_repo_id = _resolve_hub_repo_id(repo_id)
     api = shared_hf_api()
     try:
-        info = api.dataset_info(repo_id)
+        info = api.dataset_info(hub_repo_id)
     except Exception as exc:
-        logger.info("dataset_info(%s) failed: %s", repo_id, exc)
+        logger.info("dataset_info(%s) failed: %s", hub_repo_id, exc)
         raise _hub_edit_error(exc) from exc
     return {
         "repo_id": repo_id,
@@ -377,16 +383,19 @@ def set_dataset_visibility(repo_id: str, private: bool) -> dict[str, Any]:
     (this huggingface_hub version has no ``update_repo_visibility``). Refuses
     offline (can't mutate). Maps auth/permission failures to a clear message.
     Invalidates the cached Hub-existence answer so the card re-reads settings.
+    A bare repo_id is qualified first (``update_repo_settings`` is another
+    literal-lookup call — see get_hub_settings).
     """
     if hf_hub_offline():
         raise DatasetHubEditError(
             400, "The Hub is offline — you can't change a dataset's visibility right now."
         )
+    hub_repo_id = _resolve_hub_repo_id(repo_id)
     api = shared_hf_api()
     try:
-        api.update_repo_settings(repo_id, private=private, repo_type="dataset")
+        api.update_repo_settings(hub_repo_id, private=private, repo_type="dataset")
     except Exception as exc:
-        logger.info("update_repo_settings(%s, private=%s) failed: %s", repo_id, private, exc)
+        logger.info("update_repo_settings(%s, private=%s) failed: %s", hub_repo_id, private, exc)
         raise _hub_edit_error(exc) from exc
 
     invalidate_hub_status(repo_id)
@@ -402,15 +411,17 @@ def set_dataset_tags(repo_id: str, tags: list[str]) -> dict[str, Any]:
     required org/product tags (makermods / openbooth / MakerModsLab) are never dropped
     by an edit, then written with ``metadata_update(..., overwrite=True)``.
     Refuses offline. Maps auth/permission failures. Invalidates the cached
-    Hub-existence answer. Returns the final tag list actually written.
+    Hub-existence answer. Returns the final tag list actually written. A bare
+    repo_id is qualified first (see get_hub_settings).
     """
     if hf_hub_offline():
         raise DatasetHubEditError(400, "The Hub is offline — you can't edit a dataset's tags right now.")
     final_tags = with_makermodslab_tag(tags)
+    hub_repo_id = _resolve_hub_repo_id(repo_id)
     try:
-        metadata_update(repo_id, {"tags": final_tags}, repo_type="dataset", overwrite=True)
+        metadata_update(hub_repo_id, {"tags": final_tags}, repo_type="dataset", overwrite=True)
     except Exception as exc:
-        logger.info("metadata_update(%s, tags=%s) failed: %s", repo_id, final_tags, exc)
+        logger.info("metadata_update(%s, tags=%s) failed: %s", hub_repo_id, final_tags, exc)
         raise _hub_edit_error(exc) from exc
 
     invalidate_hub_status(repo_id)
@@ -774,15 +785,16 @@ def _ensure_hub_episodes_root(repo_id: str) -> Path | None:
         return None
     if not _hub_dataset_has_video(repo_id):
         return None
+    hub_repo_id = _resolve_hub_repo_id(repo_id)
     try:
-        info_path = hf_hub_download(repo_id, filename="meta/info.json", repo_type="dataset")
+        info_path = hf_hub_download(hub_repo_id, filename="meta/info.json", repo_type="dataset")
         root = Path(info_path).parents[1]  # strip "meta/info.json"'s 2 path parts
-        files = shared_hf_api().list_repo_files(repo_id, repo_type="dataset")
+        files = shared_hf_api().list_repo_files(hub_repo_id, repo_type="dataset")
         for f in files:
             if f.startswith("meta/episodes/") and f.endswith(".parquet"):
-                hf_hub_download(repo_id, filename=f, repo_type="dataset")
+                hf_hub_download(hub_repo_id, filename=f, repo_type="dataset")
     except Exception as exc:
-        logger.info("hub episode metadata fetch for %s failed: %s", repo_id, exc)
+        logger.info("hub episode metadata fetch for %s failed: %s", hub_repo_id, exc)
         return None
     return root
 
@@ -901,7 +913,11 @@ def get_episode_video_path(repo_id: str, episode_index: int, camera: str) -> Pat
     rel_video_path = Path("videos") / video_key / f"chunk-{chunk_index:03d}" / f"file-{file_index:03d}.mp4"
     if is_hub:
         try:
-            return Path(hf_hub_download(repo_id, filename=str(rel_video_path), repo_type="dataset"))
+            return Path(
+                hf_hub_download(
+                    _resolve_hub_repo_id(repo_id), filename=str(rel_video_path), repo_type="dataset"
+                )
+            )
         except Exception as exc:
             logger.info("hub video chunk fetch for %s failed: %s", repo_id, exc)
             return None
@@ -946,7 +962,11 @@ def get_episode_joint_series(repo_id: str, episode_index: int) -> dict[str, Any]
     rel_data_path = Path("data") / f"chunk-{chunk_index:03d}" / f"file-{file_index:03d}.parquet"
     if is_hub:
         try:
-            data_path = Path(hf_hub_download(repo_id, filename=str(rel_data_path), repo_type="dataset"))
+            data_path = Path(
+                hf_hub_download(
+                    _resolve_hub_repo_id(repo_id), filename=str(rel_data_path), repo_type="dataset"
+                )
+            )
         except Exception as exc:
             logger.info("hub data chunk fetch for %s failed: %s", repo_id, exc)
             return None
@@ -993,9 +1013,17 @@ _HUB_DATASET_INFO_LOCK = threading.Lock()
 
 def invalidate_hub_dataset_info(repo_id: str) -> None:
     """Drop the cached Hub summary for `repo_id`, so the next /datasets/info
-    re-fetches its meta/info.json (e.g. after an upload changed it)."""
+    re-fetches its meta/info.json (e.g. after an upload changed it).
+
+    Keyed by the resolved lookup id like the hub-status cache, so a bare id
+    also drops its "<namespace>/<repo_id>" entries — see invalidate_hub_status.
+    """
     with _HUB_DATASET_INFO_LOCK:
         _HUB_DATASET_INFO_CACHE.pop(repo_id, None)
+        if "/" not in repo_id:
+            suffix = f"/{repo_id}"
+            for key in [k for k in _HUB_DATASET_INFO_CACHE if k.endswith(suffix)]:
+                del _HUB_DATASET_INFO_CACHE[key]
 
 
 def get_hub_dataset_info(repo_id: str) -> dict[str, Any] | None:
@@ -1015,16 +1043,21 @@ def get_hub_dataset_info(repo_id: str) -> dict[str, Any] | None:
     if hf_hub_offline():
         return None
 
+    # Resolved (and cached) by the id actually fetched: hf_hub_download does a
+    # literal lookup, so a bare id needs the namespace, and the answer depends
+    # on which one — see _resolve_hub_repo_id / _HUB_STATUS_CACHE.
+    hub_repo_id = _resolve_hub_repo_id(repo_id)
+
     with _HUB_DATASET_INFO_LOCK:
-        cached = _HUB_DATASET_INFO_CACHE.get(repo_id)
+        cached = _HUB_DATASET_INFO_CACHE.get(hub_repo_id)
     if cached is not None:
         return dict(cached)
 
     try:
-        path = hf_hub_download(repo_id, filename="meta/info.json", repo_type="dataset")
+        path = hf_hub_download(hub_repo_id, filename="meta/info.json", repo_type="dataset")
         info = json.loads(Path(path).read_text())
     except Exception as exc:
-        logger.info("hub dataset info fetch for %s failed: %s", repo_id, exc)
+        logger.info("hub dataset info fetch for %s failed: %s", hub_repo_id, exc)
         return None
 
     features = info.get("features") or {}
@@ -1043,7 +1076,7 @@ def get_hub_dataset_info(repo_id: str) -> dict[str, Any] | None:
     }
 
     with _HUB_DATASET_INFO_LOCK:
-        _HUB_DATASET_INFO_CACHE[repo_id] = dict(row)
+        _HUB_DATASET_INFO_CACHE[hub_repo_id] = dict(row)
     return row
 
 
@@ -1417,9 +1450,13 @@ def _fetch_dataset_snapshot(repo_id: str) -> None:
     (the merged-listing scan), so on completion the listing source flips from
     "hub" to "both" — which downloading only into the hub snapshot cache would
     NOT achieve (that cache isn't walked by the listing). Invalidates the
-    hub-status + listing caches so the flip shows immediately."""
+    hub-status + listing caches so the flip shows immediately.
+
+    The Hub is addressed by the RESOLVED id (``snapshot_download`` is a literal
+    lookup — a bare id 404s), while the local directory keeps the id the caller
+    passed, matching the flat layout every other local path uses."""
     target = _lerobot_cache_root() / repo_id
-    snapshot_download(repo_id, repo_type="dataset", local_dir=str(target))
+    snapshot_download(_resolve_hub_repo_id(repo_id), repo_type="dataset", local_dir=str(target))
     invalidate_hub_status(repo_id)
     invalidate_dataset_listing_cache()
     # The card flips from the hub summary to full local detail — drop the

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -253,6 +253,12 @@ def _local_copy_differs_from_hub(repo_id: str) -> bool | None:
     when there's no local copy to protect, or when the Hub summary can't be
     read (offline / transport error): a degraded read must not manufacture a
     mismatch warning.
+
+    True is load-bearing (it blocks a cloud run — see JobRegistry.start), so
+    the comparison stays conservative. Episode counts decide it; frame counts
+    only sharpen it when BOTH sides report one, because a missing/unparsed
+    ``total_frames`` reads as 0 on either side and would otherwise fake a
+    mismatch against a dataset that is genuinely backed up.
     """
     local_info_path = _lerobot_cache_root() / repo_id / "meta" / "info.json"
     try:
@@ -264,10 +270,10 @@ def _local_copy_differs_from_hub(repo_id: str) -> bool | None:
     if hub is None:
         return None
 
-    return (int(local.get("total_episodes") or 0), int(local.get("total_frames") or 0)) != (
-        hub["total_episodes"],
-        hub["total_frames"],
-    )
+    if int(local.get("total_episodes") or 0) != hub["total_episodes"]:
+        return True
+    local_frames, hub_frames = int(local.get("total_frames") or 0), hub["total_frames"]
+    return bool(local_frames and hub_frames and local_frames != hub_frames)
 
 
 def get_hub_status(repo_id: str) -> dict[str, Any]:

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -2639,6 +2639,27 @@ class DatasetNotOnHubError(Exception):
         )
 
 
+class DatasetHubCopyDiffersError(Exception):
+    """Raised by JobRegistry.start when a cloud (hf_cloud) run is requested on a
+    dataset whose local copy disagrees with the Hub repo of the same name.
+
+    Cloud training runs on the HUB copy, so this would train on data the user
+    isn't looking at without saying so: either the local copy gained episodes
+    after the upload, or the name is shared with an unrelated repo (a local
+    rename frees the name while the Hub repo keeps it — see get_hub_status's
+    ``local_differs``). Uploading first resolves the former; the latter needs a
+    different name. `repo_id` is the offending dataset."""
+
+    def __init__(self, repo_id: str) -> None:
+        self.repo_id = repo_id
+        super().__init__(
+            f"Your local copy of '{repo_id}' differs from the Hub dataset of the same "
+            "name, and cloud training runs on the Hub copy. Upload the local copy "
+            "first — or, if that Hub dataset is a different recording that happens to "
+            "share the name, rename this one before training."
+        )
+
+
 class JobRegistry:
     """Owns the registry of training jobs and their persistence.
 
@@ -2867,11 +2888,21 @@ class JobRegistry:
         # fallback so a network blip doesn't wrongly refuse a Hub dataset. The
         # browser flow uploads-then-trains before ever reaching here, so this
         # path is primarily for non-UI callers.
+        #
+        # Existing-on-the-Hub is necessary but not sufficient: the pod trains on
+        # the HUB copy, so a local copy that has diverged from it (more episodes
+        # recorded since the upload, or a name now shared with an unrelated
+        # repo — see get_hub_status's local_differs) would train on data the
+        # user isn't looking at, silently. Refuse that too rather than let it
+        # through; uploading first is the fix, and the info card offers it.
         if target.runner == "hf_cloud":
             from .datasets import get_hub_status
 
-            if get_hub_status(config.dataset_repo_id).get("status") == "local_only":
+            hub_status = get_hub_status(config.dataset_repo_id)
+            if hub_status.get("status") == "local_only":
                 raise DatasetNotOnHubError(config.dataset_repo_id)
+            if hub_status.get("local_differs") is True:
+                raise DatasetHubCopyDiffersError(config.dataset_repo_id)
 
         # Resume and fine-tune are distinct and mutually exclusive: resume
         # continues optimizer+step from a checkpoint (needs training_state);

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -699,7 +699,16 @@ class HfCloudJobRunner:
 
         # Cloud pods can't see the host's LeRobot cache. If the dataset
         # only exists locally, push it to the Hub before submitting.
-        self._ensure_dataset_on_hub(config.dataset_repo_id)
+        #
+        # A locally-recorded dataset's id is bare; the pod has no local cache to
+        # fall back on and no namespace to guess from, so it must be handed the
+        # namespaced id or the job dies resolving the dataset. Resolve once here
+        # and pin it into the config, which is both what build_training_command
+        # emits and what JobRecord.config persists as "what actually ran".
+        local_dataset_repo_id = config.dataset_repo_id
+        if "/" not in local_dataset_repo_id:
+            config.dataset_repo_id = f"{username}/{local_dataset_repo_id}"
+        self._ensure_dataset_on_hub(local_dataset_repo_id, config.dataset_repo_id)
 
         # Mutate the config so build_training_command emits the right flags.
         # The mutated config is what gets persisted in JobRecord.config, so
@@ -827,27 +836,35 @@ class HfCloudJobRunner:
         except Exception as exc:
             logger.warning("Could not write upload log line: %s", exc)
 
-    def _ensure_dataset_on_hub(self, repo_id: str) -> None:
+    def _ensure_dataset_on_hub(self, local_repo_id: str, hub_repo_id: str) -> None:
         """If the dataset is local-only, push it to the Hub.
 
         The cloud pod resolves the dataset by repo_id; it can't see the
         host's `~/.cache/huggingface/lerobot`. We push synchronously and
         let any failure bubble up — JobRegistry.start marks the record
         as failed with the exception message.
+
+        `local_repo_id` addresses the host's cache (a locally-recorded dataset's
+        directory — and so its id — is bare); `hub_repo_id` is that id resolved
+        against the caller's namespace, which is what every Hub call here must
+        use: `dataset_info` does a literal lookup, so checking the bare id would
+        report an already-uploaded dataset as missing and re-push it, and
+        `push_to_hub`'s own upload/card calls would then 404 against the bare id
+        (the same asymmetry UploadManager handles).
         """
         try:
-            self._api.dataset_info(repo_id)
+            self._api.dataset_info(hub_repo_id)
             return
         except RepositoryNotFoundError:
             pass
 
         cache_root = Path(os.environ.get("HF_LEROBOT_HOME", "~/.cache/huggingface/lerobot")).expanduser()
-        if not (cache_root / repo_id / "meta" / "info.json").is_file():
+        if not (cache_root / local_repo_id / "meta" / "info.json").is_file():
             # Neither local nor on Hub. Let the trainer surface the error
             # — same behaviour as before.
             return
 
-        self._log_line(f"[upload] dataset {repo_id} not on Hub; pushing local copy (public)...")
+        self._log_line(f"[upload] dataset {hub_repo_id} not on Hub; pushing local copy (public)...")
         from lerobot.datasets import LeRobotDataset
 
         try:
@@ -857,12 +874,14 @@ class HfCloudJobRunner:
             # follows that same default so all MakerMods Lab-produced datasets are
             # discoverable. (This intentionally reverses the earlier private
             # default — an implicit upload of a local-only dataset is now public.)
-            LeRobotDataset(repo_id).push_to_hub(tags=with_makermodslab_tag(None), private=False)
+            dataset = LeRobotDataset(local_repo_id)
+            dataset.repo_id = hub_repo_id
+            dataset.push_to_hub(tags=with_makermodslab_tag(None), private=False)
         except Exception as exc:
-            msg = f"Failed to upload local dataset {repo_id} to Hub: {exc}"
+            msg = f"Failed to upload local dataset {local_repo_id} to Hub: {exc}"
             self._log_line(f"[upload] {msg}")
             raise RuntimeError(msg) from exc
-        self._log_line(f"[upload] dataset {repo_id} uploaded.")
+        self._log_line(f"[upload] dataset {hub_repo_id} uploaded.")
 
     def _tail_loop(self) -> None:
         """Stream HfApi.fetch_job_logs, teeing each line to disk and the

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -66,6 +66,7 @@ from .camera_identity import resolve_cv2_index
 from .camera_preview import CameraOpenError, camera_preview_manager
 from .identify import identify_arm_by_motion
 from .jobs import (
+    DatasetHubCopyDiffersError,
     DatasetNotOnHubError,
     JobAlreadyContinuedError,
     JobAlreadyRunningError,
@@ -1346,6 +1347,10 @@ async def create_training_job(req: Request):
             status_code=409,
             detail=f"{source} was already continued by {continued_by}. {remedy}",
         ) from exc
+    except DatasetHubCopyDiffersError as exc:
+        # Cloud run whose local dataset has diverged from the Hub repo the pod
+        # would train on. Same 409 shape: upload (or rename) first.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         # e.g. "flavor is required when runner is hf_cloud"
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1006,6 +1006,81 @@ def test_get_hub_settings_returns_private_and_tags() -> None:
     assert result == {"repo_id": "alice/pick", "private": True, "tags": ["robotics", "makermods"]}
 
 
+def test_hub_edit_calls_qualify_a_bare_repo_id() -> None:
+    """get_hub_status resolves a bare (locally-recorded) id against the caller's
+    namespace before deciding "on_hub" — so every Hub call the card then makes
+    on that same id has to resolve it the same way. dataset_info,
+    update_repo_settings and metadata_update are all literal lookups: left bare
+    they 404/403 on exactly the datasets the on_hub badge just advertised as
+    editable (useCanEditHub treats a bare id as the user's own namespace)."""
+    from makermodslab import datasets as ds
+
+    fake_info = MagicMock()
+    fake_info.private = False
+    fake_info.tags = ["makermods"]
+    fake_api = MagicMock()
+    fake_api.dataset_info.return_value = fake_info
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.hf_hub_offline", return_value=False),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.metadata_update") as fake_metadata_update,
+    ):
+        settings = ds.get_hub_settings("logo_2026")
+        ds.set_dataset_visibility("logo_2026", True)
+        ds.set_dataset_tags("logo_2026", ["robotics"])
+
+    fake_api.dataset_info.assert_called_once_with("makermods/logo_2026")
+    fake_api.update_repo_settings.assert_called_once_with(
+        "makermods/logo_2026", private=True, repo_type="dataset"
+    )
+    assert fake_metadata_update.call_args.args[0] == "makermods/logo_2026"
+    # The public contract is unchanged: callers get back the id they passed.
+    assert settings["repo_id"] == "logo_2026"
+
+
+def test_get_hub_dataset_info_qualifies_a_bare_repo_id(tmp_path: Path) -> None:
+    """The card's hub summary (and the download that follows it) address the
+    Hub by the resolved id too — hf_hub_download / snapshot_download are
+    literal lookups. The local snapshot directory keeps the caller's id, which
+    is the flat layout every local path uses."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_dataset_info_cache()
+    meta = _write_hub_meta(tmp_path, {"total_episodes": 2, "total_frames": 60, "fps": 30})
+    with (
+        patch("makermodslab.datasets.hf_hub_offline", return_value=False),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.hf_hub_download", return_value=str(meta)) as dl,
+    ):
+        row = ds.get_hub_dataset_info("logo_2026")
+        # Cached under the resolved id, but invalidated by the bare id every
+        # upload/download caller holds.
+        ds.get_hub_dataset_info("logo_2026")
+        assert dl.call_count == 1
+        assert "makermods/logo_2026" in ds._HUB_DATASET_INFO_CACHE
+        ds.invalidate_hub_dataset_info("logo_2026")
+        assert ds._HUB_DATASET_INFO_CACHE == {}
+
+    assert dl.call_args.args[0] == "makermods/logo_2026"
+    assert row is not None and row["repo_id"] == "logo_2026"
+
+
+def test_fetch_dataset_snapshot_qualifies_hub_id_but_keeps_local_dir(
+    tmp_lerobot_home: Path,
+) -> None:
+    from makermodslab import datasets as ds
+
+    with (
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.snapshot_download") as snap,
+    ):
+        ds._fetch_dataset_snapshot("logo_2026")
+
+    assert snap.call_args.args[0] == "makermods/logo_2026"
+    assert snap.call_args.kwargs["local_dir"] == str(tmp_lerobot_home / "logo_2026")
+
+
 def test_get_hub_settings_rejected_offline() -> None:
     from makermodslab import datasets as ds
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -527,8 +527,7 @@ def test_get_hub_status_bare_id_falls_back_when_unauthenticated() -> None:
 
 
 def test_get_hub_status_cache_hit_preserves_resolved_url() -> None:
-    """The cache is keyed by the bare repo_id (matching invalidate_hub_status
-    callers), but must remember the resolved URL from the first lookup so a
+    """The cache must remember the resolved URL from the first lookup so a
     cache hit doesn't regress to the unqualified (wrong) URL."""
     from makermodslab import datasets as ds
 
@@ -545,6 +544,91 @@ def test_get_hub_status_cache_hit_preserves_resolved_url() -> None:
     assert first == second
     assert second["url"] == "https://huggingface.co/datasets/makermods/makermods_logo_20260805_152059"
     fake_api.repo_exists.assert_called_once()
+
+
+def test_get_hub_status_rechecks_after_login() -> None:
+    """A status fetched BEFORE the user logs in must not pin the answer.
+
+    The app has an in-app login (handle_hf_login), so the very first hub-status
+    fetch often runs unauthenticated: no namespace to qualify with, so the bare
+    lookup 404s and the dataset reads "local_only". That answer is only valid
+    for "no token"; keying the cache by the resolved id means the post-login
+    call (which resolves to "<namespace>/<id>") misses and re-checks. Keying by
+    the bare id instead left an already-uploaded dataset reading "Local only"
+    for the process lifetime — re-offering upload, and making the cloud
+    preflight in JobRegistry.start refuse it."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    fake_api = MagicMock()
+    # Literal lookup, like the real HfApi.repo_exists: only the namespaced id.
+    fake_api.repo_exists.side_effect = lambda rid, repo_type=None: rid == "makermods/logo_2026"
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.is_dataset_available_locally", return_value=True),
+    ):
+        with patch("makermodslab.datasets.cached_whoami", return_value=None):
+            assert ds.get_hub_status("logo_2026")["status"] == "local_only"
+        with patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}):
+            after_login = ds.get_hub_status("logo_2026")
+
+    assert after_login["status"] == "on_hub"
+    assert after_login["url"] == "https://huggingface.co/datasets/makermods/logo_2026"
+    assert [c.args[0] for c in fake_api.repo_exists.call_args_list] == [
+        "logo_2026",
+        "makermods/logo_2026",
+    ]
+
+
+def test_get_hub_status_does_not_serve_another_accounts_answer() -> None:
+    """The resolved id depends on WHO is logged in, and the token can change
+    mid-process (an in-app login as a different account). A cached answer for
+    one namespace must never be served to the next one — alice would otherwise
+    see "Uploaded to HuggingFace" linking to makermods' repo."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    fake_api = MagicMock()
+    fake_api.repo_exists.side_effect = lambda rid, repo_type=None: rid == "makermods/logo_2026"
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.is_dataset_available_locally", return_value=True),
+    ):
+        with patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}):
+            assert ds.get_hub_status("logo_2026")["status"] == "on_hub"
+        with patch("makermodslab.datasets.cached_whoami", return_value={"name": "alice"}):
+            as_alice = ds.get_hub_status("logo_2026")
+
+    assert as_alice["status"] == "local_only"
+    assert as_alice["url"] is None
+
+
+def test_invalidate_hub_status_drops_namespaced_entry_for_bare_id() -> None:
+    """Callers invalidate with the id they hold — for a locally-recorded
+    dataset that's the bare one (see UploadManager) — while the cache is keyed
+    by the resolved "<namespace>/<id>". The bare invalidation must drop that
+    resolved entry too, or a successful upload wouldn't flip the card."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.is_dataset_available_locally", return_value=True),
+    ):
+        assert ds.get_hub_status("logo_2026")["status"] == "local_only"
+        assert "makermods/logo_2026" in ds._HUB_STATUS_CACHE
+
+        # Simulate a successful upload: repo now exists, cache invalidated by
+        # the bare id the UploadManager holds.
+        ds.invalidate_hub_status("logo_2026")
+        assert ds._HUB_STATUS_CACHE == {}
+        fake_api.repo_exists.return_value = True
+        assert ds.get_hub_status("logo_2026")["status"] == "on_hub"
+
+    assert fake_api.repo_exists.call_count == 2
 
 
 def test_hub_status_endpoint(client: TestClient) -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -458,6 +458,95 @@ def test_invalidate_hub_status_forces_recheck() -> None:
     assert fake_api.repo_exists.call_count == 2
 
 
+def test_get_hub_status_resolves_bare_repo_id_via_own_namespace() -> None:
+    """A locally-recorded dataset's repo_id is bare (no namespace). Unlike
+    create_repo(), repo_exists() does a literal lookup and won't auto-resolve
+    a bare id to the caller's namespace — so the bare id must be qualified
+    before the existence check, or an already-uploaded dataset reports
+    "local_only" forever (this was the bug). The response's own `repo_id`
+    stays exactly what was passed in (bare) — only the Hub lookup and the
+    returned `url` use the resolved, namespaced id."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = True
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+    ):
+        result = ds.get_hub_status("makermods_logo_20260805_152059")
+
+    assert result["repo_id"] == "makermods_logo_20260805_152059"
+    assert result["status"] == "on_hub"
+    assert result["url"] == "https://huggingface.co/datasets/makermods/makermods_logo_20260805_152059"
+    fake_api.repo_exists.assert_called_once_with(
+        "makermods/makermods_logo_20260805_152059", repo_type="dataset"
+    )
+
+
+def test_get_hub_status_does_not_qualify_already_namespaced_id() -> None:
+    """A repo_id that already has a namespace (a Hub-only dataset that was
+    never recorded locally) must be used as-is — never re-qualified — and
+    cached_whoami should not even be consulted for it."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = True
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami") as mock_whoami,
+    ):
+        result = ds.get_hub_status("someuser/some-dataset")
+
+    assert result["status"] == "on_hub"
+    assert result["url"] == "https://huggingface.co/datasets/someuser/some-dataset"
+    fake_api.repo_exists.assert_called_once_with("someuser/some-dataset", repo_type="dataset")
+    mock_whoami.assert_not_called()
+
+
+def test_get_hub_status_bare_id_falls_back_when_unauthenticated() -> None:
+    """No cached token/whoami: there's no namespace to qualify with, so this
+    degrades to the literal bare-id lookup (today's pre-fix behavior) instead
+    of raising — get_hub_status is documented to never raise."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = False
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value=None),
+        patch("makermodslab.datasets.is_dataset_available_locally", return_value=True),
+    ):
+        result = ds.get_hub_status("some_local_dataset")
+
+    assert result["status"] == "local_only"
+    fake_api.repo_exists.assert_called_once_with("some_local_dataset", repo_type="dataset")
+
+
+def test_get_hub_status_cache_hit_preserves_resolved_url() -> None:
+    """The cache is keyed by the bare repo_id (matching invalidate_hub_status
+    callers), but must remember the resolved URL from the first lookup so a
+    cache hit doesn't regress to the unqualified (wrong) URL."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = True
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+    ):
+        first = ds.get_hub_status("makermods_logo_20260805_152059")
+        second = ds.get_hub_status("makermods_logo_20260805_152059")
+
+    assert first == second
+    assert second["url"] == "https://huggingface.co/datasets/makermods/makermods_logo_20260805_152059"
+    fake_api.repo_exists.assert_called_once()
+
+
 def test_hub_status_endpoint(client: TestClient) -> None:
     _clear_hub_status_cache()
     fake_api = MagicMock()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -708,6 +708,21 @@ def test_get_hub_status_makes_no_local_differs_claim_without_a_basis(
         _clear_hub_status_cache()
         assert ds.get_hub_status("logo_2026")["local_differs"] is None
 
+    # An absent/unparsed total_frames reads as 0. It must not fake a mismatch
+    # against a dataset that is genuinely backed up — local_differs=True blocks
+    # a cloud run, so only the episode count decides on its own.
+    (tmp_lerobot_home / "no_frames_2026" / "meta").mkdir(parents=True)
+    (tmp_lerobot_home / "no_frames_2026" / "meta" / "info.json").write_text(
+        json.dumps({"total_episodes": 19})
+    )
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.get_hub_dataset_info", return_value=_hub_summary(19, 700)),
+    ):
+        _clear_hub_status_cache()
+        assert ds.get_hub_status("no_frames_2026")["local_differs"] is False
+
     # Not on the Hub: there's no repo to compare against.
     fake_api.repo_exists.return_value = False
     with (

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -631,6 +631,97 @@ def test_invalidate_hub_status_drops_namespaced_entry_for_bare_id() -> None:
     assert fake_api.repo_exists.call_count == 2
 
 
+def _hub_summary(episodes: int, frames: int) -> dict:
+    return {"total_episodes": episodes, "total_frames": frames}
+
+
+def test_get_hub_status_flags_a_local_copy_the_hub_repo_does_not_back_up(
+    tmp_lerobot_home: Path,
+) -> None:
+    """A bare id is matched to a Hub repo by NAME, and a name match is not an
+    identity match: rename_local_dataset moves only the local directory, so a
+    freed name can be reused by a different recording while the old repo still
+    answers to it (and recording more episodes into an uploaded dataset
+    diverges the same way). Reporting that as a plain "Uploaded to
+    HuggingFace" invites deleting a local copy that was never pushed."""
+    from makermodslab import datasets as ds
+
+    _clear_hub_status_cache()
+    (tmp_lerobot_home / "logo_2026" / "meta").mkdir(parents=True)
+    (tmp_lerobot_home / "logo_2026" / "meta" / "info.json").write_text(
+        json.dumps({"total_episodes": 25, "total_frames": 900})
+    )
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = True
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.get_hub_dataset_info", return_value=_hub_summary(19, 700)),
+    ):
+        differs = ds.get_hub_status("logo_2026")
+        # Cached "on_hub", but the flag is recomputed per call — local content
+        # changes (another recording session appends episodes) without any
+        # hub-status invalidation, so a cached answer would go stale.
+        cached_hit = ds.get_hub_status("logo_2026")
+
+    assert differs["status"] == "on_hub"
+    assert differs["local_differs"] is True
+    assert cached_hit["local_differs"] is True
+    fake_api.repo_exists.assert_called_once()
+
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.get_hub_dataset_info", return_value=_hub_summary(25, 900)),
+    ):
+        assert ds.get_hub_status("logo_2026")["local_differs"] is False
+
+
+def test_get_hub_status_makes_no_local_differs_claim_without_a_basis(
+    tmp_lerobot_home: Path,
+) -> None:
+    """None means "no claim": nothing local to protect, or the Hub summary
+    couldn't be read (offline / transport error). A degraded read must not
+    manufacture a mismatch warning."""
+    from makermodslab import datasets as ds
+
+    fake_api = MagicMock()
+    fake_api.repo_exists.return_value = True
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.get_hub_dataset_info", return_value=_hub_summary(19, 700)),
+    ):
+        _clear_hub_status_cache()
+        # No local copy at all: a pure Hub dataset.
+        assert ds.get_hub_status("hub_only_2026")["local_differs"] is None
+
+    (tmp_lerobot_home / "logo_2026" / "meta").mkdir(parents=True)
+    (tmp_lerobot_home / "logo_2026" / "meta" / "info.json").write_text(
+        json.dumps({"total_episodes": 25, "total_frames": 900})
+    )
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.get_hub_dataset_info", return_value=None),
+    ):
+        _clear_hub_status_cache()
+        assert ds.get_hub_status("logo_2026")["local_differs"] is None
+
+    # Not on the Hub: there's no repo to compare against.
+    fake_api.repo_exists.return_value = False
+    with (
+        patch("makermodslab.datasets.shared_hf_api", return_value=fake_api),
+        patch("makermodslab.datasets.cached_whoami", return_value={"name": "makermods"}),
+        patch("makermodslab.datasets.get_hub_dataset_info", return_value=_hub_summary(19, 700)),
+    ):
+        _clear_hub_status_cache()
+        local_only = ds.get_hub_status("logo_2026")
+
+    assert local_only["status"] == "local_only"
+    assert local_only["local_differs"] is None
+
+
 def test_hub_status_endpoint(client: TestClient) -> None:
     _clear_hub_status_cache()
     fake_api = MagicMock()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1676,6 +1676,41 @@ def test_cloud_start_rejects_local_only_dataset(tmp_path) -> None:
     assert reg.list(limit=10) == []
 
 
+def test_cloud_start_rejects_dataset_whose_local_copy_diverged(tmp_path) -> None:
+    """On the Hub is necessary but not sufficient: the pod trains on the HUB
+    copy, so a local copy that has diverged from it (episodes recorded after
+    the upload, or a name now shared with an unrelated repo) would silently
+    train on data the user isn't looking at. Refuse instead — uploading first
+    is the fix, and the info card offers it next to the same warning."""
+    from unittest.mock import patch
+
+    from makermodslab.jobs import DatasetHubCopyDiffersError, JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = JobRegistry(tmp_path / "root")
+    cfg = TrainingRequest(dataset_repo_id="sock_orange", policy_type="act")
+    target = JobTarget(runner="hf_cloud", flavor="t4-small")
+
+    with (
+        patch(
+            "makermodslab.datasets.get_hub_status",
+            return_value={
+                "repo_id": "sock_orange",
+                "status": "on_hub",
+                "url": "https://huggingface.co/datasets/makermods/sock_orange",
+                "local_differs": True,
+            },
+        ),
+        pytest.raises(DatasetHubCopyDiffersError) as exc,
+    ):
+        reg.start(cfg, target)
+
+    assert exc.value.repo_id == "sock_orange"
+    assert "differs from the Hub dataset" in str(exc.value)
+    # Nothing was registered — the guard fires before the record is created.
+    assert reg.list(limit=10) == []
+
+
 def test_cloud_start_allows_hub_dataset(tmp_path) -> None:
     """When the dataset is on the Hub, the preflight passes and the runner is
     started (stubbed here — we assert the guard doesn't block, not a real
@@ -1699,7 +1734,14 @@ def test_cloud_start_allows_hub_dataset(tmp_path) -> None:
     with (
         patch(
             "makermodslab.datasets.get_hub_status",
-            return_value={"repo_id": "user/on_hub", "status": "on_hub", "url": "u"},
+            return_value={
+                "repo_id": "user/on_hub",
+                "status": "on_hub",
+                "url": "u",
+                # In sync with the Hub copy (or no basis to claim otherwise) —
+                # the divergence guard must not fire on either.
+                "local_differs": False,
+            },
         ),
         patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", _fake_runner_factory),
     ):

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -566,7 +566,7 @@ def _submitted_command(config, tmp_path, monkeypatch, job_id: str = "child_run")
     api = MagicMock()
     api.run_job.return_value = MagicMock(id="hfjob-1", url="https://hf/jobs/1")
     runner._api = api
-    monkeypatch.setattr(runner, "_ensure_dataset_on_hub", lambda repo_id: None)
+    monkeypatch.setattr(runner, "_ensure_dataset_on_hub", lambda local_repo_id, hub_repo_id: None)
     monkeypatch.setattr(runner, "_start_worker_threads", lambda label: None)
     runner.start(job_id, config, "/host/out")
     return api.run_job.call_args.kwargs["command"]


### PR DESCRIPTION
## Summary
A dataset that was already uploaded to the Hub could still show "Local only" and offer a redundant upload button, because the Hub-status check looked up the dataset under its bare local name instead of the namespaced name it actually lives under on the Hub. This PR qualifies the lookup with the user's own namespace, so the badge and link resolve correctly.

## Before
Already uploaded to the hub
```bash
curl -s "http://127.0.0.1:8002/datasets/hub-status?repo_id=makermods_logo_20260805_152059"
# -> {"repo_id":"makermods_logo_20260805_152059","status":"local_only","url":null}
# wrong — this dataset is genuinely on the Hub
```
![Dataset card showing "Local only" with an Upload to Hub button, despite the dataset already being on the Hub](https://raw.githubusercontent.com/makermods-robotics/makermodslab/assets/pr-56-screenshots/pr-56-before-local-only.png)

## After
Already uploaded to the hub
```bash
curl -s "http://127.0.0.1:8003/datasets/hub-status?repo_id=makermods_logo_20260805_152059"
# -> {"repo_id":"makermods_logo_20260805_152059","status":"on_hub","url":"https://huggingface.co/datasets/makermods/makermods_logo_20260805_152059"}
```
![Dataset card correctly showing "Uploaded to HuggingFace" with a link to view it and manage visibility & tags](https://raw.githubusercontent.com/makermods-robotics/makermodslab/assets/pr-56-screenshots/pr-56-after-on-hub.png)

## Commits
1. Qualify a bare `repo_id` with the caller's own namespace before checking Hub status, so an already-uploaded dataset is found instead of reporting "local only" forever.

## Sensitive changes
None — this touches dataset metadata lookup only; no servo, calibration, or hardware-control code.

