### PR TITLE
Training correctness: route it for real, refuse it loudly, display it honestly

### DIFF
--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -11,7 +11,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { JobRecord, jobDisplayName, renameJob } from "@/lib/jobsApi";
+import {
+  JOB_STATE_LABELS,
+  JobRecord,
+  jobDisplayName,
+  renameJob,
+} from "@/lib/jobsApi";
 import {
   Square,
   Trash2,
@@ -66,11 +71,19 @@ const statePresentation: Record<
     Icon: React.ComponentType<{ className?: string }>;
   }
 > = {
-  running: { label: "Running", color: "text-ok", Icon: Loader2 },
-  done: { label: "Done", color: "text-muted-foreground", Icon: CheckCircle2 },
-  failed: { label: "Failed", color: "text-destructive", Icon: XCircle },
+  running: { label: JOB_STATE_LABELS.running, color: "text-ok", Icon: Loader2 },
+  done: {
+    label: JOB_STATE_LABELS.done,
+    color: "text-muted-foreground",
+    Icon: CheckCircle2,
+  },
+  failed: {
+    label: JOB_STATE_LABELS.failed,
+    color: "text-destructive",
+    Icon: XCircle,
+  },
   interrupted: {
-    label: "Interrupted",
+    label: JOB_STATE_LABELS.interrupted,
     color: "text-warn",
     Icon: AlertTriangle,
   },

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -377,15 +377,20 @@ const JobCard: React.FC<Props> = ({
   };
 
   // Fine-tune: start a FRESH run whose weights are initialized from this
-  // (imported) model's checkpoint. Unlike Continue (which needs optimizer/step
-  // state and is local-only), fine-tuning works from weights-only imports —
-  // which is exactly what imported models are. Gate on an imported source with
-  // a selectable checkpoint.
+  // model's checkpoint. Unlike Continue (which needs optimizer/step state and
+  // is local-only), fine-tuning is weights-only, so it works from ANY source
+  // that has a checkpoint — the user's own local and cloud runs included.
+  //
+  // The old gate also required runner === "imported". That was a workaround for
+  // MT2, where a hub step-ref was truncated to the bare repo id and a fine-tune
+  // of a cloud run silently trained from ROOT weights instead of the step the
+  // user picked; excluding cloud runs (and, collaterally, local ones) hid the
+  // bug rather than fixing it. jobs._resolve_finetune_pretrained_path now
+  // branches on all three runners and keeps a step-suffixed hub ref verbatim
+  // for the trainer's host to materialize, so there is nothing left to guard:
+  // gate on state and checkpoints only.
   const canFinetune =
-    selectedJob.runner === "imported" &&
-    !isRunning &&
-    lineageCheckpoints.length > 0 &&
-    selectedStep != null;
+    !isRunning && lineageCheckpoints.length > 0 && selectedStep != null;
 
   // No dialog and no route jump: fine-tuning opens the Train panel's
   // "Start a new training" form with the base skill (and the dropdown's

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -341,6 +341,11 @@ const JobCard: React.FC<Props> = ({
     selectedStep != null &&
     endedBeforeTarget;
 
+  // The configurator PREFILLS from this seed, then renders read-only the
+  // settings lerobot rebuilds from the checkpoint anyway (batch size, seed,
+  // device, optimizer, AMP). Steps, the log/save cadence, the worker count,
+  // the cloud flavor and the timeout stay editable — those a continuation can
+  // really change.
   const goToResume = (runner: "local" | "hf_cloud") => {
     if (selectedStep == null) return;
     navigate("/training", {

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -304,24 +304,36 @@ const JobCard: React.FC<Props> = ({
     onPlay(selectedJob, selectedStep);
   };
 
-  // Continue (local resume) needs a saved checkpoint with optimizer/step state
-  // on this machine — i.e. a finished local training run.
-  const canContinue =
-    selectedJob.runner === "local" &&
-    !isRunning &&
-    lineageCheckpoints.length > 0 &&
-    selectedStep != null;
-
-  // Resume (cloud): an HF Job is immutable once ended, so this launches a NEW
-  // cloud job that continues from the parent's Hub checkpoint (restoring
-  // optimizer + step, unlike Fine-tune). Offered only on a cloud run that ended
-  // BEFORE its step target — a failed/interrupted/cancelled run with a saved
-  // checkpoint. A `done` run reached its target, so there's nothing to resume.
+  // Resume — local Continue and cloud Resume alike — is for a run that stopped
+  // SHORT of what it was configured to do: failed, interrupted or cancelled,
+  // with a saved checkpoint below the step target.
+  //
+  // A `done` run is deliberately excluded. Resuming restores the optimizer AND
+  // the LR schedule's position, and a completed run's schedule is spent: the
+  // SmolVLA preset cosine-decays to a 2.5e-6 floor over a fixed 30k-step
+  // horizon, so continuing past a reached target trains at floor LR — the loss
+  // curve flattens and reads as convergence while the run is barely learning.
+  // Fine-tuning from the final checkpoint is the intended way to build on a
+  // completed run: it starts a FRESH schedule from those weights. Blanket rule,
+  // no per-policy exceptions.
   const endedBeforeTarget =
     (selectedJob.state === "failed" || selectedJob.state === "interrupted") &&
     (selectedJob.config.steps === 0 ||
       selectedStep == null ||
       selectedStep < selectedJob.config.steps);
+
+  // Continue (local resume) additionally needs the optimizer/step state to be
+  // on THIS machine — i.e. a local run's own checkpoint dir.
+  const canContinue =
+    selectedJob.runner === "local" &&
+    !isRunning &&
+    lineageCheckpoints.length > 0 &&
+    selectedStep != null &&
+    endedBeforeTarget;
+
+  // Resume (cloud): an HF Job is immutable once ended, so this launches a NEW
+  // cloud job that continues from the parent's Hub checkpoint (restoring
+  // optimizer + step, unlike Fine-tune).
   const canResumeCloud =
     selectedJob.runner === "hf_cloud" &&
     !isRunning &&

--- a/frontend/src/components/jobs/JobsDataContext.tsx
+++ b/frontend/src/components/jobs/JobsDataContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useApi } from "@/contexts/ApiContext";
@@ -122,27 +123,61 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, [refresh]);
 
-  const applyProgress = useCallback((snapshots: JobProgressSnapshot[]) => {
-    if (snapshots.length === 0) return;
-    setJobs((prev) => {
-      if (prev.length === 0) return prev;
-      const byId = new Map(snapshots.map((s) => [s.id, s]));
-      let mutated = false;
-      const next = prev.map((j) => {
-        const s = byId.get(j.id);
-        if (!s) return j;
-        mutated = true;
-        return {
-          ...j,
-          state: s.state,
-          metrics: s.metrics,
-          wandb_run_url: s.wandb_run_url,
-          checkpoint_count: s.checkpoint_count,
-        };
+  // Guards the reconciling refetch below. `healingRef` keeps the ~1Hz ticks
+  // that land while a refetch is in flight from stacking up identical fetches;
+  // `healedRef` caps each unknown id at one refetch for the life of the
+  // provider, so an id the refetch CAN'T produce doesn't refetch forever. That
+  // is a real case, not a hypothetical: /jobs is a capped page (LIMIT), so a
+  // long run with enough newer records after it is legitimately absent from
+  // the list while still reporting progress.
+  const healingRef = useRef(false);
+  const healedRef = useRef<Set<string>>(new Set());
+
+  const applyProgress = useCallback(
+    (snapshots: JobProgressSnapshot[]) => {
+      if (snapshots.length === 0) return;
+      // A snapshot for a job this provider has never heard of means the
+      // `jobs_changed` that announced it never landed — the broadcast is
+      // fire-and-forget (the server drops it outright when no connection is
+      // registered, and a socket can die without ever firing onclose), and
+      // nothing else re-reads /jobs while the studio stays mounted. Patching
+      // only known ids and silently dropping the rest is what made a run
+      // started from the Train panel's in-place form invisible until a page
+      // reload. Reconcile instead: the watchdog re-announces every running
+      // job each tick, so one refetch heals the list within about a second of
+      // the miss, whatever the miss's origin (this tab, another tab, the CLI).
+      const known = new Set(jobs.map((j) => j.id));
+      const unseen = snapshots
+        .map((s) => s.id)
+        .filter((id) => !known.has(id) && !healedRef.current.has(id));
+      if (unseen.length > 0 && !healingRef.current) {
+        for (const id of unseen) healedRef.current.add(id);
+        healingRef.current = true;
+        refresh().finally(() => {
+          healingRef.current = false;
+        });
+      }
+      setJobs((prev) => {
+        if (prev.length === 0) return prev;
+        const byId = new Map(snapshots.map((s) => [s.id, s]));
+        let mutated = false;
+        const next = prev.map((j) => {
+          const s = byId.get(j.id);
+          if (!s) return j;
+          mutated = true;
+          return {
+            ...j,
+            state: s.state,
+            metrics: s.metrics,
+            wandb_run_url: s.wandb_run_url,
+            checkpoint_count: s.checkpoint_count,
+          };
+        });
+        return mutated ? next : prev;
       });
-      return mutated ? next : prev;
-    });
-  }, []);
+    },
+    [jobs, refresh],
+  );
 
   useJobsChangedSignal(refresh, applyProgress);
 

--- a/frontend/src/components/launchpad/ActivityStrip.tsx
+++ b/frontend/src/components/launchpad/ActivityStrip.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 
 import { useApi } from "@/contexts/ApiContext";
@@ -25,10 +25,12 @@ const ActivityStrip: React.FC = () => {
   const { openJobMonitor } = useStudio();
   const [jobs, setJobs] = useState<JobRecord[]>([]);
 
+  // Returns the fetch so callers can sequence on it — the heal in
+  // applyProgress needs to know when its refetch has landed.
   const refresh = useCallback(() => {
     // Pull a generous slice so a running job isn't masked by newer records in
     // the started_at-desc ordering, then keep only what's live.
-    listJobs(baseUrl, fetchWithHeaders, 200)
+    return listJobs(baseUrl, fetchWithHeaders, 200)
       .then((j) => setJobs(j.filter((r) => r.state === "running")))
       .catch(() => setJobs([]));
   }, [baseUrl, fetchWithHeaders]);
@@ -37,21 +39,51 @@ const ActivityStrip: React.FC = () => {
     refresh();
   }, [refresh]);
 
+  // Guards the reconciling refetch below — same pair, and same rationale, as
+  // JobsDataContext's: `healingRef` stops the ~1Hz ticks that land while a
+  // refetch is in flight from stacking up identical fetches, and `healedRef`
+  // caps each unknown id at one refetch so an id the refetch CAN'T produce
+  // doesn't refetch forever. /jobs is a capped page here too (200), so a long
+  // run buried under enough newer records is legitimately absent from the list
+  // while still reporting progress.
+  const healingRef = useRef(false);
+  const healedRef = useRef<Set<string>>(new Set());
+
   // Patch progress in place from the watchdog's ~1Hz snapshots (no refetch),
   // and drop any job that just left the running state.
-  const applyProgress = useCallback((snapshots: JobProgressSnapshot[]) => {
-    if (snapshots.length === 0) return;
-    setJobs((prev) => {
-      if (prev.length === 0) return prev;
-      const byId = new Map(snapshots.map((s) => [s.id, s]));
-      return prev
-        .map((j) => {
-          const s = byId.get(j.id);
-          return s ? { ...j, state: s.state, metrics: s.metrics } : j;
-        })
-        .filter((j) => j.state === "running");
-    });
-  }, []);
+  const applyProgress = useCallback(
+    (snapshots: JobProgressSnapshot[]) => {
+      if (snapshots.length === 0) return;
+      // A snapshot names a RUNNING job, so an id this strip doesn't hold is a
+      // live run it never learned about: the `jobs_changed` that announced it
+      // was missed (the broadcast is fire-and-forget, and a dead socket never
+      // fires onclose). Dropping it left a running job off the strip until the
+      // next mount. Refetch once instead — the watchdog re-announces every
+      // running job each tick, so this heals within about a second.
+      const known = new Set(jobs.map((j) => j.id));
+      const unseen = snapshots
+        .map((s) => s.id)
+        .filter((id) => !known.has(id) && !healedRef.current.has(id));
+      if (unseen.length > 0 && !healingRef.current) {
+        for (const id of unseen) healedRef.current.add(id);
+        healingRef.current = true;
+        refresh().finally(() => {
+          healingRef.current = false;
+        });
+      }
+      setJobs((prev) => {
+        if (prev.length === 0) return prev;
+        const byId = new Map(snapshots.map((s) => [s.id, s]));
+        return prev
+          .map((j) => {
+            const s = byId.get(j.id);
+            return s ? { ...j, state: s.state, metrics: s.metrics } : j;
+          })
+          .filter((j) => j.state === "running");
+      });
+    },
+    [jobs, refresh],
+  );
 
   useJobsChangedSignal(refresh, applyProgress);
 

--- a/frontend/src/components/studio/TrainPanel.tsx
+++ b/frontend/src/components/studio/TrainPanel.tsx
@@ -43,6 +43,7 @@ import TrainingConfigurator, {
 } from "@/components/training/TrainingConfigurator";
 import TrainingJobDialog from "@/components/training/TrainingJobDialog";
 import JobsLibrary from "@/components/jobs/JobsLibrary";
+import { useJobsData } from "@/components/jobs/JobsDataContext";
 import DatasetPicker from "@/components/landing/DatasetPicker";
 import {
   LibrarySection,
@@ -125,6 +126,11 @@ const TrainPanel: React.FC = () => {
     refresh: refreshDatasets,
   } = useDatasets();
   const { selectedDataset, setSelectedDataset } = useSelectedDataset();
+  // Same registry state the jobs library below renders. The panel only needs
+  // the refetch: a launch from this form mutates the registry, and every other
+  // mutation the studio performs (stop, delete, rename, hub dismiss) already
+  // pulls the list afterwards rather than trusting the broadcast.
+  const { refresh: refreshJobs } = useJobsData();
 
   // The new-training form slides open in place; the jobs library folds to its
   // header while the form is open (still expandable by hand).
@@ -514,7 +520,18 @@ const TrainPanel: React.FC = () => {
               // Launch opens the monitor dialog over this panel (via
               // openJobMonitor in the configurator); fold the form back so
               // closing the dialog lands on the jobs library, not a stale form.
-              onStarted={() => toggleForm(false)}
+              //
+              // And pull the job list, because the new run has to be IN it:
+              // the panel never unmounts across a launch, so nothing else
+              // re-reads /jobs. A launch's only route into the list is
+              // otherwise the fire-and-forget `jobs_changed` broadcast; miss
+              // it once and the run stays invisible until the next mount
+              // (page reload). This is the same after-mutation refetch every
+              // other studio action (stop, delete, rename) already does.
+              onStarted={() => {
+                toggleForm(false);
+                refreshJobs();
+              }}
               actionsContainer={actionsEl}
             />
           </div>

--- a/frontend/src/components/training/ConfigurationTab.tsx
+++ b/frontend/src/components/training/ConfigurationTab.tsx
@@ -26,6 +26,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
   flavors,
   hardwareLoading,
   policyLocked,
+  resumeLocked,
   runnerLocked,
 }) => {
   return (
@@ -44,10 +45,19 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
         authenticated={authenticated}
         flavors={flavors}
         loading={hardwareLoading}
+        resumeLocked={resumeLocked}
         runnerLocked={runnerLocked}
       />
-      <EssentialsCard config={config} updateConfig={updateConfig} />
-      <AdvancedCard config={config} updateConfig={updateConfig} />
+      <EssentialsCard
+        config={config}
+        updateConfig={updateConfig}
+        resumeLocked={resumeLocked}
+      />
+      <AdvancedCard
+        config={config}
+        updateConfig={updateConfig}
+        resumeLocked={resumeLocked}
+      />
     </div>
   );
 };

--- a/frontend/src/components/training/ConfigurationTab.tsx
+++ b/frontend/src/components/training/ConfigurationTab.tsx
@@ -13,6 +13,10 @@ interface ConfigurationTabProps extends ConfigComponentProps {
   /** True when a base skill (fine-tune) or resume seed fixes the policy —
    * the run must train the source checkpoint's architecture. */
   policyLocked?: boolean;
+  /** True when a resume seed fixes the compute target — a resume can only
+   * continue on the parent run's runner (F7). Only about WHERE the
+   * continuation executes; it leaves the cloud flavor editable. */
+  runnerLocked?: boolean;
 }
 
 const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
@@ -22,6 +26,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
   flavors,
   hardwareLoading,
   policyLocked,
+  runnerLocked,
 }) => {
   return (
     // Order matters: Policy answers "what am I training" and so belongs with
@@ -39,6 +44,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
         authenticated={authenticated}
         flavors={flavors}
         loading={hardwareLoading}
+        runnerLocked={runnerLocked}
       />
       <EssentialsCard config={config} updateConfig={updateConfig} />
       <AdvancedCard config={config} updateConfig={updateConfig} />

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -43,9 +43,12 @@ export type ResumeSeed = {
   sourceSteps: number; // the source run's configured total, for a sane prefill
   logFreq?: number; // the source run's log cadence, to preserve on resume
   saveFreq?: number; // the source run's checkpoint cadence, to preserve on resume
-  // Cloud resume: the parent run's runner + flavor. A local Continue omits
-  // these (runner defaults to "local"). When "hf_cloud", the launched run
-  // targets the same flavor and continues into the parent's Hub output repo.
+  // The parent run's runner + flavor. A resume ALWAYS continues on the parent's
+  // runner — the form pins Compute to this value and disables it (see F7) —
+  // so `runner` is the lock's source of truth, not just a cloud convenience.
+  // Omitted ⇒ treated as "local". When "hf_cloud", the launched run targets the
+  // same flavor and continues into the parent's Hub output repo; `flavor` stays
+  // editable, since which GPU the continuation rents is a real per-launch choice.
   runner?: "local" | "hf_cloud";
   flavor?: string;
 };
@@ -155,9 +158,12 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
   const { openJobMonitor } = useStudio();
 
   const [trainingConfig, setTrainingConfig] = useState<TrainingConfig>({
-    // A cloud resume inherits the parent run's target so the continuation runs
-    // on the same flavor and pushes into the same Hub repo; everything else
-    // defaults to a fresh local run.
+    // A resume inherits the parent run's runner — a cloud one so the
+    // continuation runs on the same flavor and pushes into the same Hub repo, a
+    // local one so it reads the parent's on-disk checkpoint. The Compute
+    // control is then pinned to it (`runnerLocked` below), because neither
+    // cross-runner direction works: see F7. Everything else defaults to a fresh
+    // local run.
     target:
       resumeSeed?.runner === "hf_cloud"
         ? { runner: "hf_cloud", flavor: resumeSeed.flavor }
@@ -535,6 +541,15 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
         flavors={flavors}
         hardwareLoading={hardwareLoading}
         policyLocked={finetuneSeed != null || resumeSeed != null}
+        // Compute is pinned to the parent's runner on a resume. Cross-runner
+        // resume isn't implemented (F7) and both directions fail badly —
+        // cloud→local dies at startup on a host path that never existed,
+        // local→cloud silently restarts from step 0 wearing a resume label —
+        // so the control is disabled rather than left to fail late. The
+        // backend refuses a mismatch too (JobRegistry.start). The cloud
+        // flavor and job timeout stay editable: those a continuation can
+        // genuinely change.
+        runnerLocked={resumeSeed != null}
       />
       {needsUpload ? (
         <div className="mt-6">

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -541,6 +541,12 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
         flavors={flavors}
         hardwareLoading={hardwareLoading}
         policyLocked={finetuneSeed != null || resumeSeed != null}
+        // On a resume, lerobot rebuilds every hyperparameter but the
+        // continuation essentials from the checkpoint's train_config.json, so
+        // those controls render read-only rather than accepting edits the run
+        // will discard. configToRequest still sends the form's values, keeping
+        // the new JobRecord's persisted config truthful about what was asked.
+        resumeLocked={resumeSeed != null}
         // Compute is pinned to the parent's runner on a resume. Cross-runner
         // resume isn't implemented (F7) and both directions fail badly —
         // cloud→local dies at startup on a host path that never existed,

--- a/frontend/src/components/training/TrainingJobDialog.tsx
+++ b/frontend/src/components/training/TrainingJobDialog.tsx
@@ -234,6 +234,16 @@ const TrainingJobDialog: React.FC<{
 
   const isRunning = job?.state === "running";
 
+  // Before the trainer's first metric tick the stats panel can only say
+  // "Training starting…" — which is wrong (and worryingly quiet) for the
+  // minutes a local fine-tune spends downloading its base checkpoint. The
+  // backend writes that progress into the job's log, so surface the newest line
+  // as a status strip until real steps arrive; it then gets out of the way.
+  const preStepStatus =
+    isRunning && job.metrics.current_step === 0
+      ? (logs[logs.length - 1]?.message ?? null)
+      : null;
+
   const backButton = (
     <Button
       variant="ghost"
@@ -342,6 +352,13 @@ const TrainingJobDialog: React.FC<{
                 </Button>
               )}
             </div>
+
+            {preStepStatus ? (
+              <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
+                <span className="truncate">{preStepStatus}</span>
+              </div>
+            ) : null}
 
             <MonitoringStats
               jobId={jobId}

--- a/frontend/src/components/training/TrainingJobDialog.tsx
+++ b/frontend/src/components/training/TrainingJobDialog.tsx
@@ -16,6 +16,7 @@ import {
   getJobLogs,
   getJobLogFile,
   jobDisplayName,
+  jobStateLabel,
   stopJob,
   deleteJob,
 } from "@/lib/jobsApi";
@@ -370,8 +371,11 @@ const TrainingJobDialog: React.FC<{
                       {job.id}
                     </p>
                   ) : null}
+                  {/* The label, not the wire value: this line rendered the raw
+                      state, so a stopped run read "interrupted" here while the
+                      card behind the dialog called it something else. */}
                   <p className="text-xs text-muted-foreground">
-                    {job.state}
+                    {jobStateLabel(job.state)}
                     {job.error_message ? ` — ${job.error_message}` : ""}
                   </p>
                 </div>

--- a/frontend/src/components/training/TrainingJobDialog.tsx
+++ b/frontend/src/components/training/TrainingJobDialog.tsx
@@ -26,6 +26,43 @@ import { useStudio } from "@/contexts/StudioContext";
 const POLL_INTERVAL_MS = 1000;
 const MAX_LOG_LINES = 5000;
 
+/**
+ * Log lines the pre-step status strip must never speak for.
+ *
+ * `objc[<pid>]: Class … is implemented in both …` is the macOS Objective-C
+ * runtime's duplicate-class warning, written to stderr by the dylibs pyav
+ * bundles (libavdevice/libavformat) the moment the trainer imports them — that
+ * is, squarely inside the `current_step === 0` window this strip exists to
+ * narrate. It is harmless, it says nothing about progress, and at two absolute
+ * dylib paths it is among the longest lines the run ever emits, which is what
+ * let it crowd the header.
+ *
+ * Deliberately anchored and narrow: the runtime's own `objc[1234]:` prefix and
+ * nothing else. Matching the body instead ("implemented in both", "duplicate")
+ * would reach wider than the thing being suppressed and could swallow a real
+ * failure that happens to use those words.
+ *
+ * This is DISPLAY SELECTION, not log rewriting — the line is still in the raw
+ * log pane below, which is where a diagnostic like this belongs.
+ */
+const STATUS_NOISE_RE = /^objc\[\d+\]:/;
+
+/**
+ * The newest log line worth showing as status, or null when there is none.
+ *
+ * Walks backwards to the first line that is neither blank nor noise, so a
+ * burst of objc warnings reveals the last real message underneath them rather
+ * than blanking the strip. Blank lines are skipped for the same reason they
+ * would be useless as status text.
+ */
+function newestStatusLine(logs: LogEntry[]): string | null {
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const message = logs[i]?.message ?? "";
+    if (message.trim() && !STATUS_NOISE_RE.test(message)) return message;
+  }
+  return null;
+}
+
 function jobToStatus(
   job: JobRecord | null,
   isStarting: boolean,
@@ -239,9 +276,11 @@ const TrainingJobDialog: React.FC<{
   // minutes a local fine-tune spends downloading its base checkpoint. The
   // backend writes that progress into the job's log, so surface the newest line
   // as a status strip until real steps arrive; it then gets out of the way.
+  // Newest USEFUL line — see newestStatusLine / STATUS_NOISE_RE: the trainer's
+  // start-up stderr is exactly what a blind tail would pick up here.
   const preStepStatus =
     isRunning && job.metrics.current_step === 0
-      ? (logs[logs.length - 1]?.message ?? null)
+      ? newestStatusLine(logs)
       : null;
 
   const backButton = (
@@ -353,10 +392,22 @@ const TrainingJobDialog: React.FC<{
               )}
             </div>
 
+            {/* One line, always — whatever the trainer prints. `truncate` on
+                its own is inert here: a flex item's `min-width` defaults to
+                `auto`, which for nowrap text resolves to the FULL text width,
+                so the span could never shrink and a long line escaped the box
+                instead of ellipsing inside it. `min-w-0 flex-1` is what makes
+                the clamp real, and it holds for any future long line, not just
+                objc's. `title` keeps the whole line one hover away. */}
             {preStepStatus ? (
               <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
                 <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
-                <span className="truncate">{preStepStatus}</span>
+                <span
+                  className="min-w-0 flex-1 truncate"
+                  title={preStepStatus}
+                >
+                  {preStepStatus}
+                </span>
               </div>
             ) : null}
 

--- a/frontend/src/components/training/config/AdvancedCard.tsx
+++ b/frontend/src/components/training/config/AdvancedCard.tsx
@@ -3,16 +3,9 @@ import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AdvancedSection } from "@/components/studio/panel/primitives";
 import { cn } from "@/lib/utils";
-import { ConfigComponentProps } from "../types";
+import { ConfigComponentProps, POLICY_TYPE_OPTIONS } from "../types";
 import { useApi } from "@/contexts/ApiContext";
 import { isValidTimeout } from "@/lib/jobTimeout";
 
@@ -46,6 +39,42 @@ const OPTIMIZER_LABELS: Record<string, string> = {
   sgd: "SGD",
   multi_adam: "Multi Adam",
 };
+
+type OptimizerKnob = "lr" | "weight_decay" | "grad_clip_norm";
+
+/**
+ * Which optimizer knobs each policy actually exposes — the mirror of
+ * `_POLICY_OPTIMIZER_FIELDS` in makermodslab/train.py. Keep the two in sync.
+ *
+ * Training always runs with the policy training preset on, so lerobot rebuilds
+ * the optimizer from the POLICY config's own `optimizer_*` fields and discards
+ * anything sent to the `--optimizer.*` namespace. The backend therefore emits
+ * `--policy.optimizer_<knob>`, and only for knobs the selected policy declares
+ * (an unknown one makes the CLI parser reject the run outright). A knob missing
+ * here would silently do nothing, so the input is hidden rather than shown as a
+ * control that can't take effect.
+ *
+ * This can NOT be derived from /policy-optimizer-defaults: that endpoint
+ * reports the preset OBJECT's fields, and both AdamW and Adam presets carry a
+ * grad_clip_norm regardless of whether the policy exposes a knob for it.
+ */
+const POLICY_OPTIMIZER_KNOBS: Record<string, readonly OptimizerKnob[]> = {
+  act: ["lr", "weight_decay"],
+  diffusion: ["lr", "weight_decay"],
+  pi0: ["lr", "weight_decay", "grad_clip_norm"],
+  smolvla: ["lr", "weight_decay", "grad_clip_norm"],
+  tdmpc: ["lr"],
+  vqbet: ["lr", "weight_decay"],
+  pi0_fast: ["lr", "weight_decay", "grad_clip_norm"],
+  // Its preset is a MultiAdam built from per-group settings — no scalar knobs.
+  gaussian_actor: [],
+};
+
+// Matches the backend's fallback for a policy type absent from the table.
+const DEFAULT_OPTIMIZER_KNOBS: readonly OptimizerKnob[] = ["lr"];
+
+const policyShortLabel = (value: string): string =>
+  POLICY_TYPE_OPTIONS.find((o) => o.value === value)?.label || value;
 
 /** Advanced-parameters section of the training form. Uses the shared
  * AdvancedSection, so its trigger is the same eyebrow-level control as the
@@ -91,6 +120,14 @@ const AdvancedCard: React.FC<ConfigComponentProps> = ({
   const defaultOptimizerLabel = d
     ? OPTIMIZER_LABELS[d.optimizer] ?? d.optimizer
     : null;
+
+  // The optimizer CLASS is fixed by the policy preset and cannot be overridden
+  // from the CLI, so it is shown, not chosen. Which scalar knobs remain
+  // adjustable is likewise a property of the policy.
+  const knobs =
+    POLICY_OPTIMIZER_KNOBS[config.policy_type] ?? DEFAULT_OPTIMIZER_KNOBS;
+  const has = (k: OptimizerKnob) => knobs.includes(k);
+  const policyLabel = policyShortLabel(config.policy_type);
 
   // Cloud-only "Job timeout": the raw string drives both the input and the
   // (mirror-of-backend) inline validity check. Blank = HF Jobs default (2h).
@@ -153,64 +190,74 @@ const AdvancedCard: React.FC<ConfigComponentProps> = ({
         <section className="space-y-3">
           <SectionHeading>Optimizer</SectionHeading>
           <div className="space-y-2">
-            <Label htmlFor="optimizer_type">Optimizer</Label>
-            <Select
-              value={config.optimizer_type || "adam"}
-              onValueChange={(value) => updateConfig("optimizer_type", value)}
-            >
-              <SelectTrigger id="optimizer_type">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="adam">Adam</SelectItem>
-                <SelectItem value="adamw">AdamW</SelectItem>
-                <SelectItem value="sgd">SGD</SelectItem>
-                <SelectItem value="multi_adam">Multi Adam</SelectItem>
-              </SelectContent>
-            </Select>
-            {defaultOptimizerLabel && (
-              <p className="text-xs text-muted-foreground">
-                Policy default: {defaultOptimizerLabel}
-              </p>
-            )}
+            <Label>Optimizer</Label>
+            <p className="text-sm">
+              {defaultOptimizerLabel ?? "Set by the policy preset"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {defaultOptimizerLabel
+                ? `Set by the ${policyLabel} policy preset — the optimizer class isn't adjustable.`
+                : "The policy preset picks the optimizer class; it isn't adjustable."}
+            </p>
           </div>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-            <div className="space-y-2">
-              <Label htmlFor="optimizer_lr">Learning rate</Label>
-              <NumberInput
-                id="optimizer_lr"
-                integer={false}
-                step="0.0001"
-                value={config.optimizer_lr}
-                onChange={(v) => updateConfig("optimizer_lr", v)}
-                placeholder={lrPlaceholder}
-              />
+          {knobs.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              The {policyLabel} preset builds its optimizer from per-parameter-group
+              settings, so there are no learning-rate or weight-decay knobs to set here.
+            </p>
+          ) : (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+              {has("lr") && (
+                <div className="space-y-2">
+                  <Label htmlFor="optimizer_lr">Learning rate</Label>
+                  <NumberInput
+                    id="optimizer_lr"
+                    integer={false}
+                    step="0.0001"
+                    value={config.optimizer_lr}
+                    onChange={(v) => updateConfig("optimizer_lr", v)}
+                    placeholder={lrPlaceholder}
+                  />
+                </div>
+              )}
+              {has("weight_decay") && (
+                <div className="space-y-2">
+                  <Label htmlFor="optimizer_weight_decay">Weight decay</Label>
+                  <NumberInput
+                    id="optimizer_weight_decay"
+                    integer={false}
+                    step="0.0001"
+                    value={config.optimizer_weight_decay}
+                    onChange={(v) => updateConfig("optimizer_weight_decay", v)}
+                    placeholder={wdPlaceholder}
+                  />
+                </div>
+              )}
+              {has("grad_clip_norm") && (
+                <div className="space-y-2">
+                  <Label htmlFor="optimizer_grad_clip_norm">
+                    Gradient clipping
+                  </Label>
+                  <NumberInput
+                    id="optimizer_grad_clip_norm"
+                    integer={false}
+                    step="0.0001"
+                    value={config.optimizer_grad_clip_norm}
+                    onChange={(v) =>
+                      updateConfig("optimizer_grad_clip_norm", v)
+                    }
+                    placeholder={gradPlaceholder}
+                  />
+                </div>
+              )}
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="optimizer_weight_decay">Weight decay</Label>
-              <NumberInput
-                id="optimizer_weight_decay"
-                integer={false}
-                step="0.0001"
-                value={config.optimizer_weight_decay}
-                onChange={(v) => updateConfig("optimizer_weight_decay", v)}
-                placeholder={wdPlaceholder}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="optimizer_grad_clip_norm">
-                Gradient clipping
-              </Label>
-              <NumberInput
-                id="optimizer_grad_clip_norm"
-                integer={false}
-                step="0.0001"
-                value={config.optimizer_grad_clip_norm}
-                onChange={(v) => updateConfig("optimizer_grad_clip_norm", v)}
-                placeholder={gradPlaceholder}
-              />
-            </div>
-          </div>
+          )}
+          {knobs.length > 0 && !has("grad_clip_norm") && (
+            <p className="text-xs text-muted-foreground">
+              The {policyLabel} policy exposes no gradient-clipping setting
+              {has("weight_decay") ? "" : " or weight decay"}.
+            </p>
+          )}
         </section>
 
         {/* Logging & Checkpointing */}

--- a/frontend/src/components/training/config/AdvancedCard.tsx
+++ b/frontend/src/components/training/config/AdvancedCard.tsx
@@ -5,7 +5,11 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { AdvancedSection } from "@/components/studio/panel/primitives";
 import { cn } from "@/lib/utils";
-import { ConfigComponentProps, POLICY_TYPE_OPTIONS } from "../types";
+import {
+  ConfigComponentProps,
+  POLICY_TYPE_OPTIONS,
+  RESUME_INHERITED_NOTE,
+} from "../types";
 import { useApi } from "@/contexts/ApiContext";
 import { isValidTimeout } from "@/lib/jobTimeout";
 
@@ -79,10 +83,23 @@ const policyShortLabel = (value: string): string =>
 /** Advanced-parameters section of the training form. Uses the shared
  * AdvancedSection, so its trigger is the same eyebrow-level control as the
  * Collect form's "Advanced parameters" instead of a heavier heading that
- * outranked the sections above it. */
+ * outranked the sections above it.
+ *
+ * On a resume the first three sections (policy preset, training, optimizer) are
+ * inherited wholesale from the checkpoint — build_training_command's resume
+ * branch emits none of --policy.use_amp / --seed / --policy.optimizer_* (and
+ * lerobot restores optimizer state from the checkpoint itself) — so they get
+ * ONE section-level read-only treatment rather than a per-field repetition.
+ * "Data loading", "Logging & checkpointing" and the cloud "Job timeout" below
+ * stay live: --num_workers / --log_freq / --save_freq are on the resume argv,
+ * and the timeout is a run_job submission parameter that never reaches lerobot
+ * at all. Worker count sits outside the inherited block on purpose — it is a
+ * host-capacity knob (like the cloud flavor), not part of the experiment, and a
+ * continuation can land on different hardware than the parent run. */
 const AdvancedCard: React.FC<ConfigComponentProps> = ({
   config,
   updateConfig,
+  resumeLocked,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const { baseUrl, fetchWithHeaders } = useApi();
@@ -143,36 +160,138 @@ const AdvancedCard: React.FC<ConfigComponentProps> = ({
       summary="Optimizer, learning rate, log frequency, checkpoints, and more"
     >
       <div className="space-y-6">
-        {/* Policy */}
-        <section className="space-y-3">
-          <SectionHeading>Policy preset</SectionHeading>
-          <div className="flex items-center gap-3">
-            <Switch
-              id="policy_use_amp"
-              checked={config.policy_use_amp}
-              onCheckedChange={(checked) =>
-                updateConfig("policy_use_amp", checked)
-              }
-              className="data-[state=checked]:bg-primary"
-            />
-            <Label htmlFor="policy_use_amp">
-              Use automatic mixed precision
-            </Label>
-          </div>
-        </section>
-
-        {/* Training */}
-        <section className="space-y-3">
-          <SectionHeading>Training</SectionHeading>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="seed">Random seed</Label>
-              <NumberInput
-                id="seed"
-                value={config.seed}
-                onChange={(v) => updateConfig("seed", v)}
+        {/* Policy preset + Training + Optimizer. On a resume these are one
+            inherited block, so the explanation sits once at its head. */}
+        <div
+          className={cn(
+            "space-y-6",
+            resumeLocked && "rounded-md border border-border bg-muted/30 p-4",
+          )}
+        >
+          {resumeLocked && (
+            <p className="text-xs text-muted-foreground">
+              {RESUME_INHERITED_NOTE}
+            </p>
+          )}
+          {/* Policy */}
+          <section className="space-y-3">
+            <SectionHeading>Policy preset</SectionHeading>
+            <div className="flex items-center gap-3">
+              <Switch
+                id="policy_use_amp"
+                checked={config.policy_use_amp}
+                onCheckedChange={(checked) =>
+                  updateConfig("policy_use_amp", checked)
+                }
+                disabled={resumeLocked}
+                className="data-[state=checked]:bg-primary"
               />
+              <Label htmlFor="policy_use_amp">
+                Use automatic mixed precision
+              </Label>
             </div>
+          </section>
+
+          {/* Training */}
+          <section className="space-y-3">
+            <SectionHeading>Training</SectionHeading>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="seed">Random seed</Label>
+                <NumberInput
+                  id="seed"
+                  value={config.seed}
+                  onChange={(v) => updateConfig("seed", v)}
+                  disabled={resumeLocked}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Optimizer */}
+          <section className="space-y-3">
+            <SectionHeading>Optimizer</SectionHeading>
+            <div className="space-y-2">
+              <Label>Optimizer</Label>
+              <p className="text-sm">
+                {defaultOptimizerLabel ?? "Set by the policy preset"}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {defaultOptimizerLabel
+                  ? `Set by the ${policyLabel} policy preset — the optimizer class isn't adjustable.`
+                  : "The policy preset picks the optimizer class; it isn't adjustable."}
+              </p>
+            </div>
+            {knobs.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                The {policyLabel} preset builds its optimizer from per-parameter-group
+                settings, so there are no learning-rate or weight-decay knobs to set here.
+              </p>
+            ) : (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                {has("lr") && (
+                  <div className="space-y-2">
+                    <Label htmlFor="optimizer_lr">Learning rate</Label>
+                    <NumberInput
+                      id="optimizer_lr"
+                      integer={false}
+                      step="0.0001"
+                      value={config.optimizer_lr}
+                      onChange={(v) => updateConfig("optimizer_lr", v)}
+                      placeholder={lrPlaceholder}
+                      disabled={resumeLocked}
+                    />
+                  </div>
+                )}
+                {has("weight_decay") && (
+                  <div className="space-y-2">
+                    <Label htmlFor="optimizer_weight_decay">Weight decay</Label>
+                    <NumberInput
+                      id="optimizer_weight_decay"
+                      integer={false}
+                      step="0.0001"
+                      value={config.optimizer_weight_decay}
+                      onChange={(v) => updateConfig("optimizer_weight_decay", v)}
+                      placeholder={wdPlaceholder}
+                      disabled={resumeLocked}
+                    />
+                  </div>
+                )}
+                {has("grad_clip_norm") && (
+                  <div className="space-y-2">
+                    <Label htmlFor="optimizer_grad_clip_norm">
+                      Gradient clipping
+                    </Label>
+                    <NumberInput
+                      id="optimizer_grad_clip_norm"
+                      integer={false}
+                      step="0.0001"
+                      value={config.optimizer_grad_clip_norm}
+                      onChange={(v) =>
+                        updateConfig("optimizer_grad_clip_norm", v)
+                      }
+                      placeholder={gradPlaceholder}
+                      disabled={resumeLocked}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+            {knobs.length > 0 && !has("grad_clip_norm") && (
+              <p className="text-xs text-muted-foreground">
+                The {policyLabel} policy exposes no gradient-clipping setting
+                {has("weight_decay") ? "" : " or weight decay"}.
+              </p>
+            )}
+          </section>
+        </div>
+
+        {/* Data loading. Outside the inherited block above even on a resume:
+            --num_workers IS on the resume argv, and the host it runs on can
+            differ from the parent run's. */}
+        <section className="space-y-3">
+          <SectionHeading>Data loading</SectionHeading>
+          <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="num_workers">Number of workers</Label>
               <NumberInput
@@ -182,82 +301,11 @@ const AdvancedCard: React.FC<ConfigComponentProps> = ({
                   if (v !== undefined) updateConfig("num_workers", v);
                 }}
               />
+              <p className="text-xs text-muted-foreground">
+                DataLoader processes feeding the GPU.
+              </p>
             </div>
           </div>
-        </section>
-
-        {/* Optimizer */}
-        <section className="space-y-3">
-          <SectionHeading>Optimizer</SectionHeading>
-          <div className="space-y-2">
-            <Label>Optimizer</Label>
-            <p className="text-sm">
-              {defaultOptimizerLabel ?? "Set by the policy preset"}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {defaultOptimizerLabel
-                ? `Set by the ${policyLabel} policy preset — the optimizer class isn't adjustable.`
-                : "The policy preset picks the optimizer class; it isn't adjustable."}
-            </p>
-          </div>
-          {knobs.length === 0 ? (
-            <p className="text-xs text-muted-foreground">
-              The {policyLabel} preset builds its optimizer from per-parameter-group
-              settings, so there are no learning-rate or weight-decay knobs to set here.
-            </p>
-          ) : (
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-              {has("lr") && (
-                <div className="space-y-2">
-                  <Label htmlFor="optimizer_lr">Learning rate</Label>
-                  <NumberInput
-                    id="optimizer_lr"
-                    integer={false}
-                    step="0.0001"
-                    value={config.optimizer_lr}
-                    onChange={(v) => updateConfig("optimizer_lr", v)}
-                    placeholder={lrPlaceholder}
-                  />
-                </div>
-              )}
-              {has("weight_decay") && (
-                <div className="space-y-2">
-                  <Label htmlFor="optimizer_weight_decay">Weight decay</Label>
-                  <NumberInput
-                    id="optimizer_weight_decay"
-                    integer={false}
-                    step="0.0001"
-                    value={config.optimizer_weight_decay}
-                    onChange={(v) => updateConfig("optimizer_weight_decay", v)}
-                    placeholder={wdPlaceholder}
-                  />
-                </div>
-              )}
-              {has("grad_clip_norm") && (
-                <div className="space-y-2">
-                  <Label htmlFor="optimizer_grad_clip_norm">
-                    Gradient clipping
-                  </Label>
-                  <NumberInput
-                    id="optimizer_grad_clip_norm"
-                    integer={false}
-                    step="0.0001"
-                    value={config.optimizer_grad_clip_norm}
-                    onChange={(v) =>
-                      updateConfig("optimizer_grad_clip_norm", v)
-                    }
-                    placeholder={gradPlaceholder}
-                  />
-                </div>
-              )}
-            </div>
-          )}
-          {knobs.length > 0 && !has("grad_clip_norm") && (
-            <p className="text-xs text-muted-foreground">
-              The {policyLabel} policy exposes no gradient-clipping setting
-              {has("weight_decay") ? "" : " or weight decay"}.
-            </p>
-          )}
         </section>
 
         {/* Logging & Checkpointing */}

--- a/frontend/src/components/training/config/EssentialsCard.tsx
+++ b/frontend/src/components/training/config/EssentialsCard.tsx
@@ -10,17 +10,33 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ConfigComponentProps } from "../types";
+import { cn } from "@/lib/utils";
+import {
+  ConfigComponentProps,
+  RESUME_INHERITED_NOTE,
+  RESUME_INHERITED_SHORT,
+} from "../types";
 import WandbInstallDialog from "../WandbInstallDialog";
 import { useApi } from "@/contexts/ApiContext";
 
 /** The run's headline settings — steps, batch size, name, and W&B logging.
  * Flat: each control carries its own <Label> and the section has no eyebrow
  * heading, so nothing sits above a single field restating it. The policy
- * select lives in PolicyField, which renders earlier in the form. */
+ * select lives in PolicyField, which renders earlier in the form.
+ *
+ * On a resume, `steps` stays editable (the resume branch passes --steps, and
+ * raising it is the whole point of a continuation) while `batch_size` does not
+ * — lerobot takes it from the checkpoint's train_config.json. The whole W&B
+ * group is locked for the same reason: the resume branch emits no --wandb.*, so
+ * lerobot logs (or doesn't) exactly as the parent run's config said. The one
+ * live effect the toggle keeps is a bad one — HfCloudJobRunner reads
+ * `wandb_enable` when assembling job secrets and 400s on a missing
+ * WANDB_API_KEY, so leaving it enabled could only ever block a launch without
+ * turning any logging on. */
 const EssentialsCard: React.FC<ConfigComponentProps> = ({
   config,
   updateConfig,
+  resumeLocked,
 }) => {
   const { baseUrl, fetchWithHeaders } = useApi();
   const [wandbDialogOpen, setWandbDialogOpen] = useState(false);
@@ -73,7 +89,13 @@ const EssentialsCard: React.FC<ConfigComponentProps> = ({
             onChange={(v) => {
               if (v !== undefined) updateConfig("batch_size", v);
             }}
+            disabled={resumeLocked}
           />
+          {resumeLocked && (
+            <p className="text-xs text-muted-foreground">
+              {RESUME_INHERITED_SHORT}
+            </p>
+          )}
         </div>
       </div>
 
@@ -92,86 +114,106 @@ const EssentialsCard: React.FC<ConfigComponentProps> = ({
         </p>
       </div>
 
-      <div className="flex items-center gap-3">
-        <Switch
-          id="wandb_enable"
-          checked={config.wandb_enable}
-          onCheckedChange={handleWandbToggle}
-          className="data-[state=checked]:bg-primary"
-        />
-        <Label htmlFor="wandb_enable">Log to Weights &amp; Biases</Label>
-      </div>
-
-      <WandbInstallDialog
-        open={wandbDialogOpen}
-        onOpenChange={setWandbDialogOpen}
-        installHint={wandbInstallHint}
-      />
-
-      {config.wandb_enable && (
-        <div className="space-y-4 border-l-2 border-border pl-4">
-          <div className="space-y-2">
-            <Label htmlFor="wandb_project">W&amp;B project name</Label>
-            <Input
-              id="wandb_project"
-              value={config.wandb_project || ""}
-              onChange={(e) =>
-                updateConfig("wandb_project", e.target.value || undefined)
-              }
-              placeholder="my-robotics-project"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="wandb_entity">W&amp;B entity (optional)</Label>
-            <Input
-              id="wandb_entity"
-              value={config.wandb_entity || ""}
-              onChange={(e) =>
-                updateConfig("wandb_entity", e.target.value || undefined)
-              }
-              placeholder="your-username"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="wandb_notes">W&amp;B notes (optional)</Label>
-            <Input
-              id="wandb_notes"
-              value={config.wandb_notes || ""}
-              onChange={(e) =>
-                updateConfig("wandb_notes", e.target.value || undefined)
-              }
-              placeholder="Training run notes..."
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="wandb_mode">W&amp;B mode</Label>
-            <Select
-              value={config.wandb_mode || "online"}
-              onValueChange={(value) => updateConfig("wandb_mode", value)}
-            >
-              <SelectTrigger id="wandb_mode">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="online">Online</SelectItem>
-                <SelectItem value="offline">Offline</SelectItem>
-                <SelectItem value="disabled">Disabled</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-3">
-            <Switch
-              id="wandb_disable_artifact"
-              checked={config.wandb_disable_artifact}
-              onCheckedChange={(checked) =>
-                updateConfig("wandb_disable_artifact", checked)
-              }
-              className="data-[state=checked]:bg-primary"
-            />
-            <Label htmlFor="wandb_disable_artifact">Disable artifacts</Label>
-          </div>
+      {/* W&B is one inherited group on a resume, so it gets a single
+          section-level treatment like Advanced's locked sections. */}
+      <div
+        className={cn(
+          "space-y-4",
+          resumeLocked && "rounded-md border border-border bg-muted/30 p-4",
+        )}
+      >
+        {resumeLocked && (
+          <p className="text-xs text-muted-foreground">
+            {RESUME_INHERITED_NOTE}
+          </p>
+        )}
+        <div className="flex items-center gap-3">
+          <Switch
+            id="wandb_enable"
+            checked={config.wandb_enable}
+            onCheckedChange={handleWandbToggle}
+            disabled={resumeLocked}
+            className="data-[state=checked]:bg-primary"
+          />
+          <Label htmlFor="wandb_enable">Log to Weights &amp; Biases</Label>
         </div>
-      )}
+
+        <WandbInstallDialog
+          open={wandbDialogOpen}
+          onOpenChange={setWandbDialogOpen}
+          installHint={wandbInstallHint}
+        />
+
+        {config.wandb_enable && (
+          <div className="space-y-4 border-l-2 border-border pl-4">
+            <div className="space-y-2">
+              <Label htmlFor="wandb_project">W&amp;B project name</Label>
+              <Input
+                id="wandb_project"
+                value={config.wandb_project || ""}
+                onChange={(e) =>
+                  updateConfig("wandb_project", e.target.value || undefined)
+                }
+                placeholder="my-robotics-project"
+                disabled={resumeLocked}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="wandb_entity">W&amp;B entity (optional)</Label>
+              <Input
+                id="wandb_entity"
+                value={config.wandb_entity || ""}
+                onChange={(e) =>
+                  updateConfig("wandb_entity", e.target.value || undefined)
+                }
+                placeholder="your-username"
+                disabled={resumeLocked}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="wandb_notes">W&amp;B notes (optional)</Label>
+              <Input
+                id="wandb_notes"
+                value={config.wandb_notes || ""}
+                onChange={(e) =>
+                  updateConfig("wandb_notes", e.target.value || undefined)
+                }
+                placeholder="Training run notes..."
+                disabled={resumeLocked}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="wandb_mode">W&amp;B mode</Label>
+              <Select
+                value={config.wandb_mode || "online"}
+                onValueChange={(value) => updateConfig("wandb_mode", value)}
+                disabled={resumeLocked}
+              >
+                <SelectTrigger id="wandb_mode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="online">Online</SelectItem>
+                  <SelectItem value="offline">Offline</SelectItem>
+                  <SelectItem value="disabled">Disabled</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-3">
+              <Switch
+                id="wandb_disable_artifact"
+                checked={config.wandb_disable_artifact}
+                onCheckedChange={(checked) =>
+                  updateConfig("wandb_disable_artifact", checked)
+                }
+                disabled={resumeLocked}
+                className="data-[state=checked]:bg-primary"
+              />
+              <Label htmlFor="wandb_disable_artifact">Disable artifacts</Label>
+            </div>
+          </div>
+        )}
+      </div>
     </section>
   );
 };

--- a/frontend/src/components/training/config/TargetCard.tsx
+++ b/frontend/src/components/training/config/TargetCard.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { ConfigComponentProps } from "../types";
+import { ConfigComponentProps, RESUME_INHERITED_SHORT } from "../types";
 import { RunnerFlavor } from "@/lib/jobsApi";
 
 interface TargetCardProps extends ConfigComponentProps {
@@ -38,13 +38,16 @@ const formatFlavorLine = (f: RunnerFlavor): string => {
  * Which HARDWARE a run rents is genuinely chosen per launch, so the cloud
  * flavor stays live on a resume. WHICH RUNNER does not: a resume can only
  * continue on the parent's runner (`runnerLocked`, F7), so the toggle is pinned
- * and disabled there. */
+ * and disabled there. `policy_device` is locked too, for a different reason:
+ * the resume branch emits no --policy.device, so lerobot uses whatever the
+ * checkpoint's train_config.json recorded. */
 const TargetCard: React.FC<TargetCardProps> = ({
   config,
   updateConfig,
   authenticated,
   flavors,
   loading,
+  resumeLocked,
   runnerLocked,
 }) => {
   const target = config.target;
@@ -102,6 +105,7 @@ const TargetCard: React.FC<TargetCardProps> = ({
           <Select
             value={config.policy_device === "cpu" ? "cpu" : "auto"}
             onValueChange={(value) => updateConfig("policy_device", value)}
+            disabled={resumeLocked}
           >
             <SelectTrigger id="policy_device">
               <SelectValue />
@@ -114,7 +118,9 @@ const TargetCard: React.FC<TargetCardProps> = ({
             </SelectContent>
           </Select>
           <p className="text-xs text-muted-foreground">
-            lerobot auto-detects your GPU (CUDA/MPS); only CPU is forced.
+            {resumeLocked
+              ? RESUME_INHERITED_SHORT
+              : "lerobot auto-detects your GPU (CUDA/MPS); only CPU is forced."}
           </p>
         </div>
       ) : (

--- a/frontend/src/components/training/config/TargetCard.tsx
+++ b/frontend/src/components/training/config/TargetCard.tsx
@@ -15,6 +15,9 @@ interface TargetCardProps extends ConfigComponentProps {
   authenticated: boolean;
   flavors: RunnerFlavor[];
   loading: boolean;
+  /** True on a resume: the runner toggle is pinned to the parent run's runner
+   * and disabled (F7). The hardware flavor below it stays live. */
+  runnerLocked?: boolean;
 }
 
 const formatHourly = (unitCostUsd: number, unitLabel: string): string => {
@@ -30,17 +33,24 @@ const formatFlavorLine = (f: RunnerFlavor): string => {
 /** Where the run executes — the runner toggle plus whichever hardware control
  * that runner needs. Flat: the controls carry their own <Label>s and there is
  * no "Compute target" eyebrow above them, which used to restate the "Run
- * training on" label directly beneath it. */
+ * training on" label directly beneath it.
+ *
+ * Which HARDWARE a run rents is genuinely chosen per launch, so the cloud
+ * flavor stays live on a resume. WHICH RUNNER does not: a resume can only
+ * continue on the parent's runner (`runnerLocked`, F7), so the toggle is pinned
+ * and disabled there. */
 const TargetCard: React.FC<TargetCardProps> = ({
   config,
   updateConfig,
   authenticated,
   flavors,
   loading,
+  runnerLocked,
 }) => {
   const target = config.target;
 
   const setRunner = (runner: "local" | "hf_cloud") => {
+    if (runnerLocked) return;
     if (runner === target.runner) return;
     if (runner === "local") {
       updateConfig("target", { runner: "local" });
@@ -60,17 +70,30 @@ const TargetCard: React.FC<TargetCardProps> = ({
               key={r}
               type="button"
               onClick={() => setRunner(r)}
+              disabled={runnerLocked}
+              // When pinned, the picked half keeps its fill — the inherited
+              // runner should read as the answer, not as disabled chrome —
+              // while the unpicked half dims and stops inviting a click it
+              // would refuse.
               className={cn(
                 "px-3 py-1.5 transition-colors",
                 target.runner === r
                   ? "bg-primary text-primary-foreground"
-                  : "bg-background text-muted-foreground hover:text-foreground",
+                  : runnerLocked
+                    ? "bg-background text-muted-foreground opacity-50 cursor-not-allowed"
+                    : "bg-background text-muted-foreground hover:text-foreground",
               )}
             >
               {r === "local" ? "Local — your machine" : "Hugging Face Cloud"}
             </button>
           ))}
         </div>
+        {runnerLocked ? (
+          <p className="text-xs text-muted-foreground">
+            Continues on the parent's runner — cross-runner resume isn't
+            supported yet.
+          </p>
+        ) : null}
       </div>
 
       {target.runner === "local" ? (

--- a/frontend/src/components/training/types.ts
+++ b/frontend/src/components/training/types.ts
@@ -135,4 +135,32 @@ export interface ConfigComponentProps {
     key: T,
     value: TrainingConfig[T],
   ) => void;
+  /** True on a RESUME entry (a Continue / Resume seed). lerobot rebuilds the
+   * run's shape from the checkpoint's train_config.json, and
+   * build_training_command's resume branch (makermodslab/train.py) passes it
+   * only the continuation essentials — config_path, resume, output_dir, steps,
+   * num_workers, log_freq, save_freq, save_checkpoint, the push-to-hub flags
+   * and job_name.
+   * Every other hyperparameter the form shows is silently discarded, so on a
+   * resume those controls render read-only instead of pretending to matter. */
+  resumeLocked?: boolean;
 }
+
+// Shown once where a card's inherited (read-only) fields begin. Deliberately
+// text-only: the fine-tune flow is reached from a model's own card, not from
+// here, so this points at it in prose rather than growing a button.
+//
+// Worded around the BEHAVIOUR ("rebuilt from the checkpoint") rather than the
+// displayed value: the form does not prefill these controls from the parent
+// run's persisted config, so the number beside the note is the form's default,
+// not the parent's. Saying "inherited" of a control showing a default would be
+// a fresh untruth — the lock's whole job is to stop the form claiming influence
+// it does not have.
+export const RESUME_INHERITED_NOTE =
+  "Rebuilt from the parent run's checkpoint — a resume continues the same experiment, so changing these here has no effect. To train with different settings, fine-tune from this checkpoint instead.";
+
+// The same idea for a lone locked control that sits directly under the resume
+// banner (which already carries the full explanation) — repeating the whole
+// sentence beside every field reads as nagging.
+export const RESUME_INHERITED_SHORT =
+  "Rebuilt from the parent run's checkpoint.";

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -218,6 +218,36 @@ export function jobDisplayName(job: JobRecord): string {
   return job.display_name?.trim() || job.name;
 }
 
+/**
+ * What each job state is CALLED in the UI.
+ *
+ * The wire values are the backend's and never change — `interrupted` is what
+ * lands in job.json and what /jobs returns — so this maps them to the words a
+ * person reads. Three are the state name capitalised; the fourth is the reason
+ * this map exists. A run in `interrupted` is one the user pressed **Stop** on,
+ * so it reads "Stopped": the plainer word, and the same one as the button that
+ * produced the state. "Interrupted" suggests something happened TO the run.
+ *
+ * Lives here, beside JobState and jobDisplayName, rather than in whichever
+ * component renders a badge. The badges keep their own colour and icon —
+ * those legitimately differ — but the WORDS have to agree, and they did not:
+ * the card said "Interrupted" while the monitor dialog showed the raw wire
+ * string for the same run.
+ */
+export const JOB_STATE_LABELS: Record<JobState, string> = {
+  running: "Running",
+  done: "Done",
+  failed: "Failed",
+  interrupted: "Stopped",
+};
+
+/** `JOB_STATE_LABELS` for a state that may not be one — a state added by a
+ * newer backend than this bundle falls back to the raw wire word rather than
+ * rendering blank. */
+export function jobStateLabel(state: JobState): string {
+  return JOB_STATE_LABELS[state] ?? state;
+}
+
 /** Set a job's display alias. Metadata-only — the job id, output dir, and
  * hub repo id are immutable identity and never change on rename. */
 export async function renameJob(

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -980,6 +980,43 @@ def get_hub_dataset_info(repo_id: str) -> dict[str, Any] | None:
     return row
 
 
+def read_dataset_features(repo_id: str) -> dict[str, Any] | None:
+    """The RAW ``features`` map from a dataset's ``meta/info.json``.
+
+    The other readers above summarise info.json for a UI card (camera names,
+    episode counts); this one hands back the feature specs untouched —
+    ``dtype``/``shape``/``names`` per key — because the fine-tune preflight in
+    jobs.py compares them dimension-for-dimension against a checkpoint's own
+    ``input_features``/``output_features``. Local first (a plain file read, no
+    network), falling back to fetching just ``meta/info.json`` from the Hub for
+    a dataset with no local copy — the same tiny file get_hub_dataset_info
+    uses.
+
+    Returns None when it can't be read — not local, offline, absent/private
+    repo, malformed JSON, or no ``features`` map. None means "not established",
+    never "fine": a caller must treat it as a reason to stay silent rather than
+    as a clean bill of health.
+    """
+    path = _resolve_local_dataset_path(repo_id)
+    if path is not None:
+        try:
+            info = json.loads((path / "meta" / "info.json").read_text())
+        except (OSError, ValueError):
+            return None
+    elif hf_hub_offline():
+        return None
+    else:
+        try:
+            local = hf_hub_download(repo_id, filename="meta/info.json", repo_type="dataset")
+            info = json.loads(Path(local).read_text())
+        except Exception as exc:
+            logger.info("dataset features fetch for %s failed: %s", repo_id, exc)
+            return None
+
+    features = info.get("features") if isinstance(info, dict) else None
+    return features if isinstance(features, dict) else None
+
+
 class DatasetRenameError(Exception):
     """Raised by rename_local_dataset when the rename can't proceed. `status`
     is the HTTP status the route should return (400 invalid, 404 not found,

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -36,9 +36,11 @@ from pathlib import Path
 from queue import Empty, Queue
 from typing import Any, Literal, Protocol, runtime_checkable
 
+from huggingface_hub import hf_hub_download
 from pydantic import BaseModel
 from tqdm.auto import tqdm as _base_tqdm
 
+from .datasets import CAMERA_FEATURE_PREFIX, read_dataset_features
 from .train import TrainingRequest
 from .utils.config import is_valid_robot_name
 from .utils.hf_auth import shared_hf_api
@@ -1206,6 +1208,331 @@ def _flat_feature_dim(feat: object) -> int | None:
         return None
 
 
+def read_pretrained_config(pretrained_path: str) -> dict[str, Any] | None:
+    """Read the whole ``config.json`` of the checkpoint at
+    ``--policy.pretrained_path``.
+
+    `pretrained_path` is whatever the run will be started from: an absolute
+    local ``pretrained_model`` directory, a Hub repo id whose ROOT holds the
+    model, or a step-suffixed hub ref ('repo@checkpoints/<step_dir>') that has
+    not been materialized yet — the checks that use this run BEFORE the
+    download, so that a contradicting pair is refused without first pulling
+    gigabytes.
+
+    Only the checkpoint's ``config.json`` is fetched in every case (a few KB).
+
+    Returns the parsed object, or None when it can't be read — missing file,
+    malformed JSON, private/absent repo, or no network. None means "not
+    established", never "fine": callers must treat it as a reason to stay
+    silent rather than a clean bill of health.
+    """
+    path = Path(pretrained_path)
+    if path.is_dir():
+        with contextlib.suppress(Exception), open(path / "config.json") as f:
+            loaded = json.load(f)
+            return loaded if isinstance(loaded, dict) else None
+        return None
+
+    # A step-suffixed ref addresses one checkpoint inside the repo; anything
+    # else is a repo id whose root holds the config.
+    m = _HUB_CKPT_REF_RE.match(pretrained_path)
+    if m:
+        repo_id = m.group("repo")
+        filename = f"checkpoints/{m.group('step_dir')}/{_HUB_CKPT_SUBDIR}/config.json"
+    else:
+        repo_id, filename = pretrained_path, "config.json"
+
+    with contextlib.suppress(Exception):
+        local = hf_hub_download(repo_id=repo_id, filename=filename, repo_type="model")
+        with open(local) as f:
+            loaded = json.load(f)
+            return loaded if isinstance(loaded, dict) else None
+    return None
+
+
+def read_pretrained_feature_space(
+    pretrained_path: str,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """The checkpoint's ``(input_features, output_features)`` maps.
+
+    Read out of the same single read_pretrained_config fetch any other
+    checkpoint-side guard uses. These are the feature specs lerobot WOULD have
+    built the policy from had the run used ``--policy.path``; on MakerMods Lab's
+    launch path (``--policy.type`` + ``--policy.pretrained_path``) they are
+    never consulted, which is exactly why the preflight has to read them itself
+    (MT44).
+
+    Each map is ``{feature key: {"type": "STATE"|"VISUAL"|"ACTION", "shape":
+    [...]}}``; image shapes are CHW. None when the config can't be read or
+    carries neither map — "not established", not "fine". A config with only
+    one of the two yields the other as ``{}``, so a state-dim check can still
+    run when output_features is missing.
+    """
+    cfg = read_pretrained_config(pretrained_path)
+    if cfg is None:
+        return None
+    inputs = cfg.get("input_features")
+    outputs = cfg.get("output_features")
+    if not isinstance(inputs, dict) and not isinstance(outputs, dict):
+        return None
+    return (
+        inputs if isinstance(inputs, dict) else {},
+        outputs if isinstance(outputs, dict) else {},
+    )
+
+
+def _camera_features(features: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """The camera entries of a feature map, keyed by BARE camera name.
+
+    Both sides of the preflight name cameras the same way — the dataset's
+    ``meta/info.json`` and the checkpoint's ``config.json`` both use
+    ``observation.images.<name>`` — so stripping the prefix gives directly
+    comparable key sets. Every ``observation.images.*`` key counts here, video
+    and raw-image alike (unlike datasets._video_camera_names, which filters to
+    what the episode viewer can play): the trainer consumes both as camera
+    inputs, so both belong in the comparison.
+    """
+    return {
+        key[len(CAMERA_FEATURE_PREFIX) :]: spec
+        for key, spec in features.items()
+        if key.startswith(CAMERA_FEATURE_PREFIX) and isinstance(spec, dict)
+    }
+
+
+# A camera key a pretrained BASE ships as a placeholder rather than as the name
+# of a real mount: lerobot/smolvla_base's camera1/camera2/camera3. Matched
+# against the BARE tail (the observation.images. prefix already stripped).
+_PLACEHOLDER_CAMERA_RE = re.compile(r"^camera\d+$")
+
+
+def _is_placeholder_camera_set(names: set[str]) -> bool:
+    """True when EVERY camera key is a generic placeholder — the signature of a
+    pretrained base that was never tied to one rig. All-or-nothing on purpose: a
+    checkpoint mixing placeholders with real mounts (camera1 + wrist) is not a
+    generic base, so it does not qualify."""
+    return bool(names) and all(_PLACEHOLDER_CAMERA_RE.match(name) for name in names)
+
+
+def _image_height_width(spec: dict[str, Any]) -> tuple[int, int] | None:
+    """(height, width) of a camera feature, normalising the two shape
+    conventions this file has to compare.
+
+    A dataset's ``meta/info.json`` stores image shapes HWC — ``[480, 640, 3]``
+    with ``names: ["height", "width", "channels"]`` — while a policy
+    checkpoint's ``config.json`` stores them CHW — ``[3, 480, 640]``, no names
+    at all. Locate the channel axis by name when the spec carries names, else
+    by the only axis narrow enough to be channels (1 or 3), and return the
+    remaining two dims in order.
+
+    None when the shape isn't a 3-axis image or the channel axis is
+    ambiguous — the caller then simply doesn't compare resolutions, which in
+    phase 1 only costs a log line.
+    """
+    shape = spec.get("shape")
+    if not isinstance(shape, (list, tuple)) or len(shape) != 3:
+        return None
+
+    axis: int | None = None
+    names = spec.get("names")
+    if isinstance(names, (list, tuple)) and len(names) == 3:
+        for i, name in enumerate(names):
+            if isinstance(name, str) and name.strip().lower().rstrip("s") == "channel":
+                axis = i
+                break
+    if axis is None:
+        narrow = [i for i, dim in enumerate(shape) if dim in (1, 3)]
+        if len(narrow) != 1:
+            return None
+        axis = narrow[0]
+
+    try:
+        height, width = (int(dim) for i, dim in enumerate(shape) if i != axis)
+    except (TypeError, ValueError):
+        return None
+    return height, width
+
+
+def _describe_cameras(names: set[str]) -> str:
+    return ", ".join(sorted(names)) if names else "none"
+
+
+def _check_pretrained_feature_space(pretrained_path: str, dataset_repo_id: str) -> None:
+    """Reject a fine-tune whose checkpoint and dataset describe different robots.
+
+    Necessary because on MakerMods Lab's launch path (``--policy.type`` +
+    ``--policy.pretrained_path``) lerobot builds the policy FROM THE DATASET's
+    features and then loads the checkpoint's weights with ``strict=False``, so
+    it never compares the two. lerobot's own
+    ``validate_visual_features_consistency`` is a tautology here — it compares
+    the dataset against itself. Nothing downstream will notice the mismatch
+    (MT44).
+
+    What that costs, by class:
+
+    * STATE/ACTION WIDTH — ACT fails loudly but late, with a raw size-mismatch
+      traceback after the dataset download. SmolVLA/pi0/pi05 pad the
+      proprioceptive dims to 32, so a 6-dof checkpoint loads CLEANLY into a
+      12-dof (bimanual) run and trains garbage that is recorded as a
+      fine-tune. Refused.
+    * RENAMED CAMERAS — the same number of cameras under different keys (the
+      bimanual ``left_``-prefix case). Refused as a SELECTION mistake, not an
+      architectural one: ACT drives every camera through one shared backbone
+      (``ACT.backbone`` + a spatial-only position embedding, no per-camera
+      parameters) and SmolVLA through one shared vision tower, so the weights
+      would in fact carry over fine. What the rename actually signals is that
+      the dataset and the base model came from DIFFERENT RIGS — which in this
+      UI is never deliberate. Catching the bimanual ``left_``-prefix case is
+      the whole point of the rule.
+
+      The same rationale extends to camera sets that are FULLY DISJOINT at ANY
+      count (a 1-camera ``left`` dataset against a ``wrist``/``front``
+      checkpoint). Unequal counts would otherwise route that to the benign
+      count-change warning below, but zero overlap is not a sensor-suite
+      change: none of the checkpoint's visual inputs survive, its cameras are
+      all dropped and the dataset's all start from scratch. Same selection
+      mistake, so the same refusal.
+
+      ONE EXEMPTION — a GENERIC BASE. When every one of the CHECKPOINT's camera
+      keys is a placeholder (``camera1``/``camera2``/… — see
+      _is_placeholder_camera_set), the checkpoint was never tied to a rig at
+      all: ``lerobot/smolvla_base`` ships exactly that, and adapting it to a
+      named 3-camera rig is the CANONICAL SmolVLA fine-tune, not a mixup.
+      That case demotes to the warn path. The gate is checkpoint-side only —
+      a user's dataset always carries real mount names, so the dataset side
+      tells us nothing — and it is all-or-nothing, so a checkpoint mixing a
+      placeholder with a real mount stays refused. Phase 2 may replace this
+      exemption with an explicit confirm once there is a UI to confirm in.
+    * MISSING / EXTRA CAMERA, DIFFERENT RESOLUTION — legitimate choices
+      (ACT's shared backbone handles a changed sensor count; resolution only
+      moves the token count and VRAM). Phase 1 logs a warning; the
+      warn-and-confirm UI is phase 2. This path applies only when the two
+      sides SHARE at least one camera — with no overlap it is a different rig,
+      not a changed sensor suite, and the disjoint rule above refuses it.
+
+    Silent when either side can't be read, matching the neighbouring guards:
+    an unverifiable pair must not block a launch. Raises ValueError (→ HTTP
+    400) only on a contradiction we can actually prove.
+    """
+    # Checkpoint first: it is the side most often unreadable (a hub ref with no
+    # network, a hand-built path), and bailing here spares the dataset read.
+    feature_space = read_pretrained_feature_space(pretrained_path)
+    if feature_space is None:
+        return
+    ckpt_inputs, ckpt_outputs = feature_space
+
+    dataset_features = read_dataset_features(dataset_repo_id)
+    if not dataset_features:
+        return
+
+    # -- state / action width ------------------------------------------------
+    # The dataset's own dims are what lerobot will build the policy from, so a
+    # difference here is exactly the width the loaded weights won't fit.
+    for label, ckpt_feature, dataset_key in (
+        ("robot state", ckpt_inputs.get("observation.state"), "observation.state"),
+        ("action", ckpt_outputs.get("action"), "action"),
+    ):
+        ckpt_dim = _flat_feature_dim(ckpt_feature)
+        dataset_dim = _flat_feature_dim(dataset_features.get(dataset_key))
+        if ckpt_dim is None or dataset_dim is None or ckpt_dim == dataset_dim:
+            continue
+        raise ValueError(
+            f"The checkpoint this run starts from ({pretrained_path}) was trained "
+            f"with {ckpt_dim}-dim {label}, but the dataset {dataset_repo_id!r} "
+            f"records {dataset_dim}-dim {label} — a different robot (an SO-101 arm "
+            f"is 6 dims, a bimanual pair 12). Fine-tuning builds the policy from "
+            f"the DATASET and loads the checkpoint's weights into it without "
+            f"checking the widths, so the run would train from largely random "
+            f"weights while reporting itself as a fine-tune. Pick a dataset "
+            f"recorded on the same robot as this checkpoint, pick a base model "
+            f"trained on this robot, or train from scratch."
+        )
+
+    # -- cameras -------------------------------------------------------------
+    ckpt_cameras = _camera_features(ckpt_inputs)
+    dataset_cameras = _camera_features(dataset_features)
+    ckpt_names, dataset_names = set(ckpt_cameras), set(dataset_cameras)
+
+    renamed = ckpt_names != dataset_names and len(ckpt_names) == len(dataset_names)
+    # Zero overlap is the same selection mistake as a rename, at any count: none
+    # of the checkpoint's visual inputs survive. Equal-count disjoint sets fall
+    # to `renamed` first (its wording is accurate there), so this branch is in
+    # practice the unequal-count case the rename rule alone would let through.
+    disjoint = bool(ckpt_names) and bool(dataset_names) and ckpt_names.isdisjoint(dataset_names)
+    if (renamed or disjoint) and _is_placeholder_camera_set(ckpt_names):
+        # A generic base being bound to a named rig for the first time — the
+        # canonical smolvla_base fine-tune. Recorded, not refused.
+        logger.warning(
+            "Fine-tune feature space: checkpoint %s carries placeholder camera "
+            "names (%s); binding them to dataset %s's cameras (%s).",
+            pretrained_path,
+            _describe_cameras(ckpt_names),
+            dataset_repo_id,
+            _describe_cameras(dataset_names),
+        )
+    elif renamed:
+        raise ValueError(
+            f"The checkpoint this run starts from ({pretrained_path}) expects "
+            f"cameras {_describe_cameras(ckpt_names)}, but the dataset "
+            f"{dataset_repo_id!r} provides {_describe_cameras(dataset_names)} — "
+            f"the same number of cameras under different names. Cameras are "
+            f"matched by name, so the two were almost certainly recorded on "
+            f"different robots, and the fine-tune would be building on a base "
+            f"that never saw this rig. Pick a base model whose camera names "
+            f"match this dataset, or train from scratch."
+        )
+    elif disjoint:
+        raise ValueError(
+            f"The checkpoint this run starts from ({pretrained_path}) expects "
+            f"cameras {_describe_cameras(ckpt_names)}, but the dataset "
+            f"{dataset_repo_id!r} provides {_describe_cameras(dataset_names)} — "
+            f"no camera in common. Cameras are matched by name, so none of the "
+            f"checkpoint's visual inputs would survive: its cameras are dropped "
+            f"and the dataset's are trained from scratch, on a base that never "
+            f"saw this rig. Pick a base model whose camera names match this "
+            f"dataset, or train from scratch."
+        )
+    elif ckpt_names != dataset_names:
+        # Unequal counts: a real sensor-suite change, but a legitimate one.
+        # Phase 1 only records it (phase 2 asks the user to confirm).
+        missing = ckpt_names - dataset_names
+        extra = dataset_names - ckpt_names
+        if missing:
+            logger.warning(
+                "Fine-tune feature space: checkpoint %s expects camera(s) %s that "
+                "dataset %s does not provide; those inputs will be dropped.",
+                pretrained_path,
+                _describe_cameras(missing),
+                dataset_repo_id,
+            )
+        if extra:
+            logger.warning(
+                "Fine-tune feature space: dataset %s adds camera(s) %s the "
+                "checkpoint %s was not trained on; those inputs start from scratch.",
+                dataset_repo_id,
+                _describe_cameras(extra),
+                pretrained_path,
+            )
+
+    # Resolution differences on the cameras both sides DO share. Allowed —
+    # lerobot resizes/re-tokenizes — but it moves ACT's token count and VRAM,
+    # so it should not pass unrecorded.
+    resized = []
+    for name in sorted(ckpt_names & dataset_names):
+        ckpt_hw = _image_height_width(ckpt_cameras[name])
+        dataset_hw = _image_height_width(dataset_cameras[name])
+        if ckpt_hw is None or dataset_hw is None or ckpt_hw == dataset_hw:
+            continue
+        resized.append(f"{name} {ckpt_hw[0]}x{ckpt_hw[1]} -> {dataset_hw[0]}x{dataset_hw[1]}")
+    if resized:
+        logger.warning(
+            "Fine-tune feature space: checkpoint %s and dataset %s disagree on "
+            "camera resolution (%s); training proceeds at the dataset's size.",
+            pretrained_path,
+            dataset_repo_id,
+            "; ".join(resized),
+        )
+
+
 def _generate_job_id(policy_type: str, dataset_repo_id: str) -> str:
     """Build a sortable, collision-free job id from policy type and dataset slug."""
     from .train import _SLUG_RE
@@ -1576,19 +1903,28 @@ class JobRegistry:
             )
 
         deferred_hub_ref: str | None = None
-        if (
-            config.policy_pretrained_path
-            and not config.resume
-            and target.runner == "local"
-            and needs_local_materialization(config.policy_pretrained_path)
-        ):
-            # A step-suffixed hub ref becomes the real directory the local
-            # trainer loads — but off-request, in _materialize_then_start,
-            # which rewrites policy_pretrained_path once the bytes are here.
-            # A cloud run keeps the ref: its container materializes the same
-            # ref pod-side (see the HF Jobs wrapper), because a host path is
-            # meaningless there.
-            deferred_hub_ref = config.policy_pretrained_path
+        if config.policy_pretrained_path and not config.resume:
+            # Deliberately BEFORE the materialization: this reads only the
+            # checkpoint's config.json (a few KB), so a contradicting pair is
+            # refused without first downloading the weights it names — and
+            # refused SYNCHRONOUSLY, as a 400, with no job record left behind.
+            # lerobot sizes the policy from the DATASET on this launch path and
+            # loads the weights non-strictly, so a checkpoint whose robot or
+            # camera set contradicts the selected dataset would otherwise train
+            # silently wrong (MT44).
+            _check_pretrained_feature_space(
+                config.policy_pretrained_path, config.dataset_repo_id
+            )
+            if target.runner == "local" and needs_local_materialization(
+                config.policy_pretrained_path
+            ):
+                # A step-suffixed hub ref becomes the real directory the local
+                # trainer loads — but off-request, in _materialize_then_start,
+                # which rewrites policy_pretrained_path once the bytes are here.
+                # A cloud run keeps the ref: its container materializes the same
+                # ref pod-side (see the HF Jobs wrapper), because a host path is
+                # meaningless there.
+                deferred_hub_ref = config.policy_pretrained_path
 
         with self._lock:
             # Authoritative local-run mutex: re-checked here, under the lock

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -243,6 +243,67 @@ def _resume_total_steps(config: TrainingRequest) -> int | None:
     return config.steps if config.resume else None
 
 
+def _resume_start_step(config: TrainingRequest) -> int | None:
+    """The GLOBAL step a resumed run starts at — the step of the checkpoint it
+    continues from. None for a fresh run (which starts at 0 by definition), and
+    None when nothing on the request names the checkpoint.
+
+    Complements _resume_total_steps rather than replacing it. Once lerobot's
+    tqdm bar exists, parse_metrics_into rebases off the bar's own total
+    (`resume_total − remaining_total + bar`), which is the better source
+    because it reflects the step lerobot ACTUALLY restored rather than what the
+    request asked for. This function covers the window BEFORE the first bar
+    frame — dataset scan, video-backend init, checkpoint load — which is many
+    seconds even on a small local dataset and minutes on a real one. See
+    _initial_metrics for why that window mattered.
+
+    `resume_from_step` is the request's own answer and is preferred. It is
+    None when the user resumed "the latest checkpoint": the resolvers
+    (_resolve_resume_config_path / _resolve_cloud_resume) pick the checkpoint
+    and write their choice back onto the config, so the fallbacks read the step
+    out of that — a zero-padded checkpoint dir name either way. A resume driven
+    by a hand-supplied `config_path` need not have that layout, hence the digit
+    check and the None it can still return.
+    """
+    if not config.resume:
+        return None
+    if config.resume_from_step is not None:
+        return config.resume_from_step
+    if config.resume_from_hub_step and config.resume_from_hub_step.isdigit():
+        return int(config.resume_from_hub_step)
+    if config.config_path:
+        # <output_dir>/checkpoints/<step_dir>/pretrained_model/train_config.json
+        step_dir = Path(config.config_path).parent.parent.name
+        if step_dir.isdigit():
+            return int(step_dir)
+    return None
+
+
+def _initial_metrics(config: TrainingRequest) -> TrainingMetrics:
+    """The metrics a job record starts life with.
+
+    A FRESH run starts at 0/0 — genuinely unknown until tqdm speaks, and the UI
+    reads total_steps == 0 as "Training starting…".
+
+    A RESUMED run does NOT start at zero, and saying so was the bug: for the
+    ~12s (small local dataset) to several minutes (real one) between launching
+    and lerobot's first tqdm frame, every progress reading in the app showed
+    the run at step 0 — a confident "0 / 60 · 0.0%" where the truth was
+    "10 / 60 · 16.7%". Worse, the monitoring chart treats a step going
+    BACKWARDS as a new run and clears its history, so the seeded parent-run
+    loss curve was wiped on mount by that same 0 before the first frame
+    restored it.
+
+    Seeding the known floor fixes every consumer at once, because they all read
+    these two fields. It is a floor, not a claim about progress: the parser
+    still owns the value from the first tqdm frame onwards.
+    """
+    start = _resume_start_step(config)
+    if start is None or not config.steps:
+        return TrainingMetrics()
+    return TrainingMetrics(current_step=start, total_steps=config.steps)
+
+
 def _read_log_metrics(
     path: Path, resume_total: int | None
 ) -> builtins.list[MetricsHistoryPoint]:
@@ -2023,6 +2084,10 @@ class JobRegistry:
                 started_at=time.time(),
                 runner=target.runner,
                 hf_flavor=target.flavor,
+                # Built AFTER the resume block above, which is what resolves a
+                # "latest checkpoint" request into a concrete step — see
+                # _initial_metrics / _resume_start_step.
+                metrics=_initial_metrics(config),
             )
 
             job_dir.mkdir(parents=True, exist_ok=True)

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -37,6 +37,7 @@ from queue import Empty, Queue
 from typing import Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel
+from tqdm.auto import tqdm as _base_tqdm
 
 from .train import TrainingRequest
 from .utils.config import is_valid_robot_name
@@ -545,6 +546,93 @@ class TailingJobRunner:
             logger.exception("Tailing loop error: %s", exc)
 
 
+class PreparingJobRunner:
+    """Stand-in runner for a local job whose base checkpoint is still downloading.
+
+    A local fine-tune from a Hub checkpoint has to materialize multi-GB weights
+    before the trainer can start. That used to happen inside POST /jobs/training,
+    which blocked the request for minutes with nothing on screen. The record is
+    now created first (state "running") and the download runs in a background
+    thread; this object stands in for the real LocalJobRunner meanwhile, so the
+    registry's existing seams keep working with no special cases:
+
+      * `stream_log_lines` feeds the monitor's 1Hz /jobs/{id}/logs poll — that
+        is how download progress reaches the screen. `emit` is the writing end:
+        it appends to the SAME log.jsonl the trainer will append to next, so
+        the download is part of the run's log rather than a separate channel.
+      * `stop` records the user's cancel, which the materialize thread reads
+        between the download and the spawn (see
+        JobRegistry._materialize_then_start).
+      * `is_running` is deliberately always True. The registry ends this
+        runner's role by REPLACING it in `_runners` (handoff) or removing it
+        (finalisation), both under the registry lock. Answering False would let
+        a watchdog tick that raced the handoff finalise the job as failed while
+        the trainer it had just spawned kept running.
+
+    Not a real process: `returncode` is always None, and `start` is never called
+    (the registry constructs this runner directly).
+    """
+
+    def __init__(self, log_file_path: Path | None = None) -> None:
+        self._log_file_path = log_file_path
+        self._log_queue: Queue[LogLine] = Queue()
+        self._cancelled = threading.Event()
+
+    def emit(self, message: str) -> None:
+        """Append one line to the job's log, for the file and the live poll.
+
+        Opens and closes the file per line on purpose: this runs at most every
+        few seconds, and holding no handle keeps the file free for
+        LocalJobRunner to open in append mode at handoff."""
+        line = LogLine(timestamp=time.time(), message=message)
+        if self._log_file_path is not None:
+            try:
+                self._log_file_path.parent.mkdir(parents=True, exist_ok=True)
+                with self._log_file_path.open("a") as f:
+                    f.write(line.model_dump_json() + "\n")
+            except Exception as exc:  # pragma: no cover — best-effort persist
+                logger.exception("Error writing to log file: %s", exc)
+        # Same cap as LocalJobRunner: never grow unbounded if nobody polls.
+        if self._log_queue.qsize() >= 1000:
+            with contextlib.suppress(Empty):
+                self._log_queue.get_nowait()
+        self._log_queue.put(line)
+
+    def cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+    # -- JobRunner protocol --
+
+    def start(self, job_id: str, config: TrainingRequest, output_dir: str) -> None:
+        raise RuntimeError("PreparingJobRunner stands in for a runner; it starts nothing")
+
+    def stop(self) -> None:
+        # A huggingface_hub download can't be interrupted mid-flight, so this
+        # only records the intent; the materialize thread acts on it when the
+        # download returns.
+        self._cancelled.set()
+
+    def is_running(self) -> bool:
+        return True
+
+    def returncode(self) -> int | None:
+        return None
+
+    def stream_log_lines(self) -> list[LogLine]:
+        out: list[LogLine] = []
+        try:
+            while True:
+                out.append(self._log_queue.get_nowait())
+        except Empty:
+            pass
+        return out
+
+    def wandb_run_url(self) -> str | None:
+        # No trainer has run yet, so there is no run URL to capture. Present
+        # only because the watchdog asks every runner for one.
+        return None
+
+
 _PERSIST_THROTTLE_SECONDS = 1.0
 
 
@@ -829,6 +917,140 @@ _HUB_ROOT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@root$")
 _HUB_CKPT_SUBDIR = "pretrained_model"
 
 
+def make_snapshot_progress_tqdm(
+    report: Callable[[int, int | None], None],
+) -> type[_base_tqdm]:
+    """A ``tqdm_class`` for ``snapshot_download`` that reports byte progress.
+
+    Lives here, next to ``download_hub_checkpoint_ref``, because both consumers
+    of a Hub download need it: the inference page's progress bar (rollout.py,
+    which imports it from this module) and the local fine-tune's
+    base-checkpoint download (JobRegistry._materialize_then_start). Verified
+    against the pinned huggingface_hub 1.21.0 contract:
+    ``snapshot_download(tqdm_class=cls)`` instantiates ``cls`` twice — a
+    file-count bar and ONE shared bytes bar (``unit="B"``). Both the plain-HTTP
+    and xet download paths funnel their chunk updates into that shared bar: as
+    each file's metadata arrives its size is added by mutating ``bar.total`` in
+    place followed by ``bar.refresh()``, and downloaded chunks arrive as
+    ``bar.update(n)``. So the recorder keys off ``unit == "B"``, hooks
+    ``update`` for bytes done, and hooks ``refresh`` as the signal that the
+    (growing) total changed. The total keeps growing while file metadata is
+    discovered, so percent can legitimately drop — honest, since the real total
+    isn't known upfront.
+
+    `report` is called from huggingface_hub's download worker threads, so an
+    implementation that touches shared state must do its own locking.
+
+    Subclasses the vanilla tqdm on purpose: huggingface_hub hands non-hf
+    subclasses full responsibility (no ``disable``/``name`` injection, no
+    HF_HUB_DISABLE_PROGRESS_BARS gating), so reporting can't be silently turned
+    off by env/log-level. The bar itself is force-disabled — nothing is drawn to
+    the server's stderr — which also means tqdm's own ``n`` never advances; bytes
+    are accumulated in ``_bytes_done`` instead. ``total`` IS still set and mutable
+    on a disabled tqdm, which is all ``refresh`` needs to read."""
+
+    class _ProgressTqdm(_base_tqdm):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._is_bytes_bar = kwargs.get("unit") == "B"
+            self._bytes_done = int(kwargs.get("initial") or 0)
+            kwargs["disable"] = True
+            super().__init__(*args, **kwargs)
+
+        def _report(self) -> None:
+            total = getattr(self, "total", None)
+            report(self._bytes_done, int(total) if total else None)
+
+        def update(self, n: float | None = 1) -> bool | None:
+            if self._is_bytes_bar:
+                if n:
+                    self._bytes_done += int(n)
+                self._report()
+            return super().update(n)
+
+        def refresh(self, *args: Any, **kwargs: Any) -> bool | None:
+            if self._is_bytes_bar:
+                self._report()
+            return super().refresh(*args, **kwargs)
+
+    return _ProgressTqdm
+
+
+def _format_bytes(n: int) -> str:
+    """Human byte size for a log line: 540 MB, 1.2 GB."""
+    if n >= 1024**3:
+        return f"{n / 1024**3:.1f} GB"
+    if n >= 1024**2:
+        return f"{n / 1024**2:.0f} MB"
+    if n >= 1024:
+        return f"{n / 1024:.0f} KB"
+    return f"{n} B"
+
+
+# Written to `error_message` when a fine-tune is stopped during its
+# base-checkpoint download — before any trainer existed, so there is no exit
+# code and no crash to report, and leaving the field None would show the user
+# nothing at all where the card says why the run ended.
+_PREPARE_STOPPED_MESSAGE = "Stopped at your request, before training started."
+
+
+# How far apart two download-progress log lines have to be to be worth writing.
+# Either condition is enough. snapshot_download calls back per CHUNK (thousands
+# of times for a multi-GB checkpoint) and every line is a JSON write plus a row
+# in the monitor's log panel, so an unthrottled hook would drown the log the
+# progress is meant to make readable.
+_DOWNLOAD_LOG_PERCENT_STEP = 5.0
+_DOWNLOAD_LOG_INTERVAL_SECONDS = 5.0
+
+
+class _DownloadProgressLogger:
+    """Turn snapshot_download's byte callbacks into occasional job-log lines.
+
+    Shaped for `make_snapshot_progress_tqdm`'s `report` contract, which fires
+    from several download worker threads at once — hence the lock, which also
+    keeps the emitted lines in ascending order.
+
+    A total of None (huggingface_hub is still discovering file sizes) is
+    reported as bytes-so-far rather than a fake percentage; the total also
+    grows as metadata arrives, so the percentage can legitimately go down."""
+
+    def __init__(self, emit: Callable[[str], None], label: str) -> None:
+        self._emit = emit
+        self._label = label
+        self._lock = threading.Lock()
+        self._last_at = 0.0
+        self._last_percent: float | None = None
+        self._last_bytes = 0
+
+    def __call__(self, bytes_done: int, bytes_total: int | None) -> None:
+        with self._lock:
+            if bytes_done <= self._last_bytes:
+                # A refresh with no new bytes (the total changed, or a bar was
+                # rebuilt). Nothing to say.
+                return
+            now = time.monotonic()
+            percent = (bytes_done / bytes_total * 100) if bytes_total else None
+            due = (now - self._last_at) >= _DOWNLOAD_LOG_INTERVAL_SECONDS
+            if percent is not None:
+                due = (
+                    due
+                    or self._last_percent is None
+                    or (percent - self._last_percent) >= _DOWNLOAD_LOG_PERCENT_STEP
+                )
+            if not due:
+                return
+            self._last_at = now
+            self._last_percent = percent
+            self._last_bytes = bytes_done
+            if percent is None:
+                message = f"Downloading base checkpoint {self._label} — {_format_bytes(bytes_done)} so far"
+            else:
+                message = (
+                    f"Downloading base checkpoint {self._label} — {percent:.0f}% "
+                    f"({_format_bytes(bytes_done)} / {_format_bytes(bytes_total or 0)})"
+                )
+            self._emit(message)
+
+
 def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None) -> str:
     """Download the model a hub checkpoint ref names; return its local dir.
 
@@ -883,7 +1105,30 @@ def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None) -> str:
     raise ValueError(f"Unrecognised policy ref: {ref!r}")
 
 
-def localize_pretrained_path(pretrained_path: str) -> str:
+def needs_local_materialization(pretrained_path: str) -> bool:
+    """Would `localize_pretrained_path` have to DOWNLOAD this value?
+
+    The cheap predicate twin of that function's early return, so the start path
+    can decide — without touching the network — whether a job needs the
+    background materialization step (see JobRegistry.start). Keep the two in
+    step: anything this answers False for must pass straight through there."""
+    return bool(_HUB_CKPT_REF_RE.match(pretrained_path))
+
+
+def hub_ref_step_label(ref: str) -> str:
+    """The step directory a hub ref names ('012000'), for log lines. Falls back
+    to the whole ref when it isn't step-suffixed."""
+    m = _HUB_CKPT_REF_RE.match(ref)
+    return m.group("step_dir") if m else ref
+
+
+def hub_ref_repo_id(ref: str) -> str:
+    """The repo half of a hub ref, for log lines. The whole ref if unparseable."""
+    m = _HUB_CKPT_REF_RE.match(ref) or _HUB_ROOT_REF_RE.match(ref)
+    return m.group("repo") if m else ref
+
+
+def localize_pretrained_path(pretrained_path: str, *, tqdm_class=None) -> str:
     """Make a ``--policy.pretrained_path`` value loadable by a LOCAL trainer.
 
     A step-suffixed hub ref is materialized here, on this machine, into the real
@@ -896,13 +1141,17 @@ def localize_pretrained_path(pretrained_path: str) -> str:
     materializes the same ref pod-side and rewrites the argv), because a host
     path means nothing on the pod. One rule, two execution sites.
 
-    A failed download becomes a ValueError (→ HTTP 400) naming the checkpoint,
-    like every other user-facing refusal on the start path — the alternative is
-    a raw Hub exception surfacing as a 500 with nothing actionable in it."""
-    if not _HUB_CKPT_REF_RE.match(pretrained_path):
+    A failed download becomes a ValueError naming the checkpoint, rather than a
+    raw Hub exception with nothing actionable in it. On the local start path the
+    download no longer runs inside the request (see JobRegistry.start), so that
+    message is now written onto the job record's `error_message` instead of
+    becoming an HTTP 400 — same words, later delivery.
+
+    `tqdm_class` is forwarded to the download for byte-progress reporting."""
+    if not needs_local_materialization(pretrained_path):
         return pretrained_path
     try:
-        return download_hub_checkpoint_ref(pretrained_path)
+        return download_hub_checkpoint_ref(pretrained_path, tqdm_class=tqdm_class)
     except Exception as exc:
         raise ValueError(
             f"Could not download the base checkpoint {pretrained_path!r} to fine-tune from: {exc}"
@@ -1097,6 +1346,12 @@ class JobRegistry:
         self._records: dict[str, JobRecord] = {}
         self._runners: dict[str, JobRunner] = {}
         self._last_persist_at: dict[str, float] = {}
+
+        # job_id -> the thread materializing that job's base checkpoint before
+        # its trainer can start (see _materialize_then_start). Entries are left
+        # behind once the thread finishes — a finished Thread object is inert
+        # and joinable, and dropping it would race a caller that wants to join.
+        self._prepare_threads: dict[str, threading.Thread] = {}
 
         self._stop_watchdog = threading.Event()
         self._watchdog_thread: threading.Thread | None = None
@@ -1293,13 +1548,18 @@ class JobRegistry:
         # ------------------------------------------------------------------
         # Pretrained-path resolution runs OUTSIDE the registry lock.
         #
-        # It reads the Hub (the source's checkpoint listing) and, for a local
-        # run, DOWNLOADS the base checkpoint — minutes and gigabytes.
+        # It reads the Hub (the source's checkpoint listing) — seconds at worst.
         # self._lock is taken by list / get / stop / delete, so holding it
         # across that would freeze the whole job interface (the MT23 coupling).
-        # Nothing is registered yet either way, so a bad selection still fails
-        # with no orphaned record; the registry lookup it needs takes the lock
-        # briefly on its own.
+        # Nothing is registered yet, so a bad selection still fails with no
+        # orphaned record; the registry lookup it needs takes the lock briefly
+        # on its own.
+        #
+        # What does NOT happen here any more is the multi-GB DOWNLOAD a local
+        # fine-tune needs. Every cheap refusal above and below stays synchronous
+        # (a bad request must still fail fast with a clear 400), but the
+        # materialization itself is deferred to a background thread that starts
+        # after the record exists — see the `deferred_hub_ref` branch below.
         # ------------------------------------------------------------------
         if config.finetune_from_job_id:
             # Fine-tune: turn the selected source run + step into the
@@ -1315,14 +1575,20 @@ class JobRegistry:
                 source, config.finetune_from_step
             )
 
-        if config.policy_pretrained_path and not config.resume and target.runner == "local":
+        deferred_hub_ref: str | None = None
+        if (
+            config.policy_pretrained_path
+            and not config.resume
+            and target.runner == "local"
+            and needs_local_materialization(config.policy_pretrained_path)
+        ):
             # A step-suffixed hub ref becomes the real directory the local
-            # trainer loads. A cloud run keeps the ref: its container
-            # materializes the same ref pod-side (see the HF Jobs wrapper),
-            # because a host path is meaningless there.
-            config.policy_pretrained_path = localize_pretrained_path(
-                config.policy_pretrained_path
-            )
+            # trainer loads — but off-request, in _materialize_then_start,
+            # which rewrites policy_pretrained_path once the bytes are here.
+            # A cloud run keeps the ref: its container materializes the same
+            # ref pod-side (see the HF Jobs wrapper), because a host path is
+            # meaningless there.
+            deferred_hub_ref = config.policy_pretrained_path
 
         with self._lock:
             # Authoritative local-run mutex: re-checked here, under the lock
@@ -1428,35 +1694,177 @@ class JobRegistry:
             self._persist(record, force=True)
 
             log_path = _job_log_path(self._output_root, job_id)
-            if target.runner == "local":
-                runner = LocalJobRunner(record.metrics, log_file_path=log_path)
-            else:
-                runner = HfCloudJobRunner(record.metrics, log_path, target.flavor)
 
-            try:
-                runner.start(job_id, config, lerobot_output_dir)
-            except Exception as exc:
-                logger.exception("Failed to start runner for job %s", job_id)
-                record.state = "failed"
-                record.ended_at = time.time()
-                record.error_message = f"Failed to start runner: {exc}"
+            if deferred_hub_ref is not None:
+                # The base checkpoint still has to be downloaded (GBs, minutes).
+                # Hand the caller its job id NOW — the record exists, is
+                # "running", and has a log file — and do the download in a
+                # thread, which then starts the real trainer. The monitor opens
+                # immediately and tails the download instead of the request
+                # hanging with nothing on screen.
+                #
+                # No new JobState for this window: the job is "running" from the
+                # user's point of view (they asked for a run and one is being
+                # got ready), and a fourth state would ripple through the
+                # watchdog's finalisation, the library chips and isJobActive.
+                # What stands in for the missing process is PreparingJobRunner —
+                # registered here, under the same lock as the record, so /logs
+                # and Stop find a runner from the first request onwards.
+                prep = PreparingJobRunner(log_file_path=log_path)
+                self._runners[job_id] = prep
+                prep.emit(
+                    f"Preparing fine-tune: downloading base checkpoint "
+                    f"{hub_ref_step_label(deferred_hub_ref)} from "
+                    f"{hub_ref_repo_id(deferred_hub_ref)}…"
+                )
+                thread = threading.Thread(
+                    target=self._materialize_then_start,
+                    args=(job_id, deferred_hub_ref, lerobot_output_dir, prep),
+                    name=f"job-{job_id}-prepare",
+                    daemon=True,
+                )
+                # Kept (not popped on completion) so a caller — today only the
+                # tests — can join the thread instead of polling for its effect.
+                self._prepare_threads[job_id] = thread
+                thread.start()
+            else:
+                if target.runner == "local":
+                    runner = LocalJobRunner(record.metrics, log_file_path=log_path)
+                else:
+                    runner = HfCloudJobRunner(record.metrics, log_path, target.flavor)
+
+                try:
+                    runner.start(job_id, config, lerobot_output_dir)
+                except Exception as exc:
+                    logger.exception("Failed to start runner for job %s", job_id)
+                    record.state = "failed"
+                    record.ended_at = time.time()
+                    record.error_message = f"Failed to start runner: {exc}"
+                    self._persist(record, force=True)
+                    raise
+
+                # Capture runner-specific identifiers.
+                if target.runner == "local":
+                    record.process_pid = runner.pid()
+                else:
+                    record.hf_job_id = runner.hf_job_id()
+                    record.hf_job_url = runner.hf_job_url()
+                    # config was mutated by HfCloudJobRunner.start to set
+                    # policy_repo_id; mirror it onto the record for the UI.
+                    record.hf_repo_id = config.policy_repo_id
+
                 self._persist(record, force=True)
-                raise
-
-            # Capture runner-specific identifiers.
-            if target.runner == "local":
-                record.process_pid = runner.pid()
-            else:
-                record.hf_job_id = runner.hf_job_id()
-                record.hf_job_url = runner.hf_job_url()
-                # config was mutated by HfCloudJobRunner.start to set
-                # policy_repo_id; mirror it onto the record for the UI.
-                record.hf_repo_id = config.policy_repo_id
-
-            self._persist(record, force=True)
-            self._runners[job_id] = runner
+                self._runners[job_id] = runner
         self._notify_change()
         return record
+
+    def _materialize_then_start(
+        self,
+        job_id: str,
+        ref: str,
+        output_dir: str,
+        prep: PreparingJobRunner,
+    ) -> None:
+        """Download a local fine-tune's base checkpoint, then start its trainer.
+
+        Runs in its own thread so POST /jobs/training can return the job id
+        immediately (see JobRegistry.start). Everything that can refuse the
+        request cheaply already ran, synchronously, before the record existed;
+        what is left here can only fail for reasons that belong ON the record:
+
+          * download failed  → `failed`, carrying localize_pretrained_path's own
+            "Could not download the base checkpoint …" wording, which used to
+            reach the user as an HTTP 400.
+          * user pressed Stop → `interrupted`, with a message saying so, exactly
+            like stopping a live trainer would.
+          * trainer failed to spawn → `failed`, same wording as the synchronous
+            path's "Failed to start runner: …".
+
+        No synthetic exit code is invented for any of them: there was no
+        process, so `exit_code` stays None.
+
+        On the cancel check: a huggingface_hub download cannot be interrupted
+        mid-flight, so a Stop pressed while bytes are moving takes effect HERE —
+        after the download returns and before the trainer is spawned. The bytes
+        are already on disk (and cached for the next attempt); what the user
+        gets is a run that never starts training, which is what they asked for.
+        The spawn + runner handoff happen inside the registry lock, so a stop can
+        neither be missed (spawning a trainer nobody will signal) nor land on a
+        runner that has already been replaced.
+        """
+        reporter = _DownloadProgressLogger(prep.emit, hub_ref_step_label(ref))
+        try:
+            local_path = localize_pretrained_path(
+                ref, tqdm_class=make_snapshot_progress_tqdm(reporter)
+            )
+        except Exception as exc:
+            logger.exception("Base-checkpoint download failed for job %s", job_id)
+            message = str(exc)
+            prep.emit(message)
+            self._finalize_prepare(job_id, "failed", message)
+            return
+
+        notify = False
+        try:
+            with self._lock:
+                if prep.cancelled():
+                    prep.emit("Stopped before the trainer started.")
+                    self._finalize_prepare_locked(
+                        job_id, "interrupted", _PREPARE_STOPPED_MESSAGE
+                    )
+                    notify = True
+                    return
+                record = self._records.get(job_id)
+                if record is None or record.state != "running":
+                    # Deleted, or finalised by someone else, while the bytes
+                    # moved. Nothing to start, nothing to report.
+                    self._runners.pop(job_id, None)
+                    return
+                prep.emit("Base checkpoint ready — starting the trainer.")
+                record.config.policy_pretrained_path = local_path
+                runner = LocalJobRunner(
+                    record.metrics,
+                    log_file_path=_job_log_path(self._output_root, job_id),
+                )
+                try:
+                    runner.start(job_id, record.config, output_dir)
+                except Exception as exc:
+                    logger.exception("Failed to start runner for job %s", job_id)
+                    self._finalize_prepare_locked(
+                        job_id, "failed", f"Failed to start runner: {exc}"
+                    )
+                    notify = True
+                    return
+                record.process_pid = runner.pid()
+                self._runners[job_id] = runner
+                self._persist(record, force=True)
+                notify = True
+        finally:
+            if notify:
+                self._notify_change()
+
+    def _finalize_prepare(self, job_id: str, state: JobState, error_message: str) -> None:
+        """Lock-taking wrapper around _finalize_prepare_locked."""
+        with self._lock:
+            self._finalize_prepare_locked(job_id, state, error_message)
+        self._notify_change()
+
+    def _finalize_prepare_locked(self, job_id: str, state: JobState, error_message: str) -> None:
+        """Finalise a job that never reached its trainer. Caller holds _lock.
+
+        The watchdog's finalisation minus the exit code: it only ever sees jobs
+        with a runner that HAD a process, and this one never did. Removing the
+        PreparingJobRunner from `_runners` here is what ends its role — until
+        then it answers is_running() True precisely so the watchdog leaves this
+        window alone."""
+        record = self._records.get(job_id)
+        if record is None or record.state != "running":
+            return
+        record.state = state
+        record.ended_at = time.time()
+        record.error_message = error_message
+        self._runners.pop(job_id, None)
+        self._persist(record, force=True)
 
     def _unique_job_id(self, policy_type: str, dataset_repo_id: str) -> str:
         """_generate_job_id with a collision guard. The generated id embeds a
@@ -1598,6 +2006,15 @@ class JobRegistry:
         return record
 
     def stop(self, job_id: str) -> JobRecord:
+        """Ask a running job to stop, and wait briefly for the new state.
+
+        Works during a local fine-tune's base-checkpoint download too: that
+        window has a PreparingJobRunner registered in place of the trainer, so
+        the cancel is recorded on it as usual and the materialize thread
+        finalises the run as `interrupted` when the download returns (it can't
+        be aborted mid-flight — see _materialize_then_start). The 2s wait below
+        will usually time out on that path, so the caller sees `running` and
+        learns the outcome from the next poll."""
         with self._lock:
             record = self._records.get(job_id)
             if record is None:
@@ -1773,6 +2190,7 @@ class JobRegistry:
             self._records.pop(job_id, None)
             self._runners.pop(job_id, None)
             self._last_persist_at.pop(job_id, None)
+            self._prepare_threads.pop(job_id, None)
         with contextlib.suppress(FileNotFoundError):
             shutil.rmtree(_job_dir(self._output_root, job_id))
         self._notify_change()
@@ -2072,7 +2490,9 @@ __all__ = [
     "MetricsHistoryPoint",
     "JobRunner",
     "LocalJobRunner",
+    "PreparingJobRunner",
     "JobRegistry",
+    "make_snapshot_progress_tqdm",
     "JobAlreadyRunningError",
     "JobNotFoundError",
     "JobNotRunningError",

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -590,6 +590,11 @@ _TRAIN_CONFIG_NAME = "train_config.json"
 _HUB_TRAINING_STATE_FILE = "training_state/training_step.json"
 
 
+# Plain-language names for the runner ids, so a user-facing refusal reads like
+# the Compute control the user actually clicked rather than an internal literal.
+_RUNNER_LABELS = {"local": "Local — your machine", "hf_cloud": "Hugging Face Cloud"}
+
+
 def _resolve_cloud_resume(source: JobRecord, step: int | None) -> tuple[str, str]:
     """Return (repo_id, step_dir) identifying the Hub checkpoint a cloud run
     should resume from (`step` = None ⇒ the latest available on the Hub).
@@ -1202,6 +1207,46 @@ class JobRegistry:
                         raise ValueError(
                             f"Resume source {config.resume_from_job_id!r} not found."
                         )
+                    # A completed run is not resumable — on ANY runner, and
+                    # regardless of how the request got here (the UI hides the
+                    # button; this catches a direct API call).
+                    #
+                    # Resume restores the optimizer AND the LR schedule's
+                    # position, and a run that reached its target has spent its
+                    # schedule: SmolVLA's preset cosine-decays to a 2.5e-6 floor
+                    # over a fixed 30k-step horizon, so continuing past the
+                    # target trains at floor LR. The loss chart flattens and
+                    # reads as convergence while the run is barely learning —
+                    # the failure is silent, which is why this refuses rather
+                    # than warns. Fine-tune starts a fresh schedule from the
+                    # same weights, which is the intended way to build on a
+                    # completed run.
+                    if source.state == "done":
+                        raise ValueError(
+                            f"Run {source.id!r} already reached its step target, so there is "
+                            "nothing to resume — its learning-rate schedule is finished and a "
+                            "continuation would train at the schedule's floor. Fine-tune from "
+                            "its final checkpoint instead."
+                        )
+                    # A resume continues on the PARENT'S runner, full stop.
+                    # Neither cross direction works today (F7): cloud→local
+                    # points --config_path at a host directory that only ever
+                    # existed inside the pod, so the run dies at startup; and
+                    # local→cloud is worse — the pod has no access to the host
+                    # checkpoint, so it silently restarts from step 0 while the
+                    # record calls itself a resume. The form pins the Compute
+                    # control on a resume; this is the defense-in-depth half,
+                    # for a direct API call that flips it anyway.
+                    #
+                    # Only local/hf_cloud parents reach here: an imported record
+                    # is created with state="done", so the refusal above already
+                    # took it (imported models are fine-tune sources, never
+                    # resume sources).
+                    if source.runner != target.runner:
+                        raise ValueError(
+                            "Cross-runner resume isn't supported yet — this run continues on "
+                            f"{_RUNNER_LABELS.get(source.runner, source.runner)}. (F7)"
+                        )
                     if source.runner == "hf_cloud":
                         # An HF Job is immutable once ended: resuming a cloud run
                         # launches a NEW cloud job that continues from the parent's
@@ -1221,8 +1266,8 @@ class JobRegistry:
                 elif not config.config_path:
                     raise ValueError(
                         "Resume is on but no source checkpoint was selected. Use "
-                        '"Continue" on a completed local run rather than toggling '
-                        "resume manually."
+                        '"Continue" on a local run that stopped short of its step '
+                        "target rather than toggling resume manually."
                     )
 
             job_id = self._unique_job_id(config.policy_type, config.dataset_repo_id)

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -34,7 +34,7 @@ from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from queue import Empty, Queue
-from typing import Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
@@ -702,10 +702,16 @@ def _resolve_finetune_pretrained_path(source: JobRecord, step: int | None) -> st
       * imported local / normal local run → a `local` ref that is the absolute
         pretrained_model dir; returned directly (e.g. a flat imported dir
         becomes a step-0 checkpoint whose ref is the dir itself).
-      * imported hub / cloud run → a `hub` ref ('repo@checkpoints/<step>' or
-        'repo@root'); we return the plain repo id (the root model). lerobot's
-        pretrained_path takes a repo id, not a sub-path, so a specific hub
-        sub-step can't be targeted — see the limitation note below.
+      * imported hub / cloud run at a specific step → the step-suffixed hub ref
+        'repo@checkpoints/<step_dir>', VERBATIM. lerobot can't load a hub
+        sub-path directly, so the ref is materialized into a real directory
+        before the trainer starts — host-side by localize_pretrained_path for a
+        local run, pod-side by the HF Jobs wrapper for a cloud one. This
+        function does not download: it names the checkpoint, and the caller
+        materializes it wherever the trainer will run (MT2).
+      * imported hub / cloud run whose checkpoint is the whole repo ('repo@root')
+        → the plain repo id. The root IS the pretrained_model, which lerobot
+        resolves by itself, so there is nothing to materialize.
 
     Raises ValueError (→ HTTP 400) with a user-facing message when the source
     has no usable checkpoint.
@@ -734,12 +740,15 @@ def _resolve_finetune_pretrained_path(source: JobRecord, step: int | None) -> st
     if chosen.source == "local":
         # chosen.ref is the absolute pretrained_model dir lerobot loads directly.
         return chosen.ref
-    # Hub ref: 'repo@checkpoints/<step_dir>' or 'repo@root'. lerobot's
-    # pretrained_path accepts a repo id (root model), not a sub-step path, so we
-    # hand back the repo portion. Fine-tuning from a specific hub sub-step isn't
-    # supported here — it uses whatever weights live at the repo root.
-    repo_id = chosen.ref.split("@", 1)[0]
-    return repo_id
+    if _HUB_ROOT_REF_RE.match(chosen.ref):
+        # The repo root IS the model; lerobot loads a repo id as-is, so hand back
+        # the repo portion and let it fetch. Nothing to materialize.
+        return chosen.ref.split("@", 1)[0]
+    # A specific step: keep the whole ref. Truncating it here is what MT2 was —
+    # the run silently trained from repo-ROOT weights while the UI reported the
+    # step the user picked. The ref is turned into a directory downstream, on
+    # whichever machine will run the trainer.
+    return chosen.ref
 
 
 _CLOUD_CKPT_TTL_SECONDS = 30.0
@@ -815,6 +824,89 @@ _LANGUAGE_CONDITIONED_POLICY_TYPES = {"smolvla", "pi0", "pi0_fast", "pi05"}
 
 _HUB_CKPT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@checkpoints/(?P<step_dir>\d+)$")
 _HUB_ROOT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@root$")
+
+# What a hub ref names inside the snapshot, once downloaded.
+_HUB_CKPT_SUBDIR = "pretrained_model"
+
+
+def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None) -> str:
+    """Download the model a hub checkpoint ref names; return its local dir.
+
+    THE resolution rule for a hub ref, shared by every consumer so a ref means
+    one thing everywhere:
+
+      * 'repo@checkpoints/<step_dir>' → only that step's ``pretrained_model/``
+        is pulled, and the returned path is that directory. lerobot's
+        ``pretrained_path`` addresses a local dir or a repo ROOT and has no
+        subfolder argument (``PreTrainedConfig.from_pretrained`` hands the id
+        straight to ``hf_hub_download``), so materializing the sub-path here is
+        the only way a specific step can be loaded at all.
+      * 'repo@root' → the whole repo IS the pretrained_model; ``checkpoints/**``
+        and ``training_state/**`` are excluded because neither is needed to load
+        the policy and both can be multi-GB.
+
+    ``tqdm_class`` is forwarded to snapshot_download for byte-progress reporting
+    (the inference page's download bar). This function itself has no session or
+    UI state — callers own their own progress/phase reporting — so it is safe to
+    call from a training request without touching a live rollout.
+
+    Raises ValueError for anything that isn't a hub ref. Downloads can take
+    minutes and pull GBs: never call it while holding a lock others need.
+    """
+    # Imported at CALL time, not module scope, so that patching
+    # `huggingface_hub.snapshot_download` intercepts it — the seam the inference
+    # download tests already use, and the same reason _read_checkpoint_config
+    # re-imports hf_hub_download.
+    from huggingface_hub import snapshot_download
+
+    dl_kwargs: dict[str, Any] = {}
+    if tqdm_class is not None:
+        dl_kwargs["tqdm_class"] = tqdm_class
+    m = _HUB_CKPT_REF_RE.match(ref)
+    if m:
+        repo_id, step_dir = m.group("repo"), m.group("step_dir")
+        local_root = snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            allow_patterns=[f"checkpoints/{step_dir}/{_HUB_CKPT_SUBDIR}/*"],
+            **dl_kwargs,
+        )
+        return str(Path(local_root) / "checkpoints" / step_dir / _HUB_CKPT_SUBDIR)
+    m = _HUB_ROOT_REF_RE.match(ref)
+    if m:
+        return snapshot_download(
+            repo_id=m.group("repo"),
+            repo_type="model",
+            ignore_patterns=["checkpoints/**", "training_state/**"],
+            **dl_kwargs,
+        )
+    raise ValueError(f"Unrecognised policy ref: {ref!r}")
+
+
+def localize_pretrained_path(pretrained_path: str) -> str:
+    """Make a ``--policy.pretrained_path`` value loadable by a LOCAL trainer.
+
+    A step-suffixed hub ref is materialized here, on this machine, into the real
+    directory lerobot will load (see download_hub_checkpoint_ref). Everything
+    else passes through untouched: an absolute local dir is already what lerobot
+    wants, and a bare repo id is a repo ROOT, which lerobot resolves itself —
+    downloading it here would just duplicate the trainer's own fetch.
+
+    The cloud twin of this call happens IN the container (the HF Jobs wrapper
+    materializes the same ref pod-side and rewrites the argv), because a host
+    path means nothing on the pod. One rule, two execution sites.
+
+    A failed download becomes a ValueError (→ HTTP 400) naming the checkpoint,
+    like every other user-facing refusal on the start path — the alternative is
+    a raw Hub exception surfacing as a 500 with nothing actionable in it."""
+    if not _HUB_CKPT_REF_RE.match(pretrained_path):
+        return pretrained_path
+    try:
+        return download_hub_checkpoint_ref(pretrained_path)
+    except Exception as exc:
+        raise ValueError(
+            f"Could not download the base checkpoint {pretrained_path!r} to fine-tune from: {exc}"
+        ) from exc
 
 
 def _read_checkpoint_config(ckpt: JobCheckpoint) -> dict[str, object]:
@@ -1122,6 +1214,25 @@ class JobRegistry:
 
     # -- public API --
 
+    def _assert_no_running_local(self, target: JobTarget) -> None:
+        """Raise JobAlreadyRunningError if a local training is already running.
+
+        Local trainings are bounded by this machine's GPU/USB resources, so at
+        most one runs at a time. Cloud trainings each get their own remote
+        container, so any number can be in flight in parallel.
+
+        Takes NO lock, so it is callable both inside and outside the registry's
+        critical section (self._lock is a plain Lock — re-entering it would
+        deadlock). Iterates a snapshot, so a concurrent mutation can't break the
+        walk. `start` calls it twice on purpose: once early to fail fast, and
+        once under the lock that inserts the record — the latter is the one that
+        actually enforces the invariant."""
+        if target.runner != "local":
+            return
+        for r in list(self._records.values()):
+            if r.state == "running" and r.runner == "local":
+                raise JobAlreadyRunningError(r.id)
+
     def list(self, limit: int = 10) -> builtins.list[JobRecord]:
         with self._lock:
             records = list(self._records.values())
@@ -1161,40 +1272,63 @@ class JobRegistry:
             if get_hub_status(config.dataset_repo_id).get("status") == "local_only":
                 raise DatasetNotOnHubError(config.dataset_repo_id)
 
-        with self._lock:
-            # Local trainings are bounded by this machine's GPU/USB resources,
-            # so at most one runs at a time. Cloud trainings each get their
-            # own remote container, so any number can be in flight in parallel.
-            if target.runner == "local":
-                for r in self._records.values():
-                    if r.state == "running" and r.runner == "local":
-                        raise JobAlreadyRunningError(r.id)
+        # Resume and fine-tune are distinct and mutually exclusive: resume
+        # continues optimizer+step from a checkpoint (needs training_state);
+        # fine-tune starts a FRESH run whose weights are init'd from a
+        # checkpoint (weights-only is fine). Reject the nonsensical combo up
+        # front rather than letting one silently win.
+        if config.resume and config.finetune_from_job_id:
+            raise ValueError(
+                "A run can't both resume and fine-tune. Resume continues an "
+                "existing run's optimizer/step; fine-tune starts a fresh run "
+                "from a checkpoint's weights."
+            )
 
-            # Resume and fine-tune are distinct and mutually exclusive: resume
-            # continues optimizer+step from a checkpoint (needs training_state);
-            # fine-tune starts a FRESH run whose weights are init'd from a
-            # checkpoint (weights-only is fine). Reject the nonsensical combo up
-            # front rather than letting one silently win.
-            if config.resume and config.finetune_from_job_id:
-                raise ValueError(
-                    "A run can't both resume and fine-tune. Resume continues an "
-                    "existing run's optimizer/step; fine-tune starts a fresh run "
-                    "from a checkpoint's weights."
-                )
+        # Fail fast on the local-run mutex before any of the (possibly slow)
+        # pretrained-path work below. Re-checked under the lock at record
+        # creation — THAT is the authoritative check; this one only spares a
+        # doomed request a needless download.
+        self._assert_no_running_local(target)
 
+        # ------------------------------------------------------------------
+        # Pretrained-path resolution runs OUTSIDE the registry lock.
+        #
+        # It reads the Hub (the source's checkpoint listing) and, for a local
+        # run, DOWNLOADS the base checkpoint — minutes and gigabytes.
+        # self._lock is taken by list / get / stop / delete, so holding it
+        # across that would freeze the whole job interface (the MT23 coupling).
+        # Nothing is registered yet either way, so a bad selection still fails
+        # with no orphaned record; the registry lookup it needs takes the lock
+        # briefly on its own.
+        # ------------------------------------------------------------------
+        if config.finetune_from_job_id:
             # Fine-tune: turn the selected source run + step into the
             # pretrained_path lerobot loads weights from. A fresh run (resume
-            # stays false); no training_state required. Resolved under the lock
-            # and before the record so a bad selection fails with no orphan.
-            if config.finetune_from_job_id:
+            # stays false); no training_state required.
+            with self._lock:
                 source = self._records.get(config.finetune_from_job_id)
-                if source is None:
-                    raise ValueError(
-                        f"Fine-tune source {config.finetune_from_job_id!r} not found."
-                    )
-                config.policy_pretrained_path = _resolve_finetune_pretrained_path(
-                    source, config.finetune_from_step
+            if source is None:
+                raise ValueError(
+                    f"Fine-tune source {config.finetune_from_job_id!r} not found."
                 )
+            config.policy_pretrained_path = _resolve_finetune_pretrained_path(
+                source, config.finetune_from_step
+            )
+
+        if config.policy_pretrained_path and not config.resume and target.runner == "local":
+            # A step-suffixed hub ref becomes the real directory the local
+            # trainer loads. A cloud run keeps the ref: its container
+            # materializes the same ref pod-side (see the HF Jobs wrapper),
+            # because a host path is meaningless there.
+            config.policy_pretrained_path = localize_pretrained_path(
+                config.policy_pretrained_path
+            )
+
+        with self._lock:
+            # Authoritative local-run mutex: re-checked here, under the lock
+            # that also inserts the record, so two concurrent starts can't both
+            # pass. (The pre-flight copy above is only a fail-fast.)
+            self._assert_no_running_local(target)
 
             # Resume: turn the selected source run + step into the config_path
             # lerobot needs. Do this under the lock (source lookup) and before

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -37,13 +37,12 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel
-from tqdm.auto import tqdm as _base_tqdm
 
 from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 
 from .arm_identity import ArmIdentityError, ArmSlot, verify_devices
 from .camera_preview import camera_preview_manager
-from .jobs import download_hub_checkpoint_ref
+from .jobs import download_hub_checkpoint_ref, make_snapshot_progress_tqdm
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .record import _DEFAULT_FOURCC
 from .utils.config import (
@@ -241,60 +240,6 @@ def _detect_device() -> str:
     except Exception:
         pass
     return "cpu"
-
-
-def make_snapshot_progress_tqdm(
-    report: Callable[[int, int | None], None],
-) -> type[_base_tqdm]:
-    """A ``tqdm_class`` for ``snapshot_download`` that reports byte progress.
-
-    Mirrored (name + shape kept identical) from
-    ``datasets.make_snapshot_progress_tqdm`` on the sibling
-    ``claude/download-progress`` branch so the eventual landing of that branch
-    can dedup to a single shared helper. Verified against the pinned
-    huggingface_hub 1.21.0 contract: ``snapshot_download(tqdm_class=cls)``
-    instantiates ``cls`` twice — a file-count bar and ONE shared bytes bar
-    (``unit="B"``). Both the plain-HTTP and xet download paths funnel their chunk
-    updates into that shared bar: as each file's metadata arrives its size is
-    added by mutating ``bar.total`` in place followed by ``bar.refresh()``, and
-    downloaded chunks arrive as ``bar.update(n)``. So the recorder keys off
-    ``unit == "B"``, hooks ``update`` for bytes done, and hooks ``refresh`` as
-    the signal that the (growing) total changed. The total keeps growing while
-    file metadata is discovered, so percent can legitimately drop — honest, since
-    the real total isn't known upfront.
-
-    Subclasses the vanilla tqdm on purpose: huggingface_hub hands non-hf
-    subclasses full responsibility (no ``disable``/``name`` injection, no
-    HF_HUB_DISABLE_PROGRESS_BARS gating), so reporting can't be silently turned
-    off by env/log-level. The bar itself is force-disabled — nothing is drawn to
-    the server's stderr — which also means tqdm's own ``n`` never advances; bytes
-    are accumulated in ``_bytes_done`` instead. ``total`` IS still set and mutable
-    on a disabled tqdm, which is all ``refresh`` needs to read."""
-
-    class _ProgressTqdm(_base_tqdm):
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            self._is_bytes_bar = kwargs.get("unit") == "B"
-            self._bytes_done = int(kwargs.get("initial") or 0)
-            kwargs["disable"] = True
-            super().__init__(*args, **kwargs)
-
-        def _report(self) -> None:
-            total = getattr(self, "total", None)
-            report(self._bytes_done, int(total) if total else None)
-
-        def update(self, n: float | None = 1) -> bool | None:
-            if self._is_bytes_bar:
-                if n:
-                    self._bytes_done += int(n)
-                self._report()
-            return super().update(n)
-
-        def refresh(self, *args: Any, **kwargs: Any) -> bool | None:
-            if self._is_bytes_bar:
-                self._report()
-            return super().refresh(*args, **kwargs)
-
-    return _ProgressTqdm
 
 
 def _report_download_progress(bytes_done: int, bytes_total: int | None) -> None:

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -43,6 +43,7 @@ from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 
 from .arm_identity import ArmIdentityError, ArmSlot, verify_devices
 from .camera_preview import camera_preview_manager
+from .jobs import download_hub_checkpoint_ref
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .record import _DEFAULT_FOURCC
 from .utils.config import (
@@ -131,6 +132,10 @@ _state_lock = threading.Lock()
 # cooperative cancellation checkpoint inside _prepare_robot), so it's a
 # bounded wait-and-report rather than a true force-release.
 _STARTUP_STOP_JOIN_TIMEOUT_S = 5.0
+# The two hub-ref shapes /jobs/{id}/checkpoints hands out. Kept here for the
+# cheap no-network shape check below; the DOWNLOAD they imply lives once, in
+# jobs.download_hub_checkpoint_ref, so inference and fine-tune resolve a ref
+# identically.
 _HUB_REF_RE = re.compile(r"^(?P<repo>[^@]+)@checkpoints/(?P<step_dir>\d+)$")
 _HUB_ROOT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@root$")
 # lerobot prints this once per run, the moment its main control loop is
@@ -335,49 +340,28 @@ def _resolve_policy_path(policy_ref: str, report: Callable[[int, int | None], No
     When ``report`` is given, snapshot_download streams byte progress through it
     (see make_snapshot_progress_tqdm) so the inference page can show a real
     download bar. Local refs never download, so they never report and never flip
-    the phase."""
+    the phase.
+
+    The download itself (which patterns each ref shape pulls, and what path it
+    yields) lives in jobs.download_hub_checkpoint_ref, shared with the fine-tune
+    path so a ref resolves to the same weights whoever asks. This wrapper owns
+    only what is inference-specific: the local-dir short-circuit, the
+    downloading_model phase, and the progress hook."""
     if Path(policy_ref).is_dir():
         # A local checkpoint — nothing to fetch, so no downloading_model phase.
         return policy_ref
-    from huggingface_hub import snapshot_download
+    if not _policy_ref_is_valid(policy_ref):
+        raise ValueError(f"Unrecognised policy ref: {policy_ref!r}")
 
-    # A Hub ref: snapshot_download may pull hundreds of MB and take minutes.
+    # A Hub ref: the download may pull hundreds of MB and take minutes.
     # Announce it (downloading_model phase) so the UI names the wait, and feed
     # byte progress through the tqdm hook when a reporter is supplied. Set only on
     # the download paths (not the local branch above), and only when a session is
     # live (_set_phase no-ops otherwise), so this helper stays safe to call from
     # the unit tests.
-    dl_kwargs: dict[str, Any] = {}
-    if report is not None:
-        dl_kwargs["tqdm_class"] = make_snapshot_progress_tqdm(report)
-    m = _HUB_REF_RE.match(policy_ref)
-    if m:
-        repo_id, step_dir = m.group("repo"), m.group("step_dir")
-        _set_phase(PHASE_DOWNLOADING_MODEL)
-        local_root = snapshot_download(
-            repo_id=repo_id,
-            repo_type="model",
-            allow_patterns=[f"checkpoints/{step_dir}/pretrained_model/*"],
-            **dl_kwargs,
-        )
-        return str(Path(local_root) / "checkpoints" / step_dir / "pretrained_model")
-    m = _HUB_ROOT_REF_RE.match(policy_ref)
-    if m:
-        _set_phase(PHASE_DOWNLOADING_MODEL)
-        # A '@root' ref means the repo root IS the pretrained_model, but a repo
-        # can still carry a checkpoints/ sub-tree (per-step snapshots) and a
-        # training_state/ dir (optimizer/scheduler state) alongside it — neither
-        # is needed to run inference and both can be multi-GB. Exclude them so a
-        # flat-model download over a slow link only pulls the root pretrained
-        # files (config.json, model.safetensors, …), mirroring the tight
-        # allow_patterns scoping of the checkpoint case above.
-        return snapshot_download(
-            repo_id=m.group("repo"),
-            repo_type="model",
-            ignore_patterns=["checkpoints/**", "training_state/**"],
-            **dl_kwargs,
-        )
-    raise ValueError(f"Unrecognised policy ref: {policy_ref!r}")
+    _set_phase(PHASE_DOWNLOADING_MODEL)
+    tqdm_class = make_snapshot_progress_tqdm(report) if report is not None else None
+    return download_hub_checkpoint_ref(policy_ref, tqdm_class=tqdm_class)
 
 
 def _arm_count_mismatch(mode: str, checkpoint_state_dim: int | None) -> str | None:

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -178,6 +178,11 @@ def localize_config_for_cloud(config: TrainingRequest, flavor: str) -> None:
             "source checkpoint's train_config.json lives on this machine, not in "
             "the container. Resume a cloud run from its Hub output instead."
         )
+    # A fine-tune base is allowed to be a HUB ref — either a bare repo id (whose
+    # root lerobot resolves itself) or the step-suffixed 'repo@checkpoints/<step>'
+    # form, which the wrapper materializes pod-side before launching the trainer
+    # (the twin of the resume download above). What cannot work is a host path:
+    # the container has no view of this machine's disk.
     if config.policy_pretrained_path and Path(config.policy_pretrained_path).is_absolute():
         raise ValueError(
             "Fine-tuning a cloud job from a local checkpoint isn't supported — "
@@ -249,6 +254,23 @@ def _arg(name):
         if tok.startswith(name + "="):
             return tok.split("=", 1)[1]
     return None
+
+
+def _set_arg(name, value):
+    """Rewrite --name=foo / --name foo in trainer_argv in place. False if absent.
+
+    Mutates the list the trainer is launched with (Popen receives it directly),
+    which is how a Hub ref that only this pod can resolve becomes a real path.
+    Both spellings are handled because the value is written back in whichever
+    form the argv builder used."""
+    for i, tok in enumerate(trainer_argv):
+        if tok == name and i + 1 < len(trainer_argv):
+            trainer_argv[i + 1] = value
+            return True
+        if tok.startswith(name + "="):
+            trainer_argv[i] = name + "=" + value
+            return True
+    return False
 
 
 output_dir = _arg("--output_dir")
@@ -324,6 +346,44 @@ if resume_from:
     except Exception as exc:
         print(f"[wrapper] resume download failed: {exc}", flush=True)
         sys.exit(1)
+
+# Fine-tune from a specific Hub step: --policy.pretrained_path may carry the
+# ref 'repo@checkpoints/<step_dir>' instead of a path, because lerobot's
+# pretrained_path addresses a local dir or a repo ROOT and cannot express a
+# sub-path. Materialize it here — the pod-side twin of the host-side
+# jobs.localize_pretrained_path — and rewrite the argv to the real directory.
+# A bare repo id is left ALONE: lerobot resolves a repo root itself, and that
+# flow already works.
+#
+# Downloaded into the snapshot cache and used from there, NOT copied under
+# --output_dir like the resume tree: fine-tuning only READS these weights, and
+# anything under <output_dir>/checkpoints/ would be picked up by the uploader
+# below and republished as if this run had produced it.
+pretrained_ref = _arg("--policy.pretrained_path")
+if pretrained_ref:
+    m = re.match(r"^(?P<repo>[^@]+)@checkpoints/(?P<step_dir>\d+)$", pretrained_ref)
+    if m:
+        src_repo, step_dir = m.group("repo"), m.group("step_dir")
+        print(f"[wrapper] fine-tuning: downloading {src_repo}@checkpoints/{step_dir}", flush=True)
+        try:
+            from huggingface_hub import snapshot_download
+
+            local_root = snapshot_download(
+                repo_id=src_repo,
+                repo_type="model",
+                allow_patterns=[f"checkpoints/{step_dir}/pretrained_model/*"],
+            )
+            base_dir = Path(local_root) / "checkpoints" / step_dir / "pretrained_model"
+            if not (base_dir / "config.json").is_file():
+                print(f"[wrapper] fine-tune base has no config.json at {base_dir}", flush=True)
+                sys.exit(1)
+            if not _set_arg("--policy.pretrained_path", str(base_dir)):
+                print("[wrapper] could not rewrite --policy.pretrained_path", flush=True)
+                sys.exit(1)
+            print(f"[wrapper] fine-tune base ready at {base_dir}", flush=True)
+        except Exception as exc:
+            print(f"[wrapper] fine-tune base download failed: {exc}", flush=True)
+            sys.exit(1)
 
 stop_event = threading.Event()
 

--- a/makermodslab/train.py
+++ b/makermodslab/train.py
@@ -80,6 +80,47 @@ def _policy_hub_flags() -> list[str]:
     return ["--policy.private", "false", "--policy.tags", tag_list]
 
 
+# Which optimizer knobs each policy type actually exposes on ITS OWN config.
+#
+# Why this exists: the form always runs with `use_policy_training_preset true`,
+# and lerobot's TrainPipelineConfig.validate() then REPLACES the whole optimizer
+# with `active_cfg.get_optimizer_preset()` (configs/train.py:249-253) on every
+# fresh run. So `--optimizer.*` flags are silently discarded — the only way to
+# influence the optimizer is to set the POLICY fields the preset is built from
+# (`ACTConfig.get_optimizer_preset()` -> `AdamWConfig(lr=self.optimizer_lr,
+# weight_decay=self.optimizer_weight_decay)`), i.e. `--policy.optimizer_lr`.
+#
+# Gating is load-bearing, not cosmetic: draccus fails at CLI PARSE time when
+# given a `--policy.<field>` the selected policy config doesn't declare, so
+# emitting an unsupported knob kills the run before training starts. And the
+# /policy-optimizer-defaults payload can NOT be used to derive this — both
+# AdamWConfig and AdamConfig carry a `grad_clip_norm` field regardless of
+# whether the policy exposes an `optimizer_grad_clip_norm` knob.
+#
+# Derived by dataclass introspection of the pinned lerobot (see the `lerobot`
+# commit pin in pyproject.toml): for each policy in the form's
+# POLICY_TYPE_OPTIONS, `dataclasses.fields(make_policy_config(<type>))`.
+# Re-verify after a pin bump. Unknown/absent policy types fall back to lr-only.
+#
+# Notable: `gaussian_actor` exposes NONE of the three (its preset is a
+# MultiAdamConfig built from per-group settings), so it gets an empty set.
+_POLICY_OPTIMIZER_FIELDS: dict[str, frozenset[str]] = {
+    "act": frozenset({"lr", "weight_decay"}),
+    "diffusion": frozenset({"lr", "weight_decay"}),
+    "pi0": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
+    "smolvla": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
+    "tdmpc": frozenset({"lr"}),
+    "vqbet": frozenset({"lr", "weight_decay"}),
+    "pi0_fast": frozenset({"lr", "weight_decay", "grad_clip_norm"}),
+    "gaussian_actor": frozenset(),
+}
+
+# Conservative fallback for a policy type not in the table (e.g. one added to
+# the form ahead of this table, or an old persisted config). `optimizer_lr` is
+# the one knob every action policy in the pin declares.
+_DEFAULT_POLICY_OPTIMIZER_FIELDS = frozenset({"lr"})
+
+
 def _resolve_device(device: str | None) -> str:
     """Resolve the requested training device to a concrete backend.
 
@@ -222,6 +263,27 @@ class TrainingRequest(BaseModel):
         return text
 
 
+def _policy_optimizer_flags(request: "TrainingRequest") -> list[str]:
+    """`--policy.optimizer_*` flags for the knobs this policy actually exposes.
+
+    Fresh runs only — see `_POLICY_OPTIMIZER_FIELDS` above for why these replace
+    the inert `--optimizer.*` flags, and why unsupported knobs must be dropped
+    rather than passed through. A value the policy can't accept is silently
+    skipped: the user's stored config keeps it (so switching back to a policy
+    that does support it restores the value) but it never reaches argv.
+    """
+    supported = _POLICY_OPTIMIZER_FIELDS.get(request.policy_type, _DEFAULT_POLICY_OPTIMIZER_FIELDS)
+    flags: list[str] = []
+    for name, value in (
+        ("lr", request.optimizer_lr),
+        ("weight_decay", request.optimizer_weight_decay),
+        ("grad_clip_norm", request.optimizer_grad_clip_norm),
+    ):
+        if value is not None and name in supported:
+            flags.extend([f"--policy.optimizer_{name}", str(value)])
+    return flags
+
+
 def build_training_command(
     request: TrainingRequest, output_dir: str, python_executable: str = "python"
 ) -> list[str]:
@@ -349,15 +411,15 @@ def build_training_command(
     cmd.extend(["--eval.batch_size", str(request.eval_batch_size)])
     cmd.extend(["--eval.use_async_envs", "true" if request.eval_use_async_envs else "false"])
 
-    # Optimizer
-    if request.optimizer_type:
-        cmd.extend(["--optimizer.type", request.optimizer_type])
-    if request.optimizer_lr is not None:
-        cmd.extend(["--optimizer.lr", str(request.optimizer_lr)])
-    if request.optimizer_weight_decay is not None:
-        cmd.extend(["--optimizer.weight_decay", str(request.optimizer_weight_decay)])
-    if request.optimizer_grad_clip_norm is not None:
-        cmd.extend(["--optimizer.grad_clip_norm", str(request.optimizer_grad_clip_norm)])
+    # Optimizer. Routed through the POLICY config, never `--optimizer.*`: with
+    # the training preset on (always, below) lerobot overwrites the whole
+    # optimizer from `active_cfg.get_optimizer_preset()`, so every `--optimizer.*`
+    # flag is discarded before the first step. `request.optimizer_type` is
+    # deliberately NOT emitted — the optimizer CLASS is fixed by the policy's
+    # preset (AdamW for act/smolvla/pi0/pi0_fast, Adam for diffusion/vqbet/tdmpc)
+    # and is not overridable; the field survives on the request only because
+    # persisted job configs and the resume prefill read it. See MT43.
+    cmd.extend(_policy_optimizer_flags(request))
 
     # Advanced
     cmd.extend(["--use_policy_training_preset", "true" if request.use_policy_training_preset else "false"])

--- a/makermodslab/train.py
+++ b/makermodslab/train.py
@@ -309,7 +309,11 @@ def build_training_command(
     # from config_path, not the CLI. --steps must be raised above the resumed
     # step for the loop to do any work; --output_dir points new checkpoints at
     # this job's own dir so tracking stays consistent (state still loads from
-    # the source checkpoint).
+    # the source checkpoint). --num_workers rides along too: it is a
+    # host-capacity knob, not an experiment property, and a resume can land on a
+    # different flavor than the parent run, so inheriting the checkpoint's
+    # worker count would oversubscribe or starve the new host. (A bare int
+    # decodes fine through the config_path parse path.)
     if request.resume and request.config_path:
         # lerobot pre-parses config_path with its own parser that ONLY accepts
         # the "--config_path=<path>" form (space-separated is silently ignored,
@@ -318,6 +322,7 @@ def build_training_command(
         cmd.extend(["--resume", "true"])
         cmd.extend(["--output_dir", output_dir])
         cmd.extend(["--steps", str(request.steps)])
+        cmd.extend(["--num_workers", str(request.num_workers)])
         cmd.extend(["--log_freq", str(request.log_freq)])
         cmd.extend(["--save_freq", str(request.save_freq)])
         cmd.extend(["--save_checkpoint", "true" if request.save_checkpoint else "false"])

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -284,6 +284,117 @@ def test_parse_metrics_into_fresh_run_ignores_resume_rebase() -> None:
     assert m.total_steps == 100
 
 
+def test_resume_start_step_prefers_the_requested_step() -> None:
+    """The request's own answer wins when it has one."""
+    from makermodslab.jobs import _resume_start_step
+    from makermodslab.train import TrainingRequest
+
+    cfg = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        resume_from_step=10,
+        config_path="/out/checkpoints/000010/pretrained_model/train_config.json",
+        steps=60,
+    )
+    assert _resume_start_step(cfg) == 10
+
+
+def test_resume_start_step_reads_the_resolved_checkpoint_when_latest_was_asked_for() -> None:
+    """Resuming "the latest checkpoint" leaves resume_from_step None — the step
+    then lives only in what the resolvers wrote back onto the config, which is a
+    zero-padded checkpoint dir on either runner."""
+    from makermodslab.jobs import _resume_start_step
+    from makermodslab.train import TrainingRequest
+
+    local = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        config_path="/out/checkpoints/000010/pretrained_model/train_config.json",
+        steps=60,
+    )
+    assert _resume_start_step(local) == 10
+
+    cloud = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        resume_from_hub_repo="user/out",
+        resume_from_hub_step="004000",
+        steps=15000,
+    )
+    assert _resume_start_step(cloud) == 4000
+
+
+def test_resume_start_step_is_none_when_nothing_names_the_checkpoint() -> None:
+    """A fresh run has no floor, and neither does a resume driven by a
+    hand-supplied config_path that isn't a checkpoint tree — both must return
+    None rather than invent a step."""
+    from makermodslab.jobs import _resume_start_step
+    from makermodslab.train import TrainingRequest
+
+    fresh = TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=60)
+    assert _resume_start_step(fresh) is None
+
+    odd = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        config_path="/somewhere/custom/train_config.json",
+        steps=60,
+    )
+    assert _resume_start_step(odd) is None
+
+
+def test_initial_metrics_seeds_a_resumed_run_at_its_checkpoint_floor() -> None:
+    """Before lerobot's first tqdm frame a resumed run has no parsed metrics, and
+    reporting 0/0 there made every progress readout show a confident
+    "0 / 60 · 0.0%" for the whole (multi-second to multi-minute) startup window.
+    The floor is known from the request, so start there."""
+    from makermodslab.jobs import _initial_metrics
+    from makermodslab.train import TrainingRequest
+
+    cfg = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        resume_from_step=10,
+        steps=60,
+    )
+    m = _initial_metrics(cfg)
+    assert (m.current_step, m.total_steps) == (10, 60)
+    # A floor only — nothing is claimed about loss or ETA.
+    assert m.current_loss is None
+    assert m.eta_seconds is None
+
+
+def test_initial_metrics_leaves_a_fresh_run_at_zero() -> None:
+    """A fresh run really does start at 0, and total_steps == 0 is what the UI
+    reads as "Training starting…". Unchanged."""
+    from makermodslab.jobs import _initial_metrics
+    from makermodslab.train import TrainingRequest
+
+    cfg = TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=60)
+    m = _initial_metrics(cfg)
+    assert (m.current_step, m.total_steps) == (0, 0)
+
+
+def test_initial_metrics_needs_a_step_target_to_seed() -> None:
+    """No configured target ⇒ no honest percentage, so don't half-seed."""
+    from makermodslab.jobs import _initial_metrics
+    from makermodslab.train import TrainingRequest
+
+    cfg = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        resume_from_step=10,
+        steps=0,
+    )
+    assert _initial_metrics(cfg).current_step == 0
+
+
 def test_read_metrics_history_stitches_resume_lineage(tmp_path) -> None:
     """A resumed run's curve is continuous across the whole lineage: the source
     run's points (0→100) are prepended to the resumed run's (150→200)."""
@@ -1157,6 +1268,78 @@ def test_two_imports_of_one_task_and_policy_are_still_disambiguated(monkeypatch,
     names = {r.id: r.name for r in reg.list(limit=100)}
     assert names[a.id] == "orange_box (2026-08-03)"
     assert names[b.id] == "orange_box (2026-08-05)"
+
+
+def test_start_seeds_a_resumed_records_progress_at_the_checkpoint_step(tmp_path) -> None:
+    """The record a resume starts must already read 4,000/15,000 — not 0/0.
+
+    The tqdm rebase only helps once lerobot's bar exists, and nothing fills the
+    gap before it: on a real local resume that window was 12s of a 69s run,
+    during which every progress readout in the app said step 0. The seed has to
+    be on the RECORD (not just the runner) so the persisted job.json, the /jobs
+    payload and the ~1Hz progress broadcast all carry it from the first tick."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = JobRegistry(tmp_path / "root")
+    cfg = TrainingRequest(
+        dataset_repo_id="user/on_hub",
+        policy_type="act",
+        resume=True,
+        config_path="/somewhere/checkpoints/004000/pretrained_model/train_config.json",
+        steps=15000,
+    )
+    fake_runner = MagicMock()
+    fake_runner.hf_job_id.return_value = "job-xyz"
+    fake_runner.hf_job_url.return_value = None
+
+    with (
+        patch(
+            "makermodslab.datasets.get_hub_status",
+            return_value={"repo_id": "user/on_hub", "status": "on_hub", "url": "u"},
+        ),
+        patch(
+            "makermodslab.runners.hf_cloud.HfCloudJobRunner",
+            lambda *a, **k: fake_runner,
+        ),
+    ):
+        record = reg.start(cfg, JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    assert (record.metrics.current_step, record.metrics.total_steps) == (4000, 15000)
+    # And it survives to disk, which is what a reattach after a restart reloads.
+    persisted = _json.loads((tmp_path / "root" / record.id / "job.json").read_text())
+    assert persisted["metrics"]["current_step"] == 4000
+
+
+def test_start_leaves_a_fresh_records_progress_at_zero(tmp_path) -> None:
+    """The non-resumed path is untouched: 0/0 is correct there, and total_steps
+    == 0 is the signal the UI renders as "Training starting…"."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = JobRegistry(tmp_path / "root")
+    cfg = TrainingRequest(dataset_repo_id="user/on_hub", policy_type="act", steps=15000)
+    fake_runner = MagicMock()
+    fake_runner.hf_job_id.return_value = "job-xyz"
+    fake_runner.hf_job_url.return_value = None
+
+    with (
+        patch(
+            "makermodslab.datasets.get_hub_status",
+            return_value={"repo_id": "user/on_hub", "status": "on_hub", "url": "u"},
+        ),
+        patch(
+            "makermodslab.runners.hf_cloud.HfCloudJobRunner",
+            lambda *a, **k: fake_runner,
+        ),
+    ):
+        record = reg.start(cfg, JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    assert (record.metrics.current_step, record.metrics.total_steps) == (0, 0)
 
 
 # ── Resume is only for a run that stopped short ──────────────────────────────

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1840,3 +1840,383 @@ def test_an_unknown_finetune_source_still_refuses_before_any_record(monkeypatch,
     assert list(reg._records) == []
     assert list(reg._output_root.iterdir()) == []
     assert reg._prepare_threads == {}
+
+
+# ---------------------------------------------------------------------------
+# Feature-space guard (MT44). A matching architecture is not enough: this
+# launch path is `--policy.type` + `--policy.pretrained_path`, so lerobot sizes
+# the policy from the DATASET and loads the checkpoint's weights strict=False.
+# A dof mismatch is loud-but-late for ACT and SILENT for SmolVLA/pi0 (they pad
+# to 32 dims), and renamed or disjoint cameras are silent for every policy.
+# Phase 1 refuses those; a changed camera COUNT that still overlaps, or a
+# changed resolution, is legitimate and only warns.
+#
+# Every Hub read is patched out: the checkpoint side through
+# jobs.hf_hub_download, the dataset side through jobs.read_dataset_features.
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_CAMERAS = ("front", "wrist")
+
+
+def _feature_ckpt(
+    tmp_path: Path,
+    name: str,
+    *,
+    policy_type: str = "act",
+    state_dim: int = 6,
+    action_dim: int = 6,
+    cameras: tuple[str, ...] = _DEFAULT_CAMERAS,
+    height: int = 480,
+    width: int = 640,
+) -> Path:
+    """A pretrained_model dir whose config.json carries a real feature space.
+    Image shapes are CHW, as a policy checkpoint writes them."""
+    d = tmp_path / name
+    d.mkdir()
+    inputs: dict = {"observation.state": {"type": "STATE", "shape": [state_dim]}}
+    for cam in cameras:
+        inputs[f"observation.images.{cam}"] = {"type": "VISUAL", "shape": [3, height, width]}
+    (d / "config.json").write_text(
+        _json.dumps(
+            {
+                "type": policy_type,
+                "input_features": inputs,
+                "output_features": {"action": {"type": "ACTION", "shape": [action_dim]}},
+            }
+        )
+    )
+    return d
+
+
+def _dataset_features(
+    *,
+    state_dim: int = 6,
+    action_dim: int = 6,
+    cameras: tuple[str, ...] = _DEFAULT_CAMERAS,
+    height: int = 480,
+    width: int = 640,
+) -> dict:
+    """A dataset meta/info.json `features` map. Image shapes are HWC with named
+    axes — the opposite convention from the checkpoint above, which is exactly
+    what the guard has to normalise."""
+    features: dict = {
+        "action": {"dtype": "float32", "shape": [action_dim]},
+        "observation.state": {"dtype": "float32", "shape": [state_dim]},
+    }
+    for cam in cameras:
+        features[f"observation.images.{cam}"] = {
+            "dtype": "video",
+            "shape": [height, width, 3],
+            "names": ["height", "width", "channels"],
+        }
+    return features
+
+
+def _patch_dataset_features(features):
+    """Pin what the guard sees for the selected dataset (no Hub, no cache)."""
+    from unittest.mock import patch
+
+    return patch("makermodslab.jobs.read_dataset_features", lambda repo_id: features)
+
+
+def test_check_feature_space_rejects_single_arm_checkpoint_on_bimanual_dataset(tmp_path) -> None:
+    """The SILENT case MT44 is really about: SmolVLA pads dofs to 32, so a
+    6-dof checkpoint loads cleanly into a 12-dof run and trains garbage that is
+    recorded as a fine-tune. Both widths and both sources must be named."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "single_arm", policy_type="smolvla")
+    with (
+        _patch_dataset_features(_dataset_features(state_dim=12, action_dim=12)),
+        pytest.raises(ValueError) as exc,
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/bimanual_ds")
+    message = str(exc.value)
+    assert "6-dim robot state" in message
+    assert "12-dim robot state" in message
+    assert "user/bimanual_ds" in message
+    assert str(ckpt) in message
+
+
+def test_check_feature_space_rejects_bimanual_checkpoint_on_single_arm_dataset(tmp_path) -> None:
+    """The same refusal in the other direction — neither side is privileged."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "bimanual", state_dim=12, action_dim=12)
+    with (
+        _patch_dataset_features(_dataset_features(state_dim=6, action_dim=6)),
+        pytest.raises(ValueError) as exc,
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/single_ds")
+    message = str(exc.value)
+    assert "12-dim robot state" in message
+    assert "6-dim robot state" in message
+
+
+def test_check_feature_space_rejects_action_width_mismatch(tmp_path) -> None:
+    """State can agree while the action head doesn't (a checkpoint whose output
+    space was changed); the action side is checked on its own terms."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "wide_action", action_dim=12)
+    with (
+        _patch_dataset_features(_dataset_features()),
+        pytest.raises(ValueError, match="action"),
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/ds")
+
+
+def test_check_feature_space_rejects_renamed_cameras(tmp_path) -> None:
+    """Equal camera COUNT, different keys — the bimanual `left_` prefix case.
+    This is the refusal the whole rule exists for, and the generic-base
+    exemption below must never swallow it: `front`/`wrist` are real mounts."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "named_ckpt", cameras=("front", "wrist"))
+    with (
+        _patch_dataset_features(_dataset_features(cameras=("left_front", "left_wrist"))),
+        pytest.raises(ValueError) as exc,
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/renamed_ds")
+    message = str(exc.value)
+    assert "front, wrist" in message
+    assert "left_front, left_wrist" in message
+    # The two ways out the message must offer.
+    assert "base model" in message
+    assert "from scratch" in message
+
+
+def test_check_feature_space_rejects_disjoint_cameras_at_different_counts(tmp_path) -> None:
+    """Zero overlap is the rename mistake at an unequal count: a 1-camera `left`
+    dataset against a wrist/front checkpoint would otherwise fall past the
+    rename rule (counts differ) into the benign count-change branch. None of the
+    checkpoint's cameras survive, so it is refused."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "two_cam_ckpt", cameras=("front", "wrist"))
+    with (
+        _patch_dataset_features(_dataset_features(cameras=("left",))),
+        pytest.raises(ValueError) as exc,
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/left_only_ds")
+    message = str(exc.value)
+    assert "no camera in common" in message
+    assert "front, wrist" in message
+    assert "left" in message
+    # The two ways out the message must offer.
+    assert "base model" in message
+    assert "from scratch" in message
+
+
+def test_check_feature_space_exempts_a_generic_base_from_the_rename_rule(tmp_path, caplog) -> None:
+    """lerobot/smolvla_base ships camera1/camera2/camera3 — placeholders, not a
+    rig. Binding those to a named 3-camera dataset is THE canonical SmolVLA
+    fine-tune, so it warns instead of refusing."""
+    import logging
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(
+        tmp_path, "smolvla_base", policy_type="smolvla", cameras=("camera1", "camera2", "camera3")
+    )
+    with (
+        caplog.at_level(logging.WARNING, logger="makermodslab.jobs"),
+        _patch_dataset_features(_dataset_features(cameras=("front", "wrist", "top"))),
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/named_rig_ds")
+    assert "placeholder camera names" in caplog.text
+    assert "front, top, wrist" in caplog.text
+
+
+def test_check_feature_space_exempts_a_generic_base_from_the_disjoint_rule(tmp_path, caplog) -> None:
+    """The canonical smolvla_base fine-tune is disjoint AND unequal in count
+    (camera1/2/3 vs a real 2-camera rig), so the generic-base exemption has to
+    cover the disjoint rule too or it would refuse the commonest fine-tune there
+    is."""
+    import logging
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(
+        tmp_path, "generic_base", policy_type="smolvla", cameras=("camera1", "camera2", "camera3")
+    )
+    with (
+        caplog.at_level(logging.WARNING, logger="makermodslab.jobs"),
+        _patch_dataset_features(_dataset_features(cameras=("front", "wrist"))),
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/two_cam_ds")
+    assert "placeholder camera names" in caplog.text
+
+
+def test_check_feature_space_exemption_is_all_or_nothing(tmp_path) -> None:
+    """A checkpoint mixing a placeholder with a real mount (camera1 + wrist) is
+    not a generic base — it came off some rig — so the rename refusal stands."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "half_generic", cameras=("camera1", "wrist"))
+    with (
+        _patch_dataset_features(_dataset_features(cameras=("front", "top"))),
+        pytest.raises(ValueError, match="different names"),
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/other_rig_ds")
+
+
+def test_check_feature_space_accepts_matching_features(tmp_path) -> None:
+    """The ordinary fine-tune: same robot, same cameras, same resolution."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "matched")
+    with _patch_dataset_features(_dataset_features()):
+        _check_pretrained_feature_space(str(ckpt), "user/ds")
+
+
+def test_check_feature_space_allows_camera_count_change_with_a_warning(tmp_path, caplog) -> None:
+    """A dropped camera, with the rest still shared, is a real sensor-suite
+    change but a legitimate one (ACT's backbone is shared), so phase 1 records
+    it instead of refusing. The warn-and-confirm UI is phase 2."""
+    import logging
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "two_cams", cameras=("front", "wrist"))
+    with (
+        caplog.at_level(logging.WARNING, logger="makermodslab.jobs"),
+        _patch_dataset_features(_dataset_features(cameras=("front",))),
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/one_cam_ds")
+    assert "wrist" in caplog.text
+
+    # ...and the same for a camera the checkpoint never saw.
+    caplog.clear()
+    with (
+        caplog.at_level(logging.WARNING, logger="makermodslab.jobs"),
+        _patch_dataset_features(_dataset_features(cameras=("front", "wrist", "top"))),
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/three_cam_ds")
+    assert "top" in caplog.text
+
+
+def test_check_feature_space_allows_resolution_change_with_a_warning(tmp_path, caplog) -> None:
+    """Resolution only moves ACT's token count and VRAM — allowed, but noted.
+    Also the one case that proves CHW (checkpoint) and HWC (dataset) shapes are
+    normalised before comparison rather than compared axis-for-axis."""
+    import logging
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    ckpt = _feature_ckpt(tmp_path, "hi_res", height=480, width=640)
+    with (
+        caplog.at_level(logging.WARNING, logger="makermodslab.jobs"),
+        _patch_dataset_features(_dataset_features(height=240, width=320)),
+    ):
+        _check_pretrained_feature_space(str(ckpt), "user/small_ds")
+    assert "480x640 -> 240x320" in caplog.text
+
+
+def test_check_feature_space_silent_when_either_side_is_unreadable(tmp_path) -> None:
+    """The discipline the neighbouring guards keep: an unverifiable pair must
+    not block a launch. None means "not established", never "fine"."""
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    bare = tmp_path / "no_config"
+    bare.mkdir()
+    with _patch_dataset_features(_dataset_features(state_dim=12, action_dim=12)):
+        _check_pretrained_feature_space(str(bare), "user/bimanual_ds")
+
+    # A config.json with no feature maps at all says nothing either.
+    typed_only = tmp_path / "type_only"
+    typed_only.mkdir()
+    (typed_only / "config.json").write_text(_json.dumps({"type": "act"}))
+    with _patch_dataset_features(_dataset_features(state_dim=12, action_dim=12)):
+        _check_pretrained_feature_space(str(typed_only), "user/bimanual_ds")
+
+    # Unreadable dataset meta (offline, or a repo we can't see).
+    ckpt = _feature_ckpt(tmp_path, "readable", state_dim=6)
+    with _patch_dataset_features(None):
+        _check_pretrained_feature_space(str(ckpt), "user/unknown_ds")
+
+
+def test_read_pretrained_feature_space_reads_a_step_ref(monkeypatch, tmp_path) -> None:
+    """The read must look inside the step the ref names, not at the repo root —
+    otherwise the guard would validate different weights than the run trains
+    from."""
+    from makermodslab.jobs import read_pretrained_feature_space
+
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        _json.dumps(
+            {
+                "type": "smolvla",
+                "input_features": {"observation.state": {"type": "STATE", "shape": [6]}},
+                "output_features": {"action": {"type": "ACTION", "shape": [6]}},
+            }
+        )
+    )
+    seen: dict = {}
+
+    def fake_download(**kwargs):
+        seen.update(kwargs)
+        return str(cfg_file)
+
+    monkeypatch.setattr("makermodslab.jobs.hf_hub_download", fake_download)
+
+    inputs, outputs = read_pretrained_feature_space("user/repo@checkpoints/000500")
+    assert inputs["observation.state"]["shape"] == [6]
+    assert outputs["action"]["shape"] == [6]
+    assert seen["filename"] == "checkpoints/000500/pretrained_model/config.json"
+
+
+def test_start_rejects_feature_space_mismatch_and_leaves_no_record(tmp_path) -> None:
+    """End to end: the refusal is synchronous, is a 400-shaped ValueError, and
+    happens before anything is materialized — no record, no output dir, no
+    prepare thread."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    ckpt = _feature_ckpt(tmp_path, "single_arm", policy_type="smolvla")
+    reg = JobRegistry(tmp_path / "root")
+
+    cfg = TrainingRequest(
+        dataset_repo_id="user/bimanual_ds",
+        policy_type="smolvla",
+        policy_pretrained_path=str(ckpt),
+    )
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        _patch_dataset_features(_dataset_features(state_dim=12, action_dim=12)),
+        pytest.raises(ValueError, match="12-dim robot state"),
+    ):
+        reg.start(cfg, JobTarget(runner="local"))
+
+    assert reg.list(limit=10) == []
+    assert list(reg._output_root.iterdir()) == []
+    assert reg._prepare_threads == {}
+
+
+def test_start_allows_matching_feature_space(tmp_path) -> None:
+    """The guard must not become a new way for an ordinary fine-tune to fail:
+    a matching checkpoint/dataset pair still reaches the normal start path."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    ckpt = _feature_ckpt(tmp_path, "matched")
+    reg = JobRegistry(tmp_path / "root")
+
+    cfg = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        policy_pretrained_path=str(ckpt),
+    )
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner),
+        _patch_dataset_features(_dataset_features()),
+    ):
+        record = reg.start(cfg, JobTarget(runner="local"))
+    assert record.state == "running"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1156,3 +1156,194 @@ def test_two_imports_of_one_task_and_policy_are_still_disambiguated(monkeypatch,
     names = {r.id: r.name for r in reg.list(limit=100)}
     assert names[a.id] == "orange_box (2026-08-03)"
     assert names[b.id] == "orange_box (2026-08-05)"
+
+
+# ── Resume is only for a run that stopped short ──────────────────────────────
+# A completed run's LR schedule is spent (SmolVLA's preset cosine-decays to a
+# 2.5e-6 floor over a fixed 30k-step horizon), so a continuation trains at floor
+# LR and the flat loss curve reads as convergence. The UI hides the button; this
+# is the backend half, which also catches a direct API call. Blanket by
+# decision — no per-policy exceptions.
+
+
+def _hub_checkpoint_files(step_dir: str) -> list[str]:
+    """The repo paths a complete cloud checkpoint publishes."""
+    return [
+        f"checkpoints/{step_dir}/pretrained_model/config.json",
+        f"checkpoints/{step_dir}/pretrained_model/model.safetensors",
+        f"checkpoints/{step_dir}/pretrained_model/train_config.json",
+        f"checkpoints/{step_dir}/training_state/training_step.json",
+        f"checkpoints/{step_dir}/training_state/optimizer_state.safetensors",
+    ]
+
+
+def _resumable_source(tmp_path, state: str, *, job_id: str = "src", steps: int = 200):
+    """A local run record with one real, fully-saved checkpoint at step 100."""
+    from makermodslab.jobs import JobRecord, JobRegistry
+    from makermodslab.train import TrainingRequest
+
+    run_dir = tmp_path / job_id / "run"
+    run_dir.mkdir(parents=True)
+    _make_checkpoint(run_dir, 100)
+    reg = JobRegistry(tmp_path / "root")
+    reg._records[job_id] = JobRecord(
+        id=job_id,
+        name="run",
+        state=state,
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=steps),
+        output_dir=str(run_dir),
+        started_at=0.0,
+        runner="local",
+    )
+    return reg
+
+
+def _resume_request(job_id: str = "src"):
+    from makermodslab.train import TrainingRequest
+
+    return TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        resume_from_job_id=job_id,
+    )
+
+
+def test_start_refuses_to_resume_a_completed_run(tmp_path) -> None:
+    """The point of the gate: a `done` source is refused with a 400-shaped
+    ValueError that names fine-tuning as the way forward. No record created."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="already reached its step target"),
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+    assert [r.id for r in reg.list(limit=10)] == ["src"]
+
+
+def test_start_refuses_to_resume_a_completed_cloud_run(tmp_path) -> None:
+    """The refusal is on the source's STATE, not its runner, so it lands before
+    the local/cloud branch and covers both."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    reg._records["src"].runner = "hf_cloud"
+    reg._records["src"].hf_repo_id = "user/some-model"
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="already reached its step target"),
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+
+@pytest.mark.parametrize("state", ["interrupted", "failed"])
+def test_start_still_resumes_a_run_that_stopped_short(tmp_path, state) -> None:
+    """The gate must not swallow the case resume exists for: a run that ended
+    below its target still resumes, and still resolves its --config_path."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, state)
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_resume_request(), JobTarget(runner="local"))
+
+    assert record.config.resume is True
+    assert record.config.config_path.endswith("train_config.json")
+    assert "checkpoints/100" in record.config.config_path
+
+
+# ── …and only on the runner it stopped on ────────────────────────────────────
+# Cross-runner resume isn't implemented (F7) and both directions fail badly:
+# cloud→local hands lerobot a --config_path that only ever existed inside the
+# pod (MT4), local→cloud silently restarts from step 0 while recording itself as
+# a resume (MT42). The form pins the Compute control; these cover the
+# defense-in-depth half, which catches a direct API call that flips it anyway.
+# Reuses the section's helpers above; a cloud parent is the same record with its
+# runner/repo flipped, exactly as the done-source pair does it.
+
+
+def _cloud_parent(reg, *, job_id: str = "src"):
+    """Turn a `_resumable_source` record into a cloud run in place."""
+    reg._records[job_id].runner = "hf_cloud"
+    reg._records[job_id].hf_repo_id = "user/some-model"
+    return reg
+
+
+def test_start_refuses_a_local_parent_resumed_on_the_cloud(tmp_path, monkeypatch) -> None:
+    """local parent → Cloud target (MT42). The refusal must name the parent's
+    runner, and must leave no record behind."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    # The cloud dataset preflight sits ahead of the resume block; keep it happy
+    # (and off the network) so the cross-runner refusal is what we observe.
+    monkeypatch.setattr("makermodslab.datasets.get_hub_status", lambda repo_id: {"status": "on_hub"})
+    with (
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="Cross-runner resume isn't supported yet") as excinfo,
+    ):
+        reg.start(_resume_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    assert "Local" in str(excinfo.value)
+    assert [r.id for r in reg.list(limit=10)] == ["src"]
+
+
+def test_start_refuses_a_cloud_parent_resumed_locally(tmp_path, monkeypatch) -> None:
+    """cloud parent → Local target (MT4). Refused BEFORE _resolve_cloud_resume
+    would go to the Hub — the exploding api stand-in is the assertion that the
+    guard lands first."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    def _no_hub():
+        raise AssertionError("cross-runner resume reached the Hub")
+
+    reg = _cloud_parent(_resumable_source(tmp_path, "interrupted"))
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", _no_hub)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="Cross-runner resume isn't supported yet") as excinfo,
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+    assert "Hugging Face Cloud" in str(excinfo.value)
+    # Read the registry directly: `list` counts a cloud record's checkpoints,
+    # which would itself call the stand-in above.
+    assert list(reg._records) == ["src"]
+
+
+def test_start_still_resumes_a_cloud_run_on_the_cloud(tmp_path, monkeypatch) -> None:
+    """The other half of the gate: a same-runner cloud resume is untouched and
+    still resolves the parent's Hub checkpoint. (local→local is covered by
+    test_start_still_resumes_a_run_that_stopped_short above.)"""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _cloud_parent(_resumable_source(tmp_path, "interrupted"))
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api",
+        lambda: _FakeHubApi(_hub_checkpoint_files("000100")),
+    )
+    monkeypatch.setattr("makermodslab.datasets.get_hub_status", lambda repo_id: {"status": "on_hub"})
+    fake_runner = MagicMock()
+    fake_runner.hf_job_id.return_value = "hfjob-1"
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_resume_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    assert record.config.resume is True
+    assert record.config.resume_from_hub_repo == "user/some-model"
+    assert record.config.resume_from_hub_step == "000100"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1347,3 +1347,221 @@ def test_start_still_resumes_a_cloud_run_on_the_cloud(tmp_path, monkeypatch) -> 
     assert record.config.resume is True
     assert record.config.resume_from_hub_repo == "user/some-model"
     assert record.config.resume_from_hub_step == "000100"
+
+
+# ---------------------------------------------------------------------------
+# MT2 — fine-tuning a selected Hub step must actually train from THAT step.
+# The resolver used to return `ref.split("@")[0]`, so a picked step silently
+# became repo-ROOT weights. One rule now: a step-suffixed ref names the
+# checkpoint, and whoever will run the trainer materializes it — host-side for a
+# local run, in the container for a cloud one.
+# ---------------------------------------------------------------------------
+
+
+def _fake_snapshot(tmp_path: Path, seen: dict):
+    """A snapshot_download stand-in that records its kwargs and lays down the
+    tree the real one would (so the caller's path arithmetic is exercised)."""
+
+    def _download(**kwargs):
+        seen.update(kwargs)
+        root = tmp_path / "snapshot"
+        for pattern in kwargs.get("allow_patterns") or []:
+            (root / pattern.rsplit("/", 1)[0]).mkdir(parents=True, exist_ok=True)
+        root.mkdir(parents=True, exist_ok=True)
+        return str(root)
+
+    return _download
+
+
+def test_download_hub_checkpoint_ref_scopes_to_the_selected_step(monkeypatch, tmp_path) -> None:
+    """Only that step's pretrained_model/ is pulled, and the returned path is
+    that directory — the whole point being that lerobot cannot address a Hub
+    sub-path itself."""
+    from makermodslab.jobs import download_hub_checkpoint_ref
+
+    seen: dict = {}
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_snapshot(tmp_path, seen))
+
+    out = download_hub_checkpoint_ref("user/repo@checkpoints/000500")
+
+    assert seen["repo_id"] == "user/repo"
+    assert seen["allow_patterns"] == ["checkpoints/000500/pretrained_model/*"]
+    assert out.endswith("/checkpoints/000500/pretrained_model")
+
+
+def test_download_hub_checkpoint_ref_root_skips_the_heavy_trees(monkeypatch, tmp_path) -> None:
+    """A '@root' ref is the whole repo, minus the per-step snapshots and
+    optimizer state — neither is needed to load the policy and both can be GBs."""
+    from makermodslab.jobs import download_hub_checkpoint_ref
+
+    seen: dict = {}
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_snapshot(tmp_path, seen))
+
+    out = download_hub_checkpoint_ref("user/repo@root")
+
+    assert seen["repo_id"] == "user/repo"
+    assert seen["ignore_patterns"] == ["checkpoints/**", "training_state/**"]
+    assert out == str(tmp_path / "snapshot")
+
+
+def test_download_hub_checkpoint_ref_rejects_a_non_ref() -> None:
+    from makermodslab.jobs import download_hub_checkpoint_ref
+
+    with pytest.raises(ValueError, match="Unrecognised policy ref"):
+        download_hub_checkpoint_ref("just-a-repo-id")
+
+
+def test_localize_pretrained_path_passes_through_non_step_values(monkeypatch, tmp_path) -> None:
+    """A local dir and a bare repo id are already loadable — lerobot resolves a
+    repo root itself, so materializing one here would only duplicate its fetch."""
+    from makermodslab.jobs import localize_pretrained_path
+
+    def _no_downloads(**kwargs):
+        raise AssertionError("nothing to materialize for a non-step value")
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _no_downloads)
+    assert localize_pretrained_path("user/some-model") == "user/some-model"
+    assert localize_pretrained_path(str(tmp_path)) == str(tmp_path)
+
+
+def test_localize_pretrained_path_reports_a_failed_download(monkeypatch) -> None:
+    """A Hub failure becomes a 400-shaped ValueError naming the checkpoint,
+    rather than a raw Hub exception surfacing as a 500."""
+    from makermodslab.jobs import localize_pretrained_path
+
+    def _boom(**kwargs):
+        raise RuntimeError("hub down")
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _boom)
+    with pytest.raises(ValueError, match="Could not download the base checkpoint") as excinfo:
+        localize_pretrained_path("user/repo@checkpoints/003000")
+    assert "hub down" in str(excinfo.value)
+
+
+def test_resolve_finetune_pretrained_path_keeps_the_selected_step(monkeypatch) -> None:
+    """MT2 core: the step the user picked survives resolution. It used to be
+    truncated to the repo id here, which is repo-ROOT weights."""
+    from makermodslab.jobs import _resolve_finetune_pretrained_path
+
+    files = _hub_checkpoint_files("001000") + _hub_checkpoint_files("005000")
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: _FakeHubApi(files))
+
+    assert _resolve_finetune_pretrained_path(_cloud_record(), 1000) == "user/act_ds_2026@checkpoints/001000"
+    # step=None still means "the latest", now equally un-truncated.
+    assert _resolve_finetune_pretrained_path(_cloud_record(), None) == "user/act_ds_2026@checkpoints/005000"
+
+
+def test_resolve_finetune_pretrained_path_root_ref_stays_a_repo_id(tmp_path) -> None:
+    """An imported repo whose ROOT is the model needs no materialization —
+    lerobot loads a repo id directly, so handing it the bare id avoids a
+    pointless download."""
+    from unittest.mock import patch
+
+    from makermodslab.jobs import JobRecord, _resolve_finetune_pretrained_path
+    from makermodslab.train import TrainingRequest
+
+    record = JobRecord(
+        id="imported-src",
+        name="imported",
+        state="done",
+        config=TrainingRequest(dataset_repo_id="(imported)", policy_type="act"),
+        output_dir="",
+        started_at=0.0,
+        runner="imported",
+        hf_repo_id="user/flat_model",
+    )
+    with patch(
+        "makermodslab.jobs.shared_hf_api",
+        lambda: _FakeHubApi(["config.json", "model.safetensors"]),
+    ):
+        assert _resolve_finetune_pretrained_path(record, None) == "user/flat_model"
+
+
+def _cloud_finetune_source(reg, repo_id: str = "user/act_ds_2026"):
+    """A tracked cloud run in `reg` whose weights live on the Hub."""
+    from makermodslab.jobs import JobRecord
+    from makermodslab.train import TrainingRequest
+
+    record = JobRecord(
+        id="cloud-src",
+        name="cloud src",
+        state="done",
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=10000),
+        output_dir="",
+        started_at=0.0,
+        runner="hf_cloud",
+        hf_repo_id=repo_id,
+    )
+    reg._records[record.id] = record
+    return record
+
+
+def test_finetune_start_local_materializes_the_selected_step(monkeypatch, tmp_path) -> None:
+    """LOCAL target: the ref becomes a real directory on this machine before the
+    trainer starts, and that directory is the SELECTED step."""
+    from unittest.mock import MagicMock
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    seen: dict = {}
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api", lambda: _FakeHubApi(_hub_checkpoint_files("003000"))
+    )
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_snapshot(tmp_path, seen))
+
+    reg = JobRegistry(tmp_path / "root")
+    source = _cloud_finetune_source(reg)
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    monkeypatch.setattr("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner)
+
+    record = reg.start(
+        TrainingRequest(
+            dataset_repo_id="user/ds",
+            policy_type="act",
+            finetune_from_job_id=source.id,
+            finetune_from_step=3000,
+        ),
+        JobTarget(runner="local"),
+    )
+
+    resolved = record.config.policy_pretrained_path
+    assert "@" not in resolved  # materialized, not a ref
+    assert resolved.endswith("/checkpoints/003000/pretrained_model")
+    assert seen["allow_patterns"] == ["checkpoints/003000/pretrained_model/*"]
+
+
+def test_finetune_start_cloud_keeps_the_step_ref(monkeypatch, tmp_path) -> None:
+    """CLOUD target: the ref is passed through untouched — a host path means
+    nothing on the pod, so the container materializes the same ref itself. The
+    host must NOT download the weights for a run that happens elsewhere."""
+    from unittest.mock import MagicMock
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    def _no_downloads(**kwargs):
+        raise AssertionError("the host must not download a cloud run's base weights")
+
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api", lambda: _FakeHubApi(_hub_checkpoint_files("003000"))
+    )
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _no_downloads)
+    monkeypatch.setattr("makermodslab.datasets.get_hub_status", lambda repo_id: {"status": "on_hub"})
+    monkeypatch.setattr("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock())
+
+    reg = JobRegistry(tmp_path / "root")
+    source = _cloud_finetune_source(reg)
+
+    record = reg.start(
+        TrainingRequest(
+            dataset_repo_id="user/ds",
+            policy_type="act",
+            finetune_from_job_id=source.id,
+            finetune_from_step=3000,
+        ),
+        JobTarget(runner="hf_cloud", flavor="a10g-small"),
+    )
+
+    assert record.config.policy_pretrained_path == "user/act_ds_2026@checkpoints/003000"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json as _json
 import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -1198,6 +1199,17 @@ def _resumable_source(tmp_path, state: str, *, job_id: str = "src", steps: int =
     return reg
 
 
+def _assert_nothing_was_created(reg) -> None:
+    """A synchronous refusal must leave NO trace on disk either.
+
+    Cheap guards stayed in front of the record when the base-checkpoint download
+    moved behind it (see the deferred-materialization section), and a job
+    directory or a log file appearing here would be the first sign that one of
+    them slipped past. `_resumable_source` keeps its source run outside the
+    registry root, so the root is empty until a record is created."""
+    assert list(reg._output_root.iterdir()) == []
+
+
 def _resume_request(job_id: str = "src"):
     from makermodslab.train import TrainingRequest
 
@@ -1224,6 +1236,7 @@ def test_start_refuses_to_resume_a_completed_run(tmp_path) -> None:
         reg.start(_resume_request(), JobTarget(runner="local"))
 
     assert [r.id for r in reg.list(limit=10)] == ["src"]
+    _assert_nothing_was_created(reg)
 
 
 def test_start_refuses_to_resume_a_completed_cloud_run(tmp_path) -> None:
@@ -1298,6 +1311,7 @@ def test_start_refuses_a_local_parent_resumed_on_the_cloud(tmp_path, monkeypatch
 
     assert "Local" in str(excinfo.value)
     assert [r.id for r in reg.list(limit=10)] == ["src"]
+    _assert_nothing_was_created(reg)
 
 
 def test_start_refuses_a_cloud_parent_resumed_locally(tmp_path, monkeypatch) -> None:
@@ -1323,6 +1337,7 @@ def test_start_refuses_a_cloud_parent_resumed_locally(tmp_path, monkeypatch) -> 
     # Read the registry directly: `list` counts a cloud record's checkpoints,
     # which would itself call the stand-in above.
     assert list(reg._records) == ["src"]
+    _assert_nothing_was_created(reg)
 
 
 def test_start_still_resumes_a_cloud_run_on_the_cloud(tmp_path, monkeypatch) -> None:
@@ -1496,9 +1511,23 @@ def _cloud_finetune_source(reg, repo_id: str = "user/act_ds_2026"):
     return record
 
 
+def _join_prepare(reg, job_id: str, timeout: float = 10.0) -> None:
+    """Wait for the thread that materializes a fine-tune's base checkpoint.
+
+    Joining the thread — rather than polling for its effect — is what keeps
+    these tests off sleeps and out of the flaky column."""
+    thread = reg._prepare_threads[job_id]
+    thread.join(timeout)
+    assert not thread.is_alive(), "the preparing thread never finished"
+
+
 def test_finetune_start_local_materializes_the_selected_step(monkeypatch, tmp_path) -> None:
     """LOCAL target: the ref becomes a real directory on this machine before the
-    trainer starts, and that directory is the SELECTED step."""
+    trainer starts, and that directory is the SELECTED step.
+
+    The download now happens off-request (see the deferred-materialization
+    section below), so join the preparing thread before asserting on its
+    effect."""
     from unittest.mock import MagicMock
 
     from makermodslab.jobs import JobRegistry, JobTarget
@@ -1525,11 +1554,14 @@ def test_finetune_start_local_materializes_the_selected_step(monkeypatch, tmp_pa
         ),
         JobTarget(runner="local"),
     )
+    _join_prepare(reg, record.id)
 
     resolved = record.config.policy_pretrained_path
     assert "@" not in resolved  # materialized, not a ref
     assert resolved.endswith("/checkpoints/003000/pretrained_model")
     assert seen["allow_patterns"] == ["checkpoints/003000/pretrained_model/*"]
+    # The trainer really was handed the materialized directory, not the ref.
+    assert fake_runner.start.call_args.args[1].policy_pretrained_path == resolved
 
 
 def test_finetune_start_cloud_keeps_the_step_ref(monkeypatch, tmp_path) -> None:
@@ -1565,3 +1597,246 @@ def test_finetune_start_cloud_keeps_the_step_ref(monkeypatch, tmp_path) -> None:
     )
 
     assert record.config.policy_pretrained_path == "user/act_ds_2026@checkpoints/003000"
+
+
+# ---------------------------------------------------------------------------
+# The base-checkpoint download happens AFTER the record exists.
+#
+# Materializing a Hub checkpoint for a local fine-tune is minutes and gigabytes.
+# Doing it inside POST /jobs/training meant the request hung with nothing on
+# screen and no job to look at. The record + log file are now created first and
+# the download runs in a background thread, so the monitor opens immediately and
+# tails the progress lines. Everything that can refuse the request cheaply still
+# refuses it synchronously, before any record exists.
+# ---------------------------------------------------------------------------
+
+
+def _patch_hub_for_finetune(monkeypatch, tmp_path):
+    """Stand-in for the CHEAP Hub read a fine-tune start makes synchronously:
+    the source run's checkpoint listing."""
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api", lambda: _FakeHubApi(_hub_checkpoint_files("003000"))
+    )
+
+
+def _hub_finetune_request(source_id: str, policy_type: str = "act"):
+    from makermodslab.train import TrainingRequest
+
+    return TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type=policy_type,
+        finetune_from_job_id=source_id,
+        finetune_from_step=3000,
+    )
+
+
+def _gated_snapshot(tmp_path, *, started: threading.Event, release: threading.Event):
+    """_fake_snapshot, but it parks in the middle so a test can observe the
+    world WHILE the download is in flight."""
+    seen: dict = {}
+    inner = _fake_snapshot(tmp_path, seen)
+
+    def _download(**kwargs):
+        started.set()
+        assert release.wait(timeout=10), "the gated download was never released"
+        return inner(**kwargs)
+
+    return _download
+
+
+def _fake_local_runner(monkeypatch):
+    from unittest.mock import MagicMock
+
+    runner = MagicMock()
+    runner.pid.return_value = 4242
+    monkeypatch.setattr("makermodslab.jobs.LocalJobRunner", lambda *a, **k: runner)
+    return runner
+
+
+def test_local_finetune_start_returns_before_the_download_finishes(monkeypatch, tmp_path) -> None:
+    """The whole point: the caller gets a job id (and a log file with something
+    in it) while the gigabytes are still moving."""
+    from makermodslab.jobs import JobRegistry, JobTarget
+
+    started, release = threading.Event(), threading.Event()
+    _patch_hub_for_finetune(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        _gated_snapshot(tmp_path, started=started, release=release),
+    )
+
+    reg = JobRegistry(tmp_path / "root")
+    source = _cloud_finetune_source(reg)
+    fake_runner = _fake_local_runner(monkeypatch)
+
+    record = reg.start(_hub_finetune_request(source.id), JobTarget(runner="local"))
+    assert started.wait(timeout=10), "the download never started"
+
+    # Mid-download: the record is real, visible, and running — and no trainer
+    # has been spawned yet.
+    assert record.state == "running"
+    assert reg.get(record.id).state == "running"
+    assert fake_runner.start.call_count == 0
+
+    # The monitor's two log sources both have the opening line: the file it
+    # seeds from on mount, and the live drain it polls every second.
+    log_path = reg._output_root / record.id / "log.jsonl"
+    assert log_path.exists()
+    assert "Preparing fine-tune" in log_path.read_text()
+    assert any("Preparing fine-tune" in line.message for line in reg.drain_logs(record.id))
+    assert "003000" in reg.read_persisted_logs(record.id)[0].message
+
+    release.set()
+    _join_prepare(reg, record.id)
+
+    final = reg.get(record.id)
+    assert final.state == "running"
+    assert final.process_pid == 4242
+    assert fake_runner.start.call_count == 1
+    assert "@" not in final.config.policy_pretrained_path
+
+
+def test_local_finetune_download_failure_fails_the_record(monkeypatch, tmp_path) -> None:
+    """The failure that used to be an HTTP 400 now lands ON the record, with the
+    same wording — no orphan record, no job stuck at 'running'."""
+    from makermodslab.jobs import JobRegistry, JobTarget
+
+    def _boom(**kwargs):
+        raise RuntimeError("hub down")
+
+    _patch_hub_for_finetune(monkeypatch, tmp_path)
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _boom)
+
+    reg = JobRegistry(tmp_path / "root")
+    source = _cloud_finetune_source(reg)
+    fake_runner = _fake_local_runner(monkeypatch)
+
+    record = reg.start(_hub_finetune_request(source.id), JobTarget(runner="local"))
+    _join_prepare(reg, record.id)
+
+    final = reg.get(record.id)
+    assert final.state == "failed"
+    assert "Could not download the base checkpoint" in final.error_message
+    assert "hub down" in final.error_message
+    # No process ever existed, so no synthetic exit code is invented for one.
+    assert final.exit_code is None
+    assert final.ended_at is not None
+    assert fake_runner.start.call_count == 0
+    # The stand-in runner is gone, so the watchdog has nothing left to finalise.
+    assert record.id not in reg._runners
+    # Persisted, not just fixed in memory.
+    meta = _json.loads((reg._output_root / record.id / "job.json").read_text())
+    assert meta["state"] == "failed"
+
+
+def test_stop_during_the_download_is_interrupted(monkeypatch, tmp_path) -> None:
+    """Stop must work while the base checkpoint is downloading. huggingface_hub
+    can't be aborted mid-flight, so the cancel takes effect when the download
+    returns — before the trainer is spawned — and reads as a deliberate stop."""
+    from makermodslab.jobs import _PREPARE_STOPPED_MESSAGE, JobRegistry, JobTarget
+
+    started, release = threading.Event(), threading.Event()
+    _patch_hub_for_finetune(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        _gated_snapshot(tmp_path, started=started, release=release),
+    )
+
+    reg = JobRegistry(tmp_path / "root")
+    source = _cloud_finetune_source(reg)
+    fake_runner = _fake_local_runner(monkeypatch)
+
+    record = reg.start(_hub_finetune_request(source.id), JobTarget(runner="local"))
+    assert started.wait(timeout=10), "the download never started"
+
+    # Stop lands while the bytes are still moving; the record can only settle
+    # once the download returns, so this call reports the job as still running.
+    assert reg.stop(record.id).state == "running"
+    release.set()
+    _join_prepare(reg, record.id)
+
+    final = reg.get(record.id)
+    assert final.state == "interrupted"
+    assert final.error_message == _PREPARE_STOPPED_MESSAGE
+    assert "exited with code" not in (final.error_message or "")
+    assert final.exit_code is None
+    # The stop is honoured by NOT starting the trainer we were about to start.
+    assert fake_runner.start.call_count == 0
+    assert record.id not in reg._runners
+
+
+def test_a_download_bound_job_refuses_a_second_local_run(monkeypatch, tmp_path) -> None:
+    """The local mutex covers the download window too — the machine is spoken
+    for from the moment the record exists, not from the trainer's first step."""
+    from makermodslab.jobs import JobAlreadyRunningError, JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    started, release = threading.Event(), threading.Event()
+    _patch_hub_for_finetune(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        _gated_snapshot(tmp_path, started=started, release=release),
+    )
+
+    reg = JobRegistry(tmp_path / "root")
+    source = _cloud_finetune_source(reg)
+    _fake_local_runner(monkeypatch)
+
+    record = reg.start(_hub_finetune_request(source.id), JobTarget(runner="local"))
+    assert started.wait(timeout=10), "the download never started"
+
+    with pytest.raises(JobAlreadyRunningError):
+        reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+            JobTarget(runner="local"),
+        )
+
+    release.set()
+    _join_prepare(reg, record.id)
+
+
+def test_download_progress_logs_are_readable_not_per_chunk() -> None:
+    """The progress hook has to be worth reading: snapshot_download calls back
+    per CHUNK, and one log line per chunk would bury the run's own output. Drive
+    the tqdm class the way huggingface_hub does — one shared bytes bar plus a
+    file-count bar — and check the cadence and the wording."""
+    from makermodslab.jobs import _DownloadProgressLogger, make_snapshot_progress_tqdm
+
+    lines: list[str] = []
+    tqdm_class = make_snapshot_progress_tqdm(_DownloadProgressLogger(lines.append, "012000"))
+    bytes_bar = tqdm_class(unit="B", unit_scale=True, total=0)
+    file_bar = tqdm_class(total=4)  # not the bytes bar; must contribute nothing
+
+    bytes_bar.total = 1_288_490_188  # ~1.2 GB, discovered as metadata arrives
+    bytes_bar.refresh()
+    for _ in range(200):  # ~0.5% per chunk
+        bytes_bar.update(6_442_450)
+    file_bar.update(1)
+
+    # ~5% apart, so a 1.2 GB download is tens of lines, not thousands.
+    assert 10 <= len(lines) <= 40
+    assert lines[1] == "Downloading base checkpoint 012000 — 6% (74 MB / 1.2 GB)"
+    assert "1.2 GB / 1.2 GB" in lines[-1]
+
+
+def test_an_unknown_finetune_source_still_refuses_before_any_record(monkeypatch, tmp_path) -> None:
+    """The cheap guards did NOT move behind the record. A request that can be
+    refused without touching the Hub still fails fast, with no record, no job
+    directory, and no download."""
+    from makermodslab.jobs import JobRegistry, JobTarget
+
+    def _no_downloads(**kwargs):
+        raise AssertionError("a refused request must not download anything")
+
+    _patch_hub_for_finetune(monkeypatch, tmp_path)
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _no_downloads)
+
+    reg = JobRegistry(tmp_path / "root")
+    _fake_local_runner(monkeypatch)
+
+    with pytest.raises(ValueError, match="not found"):
+        reg.start(_hub_finetune_request("no-such-run"), JobTarget(runner="local"))
+
+    assert list(reg._records) == []
+    assert list(reg._output_root.iterdir()) == []
+    assert reg._prepare_threads == {}

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -253,6 +253,19 @@ def test_localize_rejects_local_pretrained_path_but_allows_hub_id() -> None:
     assert hub.policy_pretrained_path == "user/some-model"
 
 
+def test_localize_allows_a_step_suffixed_hub_pretrained_ref() -> None:
+    """MT2, cloud half: fine-tuning from a SPECIFIC Hub step travels as the ref
+    'repo@checkpoints/<step_dir>' — the wrapper materializes it pod-side, the
+    same way cloud resume already downloads its parent checkpoint. It must reach
+    the container verbatim, not be rejected as a host path and not be rewritten
+    here (a host path would be meaningless on the pod)."""
+    from makermodslab.runners.hf_cloud import localize_config_for_cloud
+
+    config = _request(policy_pretrained_path="user/some-model@checkpoints/003000")
+    localize_config_for_cloud(config, "t4-small")  # no raise
+    assert config.policy_pretrained_path == "user/some-model@checkpoints/003000"
+
+
 # -- in-container installer ladder (the image's uv venv ships no pip) --
 
 
@@ -327,6 +340,74 @@ def test_wrapper_source_handles_resume_download() -> None:
     assert "snapshot_download" in WRAPPER_SOURCE
     assert "training_state" in WRAPPER_SOURCE
     assert "seen.add(step_dir)" in WRAPPER_SOURCE
+
+
+def test_wrapper_source_materializes_a_step_suffixed_finetune_base() -> None:
+    """MT2, container half: a --policy.pretrained_path naming a Hub STEP is
+    downloaded pod-side and rewritten to that local dir before the trainer runs.
+
+    Two properties the block must keep:
+      * it pulls ONLY that step's pretrained_model/ (weights-only — fine-tuning
+        needs no training_state/), and
+      * it uses the snapshot cache rather than <output_dir>/checkpoints/, which
+        the uploader watches — a base checkpoint copied there would be
+        republished as if this run had produced it.
+
+    Source-level assertions: the block is top-level wrapper code (like the
+    resume download it mirrors), so it has no import seam to exec against. The
+    argv rewrite it depends on IS unit-tested below."""
+    from makermodslab.runners.hf_cloud import WRAPPER_SOURCE
+
+    compile(WRAPPER_SOURCE, "<hf-jobs-wrapper>", "exec")
+    assert '_arg("--policy.pretrained_path")' in WRAPPER_SOURCE
+    assert '_set_arg("--policy.pretrained_path", str(base_dir))' in WRAPPER_SOURCE
+    assert 'allow_patterns=[f"checkpoints/{step_dir}/pretrained_model/*"]' in WRAPPER_SOURCE
+    # Never staged under the watched output dir.
+    assert 'base_dir = Path(local_root) / "checkpoints" / step_dir / "pretrained_model"' in WRAPPER_SOURCE
+
+
+def _wrapper_argv_helpers(trainer_argv: list[str]):
+    """Exec the wrapper's own `_arg` / `_set_arg` over `trainer_argv`.
+
+    Sliced out of WRAPPER_SOURCE by name and given the globals the wrapper would
+    have, so a drift between the template and these tests fails loudly instead
+    of silently testing a host-side paraphrase."""
+    from makermodslab.runners.hf_cloud import WRAPPER_SOURCE
+
+    namespace: dict = {"trainer_argv": trainer_argv}
+    for name in ("_arg", "_set_arg"):
+        match = re.search(rf"^def {name}\(.*?(?=^\S)", WRAPPER_SOURCE, re.MULTILINE | re.DOTALL)
+        assert match, f"{name} not found in WRAPPER_SOURCE"
+        exec(compile(match.group(0), "<hf-jobs-wrapper>", "exec"), namespace)  # noqa: S102
+    return namespace["_arg"], namespace["_set_arg"]
+
+
+def test_wrapper_set_arg_rewrites_both_argv_spellings() -> None:
+    """The rewrite must hit whichever form the argv builder used, and touch
+    nothing else — this is what turns a Hub ref only the pod can resolve into a
+    real path for the trainer."""
+    joined = ["--policy.type=act", "--policy.pretrained_path=user/repo@checkpoints/003000", "--steps=10"]
+    arg, set_arg = _wrapper_argv_helpers(joined)
+    assert arg("--policy.pretrained_path") == "user/repo@checkpoints/003000"
+    assert set_arg("--policy.pretrained_path", "/tmp/base") is True
+    assert joined == ["--policy.type=act", "--policy.pretrained_path=/tmp/base", "--steps=10"]
+
+    split = ["--policy.pretrained_path", "user/repo@checkpoints/003000", "--steps", "10"]
+    arg, set_arg = _wrapper_argv_helpers(split)
+    assert arg("--policy.pretrained_path") == "user/repo@checkpoints/003000"
+    assert set_arg("--policy.pretrained_path", "/tmp/base") is True
+    assert split == ["--policy.pretrained_path", "/tmp/base", "--steps", "10"]
+
+
+def test_wrapper_set_arg_reports_a_missing_flag() -> None:
+    """A bare-repo-id fine-tune (or no fine-tune at all) leaves the argv alone;
+    the wrapper treats an unexpected miss as a hard error rather than launching
+    a run that trains from the wrong weights."""
+    argv = ["--policy.type=act"]
+    arg, set_arg = _wrapper_argv_helpers(argv)
+    assert arg("--policy.pretrained_path") is None
+    assert set_arg("--policy.pretrained_path", "/tmp/base") is False
+    assert argv == ["--policy.type=act"]
 
 
 def test_cloud_resume_argv_keeps_lineage_in_parent_repo() -> None:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -64,6 +64,10 @@ def test_resume_request_emits_minimal_argv() -> None:
     # Inherited from the checkpoint — must not be re-specified on the CLI.
     assert "--dataset.repo_id" not in cmd
     assert "--policy.type" not in cmd
+    assert "--optimizer.type" not in cmd
+    # Optimizer state comes from the checkpoint on a resume — see
+    # test_resume_emits_no_optimizer_flags for the full assertion.
+    assert not any(tok.startswith("--policy.optimizer_") for tok in cmd)
 
 
 def test_optional_dataset_fields_only_present_when_set() -> None:
@@ -227,6 +231,171 @@ def test_training_request_validates_required_field() -> None:
 
     with pytest.raises(ValidationError):
         TrainingRequest()  # dataset_repo_id is required
+
+
+# ---------------------------------------------------------------------------
+# Optimizer knobs. The form always runs with use_policy_training_preset true,
+# and lerobot then REPLACES the optimizer with the policy's preset
+# (TrainPipelineConfig.validate, configs/train.py:249-253), so `--optimizer.*`
+# is inert. The knobs must ride on the POLICY config the preset is built from,
+# and only where that policy actually declares them (draccus fails at CLI parse
+# on an unknown --policy.<field>). See MT43.
+# ---------------------------------------------------------------------------
+
+
+def test_optimizer_knobs_ride_on_policy_config() -> None:
+    """lr + weight_decay reach argv as --policy.optimizer_* for a policy (act)
+    that declares both."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    req = TrainingRequest(
+        dataset_repo_id="x",
+        policy_type="act",
+        optimizer_lr=1e-4,
+        optimizer_weight_decay=0.01,
+    )
+    cmd = build_training_command(req, "/tmp/out")
+
+    assert _arg_value(cmd, "--policy.optimizer_lr") == "0.0001"
+    assert _arg_value(cmd, "--policy.optimizer_weight_decay") == "0.01"
+
+
+def test_optimizer_knobs_absent_when_unset() -> None:
+    """A knob the user left blank must not be forced onto argv — the policy
+    preset's own default has to win."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(TrainingRequest(dataset_repo_id="x", policy_type="act"), "/tmp/out")
+
+    assert "--policy.optimizer_lr" not in cmd
+    assert "--policy.optimizer_weight_decay" not in cmd
+    assert "--policy.optimizer_grad_clip_norm" not in cmd
+
+
+def test_grad_clip_gated_on_policy_support() -> None:
+    """smolvla declares optimizer_grad_clip_norm; act does NOT. Passing it to
+    act would make draccus die at parse time, so it must be dropped even though
+    the user set a value."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    smolvla = build_training_command(
+        TrainingRequest(dataset_repo_id="x", policy_type="smolvla", optimizer_grad_clip_norm=5.0),
+        "/tmp/out",
+    )
+    assert _arg_value(smolvla, "--policy.optimizer_grad_clip_norm") == "5.0"
+
+    act = build_training_command(
+        TrainingRequest(dataset_repo_id="x", policy_type="act", optimizer_grad_clip_norm=5.0),
+        "/tmp/out",
+    )
+    assert "--policy.optimizer_grad_clip_norm" not in act
+    # ...and dropping it must not disturb the knobs act DOES support.
+    assert "--policy.type" in act
+
+
+def test_weight_decay_gated_for_tdmpc() -> None:
+    """tdmpc declares only optimizer_lr — weight_decay must be dropped."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(
+        TrainingRequest(
+            dataset_repo_id="x",
+            policy_type="tdmpc",
+            optimizer_lr=3e-4,
+            optimizer_weight_decay=0.01,
+            optimizer_grad_clip_norm=5.0,
+        ),
+        "/tmp/out",
+    )
+
+    assert _arg_value(cmd, "--policy.optimizer_lr") == "0.0003"
+    assert "--policy.optimizer_weight_decay" not in cmd
+    assert "--policy.optimizer_grad_clip_norm" not in cmd
+
+
+def test_gaussian_actor_takes_no_optimizer_knobs() -> None:
+    """gaussian_actor's preset is a MultiAdamConfig built from per-group
+    settings; its config declares none of the three scalar knobs."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(
+        TrainingRequest(
+            dataset_repo_id="x",
+            policy_type="gaussian_actor",
+            optimizer_lr=1e-4,
+            optimizer_weight_decay=0.01,
+            optimizer_grad_clip_norm=5.0,
+        ),
+        "/tmp/out",
+    )
+
+    assert not any(tok.startswith("--policy.optimizer_") for tok in cmd)
+
+
+def test_unknown_policy_type_falls_back_to_lr_only() -> None:
+    """A policy type absent from the capability table (form addition ahead of
+    the table, or an old persisted config) gets the conservative subset."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    cmd = build_training_command(
+        TrainingRequest(
+            dataset_repo_id="x",
+            policy_type="some_future_policy",
+            optimizer_lr=1e-4,
+            optimizer_weight_decay=0.01,
+            optimizer_grad_clip_norm=5.0,
+        ),
+        "/tmp/out",
+    )
+
+    assert _arg_value(cmd, "--policy.optimizer_lr") == "0.0001"
+    assert "--policy.optimizer_weight_decay" not in cmd
+    assert "--policy.optimizer_grad_clip_norm" not in cmd
+
+
+@pytest.mark.parametrize("policy_type", ["act", "diffusion", "pi0", "smolvla", "tdmpc", "vqbet", "pi0_fast"])
+def test_no_optimizer_namespace_flag_is_ever_emitted(policy_type: str) -> None:
+    """The `--optimizer.*` namespace is dead under the training preset. Nothing
+    the builder emits may land there — including the optimizer TYPE, which the
+    policy preset fixes and the CLI cannot override."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    req = TrainingRequest(
+        dataset_repo_id="x",
+        policy_type=policy_type,
+        optimizer_type="sgd",
+        optimizer_lr=1e-4,
+        optimizer_weight_decay=0.01,
+        optimizer_grad_clip_norm=5.0,
+    )
+    cmd = build_training_command(req, "/tmp/out")
+
+    assert not any(tok.startswith("--optimizer.") for tok in cmd)
+    assert "sgd" not in cmd
+    # The preset is what makes --optimizer.* inert; assert it's actually on.
+    assert _arg_value(cmd, "--use_policy_training_preset") == "true"
+
+
+def test_resume_emits_no_optimizer_flags() -> None:
+    """On resume lerobot SKIPS the preset overwrite (the `not self.resume`
+    guard) and restores optimizer state from the checkpoint. Re-specifying the
+    knobs would fight that, so neither namespace may appear."""
+    from makermodslab.train import TrainingRequest, build_training_command
+
+    req = TrainingRequest(
+        dataset_repo_id="x",
+        policy_type="smolvla",
+        resume=True,
+        config_path="/runs/abc/checkpoints/5000/pretrained_model/train_config.json",
+        optimizer_type="sgd",
+        optimizer_lr=1e-4,
+        optimizer_weight_decay=0.01,
+        optimizer_grad_clip_norm=5.0,
+    )
+    cmd = build_training_command(req, "/tmp/new")
+
+    assert not any(tok.startswith("--optimizer.") for tok in cmd)
+    assert not any(tok.startswith("--policy.optimizer_") for tok in cmd)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -48,6 +48,9 @@ def test_resume_request_emits_minimal_argv() -> None:
         resume=True,
         config_path="/runs/abc/checkpoints/5000/pretrained_model/train_config.json",
         steps=20000,
+        num_workers=12,
+        batch_size=64,
+        seed=7,
     )
     cmd = build_training_command(req, output_dir="/tmp/new")
 
@@ -61,9 +64,19 @@ def test_resume_request_emits_minimal_argv() -> None:
     assert _arg_value(cmd, "--resume") == "true"
     assert _arg_value(cmd, "--output_dir") == "/tmp/new"
     assert _arg_value(cmd, "--steps") == "20000"
+    assert _arg_value(cmd, "--log_freq") == str(req.log_freq)
+    assert _arg_value(cmd, "--save_freq") == str(req.save_freq)
+    # num_workers is a HOST-capacity knob, not an experiment property (the
+    # resumed run's flavor can differ from the parent's), so it stays editable
+    # on a continuation and must actually reach the CLI.
+    assert _arg_value(cmd, "--num_workers") == "12"
     # Inherited from the checkpoint — must not be re-specified on the CLI.
     assert "--dataset.repo_id" not in cmd
     assert "--policy.type" not in cmd
+    assert "--batch_size" not in cmd
+    assert "--seed" not in cmd
+    assert "--policy.device" not in cmd
+    assert "--policy.use_amp" not in cmd
     assert "--optimizer.type" not in cmd
     # Optimizer state comes from the checkpoint on a resume — see
     # test_resume_emits_no_optimizer_flags for the full assertion.


### PR DESCRIPTION
Eight fixes to the training path, all found the same way: the app said one
thing and the trainer did another. Three themes.

**Route it for real.** Optimizer knobs (lr, weight decay, grad clip) were
dead — `use_policy_training_preset` is always on, so lerobot rebuilt the
optimizer from the policy preset and discarded every `--optimizer.*` flag the
form sent. They now go through `--policy.optimizer_*`, gated by a per-policy
capability table. A fine-tune's checkpoint ref `repo@checkpoints/003000` was
truncated to the bare repo id, so picking "step 3000" silently trained from
repo-ROOT weights (MT2); the ref now stays whole and is materialized by
whichever machine runs the trainer — host-side for a local run, pod-side by
the HF Jobs wrapper. `--num_workers` now actually reaches a resumed run.

**Refuse it loudly.** A `done` run offered Continue, but its LR schedule is
spent (SmolVLA cosine-decays to a 2.5e-6 floor over a fixed horizon), so the
continuation trains at floor LR and the flat loss curve reads as convergence.
A cross-runner resume dies at startup one way (cloud→local, MT4) and silently
restarts from step 0 the other (local→cloud, MT42). And a fine-tune whose
checkpoint contradicts the dataset was the worst of the three: on this launch
path lerobot sizes the policy from the DATASET and loads weights
`strict=False`, so a 6-dof checkpoint loads *cleanly* into a 12-dof bimanual
run and trains garbage labelled as a fine-tune (MT44). All three now refuse
with a plain-language 400 before anything downloads, and the form refuses
first — Compute is pinned to the parent's runner on a resume.

**Display it honestly.** The resume form accepted edits to batch size, seed,
optimizer, AMP and device that lerobot rebuilds from the checkpoint and throws
away — those controls are now read-only, with num_workers deliberately left
live (host capacity, not experiment). A resumed run reported 0/0 for the
minutes before lerobot's first tqdm frame; records now start at the checkpoint
floor. A newly started run could miss the monitor entirely when the
fire-and-forget `jobs_changed` ping was dropped; both progress consumers now
self-heal an unknown id. A local fine-tune's multi-GB download ran inside the
POST with nothing on screen; the record is created first and the download
streams into the job's own log. And a stopped run said "Interrupted" on the
card and `interrupted` in the dialog — one label map now, reading "Stopped".

### Commits

1. `feat(training)` optimizer knobs through the policy config; honest preset display
2. `feat(jobs)` refuse a resume that can't work — done source, or the wrong runner
3. `ui(training)` checkpoint-rebuilt fields read-only on resume; num_workers through
4. `feat(jobs)` honor the fine-tune step a user picked (MT2)
5. `feat(jobs)` create the record first, then download the fine-tune base
6. `feat(jobs)` refuse fine-tunes whose checkpoint contradicts the dataset (MT44)
7. `fix(jobs,ui)` make the monitor tell the truth about a run it just started
8. `fix(ui)` one vocabulary for job states — a stopped run reads "Stopped"

### Test plan

- `pytest tests/` — 1031 passed, +63 over main. The 7 `test_models.py`
  failures are pre-existing on main (real-cache leakage), unchanged.
- `ruff check makermodslab/ tests/` clean.
- From `frontend/`: `npx tsc -p tsconfig.app.json --noEmit` — 5 errors, the
  same 5 as main, zero new. `npm run lint` — 3 errors / 24 warnings,
  unchanged. `npm run build` succeeds. No `frontend/dist` changes (CI
  regenerates it).
- Manual: start a local fine-tune from a Hub step and confirm the monitor
  opens immediately with download progress; press Stop mid-download and
  confirm the run reads "Stopped"; try to Continue a completed run and a
  cross-runner resume and confirm both refuse; fine-tune a single-arm
  checkpoint against a bimanual dataset and confirm the 400.

Supersedes parts of #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
