### PR TITLE
fix(naming): title model cards by task identity, and attribute a repo to the run that finished it

### DIFF
--- a/frontend/src/components/jobs/HubModelCard.tsx
+++ b/frontend/src/components/jobs/HubModelCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import MetaRows from "@/components/library/MetaRows";
+import { middleEllipsis } from "@/lib/modelNames";
 import { HubModel, deleteHubModel } from "@/lib/jobsApi";
 import { ApiError } from "@/lib/apiClient";
 import { useApi } from "@/contexts/ApiContext";
@@ -167,9 +168,15 @@ const HubModelCard: React.FC<Props> = ({ model, onDeleted, onAction }) => {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [acting, setActing] = useState<"inference" | "finetune" | null>(null);
   const url = `https://huggingface.co/${model.repo_id}`;
-  const shortName = model.repo_id.includes("/")
-    ? model.repo_id.split("/").slice(1).join("/")
-    : model.repo_id;
+  // Same title rule as the imported card next to it in the grid: namespace off
+  // (the subtitle below repeats the full repo id), and shortened from the
+  // middle rather than the end, since an uploaded repo's tail is its timestamp
+  // — the only thing separating two uploads of the same task.
+  const shortName = middleEllipsis(
+    model.repo_id.includes("/")
+      ? model.repo_id.split("/").slice(1).join("/")
+      : model.repo_id,
+  );
 
   const runAction = async (
     e: React.MouseEvent,

--- a/frontend/src/components/jobs/HubModelCard.tsx
+++ b/frontend/src/components/jobs/HubModelCard.tsx
@@ -16,6 +16,7 @@ import { HubModel, deleteHubModel } from "@/lib/jobsApi";
 import { ApiError } from "@/lib/apiClient";
 import { useApi } from "@/contexts/ApiContext";
 import { useToast } from "@/hooks/use-toast";
+import { useTruncationTitle } from "@/hooks/useTruncationTitle";
 import {
   ExternalLink,
   Lock,
@@ -177,6 +178,15 @@ const HubModelCard: React.FC<Props> = ({ model, onDeleted, onAction }) => {
       ? model.repo_id.split("/").slice(1).join("/")
       : model.repo_id,
   );
+  // Both of this title's shortenings are the caller's own — the namespace peel
+  // and middleEllipsis — so the flag is just "is what we render the whole repo
+  // id?"; the div's `truncate` on top of that is measured on hover. An
+  // unnamespaced repo whose name fits is therefore the one case with no title,
+  // and correctly so: the text on screen already IS the repo id.
+  const nameHover = useTruncationTitle(
+    model.repo_id,
+    shortName !== model.repo_id,
+  );
 
   const runAction = async (
     e: React.MouseEvent,
@@ -237,7 +247,7 @@ const HubModelCard: React.FC<Props> = ({ model, onDeleted, onAction }) => {
         <div>
           <div
             className="text-foreground font-semibold truncate flex items-center gap-1.5"
-            title={model.repo_id}
+            {...nameHover}
           >
             {model.private ? (
               <Lock className="w-3.5 h-3.5 text-muted-foreground shrink-0" />

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -30,6 +30,7 @@ import {
   Upload,
 } from "lucide-react";
 import MetaRows from "@/components/library/MetaRows";
+import DisplayName from "@/components/library/DisplayName";
 import { useApi } from "@/contexts/ApiContext";
 import { useStudio } from "@/contexts/StudioContext";
 import { useToast } from "@/hooks/use-toast";
@@ -543,12 +544,10 @@ const JobCard: React.FC<Props> = ({
           </div>
         </div>
         <div>
-          <div
-            className="text-foreground font-semibold truncate"
-            title={displayName}
-          >
-            {displayName}
-          </div>
+          <DisplayName
+            name={displayName}
+            className="text-foreground font-semibold"
+          />
           {/* When aliased, keep the true identity visible: the run id for
               trainings (imported models already show their repo id / path in
               the subtitle below). */}

--- a/frontend/src/components/library/DisplayName.tsx
+++ b/frontend/src/components/library/DisplayName.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { splitDedupeSuffix } from "@/lib/modelNames";
+import { displayDedupeSuffix, splitDedupeSuffix } from "@/lib/modelNames";
 import { useTruncationTitle } from "@/hooks/useTruncationTitle";
 
 interface Props {
@@ -26,27 +26,48 @@ interface Props {
  * hover away — and only then, since a title on a name that already fits whole
  * just repeats it (see `useTruncationTitle`).
  *
- * The suffix is deliberately rendered verbatim rather than shortened to, say, a
- * dropped year: two runs a year apart would collapse to the same visible text,
- * which is the precise failure this exists to prevent.
+ * The one thing the suffix does give up is its year (`displayDedupeSuffix`),
+ * which buys the base ~5 characters at no cost to the fields that actually
+ * separate two same-day runs. Two runs exactly a year apart do read identically
+ * until hovered — that is the trade, and the hover title is what makes it
+ * survivable.
  */
 const DisplayName: React.FC<Props> = ({ name, className }) => {
   const { base, suffix } = splitDedupeSuffix(name);
+  // Rendered a year shorter than it is stored, so the two spans below no longer
+  // spell the full name between them.
+  const displaySuffix = suffix === null ? null : displayDedupeSuffix(suffix);
   // The title hangs on the CONTAINER, and the hook sweeps its descendants —
   // the pair is one name, so either span clipping means the visible name is
   // incomplete, and the container itself never overflows (its flex children
   // shrink instead), which measuring it alone would misread as "fits".
-  const hover = useTruncationTitle(name);
+  //
+  // The dropped year is the OTHER kind of shortening, the one the DOM can't
+  // see: nothing is clipped, yet what's on screen is not the whole name. Only
+  // this component knows, so it says so — and the comparison stays true however
+  // the suffix's display form changes later.
+  const hover = useTruncationTitle(name, displaySuffix !== suffix);
   // A flex row in both cases: `truncate` needs a block-level box to clip
   // against, and keeping one shape means the suffixed and unsuffixed titles
   // share a baseline wherever they sit side by side in a grid.
   return (
     <div className={cn("flex min-w-0 items-baseline", className)} {...hover}>
-      <span className="truncate">{base}</span>
-      {/* shrink-0: the base gives up its characters first, the disambiguator
-          never does. */}
-      {suffix === null ? null : (
-        <span className="shrink-0 whitespace-nowrap">&nbsp;({suffix})</span>
+      {/* A floor on the base, because the suffix beside it can't give: with
+          none, the base starves to "e…" next to a whole timestamp. Because that
+          suffix can't give either, the floor is also what decides whether the
+          pair OVERFLOWS, so it is sized against the narrowest line these titles
+          sit on: 6ch (~53px) + a non-breaking space + a whole "(07-31 17:35)"
+          (~98px at the inherited 16px semibold) ≈ 155px, well inside the ~239px
+          interior of CappedGrid's documented 263px card. Squeezed below that,
+          the pair overflows rather than shrinking further — deliberate, since
+          what it would shrink is the disambiguator. */}
+      <span className="min-w-[6ch] truncate">{base}</span>
+      {/* shrink-0, and no `truncate`: the base gives up its characters first,
+          the disambiguator never does. Letting it ellipsize is the failure this
+          element exists to prevent — "eraser_plac… (2026-0…", where the thing
+          cut off is the only thing telling two cards apart. */}
+      {displaySuffix === null ? null : (
+        <span className="shrink-0 whitespace-nowrap">&nbsp;({displaySuffix})</span>
       )}
     </div>
   );

--- a/frontend/src/components/library/DisplayName.tsx
+++ b/frontend/src/components/library/DisplayName.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/utils";
+import { splitDedupeSuffix } from "@/lib/modelNames";
+
+interface Props {
+  /** The display name as the backend resolved it, collision suffix included. */
+  name: string;
+  className?: string;
+}
+
+/**
+ * A model/run title line whose collision suffix survives truncation.
+ *
+ * The backend hands us names like `eraser_place (2026-08-02)`, where the
+ * parenthesized tail is the ONLY thing separating that row from the one above
+ * it (see `dedupe_display_names`). A single `truncate` span eats the tail
+ * first, so in the narrow places these titles live — a card header, a select
+ * item — the disambiguator is exactly what disappears, and two rows the backend
+ * went to some trouble to distinguish arrive at the user identical, or worse,
+ * distinguished only by a stump like "(2026-0…" that no longer says which.
+ *
+ * So the two parts get their own spans: the base truncates, the suffix does
+ * not. The suffix is short and bounded by construction (a date, a date and
+ * time, or a small ordinal), so protecting it costs a fixed sliver of the line
+ * and the base absorbs the rest. The FULL name is on `title` either way, so the
+ * complete identity is always one hover away.
+ *
+ * The suffix is deliberately rendered verbatim rather than shortened to, say, a
+ * dropped year: two runs a year apart would collapse to the same visible text,
+ * which is the precise failure this exists to prevent.
+ */
+const DisplayName: React.FC<Props> = ({ name, className }) => {
+  const { base, suffix } = splitDedupeSuffix(name);
+  // A flex row in both cases: `truncate` needs a block-level box to clip
+  // against, and keeping one shape means the suffixed and unsuffixed titles
+  // share a baseline wherever they sit side by side in a grid.
+  return (
+    <div className={cn("flex min-w-0 items-baseline", className)} title={name}>
+      <span className="truncate">{base}</span>
+      {/* shrink-0: the base gives up its characters first, the disambiguator
+          never does. */}
+      {suffix === null ? null : (
+        <span className="shrink-0 whitespace-nowrap">&nbsp;({suffix})</span>
+      )}
+    </div>
+  );
+};
+
+export default DisplayName;

--- a/frontend/src/components/library/DisplayName.tsx
+++ b/frontend/src/components/library/DisplayName.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { splitDedupeSuffix } from "@/lib/modelNames";
+import { useTruncationTitle } from "@/hooks/useTruncationTitle";
 
 interface Props {
   /** The display name as the backend resolved it, collision suffix included. */
@@ -21,8 +22,9 @@ interface Props {
  * So the two parts get their own spans: the base truncates, the suffix does
  * not. The suffix is short and bounded by construction (a date, a date and
  * time, or a small ordinal), so protecting it costs a fixed sliver of the line
- * and the base absorbs the rest. The FULL name is on `title` either way, so the
- * complete identity is always one hover away.
+ * and the base absorbs the rest. When the base IS clipped, the full name is one
+ * hover away — and only then, since a title on a name that already fits whole
+ * just repeats it (see `useTruncationTitle`).
  *
  * The suffix is deliberately rendered verbatim rather than shortened to, say, a
  * dropped year: two runs a year apart would collapse to the same visible text,
@@ -30,11 +32,16 @@ interface Props {
  */
 const DisplayName: React.FC<Props> = ({ name, className }) => {
   const { base, suffix } = splitDedupeSuffix(name);
+  // The title hangs on the CONTAINER, and the hook sweeps its descendants —
+  // the pair is one name, so either span clipping means the visible name is
+  // incomplete, and the container itself never overflows (its flex children
+  // shrink instead), which measuring it alone would misread as "fits".
+  const hover = useTruncationTitle(name);
   // A flex row in both cases: `truncate` needs a block-level box to clip
   // against, and keeping one shape means the suffixed and unsuffixed titles
   // share a baseline wherever they sit side by side in a grid.
   return (
-    <div className={cn("flex min-w-0 items-baseline", className)} title={name}>
+    <div className={cn("flex min-w-0 items-baseline", className)} {...hover}>
       <span className="truncate">{base}</span>
       {/* shrink-0: the base gives up its characters first, the disambiguator
           never does. */}

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -40,6 +40,7 @@ import {
 import { JobRecord, getJob, jobDisplayName, listJobs } from "@/lib/jobsApi";
 import { ModelItem, getModels } from "@/lib/modelsApi";
 import { findJobForModel, importSourceForModel } from "@/lib/inferenceLaunch";
+import DisplayName from "@/components/library/DisplayName";
 import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
 import ModelsLibrary from "@/components/jobs/ModelsLibrary";
 import ImportModelModal from "@/components/jobs/ImportModelModal";
@@ -657,7 +658,7 @@ const DeployPanel: React.FC = () => {
             >
               <PanelEntryDot className="bg-sky-500" />
               {selectedSkillLabel ? (
-                <span className="min-w-0 truncate">{selectedSkillLabel}</span>
+                <DisplayName name={selectedSkillLabel} className="min-w-0" />
               ) : (
                 <SelectValue placeholder="Pick a skill" />
               )}
@@ -674,7 +675,7 @@ const DeployPanel: React.FC = () => {
               ) : (
                 models.map((m) => (
                   <SelectItem key={m.id} value={m.id}>
-                    <span className="truncate">{m.name}</span>
+                    <DisplayName name={m.name} className="min-w-0" />
                     <span className="ml-2 text-[10px] uppercase tracking-wide text-muted-foreground">
                       {m.source === "hub"
                         ? "hub"

--- a/frontend/src/hooks/useTruncationTitle.ts
+++ b/frontend/src/hooks/useTruncationTitle.ts
@@ -1,0 +1,91 @@
+import React, { useCallback, useState } from "react";
+
+/**
+ * Conditional hover titles for names that may have been shortened.
+ *
+ * A name displayed WHOLE needs no tooltip: a native `title` on text that
+ * already fits just repeats it under the cursor, and a grid full of those
+ * teaches the user that hovering says nothing. A name that was SHORTENED does
+ * need one, because the hidden half is usually the identifying one. So the
+ * title has to be conditional — and the two ways this app shortens a name need
+ * two different detections:
+ *
+ *   * **CSS `truncate`.** The browser decides at layout time, per card width,
+ *     so only the DOM knows: measure `scrollWidth > clientWidth` on the element
+ *     that clips. Measured on every hover rather than once at mount, which is
+ *     what makes a window resize (or a grid re-flowing 3-up to 2-up) correct
+ *     for free — no ResizeObserver, no layout effect, and nothing to keep in
+ *     sync with the CSS.
+ *   * **JS shortening** (`middleEllipsis`, a peeled namespace, a dedupe suffix
+ *     rendered a year shorter than it is stored). The caller already knows this
+ *     one, because the string it renders differs from the full one — passed in
+ *     as `shortened`.
+ *
+ * Native `title` rather than a Radix tooltip on purpose: these sit on small,
+ * tightly-measured spans inside cards and a Select trigger, and an attribute
+ * carries zero layout risk where an extra wrapper element would not.
+ *
+ * Spread the returned props onto the element the name is IN — the truncating
+ * span itself, or, where the name is rendered as a base+suffix pair, their
+ * container (`components/library/DisplayName`), which the sweep below measures
+ * as one unit.
+ */
+
+/**
+ * Is `el` — or any of the (few) elements nested inside it — visually clipped?
+ *
+ * The descendant sweep is what lets the title sit on a CONTAINER whose
+ * children are the things that truncate: DisplayName renders a name as a
+ * base+suffix span pair, and the container itself never overflows (its flex
+ * children shrink instead), so measuring the container alone would always
+ * report "fits". Non-HTML descendants (a lucide `<svg>` and its paths) have no
+ * scroll/client width and are skipped rather than compared as NaN.
+ *
+ * The 1px slack absorbs sub-pixel rounding: both widths are integers, so text
+ * that fits at a fractional width can read one pixel over. Real truncation
+ * overflows by far more than a pixel.
+ */
+function isClipped(el: HTMLElement): boolean {
+  if (el.scrollWidth - el.clientWidth > 1) return true;
+  for (const child of el.querySelectorAll("*")) {
+    if (
+      child instanceof HTMLElement &&
+      child.scrollWidth - child.clientWidth > 1
+    )
+      return true;
+  }
+  return false;
+}
+
+/**
+ * Props to spread onto the element the user hovers: the `title` — undefined
+ * while the name fits, so no tooltip appears at all — and the handler that
+ * re-measures on entry.
+ *
+ * @param full      what the tooltip should reveal: the complete name, plus
+ *                  whatever else identifies the thing (an import's source).
+ * @param shortened set when the CALLER already shortened the string it renders
+ *                  (middleEllipsis, a dropped namespace, a dropped year); CSS
+ *                  truncation is detected here and needs no flag.
+ */
+export function useTruncationTitle(
+  full: string | null | undefined,
+  shortened = false,
+): {
+  title: string | undefined;
+  onMouseEnter: React.MouseEventHandler<HTMLElement>;
+} {
+  const [clipped, setClipped] = useState(false);
+  // Setting state on hover re-renders long before the browser's ~1s tooltip
+  // delay elapses, so the attribute is in place by the time the tooltip is due.
+  const onMouseEnter = useCallback<React.MouseEventHandler<HTMLElement>>(
+    (e) => setClipped(isClipped(e.currentTarget)),
+    [],
+  );
+  return {
+    title: full && (shortened || clipped) ? full : undefined,
+    onMouseEnter,
+  };
+}
+
+export default useTruncationTitle;

--- a/frontend/src/lib/inferenceLaunch.ts
+++ b/frontend/src/lib/inferenceLaunch.ts
@@ -31,8 +31,22 @@ export function findJobForModel(
   // mirrors the backend's find_imported and JobsSection's trackedRepoIds).
   const repo = (model.hf_repo_id ?? "").toLowerCase();
   if (repo) {
-    const byRepo = jobs.find((j) => j.hf_repo_id?.toLowerCase() === repo);
-    if (byRepo) return byRepo;
+    // SEVERAL records can share one repo: a cloud resume reuses its parent's
+    // output repo, so an N-deep chain is N records pointing at the same
+    // weights. First-match took whichever the registry listed first — often a
+    // failed early link, whose checkpoint list is not the finished model's.
+    // Rank as the backend does (models.py `_job_outranks`): a run that reached
+    // "done" published the final policy at the repo root and wins; among
+    // equals the later-started run (the deepest link of the chain) wins.
+    return jobs
+      .filter((j) => j.hf_repo_id?.toLowerCase() === repo)
+      .reduce<JobRecord | null>((best, j) => {
+        if (!best) return j;
+        const jDone = j.state === "done";
+        const bestDone = best.state === "done";
+        if (jDone !== bestDone) return jDone ? j : best;
+        return j.started_at > best.started_at ? j : best;
+      }, null);
   }
   return null;
 }

--- a/frontend/src/lib/modelNames.ts
+++ b/frontend/src/lib/modelNames.ts
@@ -52,3 +52,36 @@ export function splitDedupeSuffix(name: string): {
   if (!match) return { base: name, suffix: null };
   return { base: match[1], suffix: match[2] };
 }
+
+/**
+ * A dedupe suffix's shape when it is a timestamp: `YYYY-MM-DD` or
+ * `YYYY-MM-DD HH:MM` — the ladder `utils/naming.imported_name_suffixes` /
+ * `iso_time_suffixes` walk, as `splitDedupeSuffix` hands it back (parentheses
+ * already stripped). Anchored and fully specified so nothing else can match:
+ * the same ladder ends in a namespace (`lerobot`) or a bare ordinal (`2`) when
+ * no timestamp separates the collision, and neither has a year to drop.
+ */
+const DEDUPE_DATE_SUFFIX_RE = /^\d{4}-(\d{2}-\d{2}(?: \d{2}:\d{2})?)$/;
+
+/**
+ * The DISPLAY form of a dedupe suffix: the same suffix with its year dropped.
+ *
+ * The suffix is the only thing telling two same-titled cards apart, so it is
+ * the half that must render whole (DisplayName makes it `shrink-0` for exactly
+ * that reason) — but at a narrow card width the full `2026-07-31 17:35` leaves
+ * the base name almost nothing, and something has to give. The year is what
+ * gives: it is the least distinguishing field in it (a collision is between two
+ * imports of the same task, which nearly always happened in the same year, and
+ * the hh:mm is what actually separates two runs on one day). Dropping it buys
+ * ~5 characters for the base. The year stays reachable: dropping it counts as
+ * shortening, so the hover title carries the untouched name.
+ *
+ * The residual risk this trades for that room: two runs exactly a year apart
+ * now read identically until hovered. Only the timestamp shapes are touched —
+ * an ordinal or namespace suffix has no year to drop and passes through
+ * verbatim — and the backend's stored suffix is untouched either way.
+ */
+export function displayDedupeSuffix(suffix: string): string {
+  const match = DEDUPE_DATE_SUFFIX_RE.exec(suffix);
+  return match ? match[1] : suffix;
+}

--- a/frontend/src/lib/modelNames.ts
+++ b/frontend/src/lib/modelNames.ts
@@ -1,0 +1,54 @@
+/**
+ * Presentation helpers for model/skill card titles.
+ *
+ * The derivation itself is the backend's — `derive_imported_title` in
+ * makermodslab/utils/naming.py peels an imported model's repo id down to its
+ * task segment, and `dedupe_display_names` keeps two of them apart — so a card
+ * only has to render the name it is given. What CSS can't do is what lives
+ * here: `truncate` always eats the tail, which is the wrong half for a name
+ * whose distinguishing text sits at the end.
+ */
+
+/**
+ * Shorten `text` from the MIDDLE, keeping both ends readable.
+ *
+ * End-truncation is the wrong default for repo-derived names: their head is
+ * boilerplate the author repeats across every model and their tail is the part
+ * that identifies this one, so cutting the tail hides exactly what the user is
+ * scanning for. Returns `text` untouched when it already fits, which is the
+ * normal case for a derived title — this only bites on the fallback path, a
+ * community repo whose name we can't parse and therefore can't shorten safely.
+ */
+export function middleEllipsis(text: string, max = 32): string {
+  if (max < 5 || text.length <= max) return text;
+  // One char of the budget goes to the ellipsis; the head keeps the odd char,
+  // since a name's first word is usually the more recognizable of the two.
+  const head = Math.ceil((max - 1) / 2);
+  const tail = max - 1 - head;
+  return `${text.slice(0, head)}…${text.slice(text.length - tail)}`;
+}
+
+/**
+ * A trailing " (…)" the backend appended to break a name collision.
+ *
+ * `dedupe_display_names` (makermodslab/utils/naming.py) resolves two rows that
+ * derived the same title by appending the one fact that separates them — the
+ * run's date, its date and time, or an ordinal. That suffix is therefore the
+ * MOST load-bearing text in the whole label and the LEAST survivable: it sits
+ * at the very end, where `truncate` starts eating. "eraser_place (2026-08-…"
+ * and "eraser_place (2026-08-…" are two rows the suffix was added to tell
+ * apart, rendered identically.
+ *
+ * Splitting lets the caller render the base and the suffix as separate spans,
+ * so only the base shrinks (see DisplayName). A name the user typed that
+ * happens to end in parentheses splits too — harmless, since both halves are
+ * rendered adjacent and read exactly as before.
+ */
+export function splitDedupeSuffix(name: string): {
+  base: string;
+  suffix: string | null;
+} {
+  const match = /^(.*\S)\s\(([^()]+)\)$/.exec(name);
+  if (!match) return { base: name, suffix: null };
+  return { base: match[1], suffix: match[2] };
+}

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -41,6 +41,11 @@ from pydantic import BaseModel
 from .train import TrainingRequest
 from .utils.config import is_valid_robot_name
 from .utils.hf_auth import shared_hf_api
+from .utils.naming import (
+    dedupe_display_names,
+    derive_imported_title,
+    imported_name_suffixes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -890,6 +895,35 @@ def _normalize_import_source(source: str) -> str:
     return src.rstrip("/")
 
 
+# What register_imported used to auto-name a card before titles were derived
+# ("Imported · makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30"). The
+# prefix duplicated the card's own provenance chip and pushed the one useful
+# segment — the task — past the truncation. Recognized so existing records
+# re-derive on load instead of keeping a name no new import would produce.
+_LEGACY_IMPORT_NAME_PREFIX = "Imported · "
+
+
+def _auto_imported_name(record: JobRecord) -> str | None:
+    """The title an imported record's source derives to, or None to leave it be.
+
+    Returns None for a record whose `name` the CALLER chose (POST /jobs/import
+    takes an optional name): an explicit name is the user's, and re-deriving
+    would silently throw it away. Everything the auto-namer has ever produced is
+    recognizable — the legacy prefixed form, the bare derived title, and a
+    derived title carrying a collision suffix — so the test is precise rather
+    than a guess about which names look generated.
+    """
+    source = record.hf_repo_id or record.output_dir
+    if record.runner != "imported" or not source:
+        return None
+    derived = derive_imported_title(source)
+    if record.name.startswith(_LEGACY_IMPORT_NAME_PREFIX):
+        return derived
+    if record.name == derived or record.name.startswith(f"{derived} ("):
+        return derived
+    return None
+
+
 def _paths_are_same_dir(a: str, b: str) -> bool:
     """True when two path strings refer to the same directory on disk.
 
@@ -986,6 +1020,9 @@ class JobRegistry:
         self._migrate_legacy_cwd_jobs()
         self._load_from_disk()
         self._dedupe_imported_records()
+        # After the dedupe, so a collapsed duplicate can't be counted as a
+        # colliding title and drag a suffix onto the card that survived it.
+        self._resolve_imported_names()
         self._start_watchdog()
 
     def _migrate_legacy_cwd_jobs(self) -> None:
@@ -1312,11 +1349,9 @@ class JobRegistry:
             resolved = str(local_path.resolve())
             ckpts = _list_imported_local(resolved)
             output_dir, hf_repo_id = resolved, None
-            label = local_path.name or resolved
         else:
             ckpts = _list_imported_hub(shared_hf_api(), src)
             output_dir, hf_repo_id = "", src
-            label = src
 
         if not ckpts:
             raise ValueError(
@@ -1336,7 +1371,10 @@ class JobRegistry:
             job_id = self._unique_job_id(policy_type, "imported")
             record = JobRecord(
                 id=job_id,
-                name=name or f"Imported · {label}",
+                # Identity only — no "Imported ·" prefix (the card's own
+                # provenance chip says that) and no namespace or policy token
+                # (the policy row says that). See derive_imported_title.
+                name=name or derive_imported_title(hf_repo_id or output_dir),
                 state="done",
                 config=TrainingRequest(dataset_repo_id="(imported)", policy_type=policy_type),
                 output_dir=output_dir,
@@ -1347,6 +1385,10 @@ class JobRegistry:
             )
             self._records[job_id] = record
             self._persist(record, force=True)
+        # Two imports of one task derive the same title; re-run over the whole
+        # set (not just the newcomer) so BOTH cards get a disambiguator and
+        # neither is left as the bare, ambiguous-looking one.
+        self._resolve_imported_names()
         self._notify_change()
         return record
 
@@ -1698,6 +1740,49 @@ class JobRegistry:
                     keeper.hf_repo_id or keeper.output_dir,
                     "" if removed else " — pointer dropped from the registry only",
                 )
+
+    def _resolve_imported_names(self) -> None:
+        """Re-derive every auto-named imported record's title, collisions and all.
+
+        Idempotent and whole-set by design, which is what lets it run both at
+        boot and after each import: the title is recomputed from the source each
+        time, so a record named before titles were derived ("Imported · …") is
+        upgraded, and a suffix added to break a collision is recomputed rather
+        than accumulated. Records the user named — explicitly at import, or via
+        `rename`, which writes `display_name` and always wins on the card — are
+        never touched (see _auto_imported_name).
+
+        Collisions are counted per (title, policy type), the pair a card
+        actually renders: an ACT and a SmolVLA of one task read as two rows
+        already, because the Policy row below the title says so. Grouping on the
+        stored `config.policy_type` rather than a re-derivation keeps the rule
+        honest — when the import could not read a policy type, the two cards
+        really are indistinguishable and really do need the suffix.
+
+        Oldest-first so the disambiguated labels are stable across restarts and
+        don't depend on which record happened to be read from disk first.
+        """
+        with self._lock:
+            records = sorted(
+                (r for r in self._records.values() if r.runner == "imported"),
+                key=lambda r: (r.started_at, r.id),
+            )
+        targets: builtins.list[JobRecord] = []
+        entries: builtins.list[tuple[str, builtins.list[str]]] = []
+        for record in records:
+            derived = _auto_imported_name(record)
+            if derived is None:
+                continue
+            targets.append(record)
+            entries.append((derived, imported_name_suffixes(record.hf_repo_id or record.output_dir)))
+
+        resolved_names = dedupe_display_names(entries, group_keys=[r.config.policy_type for r in targets])
+        for record, resolved in zip(targets, resolved_names, strict=True):
+            if record.name == resolved:
+                continue
+            logger.info("Renamed imported model %s: %r -> %r", record.id, record.name, resolved)
+            record.name = resolved
+            self._write_meta(record)
 
     def _start_watchdog(self) -> None:
         self._watchdog_thread = threading.Thread(

--- a/makermodslab/models.py
+++ b/makermodslab/models.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import shutil
 import threading
 import time
@@ -64,6 +63,14 @@ from .utils.config import (
     with_makermodslab_tag,
 )
 from .utils.hf_auth import cached_whoami, hf_hub_offline, shared_hf_api
+from .utils.naming import (
+    KNOWN_POLICY_TYPES,
+    POLICY_TYPES_BY_LENGTH as _POLICY_TYPES_BY_LENGTH,
+    RUN_REPO_TIMESTAMP_RE,
+    dedupe_display_names,
+    imported_name_suffixes,
+    iso_time_suffixes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,29 +81,9 @@ _LOCAL_MODEL_SCAN_LIMIT = 500
 # A repo qualifies as a MakerMods Lab-relevant model if it carries the `lerobot` library
 # tag (what push_to_hub stamps) OR its name matches the MakerMods Lab run-repo pattern
 # (a "_<timestamp>" suffix). Same union as server.py's _list_author_models.
-_RUN_REPO_RE = re.compile(r"_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$")
-
-# Canonical policy types lerobot can load — mirrors the registry in
-# lerobot/policies/factory.py (get_policy_class / make_policy_config). Defined
-# once here as the single source of truth for recognizing a Hub repo's policy
-# type from its tags / name / card; update alongside lerobot pin bumps.
-KNOWN_POLICY_TYPES = {
-    "tdmpc",
-    "diffusion",
-    "act",
-    "multi_task_dit",
-    "vqbet",
-    "pi0",
-    "pi05",
-    "gaussian_actor",
-    "smolvla",
-    "wall_x",
-    "pi0_fast",
-}
-
-# Longest-first for name-prefix matching, so a shorter type can never shadow a
-# longer one it prefixes (pi0 must not swallow a pi0_fast_... repo name).
-_POLICY_TYPES_BY_LENGTH = sorted(KNOWN_POLICY_TYPES, key=len, reverse=True)
+# The pattern itself now lives in utils/naming.py, which also derives titles from
+# it — one definition, so a repo that reads as generated to one reads so to both.
+_RUN_REPO_RE = RUN_REPO_TIMESTAMP_RE
 
 
 def _hub_policy_type(tags: list[str] | None, repo_name: str) -> str | None:
@@ -523,6 +510,193 @@ def list_hub_models() -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def _job_run_steps(record: JobRecord) -> int | None:
+    """How many steps the run behind a Hub repo actually trained.
+
+    A run that reached "done" trained to its configured target, and
+    `config.steps` is that target in GLOBAL steps even for a resumed run —
+    prefer it, because the metrics tail can stop short of the end (the last log
+    lines are parsed at log_freq granularity, and a terminal transition can drop
+    the final one). Otherwise the run stopped early, so the last step its metrics
+    observed is the honest number. None when neither is known: the row keeps the
+    listing's null rather than invent one.
+    """
+    if record.state == "done" and record.config.steps:
+        return record.config.steps
+    if record.metrics.current_step:
+        return record.metrics.current_step
+    return None
+
+
+def _job_outranks(candidate: JobRecord, incumbent: JobRecord) -> bool:
+    """Ranking used to pick which run identifies a shared output repo: a run
+    that reached "done" beats one that didn't (it is the one that published the
+    final policy at the repo root), and among equals the later-started run
+    wins (the deepest link of a resume chain)."""
+    candidate_done = candidate.state == "done"
+    incumbent_done = incumbent.state == "done"
+    if candidate_done != incumbent_done:
+        return candidate_done
+    return candidate.started_at > incumbent.started_at
+
+
+def _jobs_by_hub_repo() -> dict[str, JobRecord]:
+    """Tracked runs keyed by the Hub repo they publish to, one run per repo.
+
+    A cloud resume REUSES its parent's output repo (hf_cloud sets
+    `policy_repo_id = resume_from_hub_repo`), so an N-deep resume chain shares a
+    single repo named after run #1 — and the Hub listing, which keys on repo_id,
+    then has no row under the name of the run that actually finished. Collapse
+    each repo to the run that best identifies it (see _job_outranks).
+
+    IMPORTED records are skipped: an import REGISTERS an existing repo rather
+    than producing it, so its config is a placeholder (dataset_repo_id
+    "(imported)", the default step count) and its auto-generated name says less
+    than the repo id does. They are also always "done" and usually the newest
+    record for their repo, so ranking them would let a placeholder outrank the
+    run that actually trained the weights.
+
+    Reads the registry, never mutates it. The scan limit matches
+    list_local_models so the two passes share the registry's per-record
+    checkpoint-count work (and, for cloud records, its 30s Hub cache) instead of
+    doubling it."""
+    best: dict[str, JobRecord] = {}
+    for record in job_registry.list(limit=_LOCAL_MODEL_SCAN_LIMIT):
+        repo_id = record.hf_repo_id
+        if not repo_id or record.runner == "imported":
+            continue
+        incumbent = best.get(repo_id)
+        if incumbent is None or _job_outranks(record, incumbent):
+            best[repo_id] = record
+    return best
+
+
+def _run_identity_name(record: JobRecord) -> str:
+    """A run's human name peeled down to the TASK it learned.
+
+    jobs.start auto-generates an unnamed run's name as
+    "{POLICY} · {dataset_repo_id}" — "SMOLVLA · makermods/eraser_place". Both
+    halves of that are stated elsewhere on every surface that renders it: the
+    row carries `policy_type` in its own field and `dataset` (the full repo id,
+    namespace included) in another, so the title line — the widest and the first
+    to truncate — spends its pixels on facts printed twice. Peel both:
+
+      "SMOLVLA · makermods/eraser_place"  ->  "eraser_place"
+
+    which converges model-card naming on one philosophy: the task identity,
+    policy-free and namespace-free. Imported titles already read this way
+    (utils.naming.derive_imported_title), and the retired "Imported · " prefix
+    (jobs._LEGACY_IMPORT_NAME_PREFIX) went for the same reason.
+
+    Only the GENERATED shape is peeled, and only when the head is a policy type
+    we recognize — a user-typed job_name that happens to contain " · " keeps
+    every word, and so does a name whose head isn't a policy. The namespace peel
+    is gated behind that same check, so it can never eat a slash out of a name a
+    human wrote. A rename (`display_name`) never reaches here; the caller
+    prefers it outright.
+
+    Two datasets that share a task name across namespaces (a/pick and b/pick)
+    now render one label twice — that is what _dedupe_listing_names exists for,
+    and its date suffix separates them.
+    """
+    head, separator, tail = record.name.partition(" · ")
+    if not (separator and tail and head.lower() in KNOWN_POLICY_TYPES):
+        return record.name
+    # The tail is a dataset repo id: keep the segment after the namespace. A
+    # bare name with no slash is already the task.
+    _namespace, slash, task = tail.partition("/")
+    return task if slash and task else tail
+
+
+def _enrich_repo_rows_from_jobs(merged: dict[str, dict[str, Any]]) -> None:
+    """Give each repo-keyed row the identity of the run that produced it.
+
+    Applies only to rows still named after their repo id — i.e. rows no local
+    checkpoint has claimed (a "both" collapse from a local run already put the
+    run's own name and detail there, and local always wins). That covers the
+    hub-only rows, hub rows flipped to "both" by a downloaded copy, and pinned
+    rows the Hub listing didn't return.
+
+    Identity fields are NOT touched: `id`, `repo_id` and `hf_repo_id` route
+    every request (info / download / pin / hide / deploy) and a resume chain's
+    repo keeps the name of run #1 on the Hub. Only the human-facing `name` is
+    replaced, plus the detail fields the repo listing could not know — filled in
+    only where they are still null, so a checkpoint-derived value always wins.
+    """
+    by_repo = _jobs_by_hub_repo()
+    if not by_repo:
+        return
+    for row in merged.values():
+        repo_id = row.get("hf_repo_id")
+        if not repo_id or row.get("name") != repo_id:
+            continue
+        record = by_repo.get(repo_id)
+        if record is None:
+            continue
+        row["name"] = record.display_name or _run_identity_name(record)
+        if row.get("policy_type") is None:
+            row["policy_type"] = record.config.policy_type or None
+        if row.get("dataset") is None:
+            row["dataset"] = record.config.dataset_repo_id or None
+        if row.get("steps") is None:
+            row["steps"] = _job_run_steps(record)
+
+
+def _row_dedupe_suffixes(row: dict[str, Any]) -> list[str]:
+    """The disambiguator ladder for one listing row, least → most specific.
+
+    Prefers the run timestamp embedded in the row's own NAME — every repo a
+    MakerMods Lab run publishes to carries the `_<date>_<time>` tail its run id
+    was generated with — over the Hub's `last_modified`. The two usually agree,
+    and where they disagree the name is the one the user means: last_modified
+    moves whenever anything is pushed to the repo (a re-push of the same
+    weights, a README edit, a later checkpoint upload), so a row could acquire a
+    date months after the run it labels and read as simply wrong next to its
+    sibling. The name's stamp is when the run STARTED and never moves.
+
+    Falls back to last_modified for a row whose name carries no stamp — a
+    community repo, a hand-named upload — which is the only signal there is.
+    Both ladders come from utils.naming, so a name-derived suffix and a
+    time-derived one are formatted identically and can disambiguate each other.
+    """
+    source = str(row.get("hf_repo_id") or row.get("id") or "")
+    if source and _RUN_REPO_RE.search(source.rsplit("/", 1)[-1]):
+        return imported_name_suffixes(source)
+    return iso_time_suffixes(row.get("last_modified"))
+
+
+def _dedupe_listing_names(merged: dict[str, dict[str, Any]]) -> None:
+    """Make the listing's display names unique, in place.
+
+    Run names are auto-generated from policy + dataset (jobs.start →
+    "SMOLVLA · ns/task", which the enrichment peels down to "task" — see
+    _run_identity_name), so retraining one task — a longer run, a different
+    seed — produces a SECOND row with a byte-identical name. Naming rows after
+    their run (see _enrich_repo_rows_from_jobs) makes that collision visible in
+    the picker, where two rows then read as duplicates of each other with
+    nothing on either to say which is which.
+
+    Disambiguate least-specific first (see _row_dedupe_suffixes for where the
+    date comes from, and dedupe_display_names, which escalates to date + time
+    and falls back to an ordinal if even that ties). Runs over EVERY row, not
+    just the enriched ones — two local runs of one policy on one dataset collide
+    the same way and never went near the enrichment.
+
+    Rows are grouped by (name, policy_type), so an ACT and a SmolVLA of one task
+    are NOT suffixed: the Policy row on the card already separates them, and a
+    date there would imply the difference between the two is when they ran.
+    Identity fields are left alone, on the same rule as the enrichment: only
+    `name` is display.
+    """
+    rows = list(merged.values())
+    resolved = dedupe_display_names(
+        [(str(row.get("name") or ""), _row_dedupe_suffixes(row)) for row in rows],
+        group_keys=[row.get("policy_type") for row in rows],
+    )
+    for row, name in zip(rows, resolved, strict=True):
+        row["name"] = name
+
+
 def list_all_models() -> list[dict[str, Any]]:
     """Merged listing: local completed runs + Hub policy repos, with a `source`.
 
@@ -531,6 +705,11 @@ def list_all_models() -> list[dict[str, Any]]:
     local-only run is "local". Mirrors list_all_datasets's merge/dedup/sort and
     its resilience: the Hub half is best-effort (list_hub_models never raises),
     so a Hub outage degrades to local-only rather than crashing.
+
+    A row still named after its repo id is then named after the tracked run that
+    produced it (see _enrich_repo_rows_from_jobs) — a repo id names a run only
+    by accident, and never names the right one for a cloud resume chain, which
+    publishes every link into the FIRST run's repo.
 
     Cached for up to _LISTING_CACHE_TTL_S so repeated startup/nav loads reuse a
     recent listing; a mutation invalidates the cache (see
@@ -650,6 +829,21 @@ def list_all_models() -> list[dict[str, Any]]:
             existing["source"] = "both"
             existing["hf_repo_id"] = repo_id
             existing["saved_custom"] = True
+
+    # Name the repo-keyed rows after the run that produced them, now that every
+    # source has merged in. A tracked run whose output repo is shared with its
+    # resume chain (or simply never collapsed into a local row) would otherwise
+    # reach the picker as a bare repo id with null steps/dataset — under the
+    # name of the FIRST run in the chain, never the one that finished. Runs
+    # after the merge and before the hidden filter so it can't resurrect a
+    # hidden row, and so local-checkpoint detail always wins (see the helper).
+    _enrich_repo_rows_from_jobs(merged)
+
+    # Then separate the rows the naming above left indistinguishable: two runs
+    # of one policy on one dataset carry the same auto-generated name, so the
+    # picker would show the same label twice. Immediately after the enrichment
+    # so it sees the final names, and still before the hidden filter.
+    _dedupe_listing_names(merged)
 
     # Hidden models ("removed from list") are filtered LAST — after the
     # hub/local/downloaded merge and the pin fold — so a hidden id can't

--- a/makermodslab/utils/naming.py
+++ b/makermodslab/utils/naming.py
@@ -1,0 +1,212 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Human-facing names derived from Hub repo ids, model paths and run metadata.
+
+A leaf module by necessity as well as by taste: `models` already imports `jobs`
+at module scope, so the naming rules the two share (the policy-type vocabulary,
+the MakerMods Lab run-repo timestamp suffix, collision resolution) can only live
+somewhere both can import without a cycle. Nothing here touches the filesystem,
+the Hub, or the registry — every function is a pure string transform, which is
+also what makes the derivation cheap to unit-test.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Hashable, Sequence
+
+# Canonical policy types lerobot can load — mirrors the registry in
+# lerobot/policies/factory.py (get_policy_class / make_policy_config). Defined
+# once here as the single source of truth for recognizing a model's policy type
+# from its tags / name / card; update alongside lerobot pin bumps.
+KNOWN_POLICY_TYPES = {
+    "tdmpc",
+    "diffusion",
+    "act",
+    "multi_task_dit",
+    "vqbet",
+    "pi0",
+    "pi05",
+    "gaussian_actor",
+    "smolvla",
+    "wall_x",
+    "pi0_fast",
+}
+
+# Longest-first for name-prefix matching, so a shorter type can never shadow a
+# longer one it prefixes (pi0 must not swallow a pi0_fast_... repo name).
+POLICY_TYPES_BY_LENGTH = sorted(KNOWN_POLICY_TYPES, key=len, reverse=True)
+
+# The `_<date>_<time>` tail every MakerMods Lab run id (and therefore every repo
+# a run publishes to) carries — see jobs._generate_job_id. Its presence is what
+# marks a name as machine-generated rather than human-chosen.
+RUN_REPO_TIMESTAMP_RE = re.compile(r"_(\d{4}-\d{2}-\d{2})_(\d{2})-(\d{2})-(\d{2})$")
+
+
+def _split_source(source: str) -> tuple[str, str]:
+    """(namespace, basename) for an import source.
+
+    Handles both shapes `register_imported` stores: a bare Hub repo id
+    (`ns/name` — exactly one slash, no leading `/`, `~` or `.`) and a local
+    directory path. Only a repo id yields a namespace; a path's parent
+    directory is not one, and using it would strip real text out of titles.
+    """
+    src = source.strip().replace("\\", "/").rstrip("/")
+    basename = src.rsplit("/", 1)[-1]
+    is_repo_id = src.count("/") == 1 and not src.startswith(("/", "~", "."))
+    namespace = src.split("/", 1)[0] if is_repo_id else ""
+    return namespace, basename
+
+
+def policy_type_from_name(name: str) -> str | None:
+    """The policy type a MakerMods Lab-generated model name starts with, or None.
+
+    Matched longest-first so `pi0` never shadows `pi0_fast`. Mirrors (and now
+    backs) models._hub_policy_type's name-prefix signal.
+    """
+    for policy_type in POLICY_TYPES_BY_LENGTH:
+        if name.startswith(policy_type + "_"):
+            return policy_type
+    return None
+
+
+def derive_imported_title(source: str) -> str:
+    """The card title for an imported model, derived from its repo id or path.
+
+    A model MakerMods Lab trained is published under a fully machine-generated
+    name — `{namespace}/{policy}_{dataset_slug}_{timestamp}` (jobs.start →
+    _generate_job_id) — in which every segment but one is already stated
+    elsewhere on the card: the provenance chip says it was imported, the Policy
+    row says which policy, the subtitle carries the full source. The title's
+    pixels are worth more spent on the one thing nothing else says, the TASK, so
+    peel off the rest:
+
+      makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30 → orange_box
+
+    namespace → policy token → the dataset's own namespace repeated as an infix
+    (taken from the repo's namespace rather than hardcoded, so it strips for any
+    user) → the trailing timestamp, which the subtitle keeps.
+
+    The timestamp is the signature of a generated name, so a source WITHOUT one
+    is treated as human-chosen and only loses its namespace — a community repo
+    like `lerobot/smolvla_base` keeps every word its author wrote, including a
+    leading policy token that here is part of the name rather than a prefix.
+    Callers render long fallbacks with a middle ellipsis (see
+    frontend/src/lib/modelNames.ts) so both ends stay readable.
+    """
+    namespace, basename = _split_source(source)
+    match = RUN_REPO_TIMESTAMP_RE.search(basename)
+    if match is None:
+        return basename or source.strip()
+
+    stem = basename[: match.start()]
+    policy_type = policy_type_from_name(stem)
+    if policy_type:
+        stem = stem[len(policy_type) + 1 :]
+    if namespace and stem.lower().startswith(namespace.lower() + "_"):
+        stem = stem[len(namespace) + 1 :]
+    return stem or basename
+
+
+def imported_name_suffixes(source: str) -> list[str]:
+    """Disambiguators for an imported title, least → most specific.
+
+    Two imports of the same task — a rerun, or the same policy retrained on more
+    steps — derive the same title, so the timestamp `derive_imported_title` drops
+    comes back as the tiebreak: first its date, then date + time for two runs on
+    one day. A source with no timestamp offers its namespace instead, which
+    separates the common case of the same model pulled from two authors.
+    """
+    namespace, basename = _split_source(source)
+    match = RUN_REPO_TIMESTAMP_RE.search(basename)
+    if match is None:
+        return [namespace] if namespace else []
+    date, hour, minute, _second = match.groups()
+    return [date, f"{date} {hour}:{minute}"]
+
+
+def iso_time_suffixes(iso: str | None) -> list[str]:
+    """The same ladder as `imported_name_suffixes`, read off an ISO timestamp.
+
+    Used for listing rows, whose disambiguator is the repo/checkpoint's
+    last-modified time rather than a name they may not carry one in.
+    """
+    if not iso or len(iso) < 10:
+        return []
+    date = iso[:10]
+    if len(iso) >= 16 and iso[10] in " T":
+        return [date, f"{date} {iso[11:16]}"]
+    return [date]
+
+
+def dedupe_display_names(
+    entries: Sequence[tuple[str, Sequence[str]]],
+    group_keys: Sequence[Hashable] | None = None,
+) -> list[str]:
+    """Make a listing's auto-generated display names unique.
+
+    Auto-generated names collide by construction: two runs of one policy on one
+    dataset are both named "SMOLVLA · ns/task" (jobs.start), and two imports of
+    one task both derive to "task". The listing then shows several rows under a
+    single label with nothing on the card to tell them apart.
+
+    `entries` pairs each item's name with its candidate disambiguators, ordered
+    least → most specific. A name that occurs once is returned untouched. For a
+    colliding group the FIRST candidate level that separates every member is
+    appended as " (<suffix>)"; if no level does — no candidates, or two items
+    genuinely share even the most specific one — a 1-based ordinal is appended
+    so the result is unique regardless.
+
+    `group_keys`, when given, is a parallel sequence naming a SECOND axis the
+    listing already renders in its own field — in practice the policy type. Two
+    items only collide when they match on the name AND that key, because an ACT
+    and a SmolVLA of one task are told apart by the Policy row a few pixels
+    below the title: suffixing them would spend the title's scarcest space
+    restating a fact the card already prints, and imply a difference in identity
+    where the real one is in policy. The key affects GROUPING only; the label
+    stays the bare name, since the key is never what the title should carry.
+
+    Order-preserving and deterministic: the labels don't reshuffle between two
+    requests over the same data, which is what makes them safe to show on a card
+    the user is reading.
+    """
+    names = [name for name, _ in entries]
+    keys: list[tuple[str, Hashable]] = (
+        [(name, key) for name, key in zip(names, group_keys, strict=True)]
+        if group_keys is not None
+        else [(name, None) for name in names]
+    )
+    counts = Counter(keys)
+    resolved = list(names)
+
+    groups: dict[tuple[str, Hashable], list[int]] = {}
+    for index, key in enumerate(keys):
+        if counts[key] > 1:
+            groups.setdefault(key, []).append(index)
+
+    for (name, _key), indices in groups.items():
+        depth = max(len(entries[i][1]) for i in indices)
+        for level in range(depth):
+            candidates = [entries[i][1][level] if level < len(entries[i][1]) else "" for i in indices]
+            if all(candidates) and len(set(candidates)) == len(candidates):
+                for index, suffix in zip(indices, candidates, strict=True):
+                    resolved[index] = f"{name} ({suffix})"
+                break
+        else:
+            for ordinal, index in enumerate(indices, start=1):
+                resolved[index] = f"{name} ({ordinal})"
+
+    return resolved

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -974,3 +974,185 @@ def test_local_start_skips_hub_preflight(tmp_path) -> None:
 
     get_status.assert_not_called()
     assert record.runner == "local"
+
+
+# ── Imported-model card titles ───────────────────────────────────────────────
+# The name an imported record is born with, and how the registry keeps two of
+# them apart. The derivation rules themselves live in tests/test_naming.py.
+
+
+def _hub_reg(monkeypatch, tmp_path, root="root"):
+    """A registry whose Hub probe always reports a root-level checkpoint, so a
+    hub import succeeds offline."""
+    from makermodslab.jobs import JobRegistry
+
+    class FakeApi:
+        def list_repo_files(self, repo_id, repo_type):
+            return ["config.json", "model.safetensors"]
+
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: FakeApi())
+    return JobRegistry(tmp_path / root)
+
+
+def test_imported_name_is_the_derived_task_not_the_repo_id(monkeypatch, tmp_path) -> None:
+    """No "Imported ·" prefix (the card's provenance chip already says it) and
+    no namespace or policy token (the policy row says that) — just the task, so
+    the title's pixels go to the one thing nothing else on the card states."""
+    reg = _hub_reg(monkeypatch, tmp_path)
+    rec = reg.register_imported("makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30")
+
+    assert rec.name == "orange_box"
+    assert "Imported" not in rec.name
+
+
+def test_imported_name_from_a_local_dir(tmp_path) -> None:
+    from makermodslab.jobs import JobRegistry
+
+    model = tmp_path / "smolvla_me_orange_box_2026-08-03_12-53-30"
+    _make_pretrained(model)
+    reg = JobRegistry(tmp_path / "root")
+    # No namespace on a path, so only the policy token and the timestamp go.
+    assert reg.register_imported(str(model)).name == "me_orange_box"
+
+
+def test_imported_name_keeps_a_community_repo_name(monkeypatch, tmp_path) -> None:
+    """A repo with no generated timestamp was named by a human, so nothing but
+    the namespace is dropped — the card falls back to a middle-ellipsized
+    basename rather than guessing at structure that isn't there."""
+    reg = _hub_reg(monkeypatch, tmp_path)
+    assert reg.register_imported("lerobot/smolvla_base").name == "smolvla_base"
+
+
+def test_explicit_import_name_wins_over_the_derivation(monkeypatch, tmp_path) -> None:
+    """POST /jobs/import may carry a name. It's the user's, so neither the
+    derivation nor the collision pass may overwrite it."""
+    reg = _hub_reg(monkeypatch, tmp_path)
+    rec = reg.register_imported(
+        "makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30",
+        name="Orange picker v2",
+    )
+    assert rec.name == "Orange picker v2"
+
+    reg2 = _hub_reg(monkeypatch, tmp_path)  # reload from disk
+    assert reg2.get(rec.id).name == "Orange picker v2"
+
+
+def test_rename_alias_survives_the_collision_pass(monkeypatch, tmp_path) -> None:
+    """A user-set display_name always wins on the card; re-deriving `name`
+    underneath it must not disturb the alias."""
+    reg = _hub_reg(monkeypatch, tmp_path)
+    rec = reg.register_imported("makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30")
+    reg.rename(rec.id, "Orange picker")
+
+    reg2 = _hub_reg(monkeypatch, tmp_path)
+    reloaded = reg2.get(rec.id)
+    assert reloaded.display_name == "Orange picker"
+    assert reloaded.name == "orange_box"
+
+
+def test_two_imports_of_one_task_are_disambiguated(monkeypatch, tmp_path) -> None:
+    """Both titles derive to "orange_box". BOTH cards get the timestamp back as
+    a suffix — leaving the first bare would make it the ambiguous one."""
+    reg = _hub_reg(monkeypatch, tmp_path)
+    a = reg.register_imported("makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30")
+    b = reg.register_imported("makermods/act_makermods_orange_box_2026-08-05_09-00-00")
+
+    names = {r.id: r.name for r in reg.list(limit=100)}
+    assert names[a.id] == "orange_box (2026-08-03)"
+    assert names[b.id] == "orange_box (2026-08-05)"
+
+
+def test_same_day_imports_escalate_to_the_time(monkeypatch, tmp_path) -> None:
+    reg = _hub_reg(monkeypatch, tmp_path)
+    a = reg.register_imported("makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30")
+    b = reg.register_imported("makermods/act_makermods_orange_box_2026-08-03_18-04-00")
+
+    names = {r.id: r.name for r in reg.list(limit=100)}
+    assert names[a.id] == "orange_box (2026-08-03 12:53)"
+    assert names[b.id] == "orange_box (2026-08-03 18:04)"
+
+
+def test_collision_suffixes_are_recomputed_not_accumulated(monkeypatch, tmp_path) -> None:
+    """The pass is idempotent: it re-derives from the source every time, so a
+    reload (or a third import) never stacks "(date) (date)" onto a title."""
+    reg = _hub_reg(monkeypatch, tmp_path)
+    reg.register_imported("makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30")
+    reg.register_imported("makermods/act_makermods_orange_box_2026-08-05_09-00-00")
+
+    reg2 = _hub_reg(monkeypatch, tmp_path)
+    reg3 = _hub_reg(monkeypatch, tmp_path)
+    assert sorted(r.name for r in reg3.list(limit=100)) == sorted(r.name for r in reg2.list(limit=100))
+    assert all(r.name.count("(") <= 1 for r in reg3.list(limit=100))
+
+
+def test_legacy_imported_name_is_re_derived_on_load(monkeypatch, tmp_path) -> None:
+    """Records written before titles were derived carry the old
+    "Imported · <repo id>" name. Boot upgrades them in place, so the fix reaches
+    the cards already in the user's library and not only the next import."""
+    from makermodslab.jobs import JobRecord, JobRegistry
+    from makermodslab.train import TrainingRequest
+
+    root = tmp_path / "root"
+    job_dir = root / "smolvla_imported_2026-08-03_12-53-30"
+    job_dir.mkdir(parents=True)
+    legacy = JobRecord(
+        id=job_dir.name,
+        name="Imported · makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30",
+        state="done",
+        config=TrainingRequest(dataset_repo_id="(imported)", policy_type="smolvla"),
+        output_dir="",
+        started_at=1.0,
+        ended_at=1.0,
+        runner="imported",
+        hf_repo_id="makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30",
+    )
+    (job_dir / "job.json").write_text(legacy.model_dump_json(indent=2))
+
+    reg = JobRegistry(root)
+    assert reg.get(legacy.id).name == "orange_box"
+    # Persisted, not just fixed in memory.
+    assert _json.loads((job_dir / "job.json").read_text())["name"] == "orange_box"
+
+
+
+
+def _typed_hub_reg(monkeypatch, tmp_path, policy_by_repo, root="root"):
+    """`_hub_reg` plus a readable checkpoint config, so each import lands with a
+    real `config.policy_type` — the field the card's Policy row renders, and the
+    one the collision pass groups on."""
+    reg = _hub_reg(monkeypatch, tmp_path, root=root)
+    monkeypatch.setattr(
+        "makermodslab.jobs._read_checkpoint_config",
+        # A hub checkpoint's ref is "<repo_id>@root" (see _list_imported_hub).
+        lambda ckpt: {"type": policy_by_repo[ckpt.ref.split("@", 1)[0]]},
+    )
+    return reg
+
+
+def test_two_policies_of_one_task_are_not_disambiguated(monkeypatch, tmp_path) -> None:
+    """Both derive to "orange_box", but one card says ACT and the other SmolVLA
+    a line below the title — they are already told apart, so a date suffix would
+    only crowd out the task name it is meant to clarify."""
+    act_repo = "makermods/act_makermods_orange_box_2026-08-05_09-00-00"
+    smolvla_repo = "makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30"
+    reg = _typed_hub_reg(monkeypatch, tmp_path, {act_repo: "act", smolvla_repo: "smolvla"})
+    a = reg.register_imported(smolvla_repo)
+    b = reg.register_imported(act_repo)
+
+    names = {r.id: r.name for r in reg.list(limit=100)}
+    assert names[a.id] == "orange_box"
+    assert names[b.id] == "orange_box"
+
+
+def test_two_imports_of_one_task_and_policy_are_still_disambiguated(monkeypatch, tmp_path) -> None:
+    """Same task AND same policy: nothing on either card separates them, so the
+    timestamp the title dropped comes back on both."""
+    early = "makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30"
+    late = "makermods/smolvla_makermods_orange_box_2026-08-05_09-00-00"
+    reg = _typed_hub_reg(monkeypatch, tmp_path, {early: "smolvla", late: "smolvla"})
+    a = reg.register_imported(early)
+    b = reg.register_imported(late)
+
+    names = {r.id: r.name for r in reg.list(limit=100)}
+    assert names[a.id] == "orange_box (2026-08-03)"
+    assert names[b.id] == "orange_box (2026-08-05)"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,8 +19,10 @@ are seeded into a temp outputs/train via a fresh JobRegistry."""
 
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -326,6 +328,476 @@ def test_list_all_models_infers_pinned_model_policy_type_from_name(registry) -> 
     assert row["hf_repo_id"] == "makermods/smolvla_makermods_sock_2026-07-08_01-47-15"
     assert row["saved_custom"] is True
     assert row["policy_type"] == "smolvla"
+
+
+# ---------------------------------------------------------------------------
+# list_all_models — naming a repo-keyed row after the run that produced it.
+# ---------------------------------------------------------------------------
+
+
+def _seed_cloud_run(
+    registry,
+    job_id: str,
+    *,
+    repo_id: str,
+    state: str = "done",
+    started_at: float = 1.0,
+    policy_type: str = "smolvla",
+    dataset: str = "makermods/eraser",
+    steps: int = 20000,
+    display_name: str | None = None,
+) -> None:
+    """Register a cloud JobRecord publishing to `repo_id`. No local checkpoint:
+    a cloud run's artifacts live on the Hub, so it never appears in
+    list_local_models — only as the identity behind a Hub-keyed row."""
+    from makermodslab.jobs import JobRecord
+    from makermodslab.train import TrainingRequest
+
+    registry._records[job_id] = JobRecord(
+        id=job_id,
+        name=job_id,
+        display_name=display_name,
+        state=state,
+        config=TrainingRequest(dataset_repo_id=dataset, policy_type=policy_type, steps=steps),
+        output_dir="",
+        started_at=started_at,
+        ended_at=started_at + 1.0,
+        runner="hf_cloud",
+        hf_repo_id=repo_id,
+    )
+
+
+class _NoHubFiles:
+    """HfApi stand-in for the registry's per-record checkpoint count: an empty
+    repo listing, so seeding cloud records costs no network."""
+
+    def list_repo_files(self, repo_id, repo_type):
+        return []
+
+
+def _sandboxed_listing(hub_rows: list[dict[str, Any]]):
+    """The patches every list_all_models test needs to stay off the network and
+    off the developer's real pinned/hidden-model files."""
+    return (
+        patch("makermodslab.models.list_hub_models", return_value=hub_rows),
+        patch("makermodslab.models.get_saved_custom_models", return_value=[]),
+        patch("makermodslab.models.get_hidden_models", return_value=set()),
+        patch("makermodslab.jobs.shared_hf_api", return_value=_NoHubFiles()),
+    )
+
+
+_SHARED_REPO = "makermods/smolvla_eraser_2026-07-31_17-35-54"
+
+
+def test_list_all_models_names_repo_row_after_the_run_that_finished(registry, tmp_lerobot_home) -> None:
+    """MT12's user-facing symptom: a cloud resume reuses its PARENT's output
+    repo, so a resume chain shares one repo named after run #1. /models keys Hub
+    entries by repo_id, so the run that actually finished had no entry under its
+    own name — the only row was the parent's, with null steps/dataset. The row
+    now carries the finishing run's identity while its routing keys (id /
+    repo_id / hf_repo_id) stay the repo id."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "run_17-35-54", repo_id=_SHARED_REPO, state="failed", started_at=100.0)
+    _seed_cloud_run(registry, "run_20-31-48", repo_id=_SHARED_REPO, state="failed", started_at=200.0)
+    # The one that reached its 20k target — newer AND done, so it names the repo.
+    _seed_cloud_run(registry, "run_22-40-15", repo_id=_SHARED_REPO, state="done", started_at=300.0)
+
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    row = next(r for r in result if r["repo_id"] == _SHARED_REPO)
+    assert row["name"] == "run_22-40-15"
+    # Identity is untouched — every request (info / download / deploy) routes on it.
+    assert row["id"] == _SHARED_REPO
+    assert row["hf_repo_id"] == _SHARED_REPO
+    assert row["source"] == "hub"
+    # Detail the Hub listing had no way to know.
+    assert row["steps"] == 20000
+    assert row["dataset"] == "makermods/eraser"
+    assert row["policy_type"] == "smolvla"
+
+
+def test_list_all_models_repo_row_prefers_done_over_newer_unfinished(registry, tmp_lerobot_home) -> None:
+    """A later resume attempt that failed does not get to name the repo: the run
+    that reached "done" published the policy sitting at the repo root."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "finished", repo_id=_SHARED_REPO, state="done", started_at=100.0)
+    _seed_cloud_run(registry, "later_crash", repo_id=_SHARED_REPO, state="failed", started_at=999.0)
+
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    assert next(r for r in result if r["repo_id"] == _SHARED_REPO)["name"] == "finished"
+
+
+def test_list_all_models_repo_row_uses_display_name_when_renamed(registry, tmp_lerobot_home) -> None:
+    """A renamed run shows its alias — the same display_name/name precedence the
+    local rows and the job cards use."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(
+        registry, "raw_run_id", repo_id=_SHARED_REPO, state="done", display_name="Eraser placing v3"
+    )
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    assert next(r for r in result if r["repo_id"] == _SHARED_REPO)["name"] == "Eraser placing v3"
+
+
+def test_list_all_models_repo_row_falls_back_to_newest_when_none_done(registry, tmp_lerobot_home) -> None:
+    """No run in the chain finished (all failed/interrupted): the newest one
+    still names the repo — it is the last thing that wrote to it."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "older", repo_id=_SHARED_REPO, state="failed", started_at=100.0)
+    _seed_cloud_run(registry, "newest", repo_id=_SHARED_REPO, state="interrupted", started_at=400.0)
+
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    row = next(r for r in result if r["repo_id"] == _SHARED_REPO)
+    assert row["name"] == "newest"
+    # Never finished and never reported a step ⇒ no step count invented.
+    assert row["steps"] is None
+
+
+def test_list_all_models_local_checkpoint_detail_wins_over_job_identity(registry, tmp_lerobot_home) -> None:
+    """A local run collapsed into its Hub row already owns the row's name and
+    checkpoint-derived detail; the run-identity pass must not overwrite it."""
+    from makermodslab.models import list_all_models
+
+    _seed_run(
+        registry,
+        "pushed_run",
+        state="done",
+        dataset="user/pick",
+        steps=250,
+        hf_repo_id="user/hub_model",
+    )
+    hub_rows = [{"repo_id": "user/hub_model", "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    row = next(r for r in result if r["repo_id"] == "user/hub_model")
+    assert row["source"] == "both"
+    assert row["name"] == "run pushed_run"  # the local row's name, not re-derived
+    assert row["steps"] == 250  # the checkpoint's real step, not the config target
+    assert row["id"] == "pushed_run"
+
+
+def test_list_all_models_repo_row_ignores_imported_records(registry, tmp_lerobot_home) -> None:
+    """Re-importing a repo registers a POINTER to it, whose config is a
+    placeholder (dataset "(imported)", the default 10000 steps) and which is
+    always done + newest. It must not outrank the run that trained the weights,
+    or the row would advertise a step count and dataset nobody trained on."""
+    from makermodslab.jobs import JobRecord
+    from makermodslab.models import list_all_models
+    from makermodslab.train import TrainingRequest
+
+    _seed_cloud_run(registry, "real_run", repo_id=_SHARED_REPO, state="done", started_at=100.0)
+    registry._records["smolvla_imported_x"] = JobRecord(
+        id="smolvla_imported_x",
+        name="smolvla_imported_x",
+        state="done",
+        config=TrainingRequest(dataset_repo_id="(imported)", policy_type="smolvla", steps=10000),
+        output_dir="",
+        started_at=900.0,  # newest, and done — would win without the guard
+        runner="imported",
+        hf_repo_id=_SHARED_REPO,
+    )
+
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    row = next(r for r in result if r["repo_id"] == _SHARED_REPO)
+    assert row["name"] == "real_run"
+    assert row["steps"] == 20000
+    assert row["dataset"] == "makermods/eraser"
+
+
+def test_list_all_models_reduces_a_generated_run_name_to_the_task(registry, tmp_lerobot_home) -> None:
+    """An auto-generated run name is "{POLICY} · {dataset}" (jobs.start). Both
+    halves are printed elsewhere on the row — policy_type and dataset each have
+    their own field — so the title line keeps only the task: policy prefix and
+    dataset namespace both peeled."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "generated", repo_id=_SHARED_REPO, state="done")
+    registry._records["generated"].name = "SMOLVLA · makermods/eraser_place"
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    row = next(r for r in result if r["repo_id"] == _SHARED_REPO)
+    assert row["name"] == "eraser_place"
+    # Neither fact is lost, just moved to where each is rendered once.
+    assert row["policy_type"] == "smolvla"
+    assert row["dataset"] == "makermods/eraser"
+
+
+def test_list_all_models_keeps_a_generated_name_whose_dataset_has_no_namespace(
+    registry, tmp_lerobot_home
+) -> None:
+    """A dataset id with no "/" is already the task — nothing to peel off it."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "bare", repo_id=_SHARED_REPO, state="done")
+    registry._records["bare"].name = "ACT · eraser_place"
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    assert next(r for r in result if r["repo_id"] == _SHARED_REPO)["name"] == "eraser_place"
+
+
+def test_list_all_models_keeps_a_user_name_that_contains_the_separator(registry, tmp_lerobot_home) -> None:
+    """Only the GENERATED shape is peeled. A job_name the user typed keeps every
+    word, even when it contains " · " — the head isn't a policy type."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "typed", repo_id=_SHARED_REPO, state="done")
+    registry._records["typed"].name = "Monday · eraser retrain"
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    assert next(r for r in result if r["repo_id"] == _SHARED_REPO)["name"] == ("Monday · eraser retrain")
+
+
+def test_list_all_models_leaves_untracked_repo_row_alone(registry, tmp_lerobot_home) -> None:
+    """A Hub repo no tracked run publishes to keeps the repo id as its name —
+    the enrichment is a fill-in, never a rewrite of unknown rows."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "other_run", repo_id="makermods/some_other_repo", state="done")
+    hub_rows = [{"repo_id": "user/untracked", "last_modified": None, "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    row = next(r for r in result if r["repo_id"] == "user/untracked")
+    assert row["name"] == "user/untracked"
+    assert row["steps"] is None
+
+
+def test_list_all_models_separates_two_runs_that_share_a_name(registry, tmp_lerobot_home) -> None:
+    """The reported case: retraining one task publishes a SECOND repo, and both
+    rows take the same auto-generated run name ("SMOLVLA · ns/task", from
+    jobs.start, peeled to "ns/task" by the enrichment) — the picker then showed
+    one label twice with nothing on either row to say which is which. The rows'
+    last-modified dates break the tie; the routing keys stay untouched."""
+    from makermodslab.models import list_all_models
+
+    shared_name = "SMOLVLA · makermods/eraser_place_unblurry_real"
+    # What the enrichment renders: the task alone — policy prefix and dataset
+    # namespace both dropped (each has its own field on the row).
+    shown = "eraser_place_unblurry_real"
+    long_repo = "makermods/smolvla_makermods_eraser_place_unblurry_real_2026-07-31_17-35-54"
+    short_repo = "makermods/smolvla_makermods_eraser_place_unblurry_real_2026-08-02_12-22-54"
+    _seed_cloud_run(registry, "run_long", repo_id=long_repo, state="done", steps=20000)
+    _seed_cloud_run(registry, "run_short", repo_id=short_repo, state="done", steps=5500)
+    registry._records["run_long"].name = shared_name
+    registry._records["run_short"].name = shared_name
+
+    hub_rows = [
+        {"repo_id": long_repo, "last_modified": "2026-07-31T17:35:54Z", "private": False},
+        {"repo_id": short_repo, "last_modified": "2026-08-02T12:22:54Z", "private": False},
+    ]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    by_repo = {r["repo_id"]: r for r in result}
+    assert by_repo[long_repo]["name"] == f"{shown} (2026-07-31)"
+    assert by_repo[short_repo]["name"] == f"{shown} (2026-08-02)"
+    assert by_repo[long_repo]["hf_repo_id"] == long_repo
+    assert by_repo[short_repo]["hf_repo_id"] == short_repo
+
+
+def test_list_all_models_same_day_collision_escalates_to_the_time(registry, tmp_lerobot_home) -> None:
+    """Two runs of one task on one day: the date alone doesn't separate them, so
+    the next rung of the ladder is used for BOTH rows."""
+    from makermodslab.models import list_all_models
+
+    shared_name = "SMOLVLA · makermods/eraser_place_unblurry_real"
+    shown = "eraser_place_unblurry_real"
+    a_repo = "makermods/smolvla_a_2026-07-31_17-35-54"
+    b_repo = "makermods/smolvla_b_2026-07-31_12-22-54"
+    _seed_cloud_run(registry, "run_a", repo_id=a_repo, state="done")
+    _seed_cloud_run(registry, "run_b", repo_id=b_repo, state="done")
+    registry._records["run_a"].name = shared_name
+    registry._records["run_b"].name = shared_name
+
+    hub_rows = [
+        {"repo_id": a_repo, "last_modified": "2026-07-31T17:35:54Z", "private": False},
+        {"repo_id": b_repo, "last_modified": "2026-07-31T12:22:54Z", "private": False},
+    ]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    by_repo = {r["repo_id"]: r for r in result}
+    assert by_repo[a_repo]["name"] == f"{shown} (2026-07-31 17:35)"
+    assert by_repo[b_repo]["name"] == f"{shown} (2026-07-31 12:22)"
+
+
+def test_list_all_models_does_not_separate_two_policies_of_one_task(registry, tmp_lerobot_home) -> None:
+    """An ACT and a SmolVLA of one task both enrich to the same title, but the
+    row already carries `policy_type` in its own field — the card's Policy row
+    separates them. Suffixing would spend the title line restating that, and
+    would suggest the pair differs by when it ran rather than by what it is."""
+    from makermodslab.models import list_all_models
+
+    act_repo = "makermods/act_makermods_eraser_place_2026-07-31_17-35-54"
+    smolvla_repo = "makermods/smolvla_makermods_eraser_place_2026-08-02_12-22-54"
+    _seed_cloud_run(registry, "run_act", repo_id=act_repo, state="done", policy_type="act")
+    _seed_cloud_run(registry, "run_smolvla", repo_id=smolvla_repo, state="done", policy_type="smolvla")
+    registry._records["run_act"].name = "ACT · makermods/eraser_place"
+    registry._records["run_smolvla"].name = "SMOLVLA · makermods/eraser_place"
+
+    hub_rows = [
+        {"repo_id": act_repo, "last_modified": "2026-07-31T17:35:54Z", "private": False},
+        {"repo_id": smolvla_repo, "last_modified": "2026-08-02T12:22:54Z", "private": False},
+    ]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    by_repo = {r["repo_id"]: r for r in result}
+    assert by_repo[act_repo]["name"] == "eraser_place"
+    assert by_repo[smolvla_repo]["name"] == "eraser_place"
+    # The fact that separates them is rendered where it belongs.
+    assert by_repo[act_repo]["policy_type"] == "act"
+    assert by_repo[smolvla_repo]["policy_type"] == "smolvla"
+
+
+def test_list_all_models_still_separates_two_runs_of_one_policy(registry, tmp_lerobot_home) -> None:
+    """The policy key narrows collisions rather than abolishing them: two
+    SmolVLA runs of one task are still two rows nothing else tells apart."""
+    from makermodslab.models import list_all_models
+
+    a_repo = "makermods/smolvla_makermods_eraser_place_2026-07-31_17-35-54"
+    b_repo = "makermods/smolvla_makermods_eraser_place_2026-08-02_12-22-54"
+    _seed_cloud_run(registry, "run_a", repo_id=a_repo, state="done", policy_type="smolvla")
+    _seed_cloud_run(registry, "run_b", repo_id=b_repo, state="done", policy_type="smolvla")
+    registry._records["run_a"].name = "SMOLVLA · makermods/eraser_place"
+    registry._records["run_b"].name = "SMOLVLA · makermods/eraser_place"
+
+    hub_rows = [
+        {"repo_id": a_repo, "last_modified": "2026-07-31T17:35:54Z", "private": False},
+        {"repo_id": b_repo, "last_modified": "2026-08-02T12:22:54Z", "private": False},
+    ]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    by_repo = {r["repo_id"]: r for r in result}
+    assert by_repo[a_repo]["name"] == "eraser_place (2026-07-31)"
+    assert by_repo[b_repo]["name"] == "eraser_place (2026-08-02)"
+
+
+def test_list_all_models_suffix_prefers_the_name_stamp_over_last_modified(registry, tmp_lerobot_home) -> None:
+    """The disambiguator is WHEN THE RUN RAN, and the repo name carries that
+    verbatim. `last_modified` does not: it moves on any push to the repo — a
+    re-push of the same weights, a README edit, a later checkpoint upload — so
+    two runs weeks apart can both report a date in September and read, next to
+    each other, as simply wrong. The name's stamp never moves."""
+    from makermodslab.models import list_all_models
+
+    july_repo = "makermods/smolvla_makermods_eraser_place_2026-07-31_17-35-54"
+    august_repo = "makermods/smolvla_makermods_eraser_place_2026-08-02_12-22-54"
+    _seed_cloud_run(registry, "run_july", repo_id=july_repo, state="done")
+    _seed_cloud_run(registry, "run_august", repo_id=august_repo, state="done")
+    registry._records["run_july"].name = "SMOLVLA · makermods/eraser_place"
+    registry._records["run_august"].name = "SMOLVLA · makermods/eraser_place"
+
+    # Both repos re-pushed on the same later day: last_modified would date both
+    # rows to September, and the date rung wouldn't even separate them.
+    hub_rows = [
+        {"repo_id": july_repo, "last_modified": "2026-09-20T10:00:00Z", "private": False},
+        {"repo_id": august_repo, "last_modified": "2026-09-20T11:00:00Z", "private": False},
+    ]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    by_repo = {r["repo_id"]: r for r in result}
+    assert by_repo[july_repo]["name"] == "eraser_place (2026-07-31)"
+    assert by_repo[august_repo]["name"] == "eraser_place (2026-08-02)"
+
+
+def test_list_all_models_suffix_falls_back_to_last_modified_without_a_stamp(
+    registry, tmp_lerobot_home
+) -> None:
+    """A repo whose name carries no run stamp — a hand-named upload, a community
+    repo — has only last_modified to offer, so that is what it uses."""
+    from makermodslab.models import list_all_models
+
+    v1_repo = "makermods/eraser_place_v1"
+    v2_repo = "makermods/eraser_place_v2"
+    _seed_cloud_run(registry, "run_v1", repo_id=v1_repo, state="done")
+    _seed_cloud_run(registry, "run_v2", repo_id=v2_repo, state="done")
+    registry._records["run_v1"].name = "SMOLVLA · makermods/eraser_place"
+    registry._records["run_v2"].name = "SMOLVLA · makermods/eraser_place"
+
+    hub_rows = [
+        {"repo_id": v1_repo, "last_modified": "2026-07-31T17:35:54Z", "private": False},
+        {"repo_id": v2_repo, "last_modified": "2026-08-02T12:22:54Z", "private": False},
+    ]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    by_repo = {r["repo_id"]: r for r in result}
+    assert by_repo[v1_repo]["name"] == "eraser_place (2026-07-31)"
+    assert by_repo[v2_repo]["name"] == "eraser_place (2026-08-02)"
+
+
+def test_list_all_models_leaves_unique_names_alone(registry, tmp_lerobot_home) -> None:
+    """The collision pass is a no-op on a listing with no duplicates — a row
+    never acquires a date it doesn't need to be distinguishable."""
+    from makermodslab.models import list_all_models
+
+    _seed_cloud_run(registry, "solo_run", repo_id=_SHARED_REPO, state="done")
+    hub_rows = [{"repo_id": _SHARED_REPO, "last_modified": "2026-07-31T17:35:54Z", "private": False}]
+    with contextlib.ExitStack() as stack:
+        for cm in _sandboxed_listing(hub_rows):
+            stack.enter_context(cm)
+        result = list_all_models()
+
+    assert next(r for r in result if r["repo_id"] == _SHARED_REPO)["name"] == "solo_run"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,218 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for makermodslab.utils.naming — the pure title/collision rules shared
+by the jobs registry and the models listing. No filesystem, no Hub, no registry:
+every case here is a string in and a string out."""
+
+from __future__ import annotations
+
+import pytest
+
+from makermodslab.utils.naming import (
+    dedupe_display_names,
+    derive_imported_title,
+    imported_name_suffixes,
+    iso_time_suffixes,
+    policy_type_from_name,
+)
+
+# ── derive_imported_title ────────────────────────────────────────────────────
+
+
+def test_derive_title_peels_a_generated_repo_id_down_to_the_task() -> None:
+    """The shape MakerMods Lab publishes: namespace, policy token, the dataset's
+    namespace repeated as an infix, and a timestamp — none of which the title
+    needs to carry (the chip, the policy row and the subtitle say all three)."""
+    assert derive_imported_title("makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30") == "orange_box"
+    assert (
+        derive_imported_title("makermods/act_makermods_eraser_place_unblurry_real_2026-07-31_17-35-54")
+        == "eraser_place_unblurry_real"
+    )
+
+
+def test_derive_title_strips_the_longest_policy_token() -> None:
+    """pi0 must not swallow a pi0_fast repo's name (same longest-first rule as
+    models._hub_policy_type)."""
+    assert derive_imported_title("ns/pi0_fast_ns_sock_2026-01-01_10-00-00") == "sock"
+    assert derive_imported_title("ns/pi0_ns_sock_2026-01-01_10-00-00") == "sock"
+
+
+def test_derive_title_only_strips_the_repos_own_namespace_as_infix() -> None:
+    """The infix is stripped because it repeats the namespace, not because it
+    reads like an org — a dataset owned by someone else keeps its prefix."""
+    assert derive_imported_title("alice/act_bob_orange_box_2026-08-03_12-53-30") == "bob_orange_box"
+
+
+def test_derive_title_leaves_a_community_repo_alone_but_for_its_namespace() -> None:
+    """No timestamp ⇒ a human named this, so every word is load-bearing. Notably
+    the leading policy token stays: in `smolvla_base` it IS the name."""
+    assert derive_imported_title("lerobot/smolvla_base") == "smolvla_base"
+    assert derive_imported_title("lerobot/pi0") == "pi0"
+    assert derive_imported_title("physical-intelligence/pi05_droid") == "pi05_droid"
+
+
+def test_derive_title_handles_local_paths() -> None:
+    """A local import's source is a path: the basename is the title, and a
+    parent directory is never treated as a namespace to strip."""
+    assert derive_imported_title("/Users/me/models/my_policy") == "my_policy"
+    # The timestamp still marks the name as generated, so the policy token goes
+    # — but the "me_" infix stays: with no namespace there is nothing saying it
+    # is a repetition rather than part of the task.
+    assert derive_imported_title("/Users/me/smolvla_me_orange_box_2026-08-03_12-53-30") == "me_orange_box"
+    assert derive_imported_title("/Users/me/models/trailing/") == "trailing"
+
+
+def test_derive_title_never_returns_empty() -> None:
+    """Degenerate names must still label a card."""
+    assert derive_imported_title("ns/_2026-08-03_12-53-30") == "_2026-08-03_12-53-30"
+    assert derive_imported_title("ns/smolvla_2026-08-03_12-53-30") == "smolvla"
+
+
+def test_policy_type_from_name() -> None:
+    assert policy_type_from_name("pi0_fast_sock_2026-01-01_10-00-00") == "pi0_fast"
+    assert policy_type_from_name("pi0_sock_2026-01-01_10-00-00") == "pi0"
+    assert policy_type_from_name("orange_box") is None
+    # A human-named repo can open with a policy token too — which is exactly why
+    # derive_imported_title consults this only for a timestamped (generated)
+    # name, and leaves `smolvla_base` whole.
+    assert policy_type_from_name("smolvla_base") == "smolvla"
+
+
+# ── suffix ladders ───────────────────────────────────────────────────────────
+
+
+def test_imported_name_suffixes_ladder() -> None:
+    assert imported_name_suffixes("ns/smolvla_ns_box_2026-08-03_12-53-30") == [
+        "2026-08-03",
+        "2026-08-03 12:53",
+    ]
+    # No timestamp to fall back on — the namespace separates two authors' copies.
+    assert imported_name_suffixes("lerobot/pi0") == ["lerobot"]
+    assert imported_name_suffixes("/Users/me/models/pi0") == []
+
+
+def test_iso_time_suffixes_ladder() -> None:
+    assert iso_time_suffixes("2026-07-31T17:35:54Z") == ["2026-07-31", "2026-07-31 17:35"]
+    assert iso_time_suffixes("2026-07-31") == ["2026-07-31"]
+    assert iso_time_suffixes(None) == []
+    assert iso_time_suffixes("") == []
+
+
+# ── dedupe_display_names ─────────────────────────────────────────────────────
+
+
+def test_dedupe_leaves_unique_names_untouched() -> None:
+    assert dedupe_display_names([("a", ["x"]), ("b", ["y"])]) == ["a", "b"]
+
+
+def test_dedupe_separates_two_runs_of_one_policy_on_one_dataset() -> None:
+    """The reported case: two repos, same policy, same dataset, so the listing
+    served the same enriched name twice with nothing to tell them apart."""
+    name = "SMOLVLA · makermods/eraser_place_unblurry_real"
+    assert dedupe_display_names(
+        [
+            (name, iso_time_suffixes("2026-07-31T17:35:54Z")),
+            (name, iso_time_suffixes("2026-08-02T12:22:54Z")),
+        ]
+    ) == [f"{name} (2026-07-31)", f"{name} (2026-08-02)"]
+
+
+def test_dedupe_escalates_to_time_for_two_runs_on_one_day() -> None:
+    """The date alone doesn't separate them, so the ladder's next rung does —
+    and the shorter rung is not used for either, or one card would read as the
+    more specific of a pair that isn't."""
+    name = "SMOLVLA · makermods/eraser_place_unblurry_real"
+    assert dedupe_display_names(
+        [
+            (name, iso_time_suffixes("2026-07-31T17:35:54Z")),
+            (name, iso_time_suffixes("2026-07-31T12:22:54Z")),
+        ]
+    ) == [f"{name} (2026-07-31 17:35)", f"{name} (2026-07-31 12:22)"]
+
+
+def test_dedupe_falls_back_to_an_ordinal_when_nothing_separates() -> None:
+    """No candidates at all, and a tie on the most specific one, both resolve —
+    a listing must never show one label twice."""
+    assert dedupe_display_names([("box", []), ("box", [])]) == ["box (1)", "box (2)"]
+    assert dedupe_display_names([("box", ["2026-08-03"]), ("box", ["2026-08-03"])]) == ["box (1)", "box (2)"]
+
+
+def test_dedupe_does_not_suffix_two_policies_of_one_task() -> None:
+    """An ACT and a SmolVLA of `eraser_place` derive the same title, but the
+    card's Policy row already separates them — a date suffix there would spend
+    the title's scarcest pixels restating a fact printed just below it, and
+    imply the two differ by WHEN they ran rather than by what they are."""
+    assert dedupe_display_names(
+        [
+            ("eraser_place", ["2026-07-31"]),
+            ("eraser_place", ["2026-08-02"]),
+        ],
+        group_keys=["act", "smolvla"],
+    ) == ["eraser_place", "eraser_place"]
+
+
+def test_dedupe_still_separates_two_runs_of_one_policy() -> None:
+    """The key narrows collisions, it doesn't abolish them: same title AND same
+    policy is still two rows a user can't tell apart."""
+    assert dedupe_display_names(
+        [
+            ("eraser_place", ["2026-07-31"]),
+            ("eraser_place", ["2026-08-02"]),
+        ],
+        group_keys=["smolvla", "smolvla"],
+    ) == ["eraser_place (2026-07-31)", "eraser_place (2026-08-02)"]
+
+
+def test_dedupe_group_key_splits_only_within_a_shared_title() -> None:
+    """Three of one task: the two SmolVLAs disambiguate against each other and
+    the lone ACT stays bare — a suffix it doesn't need would read as a fourth
+    thing to compare."""
+    assert dedupe_display_names(
+        [
+            ("eraser_place", ["2026-07-31"]),
+            ("eraser_place", ["2026-08-02"]),
+            ("eraser_place", ["2026-08-05"]),
+        ],
+        group_keys=["smolvla", "smolvla", "act"],
+    ) == ["eraser_place (2026-07-31)", "eraser_place (2026-08-02)", "eraser_place"]
+
+
+def test_dedupe_treats_an_unknown_policy_as_its_own_key() -> None:
+    """Two rows whose policy could not be read show the SAME Policy row (or
+    none), so they are genuinely indistinguishable and must still be suffixed —
+    the key groups on what the card renders, not on what is true."""
+    assert dedupe_display_names(
+        [("box", ["2026-08-03"]), ("box", ["2026-08-05"])],
+        group_keys=[None, None],
+    ) == ["box (2026-08-03)", "box (2026-08-05)"]
+
+
+def test_dedupe_group_keys_length_is_checked() -> None:
+    """A caller that zips a shorter key list would silently mis-group rows."""
+    with pytest.raises(ValueError):
+        dedupe_display_names([("a", []), ("a", [])], group_keys=["act"])
+
+
+def test_dedupe_is_order_preserving_and_deterministic() -> None:
+    entries = [
+        ("box", ["2026-08-03"]),
+        ("sock", ["2026-08-01"]),
+        ("box", ["2026-08-04"]),
+    ]
+    assert dedupe_display_names(entries) == [
+        "box (2026-08-03)",
+        "sock",
+        "box (2026-08-04)",
+    ]
+    assert dedupe_display_names(entries) == dedupe_display_names(entries)


### PR DESCRIPTION
## Summary

Model and run cards currently spend their title line on text the card already prints elsewhere. An imported model is titled `Imported · makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30` — a provenance chip already says "imported", a Policy row already says SmolVLA, and the subtitle already carries the full repo id. What nothing else on the card says is the *task*, and that is the one segment truncation reliably eats.

This PR converges every model-naming surface on one rule: **the title carries task identity; namespace, policy, and timestamp live in the fields that already render them.** Those facts aren't discarded, just moved to where each is shown once. When peeling makes two cards collide, the timestamp comes back as a parenthesized disambiguator — but only when nothing else separates them.

A name a human chose is never rewritten. Renames (`display_name`) always win, an explicit name passed to `POST /jobs/import` is never re-derived, and a repo with no generated timestamp is treated as human-named and keeps every word.

The naming rules move into a new leaf module, `makermodslab/utils/naming.py`. `models` already imports `jobs`, so the vocabulary the two share had nowhere else to live without a cycle. Everything in it is a pure string transform, which is what makes it cheap to test.

## User-visible fixes

**Attribution — the headline correctness fix.** A cloud resume reuses its parent's output repo, so an N-deep resume chain is N job records pointing at one repo. Today `/models` keys Hub rows by `repo_id` and `findJobForModel` returns the first record it happens to match, so **the Deploy picker can attribute a chain's weights to its failed first run** — showing that run's name, and offering its checkpoint list rather than the finished model's. Both sides now rank identically: the run that reached `done` published the policy at the repo root and wins; among equals the later-started run (the deepest link) wins. Imported pointer records are excluded, since their config is a placeholder that would otherwise outrank the run that actually trained the weights.

**Imported titles.** `Imported · makermods/smolvla_makermods_orange_box_2026-08-03_12-53-30` → `orange_box`. Long generated repo ids currently all render as identical truncated labels, because the segment that differs is past the cutoff. Existing records are upgraded in place at boot, so the fix reaches the library a user already has and not only their next import.

**Run titles in listings.** `SMOLVLA · makermods/eraser_place` → `eraser_place`, with the policy and the full dataset id still shown in their own rows.

**Rows that were bare repo ids.** A cloud run's repo reached the picker as a raw `repo_id` with null steps and null dataset. It now carries the finishing run's name, policy, dataset, and step count. Routing keys (`id`, `repo_id`, `hf_repo_id`) are untouched.

**Disambiguation.** Two runs of one task now read `eraser_place (2026-07-31)` and `eraser_place (2026-08-02)`, escalating to date + time for two runs in one day and to an ordinal if even that ties. Three refinements over the naive rule:

- An ACT and a SmolVLA of one task get **no** suffix — the Policy row already separates them, and a date there would imply they differ by *when* they ran.
- The date comes from the run timestamp in the repo **name**, not the Hub's `last_modified`. `last_modified` moves on any push — a re-push, a README edit, a later checkpoint upload — so a row could acquire a date months after the run it labels. `last_modified` remains the fallback for names with no stamp.
- The suffix no longer truncates. It renders in its own non-shrinking span so the base name absorbs the truncation instead; the full name stays in the tooltip. Previously two rows could both render `eraser_place (2026-0…`, which is worse than no suffix at all.

**Unparseable names** (community repos we can't safely peel) shorten from the middle rather than the end, so both the recognizable head and the identifying tail stay visible.

## Test plan

- `tests/test_naming.py` (new, 19 tests): the pure transforms — title derivation, longest-first policy matching so `pi0` never shadows `pi0_fast`, local-path handling, the suffix ladders, and the collision resolver including the policy grouping key and its order-preserving determinism.
- `tests/test_models.py` (+17): the resume-chain attribution and its ranking (done beats newer-unfinished, newest wins when none finished, imported records never rank), `display_name` precedence, local-checkpoint detail winning over job identity, untracked rows left alone, generated-vs-typed name peeling, and the dedupe cases — policy-split, same-policy collision, name-stamp preference, and `last_modified` fallback.
- `tests/test_jobs.py` (+11): derived import titles, explicit names and rename aliases surviving the pass, collision handling, idempotence across reloads (suffixes recomputed, never stacked), legacy `Imported · ` records upgraded and persisted, and the policy-grouping behavior.
- Frontend: `npx tsc --noEmit` and `npm run lint` clean against baseline. `findJobForModel` is a pure function; its ranking mirrors the backend's and is covered by the backend tests for that rule.
- Full suite shows no new failures (the 7 pre-existing `test_models` failures that read the developer's real HF cache are identical before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
