### PR TITLE
feat(inference): multi-episode evaluation suite — persistent runner, RTC engine, honest logs

### DIFF
--- a/frontend/src/components/inference/InferenceSessionDialog.tsx
+++ b/frontend/src/components/inference/InferenceSessionDialog.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
   EpisodeResult,
   InferenceStatus,
+  InferenceLogOwner,
   InferencePhase,
   getInferenceStatus,
   getInferenceLog,
@@ -105,6 +106,10 @@ const InferenceSessionDialog: React.FC<{
   const { toast } = useToast();
   const [status, setStatus] = useState<InferenceStatus | null>(null);
   const [logs, setLogs] = useState("");
+  // Which run the fetched log belongs to. Never inferred from the text: the
+  // backend says so explicitly, because a log file on disk carries no evidence
+  // of which run wrote it.
+  const [logOwner, setLogOwner] = useState<InferenceLogOwner>(null);
   const [stopping, setStopping] = useState(false);
   // Eval mode only: in-flight guards for the two per-episode controls, so a
   // double-click can't fire "succeeded" or "next episode" twice.
@@ -171,7 +176,10 @@ const InferenceSessionDialog: React.FC<{
         // Best-effort: a log fetch failure must not disturb status handling.
         try {
           const log = await getInferenceLog(baseUrl, fetchWithHeaders);
-          if (!cancelled) setLogs(log.logs);
+          if (!cancelled) {
+            setLogs(log.logs);
+            setLogOwner(log.belongs_to);
+          }
         } catch {
           // Ignore; the next tick retries.
         }
@@ -375,6 +383,18 @@ const InferenceSessionDialog: React.FC<{
   const finishedWarn = isFinished && outcome === "ran_with_warning";
   const finishedFailed = isFinished && outcome === "failed";
   const showOutcome = finishedWarn || finishedFailed;
+  // What to put in the log panel. `logs` is only THIS run's output when the
+  // backend says the log belongs to the active session; a finished run's own log
+  // is equally fine to show once the session has ended. Anything else means this
+  // run has produced no output, and printing the text anyway is how a previous
+  // run's log gets read as the current one — a live incident, where a failed run
+  // showed a three-day-old run's output and the user concluded the wrong policy
+  // had executed.
+  const logIsThisRun =
+    logOwner === "active" || (logOwner === "last_run" && !status?.inference_active);
+  const logPlaceholder = finishedFailed
+    ? "This run failed before the rollout process started, so it produced no log — see the error above."
+    : "No log yet for this run — it hasn't started producing output.";
   // The live timer/progress block is replaced by the reset screen between
   // episodes and by the summary once an evaluation ends.
   const showTimer = !isFinished && !isResetting;
@@ -791,7 +811,7 @@ const InferenceSessionDialog: React.FC<{
 
             <div className="mt-4">
               <LogPanel
-                logs={logs}
+                logs={logIsThisRun ? logs : logPlaceholder}
                 title="Inference log"
                 defaultCollapsed
                 wrap={false}

--- a/frontend/src/components/inference/InferenceSessionDialog.tsx
+++ b/frontend/src/components/inference/InferenceSessionDialog.tsx
@@ -1,15 +1,18 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Loader2, Square } from "lucide-react";
+import { CheckCircle2, Loader2, Play, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useApi } from "@/contexts/ApiContext";
 import { useToast } from "@/hooks/use-toast";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
+  EpisodeResult,
   InferenceStatus,
   InferencePhase,
   getInferenceStatus,
   getInferenceLog,
+  startNextInferenceEpisode,
   stopInference,
+  stopInferenceEpisode,
 } from "@/lib/inferenceApi";
 import LogPanel from "@/components/LogPanel";
 import { formatBytes } from "@/lib/formatBytes";
@@ -33,7 +36,28 @@ const PHASE_META: Record<
   stopping: { label: "Stopping…", tone: "amber", pulse: true },
   stopped: { label: "Stopped", tone: "green", pulse: false },
   error: { label: "Error — see log", tone: "red", pulse: false },
+  resetting: { label: "Reset the scene", tone: "amber", pulse: false },
+  finished: { label: "Evaluation complete", tone: "green", pulse: false },
+  aborted: { label: "Evaluation aborted", tone: "amber", pulse: false },
 };
+
+// Per-episode verdict styling for the tally + the final per-episode list.
+const RESULT_META: Record<
+  EpisodeResult,
+  { label: string; dot: string; text: string }
+> = {
+  success: { label: "Success", dot: "bg-ok", text: "text-ok" },
+  failure: { label: "Failure", dot: "bg-muted-foreground", text: "text-muted-foreground" },
+  error: { label: "Error", dot: "bg-destructive", text: "text-destructive" },
+};
+
+function tally(results: EpisodeResult[]): Record<EpisodeResult, number> {
+  return {
+    success: results.filter((r) => r === "success").length,
+    failure: results.filter((r) => r === "failure").length,
+    error: results.filter((r) => r === "error").length,
+  };
+}
 
 const PHASE_DOT: Record<"amber" | "green" | "red", string> = {
   amber: "bg-warn",
@@ -82,6 +106,10 @@ const InferenceSessionDialog: React.FC<{
   const [status, setStatus] = useState<InferenceStatus | null>(null);
   const [logs, setLogs] = useState("");
   const [stopping, setStopping] = useState(false);
+  // Eval mode only: in-flight guards for the two per-episode controls, so a
+  // double-click can't fire "succeeded" or "next episode" twice.
+  const [endingEpisode, setEndingEpisode] = useState(false);
+  const [startingNext, setStartingNext] = useState(false);
   const exitedRef = useRef(false);
   // Independent flag: we may request a stop (safety net) before the run
   // is actually inactive. We must not flip exitedRef yet — that
@@ -170,6 +198,30 @@ const InferenceSessionDialog: React.FC<{
             });
             return;
           }
+          // An evaluation that ran its course (or was aborted) ends on its
+          // SUMMARY, not by bouncing away: the accuracy and the per-episode
+          // list are the entire point of the run. Freeze here and let the user
+          // close. Checked after the failure branch above so a session-level
+          // startup failure still renders as an error, not a summary.
+          if (next.eval_mode && next.exited) {
+            markHandled();
+            exitedRef.current = true;
+            doneRef.current = true;
+            toast({
+              title:
+                next.phase === "aborted"
+                  ? "Evaluation aborted"
+                  : "Evaluation complete",
+              description:
+                next.phase === "aborted"
+                  ? "Partial results — no accuracy recorded."
+                  : next.accuracy != null
+                    ? `${Math.round(next.accuracy * 100)}% success rate.`
+                    : "No scoreable episodes.",
+              duration: 10000,
+            });
+            return;
+          }
           // A clean finish (completed / user stop): toast + auto-close.
           // Mark the exit handled so the leave guard doesn't fire a spurious
           // stop on the imminent unmount.
@@ -246,16 +298,72 @@ const InferenceSessionDialog: React.FC<{
     }
   };
 
+  // Eval mode: "the robot did the task". Ends THIS episode and scores it a
+  // success; the session stays up and moves into its reset phase. Deliberately
+  // not `handleStop` — that aborts the whole evaluation.
+  const handleEpisodeSuccess = async () => {
+    setEndingEpisode(true);
+    try {
+      await stopInferenceEpisode(baseUrl, fetchWithHeaders);
+      // The status poll picks up the reset phase and the updated tally.
+    } catch (e) {
+      toast({
+        title: "Couldn't end the episode",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "destructive",
+      });
+    } finally {
+      setEndingEpisode(false);
+    }
+  };
+
+  const handleNextEpisode = async () => {
+    setStartingNext(true);
+    try {
+      await startNextInferenceEpisode(baseUrl, fetchWithHeaders);
+    } catch (e) {
+      toast({
+        title: "Couldn't start the next episode",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "destructive",
+      });
+    } finally {
+      setStartingNext(false);
+    }
+  };
+
   // Dismissal is blocked while the run is (or may still be) live — before the
   // first status lands we treat the session as live, since the launcher just
-  // started it.
+  // started it. A reset between episodes counts as live: the session still owns
+  // the arm and the cameras.
   const live = status == null || status.inference_active === true;
 
   const setupElapsed = status?.elapsed_s ?? 0;
   const rolloutElapsed = status?.rollout_elapsed_s ?? 0;
   const duration = status?.duration_s ?? 0;
+  // --- Multi-episode evaluation --------------------------------------------
+  // `eval_mode` is the single flag to branch on: a plain run reports it false
+  // with null companions, so everything below collapses to the old behaviour.
+  const evalMode = status?.eval_mode === true;
+  const episodesTotal = status?.episodes_total ?? null;
+  const episodeIndex = status?.episode_index ?? null;
+  const results = (status?.episode_results ?? []) as EpisodeResult[];
+  const counts = tally(results);
+  const accuracy = status?.accuracy ?? null;
+  // Parked between episodes, waiting for the user to rearrange the scene.
+  const isResetting = evalMode && status?.phase === "resetting";
+  const evalFinished = evalMode && status?.phase === "finished";
+  const evalAborted = evalMode && status?.phase === "aborted";
+  const isEvalDone = evalFinished || evalAborted;
+  // A crashed episode parks in the reset phase carrying its error — the reset
+  // screen doubles as "this one broke, continue or abort?".
+  const episodeCrashed = isResetting && !!status?.error;
+
   const isSettingUp =
-    status != null && status.inference_active && status.rollout_started_at == null;
+    status != null &&
+    status.inference_active &&
+    !isResetting &&
+    status.rollout_started_at == null;
   const isRunning =
     status != null && status.inference_active && status.rollout_started_at != null;
 
@@ -267,6 +375,9 @@ const InferenceSessionDialog: React.FC<{
   const finishedWarn = isFinished && outcome === "ran_with_warning";
   const finishedFailed = isFinished && outcome === "failed";
   const showOutcome = finishedWarn || finishedFailed;
+  // The live timer/progress block is replaced by the reset screen between
+  // episodes and by the summary once an evaluation ends.
+  const showTimer = !isFinished && !isResetting;
 
   // When setting up: progress is uncertain — show a soft pulsing bar.
   // When rolling out: progress is rolloutElapsed / duration.
@@ -278,6 +389,12 @@ const InferenceSessionDialog: React.FC<{
     ? "red"
     : finishedWarn
     ? "amber"
+    : evalAborted
+    ? "amber"
+    : evalFinished
+    ? "green"
+    : isResetting
+    ? "amber"
     : isSettingUp
     ? "amber"
     : "green";
@@ -285,6 +402,12 @@ const InferenceSessionDialog: React.FC<{
     ? "FAILED"
     : finishedWarn
     ? "RAN WITH WARNING"
+    : evalAborted
+    ? "ABORTED"
+    : evalFinished
+    ? "EVALUATION COMPLETE"
+    : isResetting
+    ? "RESET THE SCENE"
     : isSettingUp
     ? "SETTING UP"
     : isRunning
@@ -357,7 +480,141 @@ const InferenceSessionDialog: React.FC<{
               </div>
             </div>
 
-            {!isFinished && (
+            {/* Evaluation header — which episode we're on, and the tally so
+                far. Rendered on every eval screen (running, reset, summary) so
+                the score is never more than a glance away. */}
+            {evalMode && (
+              <div className="mb-6 rounded-lg border border-border bg-muted/30 p-4">
+                <div className="flex items-baseline justify-between gap-4">
+                  <span className="text-sm font-semibold">
+                    {isEvalDone
+                      ? `${episodesTotal ?? results.length} episodes`
+                      : `Episode ${episodeIndex ?? 1} of ${episodesTotal ?? "?"}`}
+                  </span>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {results.length} done
+                  </span>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-1 text-sm tabular-nums">
+                  {(["success", "failure", "error"] as EpisodeResult[]).map(
+                    (key) => (
+                      <span key={key} className="flex items-center gap-1.5">
+                        <span
+                          className={`h-2 w-2 rounded-full ${RESULT_META[key].dot}`}
+                        />
+                        <span className={RESULT_META[key].text}>
+                          {RESULT_META[key].label}
+                        </span>
+                        <span className="font-semibold">{counts[key]}</span>
+                      </span>
+                    ),
+                  )}
+                </div>
+                {counts.error > 0 && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Errored episodes are excluded from the accuracy — a hardware
+                    hiccup isn't a policy failure.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Evaluation summary — the point of the whole run. */}
+            {isEvalDone && (
+              <div
+                className={`mb-6 rounded-lg border p-4 ${
+                  evalAborted
+                    ? "border-warn/40 bg-warn/10"
+                    : "border-ok/40 bg-ok/10"
+                }`}
+              >
+                {evalAborted ? (
+                  <p className="text-sm leading-relaxed text-warn">
+                    Aborted after {results.length} of {episodesTotal ?? "?"}{" "}
+                    episodes — no accuracy recorded for a partial run.
+                  </p>
+                ) : accuracy != null ? (
+                  <div className="text-center">
+                    <div className="text-5xl font-mono font-bold leading-none text-ok">
+                      {Math.round(accuracy * 100)}%
+                    </div>
+                    <div className="mt-2 text-sm text-muted-foreground tabular-nums">
+                      {counts.success} / {counts.success + counts.failure}{" "}
+                      episodes succeeded
+                      {counts.error > 0
+                        ? ` (${counts.error} excluded as errors)`
+                        : ""}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm leading-relaxed text-warn">
+                    No scoreable episodes — every episode errored, so there's no
+                    accuracy to report.
+                  </p>
+                )}
+                {results.length > 0 && (
+                  <ol className="mt-4 space-y-1 text-xs tabular-nums">
+                    {results.map((r, i) => (
+                      <li
+                        key={i}
+                        className="flex items-center gap-2 text-muted-foreground"
+                      >
+                        <span className="w-10 shrink-0">#{i + 1}</span>
+                        <span
+                          className={`h-1.5 w-1.5 rounded-full ${RESULT_META[r].dot}`}
+                        />
+                        <span className={RESULT_META[r].text}>
+                          {RESULT_META[r].label}
+                        </span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+            )}
+
+            {/* Reset between episodes — user-ended, no timer. */}
+            {isResetting && (
+              <div
+                className={`mb-6 rounded-lg border p-4 ${
+                  episodeCrashed
+                    ? "border-destructive/40 bg-destructive/10"
+                    : "border-warn/40 bg-warn/10"
+                }`}
+              >
+                {episodeCrashed ? (
+                  <>
+                    <div className="flex items-center gap-2 text-sm font-semibold text-destructive">
+                      <span className="h-2 w-2 rounded-full bg-destructive" />
+                      Episode {results.length} crashed
+                    </div>
+                    <p className="mt-2 text-sm leading-relaxed text-destructive/90">
+                      It counts as neither a success nor a failure. Continue to
+                      run the next episode, or abort the evaluation.
+                    </p>
+                    {status.hint && (
+                      <p className="mt-2 text-sm leading-relaxed text-destructive/90">
+                        {status.hint}
+                      </p>
+                    )}
+                    {status.error && (
+                      <pre className="mt-3 max-h-40 overflow-auto rounded bg-muted p-2 text-xs text-muted-foreground whitespace-pre-wrap break-words">
+                        {status.error}
+                      </pre>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-sm leading-relaxed text-warn">
+                    Episode {results.length} recorded as{" "}
+                    <strong>{RESULT_META[results.at(-1) ?? "failure"].label}</strong>
+                    . Rearrange the scene, then start the next episode — there's
+                    no timer, take as long as you need.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {showTimer && (
               <>
                 <div className="text-center mb-4">
                   <div
@@ -434,6 +691,57 @@ const InferenceSessionDialog: React.FC<{
               >
                 Close
               </Button>
+            ) : isResetting ? (
+              // Reset screen: continue is the primary action, abort stays
+              // available alongside it.
+              <div className="space-y-2">
+                <Button
+                  onClick={handleNextEpisode}
+                  disabled={startingNext}
+                  className="w-full font-semibold py-6 text-lg disabled:opacity-50"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  {startingNext
+                    ? "Starting…"
+                    : `Start episode ${Math.min(
+                        results.length + 1,
+                        episodesTotal ?? results.length + 1,
+                      )}`}
+                </Button>
+                <Button
+                  onClick={handleStop}
+                  disabled={stopping}
+                  variant="outline"
+                  className="w-full font-semibold disabled:opacity-50"
+                >
+                  <Square className="w-4 h-4 mr-2" />
+                  {stopping ? "Aborting…" : "Abort evaluation"}
+                </Button>
+              </div>
+            ) : evalMode ? (
+              // Running an episode: calling it a success is the primary action,
+              // and it is NOT the same button as aborting the whole run.
+              <div className="space-y-2">
+                <Button
+                  onClick={handleEpisodeSuccess}
+                  disabled={!isRunning || endingEpisode}
+                  className="w-full font-semibold py-6 text-lg disabled:opacity-50"
+                >
+                  <CheckCircle2 className="w-5 h-5 mr-2" />
+                  {endingEpisode
+                    ? "Ending episode…"
+                    : "Task succeeded — end episode"}
+                </Button>
+                <Button
+                  onClick={handleStop}
+                  disabled={!status.inference_active || stopping}
+                  variant="outline"
+                  className="w-full font-semibold disabled:opacity-50"
+                >
+                  <Square className="w-4 h-4 mr-2" />
+                  {stopping ? "Aborting…" : "Abort evaluation"}
+                </Button>
+              </div>
             ) : (
               <Button
                 onClick={handleStop}

--- a/frontend/src/components/landing/InferenceModal.tsx
+++ b/frontend/src/components/landing/InferenceModal.tsx
@@ -167,6 +167,9 @@ const InferenceModal: React.FC<Props> = ({
   const [selectedStep, setSelectedStep] = useState<number | null>(initialStep);
   const [task, setTask] = useState("");
   const [durationS, setDurationS] = useState(60);
+  // Inference engine A/B. "sync" is the server default and the historical
+  // behaviour; "rtc" is experimental (see StartInferenceRequest).
+  const [inferenceEngine, setInferenceEngine] = useState<"sync" | "rtc">("sync");
   const [submitting, setSubmitting] = useState(false);
 
   const [policyConfig, setPolicyConfig] = useState<PolicyConfigSummary | null>(null);
@@ -435,6 +438,7 @@ const InferenceModal: React.FC<Props> = ({
         // same arm-count guard authoritatively (null when the checkpoint omits
         // observation.state — the server then defers to its shape check).
         checkpoint_state_dim: policyConfig.state_dim ?? undefined,
+        inference_engine: inferenceEngine,
       });
       onOpenChange(false);
       openInferenceSession();
@@ -582,6 +586,33 @@ const InferenceModal: React.FC<Props> = ({
                 }}
                 className=""
               />
+            </div>
+            <div className="space-y-2">
+              <Label
+                htmlFor="inference-engine"
+                className="text-sm font-medium text-muted-foreground"
+              >
+                Inference engine
+              </Label>
+              <Select
+                value={inferenceEngine}
+                onValueChange={(v) => setInferenceEngine(v as "sync" | "rtc")}
+              >
+                <SelectTrigger id="inference-engine">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="sync">Sync (default)</SelectItem>
+                  <SelectItem value="rtc">
+                    RTC — experimental, smoother control
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {inferenceEngine === "rtc"
+                  ? "Real-Time Chunking overlaps inference with motion, removing the pause between action chunks. It also changes how actions are generated — compare against Sync before trusting a result."
+                  : "One policy forward per control step. The arm pauses briefly between action chunks."}
+              </p>
             </div>
           </div>
 

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -194,6 +194,9 @@ const DeployPanel: React.FC = () => {
   // switches the session dialog into eval mode — N scored episodes with a reset
   // between each and an accuracy at the end. Clamped again server-side.
   const [evalEpisodes, setEvalEpisodes] = useState(1);
+  // Inference engine A/B. "sync" is the server default and the historical
+  // behaviour; "rtc" is experimental (see StartInferenceRequest).
+  const [inferenceEngine, setInferenceEngine] = useState<"sync" | "rtc">("sync");
   const [submitting, setSubmitting] = useState(false);
 
   const [policyConfig, setPolicyConfig] = useState<PolicyConfigSummary | null>(
@@ -586,6 +589,7 @@ const DeployPanel: React.FC = () => {
         robot_name: robot.name,
         checkpoint_state_dim: policyConfig.state_dim ?? undefined,
         eval_episodes: evalEpisodes,
+        inference_engine: inferenceEngine,
       });
       // The run surfaces as the InferenceSessionDialog over this panel —
       // closing it lands back here (the studio stays open underneath).
@@ -859,6 +863,28 @@ const DeployPanel: React.FC = () => {
                   {evalEpisodes > 1
                     ? `Evaluation run: ${evalEpisodes} episodes with a reset between each, scored into an accuracy.`
                     : "Leave at 1 for a single run. More than 1 starts a scored evaluation."}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="deploy-engine">Inference engine</Label>
+                <Select
+                  value={inferenceEngine}
+                  onValueChange={(v) => setInferenceEngine(v as "sync" | "rtc")}
+                >
+                  <SelectTrigger id="deploy-engine">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="sync">Sync (default)</SelectItem>
+                    <SelectItem value="rtc">
+                      RTC — experimental, smoother control
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {inferenceEngine === "rtc"
+                    ? "Real-Time Chunking overlaps inference with motion, removing the pause between action chunks. It also changes how actions are generated — compare against Sync before trusting a result."
+                    : "One policy forward per control step. The arm pauses briefly between action chunks."}
                 </p>
               </div>
             </>

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -76,6 +76,9 @@ import BackendCameraStream from "@/components/BackendCameraStream";
 
 const DEFAULT_FPS = 30;
 const JOB_SCAN_LIMIT = 200;
+// Mirrors rollout.MAX_EVAL_EPISODES — the server clamps to the same bound, this
+// just stops the stepper from offering a number that would be silently reduced.
+const MAX_EVAL_EPISODES = 200;
 
 const cameraKey = (cam: AvailableCamera) => String(cam.index);
 
@@ -187,6 +190,10 @@ const DeployPanel: React.FC = () => {
   const [selectedStep, setSelectedStep] = useState<number | null>(null);
   const [task, setTask] = useState("");
   const [durationS, setDurationS] = useState(60);
+  // Multi-episode evaluation. 1 (the default) is the plain single rollout; >1
+  // switches the session dialog into eval mode — N scored episodes with a reset
+  // between each and an accuracy at the end. Clamped again server-side.
+  const [evalEpisodes, setEvalEpisodes] = useState(1);
   const [submitting, setSubmitting] = useState(false);
 
   const [policyConfig, setPolicyConfig] = useState<PolicyConfigSummary | null>(
@@ -578,6 +585,7 @@ const DeployPanel: React.FC = () => {
         right_follower_config: robot.right_follower_config,
         robot_name: robot.name,
         checkpoint_state_dim: policyConfig.state_dim ?? undefined,
+        eval_episodes: evalEpisodes,
       });
       // The run surfaces as the InferenceSessionDialog over this panel —
       // closing it lands back here (the studio stays open underneath).
@@ -831,6 +839,27 @@ const DeployPanel: React.FC = () => {
                     if (v !== undefined) setDurationS(v);
                   }}
                 />
+                <p className="text-xs text-muted-foreground">
+                  Per episode. An episode that runs this long without you
+                  calling it a success counts as a failure.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="deploy-episodes">Episodes</Label>
+                <NumberInput
+                  id="deploy-episodes"
+                  min={1}
+                  max={MAX_EVAL_EPISODES}
+                  value={evalEpisodes}
+                  onChange={(v) => {
+                    if (v !== undefined) setEvalEpisodes(v);
+                  }}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {evalEpisodes > 1
+                    ? `Evaluation run: ${evalEpisodes} episodes with a reset between each, scored into an accuracy.`
+                    : "Leave at 1 for a single run. More than 1 starts a scored evaluation."}
+                </p>
               </div>
             </>
           ) : null}
@@ -918,7 +947,11 @@ const DeployPanel: React.FC = () => {
           className="flex-1 gap-2"
         >
           <Play className="h-4 w-4" />
-          {submitting ? "Starting…" : "Start inference"}
+          {submitting
+            ? "Starting…"
+            : evalEpisodes > 1
+              ? `Start evaluation (${evalEpisodes})`
+              : "Start inference"}
         </Button>
         <Button
           onClick={handleStop}

--- a/frontend/src/lib/inferenceApi.ts
+++ b/frontend/src/lib/inferenceApi.ts
@@ -30,6 +30,12 @@ export interface StartInferenceRequest {
   // preflight, one camera handover), each scored success/failure, ending in an
   // accuracy. Clamped server-side to [1, 200].
   eval_episodes?: number;
+  // Which lerobot inference engine runs the rollout. "sync" (the server-side
+  // default) does one policy forward per control tick, so the arm pauses
+  // between action chunks; "rtc" (Real-Time Chunking) overlaps that forward
+  // with action playback on a background thread. Experimental: RTC changes the
+  // policy's action-generation path, not just its scheduling.
+  inference_engine?: "sync" | "rtc";
 }
 
 // Structured startup sub-phase, mirrored from rollout.py's phase constants.

--- a/frontend/src/lib/inferenceApi.ts
+++ b/frontend/src/lib/inferenceApi.ts
@@ -25,12 +25,19 @@ export interface StartInferenceRequest {
   // Checkpoint's flat state width (6 = single arm, 12 = bimanual). Lets the
   // server reject an arm-count mismatch before spawning the rollout subprocess.
   checkpoint_state_dim?: number;
+  // Multi-episode EVALUATION mode. Omitted/1 = the historical single rollout.
+  // >1 runs N sequential episodes in one session (one model download, one arm
+  // preflight, one camera handover), each scored success/failure, ending in an
+  // accuracy. Clamped server-side to [1, 200].
+  eval_episodes?: number;
 }
 
 // Structured startup sub-phase, mirrored from rollout.py's phase constants.
 // Names which substep a slow startup is in so the UI can say "Downloading
 // model…" / "Connecting to arm…" instead of one opaque spinner. Absent/null
 // when no session has seeded a phase yet.
+// The startup phases repeat PER EPISODE in evaluation mode (each episode is its
+// own rollout subprocess); `resetting`/`finished`/`aborted` are eval-only.
 export type InferencePhase =
   | "downloading_model"
   | "starting"
@@ -39,7 +46,20 @@ export type InferencePhase =
   | "running"
   | "stopping"
   | "stopped"
-  | "error";
+  | "error"
+  // Eval only: an episode ended and was scored; the session is parked waiting
+  // for the user to rearrange the scene and start the next one. Also where a
+  // CRASHED episode parks, with `error`/`hint` populated.
+  | "resetting"
+  // Eval only, terminal: every episode ran — `accuracy` is populated.
+  | "finished"
+  // Eval only, terminal: the user aborted. Partial tally, NO accuracy claimed.
+  | "aborted";
+
+// One episode's verdict. `error` (a crash: serial glitch, camera drop, policy
+// blow-up) is deliberately NEITHER success nor failure — it's excluded from the
+// accuracy denominator so one hardware hiccup can't poison a 20-episode number.
+export type EpisodeResult = "success" | "failure" | "error";
 
 // How a finished run turned out (present only on the exited status payload):
 //   ok               — clean exit.
@@ -78,6 +98,19 @@ export interface InferenceStatus {
   // Warn-but-allow arm-identity finding, surfaced once the run is up (the
   // preflight now runs server-side in the background, after the POST returned).
   warning?: string | null;
+  // --- Multi-episode evaluation -------------------------------------------
+  // False (with null companions) for a plain single rollout — the shape is
+  // stable, so `eval_mode` is the only flag worth branching on.
+  eval_mode?: boolean;
+  // 1-based index of the episode running / just scored, clamped to the total.
+  episode_index?: number | null;
+  episodes_total?: number | null;
+  // Verdicts in episode order; its length is how many episodes have finished.
+  episode_results?: EpisodeResult[] | null;
+  // successes / (successes + failures). Claimed ONLY on the `finished` payload:
+  // an aborted session reports its partial tally with accuracy null, and so
+  // does a session where every episode crashed.
+  accuracy?: number | null;
 }
 
 // The POST now returns immediately: it only validates the request cheaply, then
@@ -106,6 +139,36 @@ export async function stopInference(
     method: "POST",
     action: "Stop inference",
   });
+}
+
+// Evaluation mode only: end the CURRENT episode early and score it a SUCCESS
+// ("the robot did the task"). The session stays up and moves into its reset
+// phase — this is NOT stopInference, which aborts the whole run.
+export async function stopInferenceEpisode(
+  baseUrl: string,
+  fetcher: Fetcher,
+): Promise<{ message: string }> {
+  return apiRequest<{ message: string }>(
+    baseUrl,
+    fetcher,
+    "/inference-episode-stop",
+    { method: "POST", action: "Stop inference episode" },
+  );
+}
+
+// Evaluation mode only: leave the reset phase and start the next episode. The
+// reset is user-ended (no auto-timer) — rearranging a bench scene shouldn't be
+// on a clock.
+export async function startNextInferenceEpisode(
+  baseUrl: string,
+  fetcher: Fetcher,
+): Promise<{ message: string }> {
+  return apiRequest<{ message: string }>(
+    baseUrl,
+    fetcher,
+    "/inference-next-episode",
+    { method: "POST", action: "Start next episode" },
+  );
 }
 
 export async function getInferenceStatus(

--- a/frontend/src/lib/inferenceApi.ts
+++ b/frontend/src/lib/inferenceApi.ts
@@ -188,9 +188,22 @@ export async function getInferenceStatus(
   });
 }
 
+// Which run the returned log belongs to. The backend only ever serves a log it
+// opened itself, so this is never a guess:
+//   "active"   — the currently running session's own log
+//   "last_run" — the most recent FINISHED run of this server process
+//   null       — there is no log to show
+// A live session reporting anything other than "active" simply has not produced
+// output yet (it is still downloading/preflighting, or it failed before the
+// rollout process started). Rendering `logs` in that case is how a previous
+// run's output gets presented as the current run's — the defect this field
+// exists to prevent.
+export type InferenceLogOwner = "active" | "last_run" | null;
+
 export interface InferenceLog {
   logs: string;
   log_path: string | null;
+  belongs_to: InferenceLogOwner;
 }
 
 // Tail of the active/most-recent rollout's log file. Read-only + bounded on the

--- a/makermodslab/eval_protocol.py
+++ b/makermodslab/eval_protocol.py
@@ -1,0 +1,112 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Line protocol spoken between the eval orchestrator and the eval runner.
+
+Its own module, deliberately free of any heavy import, because BOTH ends need
+it and they live on opposite sides of a dependency wall:
+
+  - the orchestrator (`makermodslab.rollout`) is imported by the FastAPI server at
+    boot and must NOT drag in `lerobot.rollout` (torch, datasets, …);
+  - the runner (`makermodslab.eval_runner`) is exactly the process that does.
+
+Restating the strings in both modules would be a silent-drift bug the first
+time one side renames a marker — the orchestrator would simply stop
+recognising episode boundaries and every episode would look like a crash.
+
+Commands — orchestrator → runner stdin, one bare word per line:
+    EPISODE   run one rollout, up to the configured `--duration`
+    STOP      end the RUNNING episode early (clean; not a kill)
+    QUIT      return to the initial pose, disconnect, exit
+
+Events — runner → stdout, one line each, carrying a grep-able prefix so the
+orchestrator's log pump can pick them out of lerobot's own INFO chatter (the
+runner's stderr is merged into the same pipe):
+    MAKERMODSLAB-EVAL READY
+    MAKERMODSLAB-EVAL EPISODE_STARTED
+    MAKERMODSLAB-EVAL EPISODE_ENDED reason=duration
+    MAKERMODSLAB-EVAL EPISODE_ENDED reason=stopped
+    MAKERMODSLAB-EVAL ERROR <message, whitespace collapsed to one line>
+    MAKERMODSLAB-EVAL BYE
+
+The runner emits NO event for an episode cut short by QUIT: aborting a session
+deliberately leaves the in-flight episode unscored (see `_abort_eval_locked`),
+so reporting an end there would race the abort into scoring a verdict the user
+never asked for.
+"""
+
+from __future__ import annotations
+
+# --- Commands (stdin) -------------------------------------------------------
+CMD_EPISODE = "EPISODE"
+CMD_STOP = "STOP"
+CMD_QUIT = "QUIT"
+
+# --- Events (stdout) --------------------------------------------------------
+# Prefix chosen to be unmistakable in a log full of lerobot INFO lines and
+# unlikely to appear in a traceback.
+EVENT_PREFIX = "MAKERMODSLAB-EVAL"
+
+EVENT_READY = "READY"
+EVENT_EPISODE_STARTED = "EPISODE_STARTED"
+EVENT_EPISODE_ENDED = "EPISODE_ENDED"
+EVENT_ERROR = "ERROR"
+EVENT_BYE = "BYE"
+
+# `EPISODE_ENDED reason=` values. `stopped` is the user's "task succeeded"
+# button, `duration` is the episode running out its clock — the orchestrator
+# maps them onto the success/failure verdicts.
+REASON_DURATION = "duration"
+REASON_STOPPED = "stopped"
+
+
+def format_event(event: str, payload: str = "") -> str:
+    """Render one protocol line.
+
+    The payload's whitespace is collapsed so a multi-line exception message can
+    never split one event across several lines — the reader is line-oriented and
+    a wrapped traceback would otherwise be read as several unknown events."""
+    body = " ".join(str(payload).split())
+    return f"{EVENT_PREFIX} {event} {body}".rstrip()
+
+
+def parse_event(line: str) -> tuple[str, str] | None:
+    """`(event, payload)` for a protocol line, or None when the line isn't one.
+
+    Matches the prefix anywhere in the line rather than only at the start: the
+    runner's logging handler writes to the same merged pipe, and a log record
+    flushed without its trailing newline would otherwise swallow the event that
+    follows it on the wire. A line that merely mentions the prefix can't be
+    produced by the runner (it only ever writes it via `format_event`)."""
+    idx = line.find(EVENT_PREFIX)
+    if idx < 0:
+        return None
+    rest = line[idx + len(EVENT_PREFIX) :].strip()
+    if not rest:
+        return None
+    event, _, payload = rest.partition(" ")
+    return event, payload.strip()
+
+
+def parse_episode_end_reason(payload: str) -> str:
+    """Pull `reason=<value>` out of an EPISODE_ENDED payload.
+
+    Returns "" when the payload carries no recognisable reason, which the
+    orchestrator treats as "ended, cause unknown" rather than guessing a
+    verdict — a renamed/absent reason must not silently score an episode."""
+    for token in payload.split():
+        key, sep, value = token.partition("=")
+        if sep and key == "reason":
+            return value
+    return ""

--- a/makermodslab/eval_runner.py
+++ b/makermodslab/eval_runner.py
@@ -1,0 +1,333 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Persistent multi-episode rollout runner for MakerLab's evaluation mode.
+
+    python -m makermodslab.eval_runner <exactly the lerobot-rollout argv>
+
+Why it exists
+-------------
+Evaluation runs N episodes of the SAME policy on the SAME robot. Spawning
+`lerobot-rollout` once per episode re-pays the two expensive setup steps every
+single time — loading the policy onto the accelerator (15-40 s for SmolVLA on
+MPS) and connecting the serial bus + every camera (several more seconds, plus a
+camera-handover window where a preview can steal a device). Over a 20-episode
+eval that is 5-10 minutes of dead time and 20 chances for a camera to come back
+on a different index.
+
+This runner pays both costs ONCE. It builds lerobot's rollout context, then
+parks on stdin serving a tiny line protocol (see `makermodslab.eval_protocol`):
+`EPISODE` runs one rollout, `STOP` ends the running one early, `QUIT` tears
+down. Everything that actually drives the arm is lerobot's own code —
+`build_rollout_context` for the policy/robot/processor wiring, `BaseStrategy`
+for the control loop, and `RolloutStrategy._return_to_initial_position` for the
+ease-home — so an upstream change to how a rollout behaves lands here too.
+
+Deliberate behaviour differences from N separate `lerobot-rollout` processes
+-----------------------------------------------------------------------------
+1. **The follower stays energized between episodes.** A per-episode subprocess
+   disconnects at exit, which drops torque and leaves the arm limp during the
+   reset window. Here the robot is only disconnected at QUIT, so between
+   episodes the arm HOLDS the initial pose it was just eased back to. Nothing
+   moves at the transition (it is already at that pose), and the arm can't flop
+   while the user rearranges the scene — but it also can't be repositioned by
+   hand without stopping the session.
+2. **`initial_position` is captured once**, at the session's connect, and every
+   episode ends by easing back to it. Per-episode subprocesses each captured
+   wherever the arm happened to be sitting, so "home" could drift across a long
+   eval. Here every episode starts from the same pose.
+
+Neither the policy nor the control loop is reimplemented; the episode loop only
+decides WHEN lerobot's loop runs and when the arm goes home.
+"""
+
+# NO `from __future__ import annotations` here, deliberately: lerobot's
+# parser.wrap() reads run()'s RAW annotation (getfullargspec, not
+# get_type_hints) to find the draccus config class. PEP 563 would turn it
+# into the string 'RolloutConfig' and draccus dies with "must be called
+# with a dataclass type or instance". Same reason no lerobot script uses it.
+import logging
+import queue
+import sys
+import threading
+from collections.abc import Callable
+
+from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401  (registers --robot.cameras type)
+from lerobot.configs import parser
+from lerobot.robots import (  # noqa: F401  (registers --robot.type=so101_follower / bi_so_follower)
+    bi_so_follower,
+    so_follower,
+)
+from lerobot.rollout import (
+    RolloutConfig,
+    RolloutContext,
+    RolloutStrategy,
+    build_rollout_context,
+    create_strategy,
+)
+from lerobot.utils.import_utils import register_third_party_plugins
+from lerobot.utils.process import ProcessSignalHandler
+from lerobot.utils.utils import init_logging
+
+from .eval_protocol import (
+    CMD_EPISODE,
+    CMD_QUIT,
+    CMD_STOP,
+    EVENT_BYE,
+    EVENT_EPISODE_ENDED,
+    EVENT_EPISODE_STARTED,
+    EVENT_ERROR,
+    EVENT_READY,
+    REASON_DURATION,
+    REASON_STOPPED,
+    format_event,
+)
+
+logger = logging.getLogger(__name__)
+
+# Logged (not emitted as an event) once the one-time setup is behind us, purely
+# so the familiar lerobot landmark still appears in the inference log a human —
+# or a future grep — goes looking for. The orchestrator does NOT key its
+# `running` phase off this line in runner mode: setup happens once per SESSION
+# but the phase has to flip once per EPISODE, which is what EPISODE_STARTED is
+# for. See `_ROLLOUT_START_MARKER` in makermodslab/rollout.py.
+_SETUP_COMPLETE_LOG = "Rollout setup complete"
+
+
+def _emit(event: str, payload: str = "") -> None:
+    """Write one protocol event to stdout, flushed.
+
+    stdout is a pipe here, so it is block-buffered by default — without the
+    flush the orchestrator would not see an episode boundary until 4-8 KB of
+    unrelated log had accumulated behind it, which is most of an episode."""
+    print(format_event(event, payload), flush=True)
+
+
+def _read_commands(
+    commands: queue.Queue,
+    stop_event: threading.Event,
+    quit_event: threading.Event,
+) -> None:
+    """Read the command protocol off stdin until EOF (runs on its own thread).
+
+    STOP and QUIT are acted on HERE rather than being queued, because their
+    whole point is to interrupt an episode that is currently running — the main
+    thread is inside lerobot's control loop and won't drain the queue until that
+    loop returns. Both set `stop_event`, which is the loop's shutdown event, so
+    the episode breaks out on its next tick.
+
+    Started only AFTER the robot is connected: `SOFollower.calibrate()` prompts
+    with `input()` during `connect()`, reading the very same stdin, and the
+    orchestrator pre-seeds a newline per arm to answer it. Racing that prompt
+    with this reader would let a real command be eaten by the prompt (or the
+    seed newline be read as a command). Any seed newline the prompt didn't
+    consume arrives here as a blank line and is ignored."""
+    try:
+        for raw in sys.stdin:
+            cmd = raw.strip().upper()
+            if not cmd:
+                continue
+            if cmd == CMD_STOP:
+                logger.info("STOP received — ending the current episode early")
+                stop_event.set()
+                continue
+            if cmd == CMD_QUIT:
+                logger.info("QUIT received — tearing down")
+                quit_event.set()
+                # Break out of a running episode first; the main loop then sees
+                # quit_event and skips reporting the (unscored) partial episode.
+                stop_event.set()
+            commands.put(cmd)
+    except Exception:
+        logger.exception("Eval runner stdin reader failed")
+    finally:
+        # EOF (the orchestrator died or closed the pipe) must not leave the main
+        # thread blocked on an empty queue forever.
+        commands.put(None)
+
+
+def _run_episode(
+    strategy: RolloutStrategy,
+    ctx: RolloutContext,
+    stop_event: threading.Event,
+) -> str:
+    """Run ONE episode and ease the arm home. Returns the end reason.
+
+    `strategy.setup` is lerobot's own per-run arming step (fresh action
+    interpolator, `engine.reset()` to clear the policy's hidden state and
+    processor queues, `engine.start()`, cleared observation cache) — calling it
+    per episode is what makes episode k+1 indistinguishable from a fresh
+    process, minus the load and the connect. Its counterpart `engine.stop()` is
+    called at the end so an async backend's worker thread is not leaked per
+    episode; both are no-op logs for the default sync engine.
+
+    The ease-home runs in a `finally` so a crashed episode still puts the arm
+    back before the failure is reported."""
+    stop_event.clear()
+    strategy.setup(ctx)
+    _emit(EVENT_EPISODE_STARTED)
+    try:
+        strategy.run(ctx)
+    finally:
+        _return_to_initial(ctx)
+        ctx.policy.inference.stop()
+    return REASON_STOPPED if stop_event.is_set() else REASON_DURATION
+
+
+def _return_to_initial(ctx: RolloutContext) -> None:
+    """Ease the follower back to the pose captured at connect, between episodes.
+
+    Delegates to lerobot's own helper — the exact routine
+    `--return_to_initial_position=true` runs at process teardown — rather than
+    re-deriving the interpolation, so the promise the stop dialog makes ("eases
+    the follower back to its start pose") stays literally the same code. It is
+    a `staticmethod` on `RolloutStrategy` with a leading underscore, i.e. not a
+    stability contract: if an upstream bump moves it, this call site is the one
+    to fix (the arm would stop easing home between episodes, loudly).
+
+    Unlike teardown this does NOT disconnect, so the arm holds the pose under
+    torque through the reset window — see the module docstring."""
+    if not ctx.runtime.cfg.return_to_initial_position:
+        logger.info("Skipping return-to-initial-position between episodes (disabled by config)")
+        return
+    if not ctx.hardware.initial_position:
+        logger.warning("No initial position was captured; leaving the arm where the episode ended")
+        return
+    logger.info("Returning robot to initial position before the reset...")
+    RolloutStrategy._return_to_initial_position(ctx.hardware)
+
+
+# How long the idle loop blocks on the command queue before re-checking whether
+# it should quit. Bounded rather than infinite because a signal that lands while
+# we are parked between episodes only flips a flag — the blocking `get()` itself
+# resumes waiting once the handler returns, so without a timeout a SIGTERM
+# arriving during a reset would go unanswered until the orchestrator's SIGKILL.
+_COMMAND_POLL_S = 0.5
+
+
+def _serve(
+    strategy: RolloutStrategy,
+    ctx: RolloutContext,
+    stop_event: threading.Event,
+    should_quit: Callable[[], bool],
+    commands: queue.Queue,
+) -> None:
+    """Main command loop: one episode per EPISODE, until QUIT, a signal, or EOF."""
+    while not should_quit():
+        try:
+            cmd = commands.get(timeout=_COMMAND_POLL_S)
+        except queue.Empty:
+            continue
+        if cmd is None or cmd == CMD_QUIT:
+            return
+        if cmd != CMD_EPISODE:
+            logger.warning("Ignoring unrecognised eval-runner command %r", cmd)
+            continue
+        reason = _run_episode(strategy, ctx, stop_event)
+        if should_quit():
+            # Aborted mid-episode. The orchestrator does not score the in-flight
+            # episode of an aborted session, so reporting an end here would race
+            # a verdict in that the user never asked for.
+            logger.info("Episode cut short by QUIT — not reporting an episode end")
+            return
+        logger.info("Episode ended (reason=%s)", reason)
+        _emit(EVENT_EPISODE_ENDED, f"reason={reason}")
+
+
+@parser.wrap()
+def run(cfg: RolloutConfig) -> None:
+    """Load once, connect once, then serve episodes off stdin.
+
+    Takes the identical argv `lerobot-rollout` takes (the orchestrator builds
+    one arg list and points it at either entry point), so `--strategy.type`,
+    `--policy.*`, `--robot.*`, `--task` and `--duration` all mean exactly what
+    they mean there. `--duration` is the per-EPISODE limit, not a session
+    budget: the runner has no idea how many episodes it will be asked for."""
+    init_logging()
+
+    # Same handler lerobot's own CLI installs: a SIGTERM (the orchestrator's
+    # fallback when a QUIT goes unanswered) sets an event rather than killing us
+    # mid-motion, so the arm still eases home. Its `counter` is what lets us
+    # treat a signal as QUIT rather than as a per-episode STOP — otherwise the
+    # signalled episode would end and the runner would park for the next one.
+    signal_handler = ProcessSignalHandler(use_threads=True, display_pid=False)
+    stop_event = signal_handler.shutdown_event
+    quit_event = threading.Event()
+
+    def _should_quit() -> bool:
+        return quit_event.is_set() or signal_handler.counter > 0
+
+    logger.info("Building rollout context (policy + robot are loaded ONCE for the whole session)...")
+    # Hands `stop_event` to lerobot as the control loop's shutdown event; we
+    # clear it at the start of every episode, which is what turns a one-shot
+    # shutdown flag into a per-episode "end this one now".
+    ctx = build_rollout_context(cfg, stop_event)
+    strategy = create_strategy(cfg.strategy)
+    logger.info("Rollout strategy: %s", cfg.strategy.type)
+    logger.info(
+        "Robot: %s | FPS: %.0f | Episode duration: %s",
+        cfg.robot.type if cfg.robot else "?",
+        cfg.fps,
+        f"{cfg.duration}s" if cfg.duration > 0 else "infinite",
+    )
+    logger.info("%s — eval runner waiting for episode commands", _SETUP_COMPLETE_LOG)
+
+    # Only now is it safe to read stdin: the calibration prompt inside
+    # `robot.connect()` has had its turn (see `_read_commands`).
+    commands: queue.Queue = queue.Queue()
+    threading.Thread(
+        target=_read_commands,
+        args=(commands, stop_event, quit_event),
+        name="eval-runner-stdin",
+        daemon=True,
+    ).start()
+
+    failure: BaseException | None = None
+    try:
+        _emit(EVENT_READY)
+        _serve(strategy, ctx, stop_event, _should_quit, commands)
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+    except BaseException as exc:  # noqa: BLE001 — reported, then re-raised as a non-zero exit
+        failure = exc
+        logger.exception("Eval runner failed")
+        # Give the orchestrator the real exception text on the wire. It also
+        # mines the log tail, but that is a heuristic over a traceback; this is
+        # the message itself, delivered before the process is gone.
+        _emit(EVENT_ERROR, f"{type(exc).__name__}: {exc}")
+    finally:
+        # Full lerobot teardown: ease home (already there, so a no-op move),
+        # disconnect the bus and every camera. Guarded because the failure that
+        # brought us here is often exactly what teardown will trip over again,
+        # and masking it with a second traceback helps nobody.
+        try:
+            strategy.teardown(ctx)
+        except Exception:
+            logger.exception("Eval runner teardown failed")
+        _emit(EVENT_BYE)
+
+    if failure is not None:
+        # Exit non-zero so the orchestrator classifies the in-flight episode an
+        # `error` (excluded from the accuracy denominator) rather than a verdict.
+        sys.exit(1)
+
+
+def main() -> None:
+    """Entry point for `python -m makermodslab.eval_runner`."""
+    register_third_party_plugins()
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -50,7 +50,7 @@ from collections.abc import Callable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, Literal
 
 from pydantic import BaseModel
 
@@ -122,6 +122,16 @@ class InferenceRequest(BaseModel):
     # download, one arm preflight, one camera handover), scoring each episode.
     # Clamped server-side to [1, MAX_EVAL_EPISODES] — see clamp_eval_episodes.
     eval_episodes: int = 1
+    # Which lerobot inference engine drives the rollout (--inference.type).
+    # "sync" is lerobot's own default and stays ours: one policy forward per
+    # control tick, so a 50-action SmolVLA chunk replays for ~1.6s and the loop
+    # then stalls ~430ms on MPS computing the next one. "rtc" (Real-Time
+    # Chunking) moves that forward onto a background thread and blends the new
+    # chunk onto the previous chunk's leftover prefix, removing the stall — but
+    # it also routes flow-matching through the RTC processor, a DIFFERENT
+    # action-generation path than the one a checkpoint was evaluated under.
+    # Experimental on purpose: A/B it per run, don't assume equivalence.
+    inference_engine: Literal["sync", "rtc"] = "sync"
 
 
 inference_active: bool = False
@@ -936,6 +946,13 @@ def _rollout_cli_args(request: InferenceRequest, policy_path: str, robot_args: l
     added for one is never missing from the other."""
     return [
         "--strategy.type=base",
+        # Emitted unconditionally, including for the "sync" default — same
+        # reasoning as --strategy.type=base above and the teardown pin below:
+        # `inference` is a draccus ChoiceRegistry field whose default lives
+        # upstream (RolloutConfig.inference = SyncInferenceConfig), so naming it
+        # makes the choice ours and keeps an upstream default flip from
+        # silently changing which engine drives the arm.
+        f"--inference.type={request.inference_engine}",
         f"--policy.path={policy_path}",
         f"--policy.device={_detect_device()}",
         *robot_args,

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -19,6 +19,21 @@ with teleoperation/recording (the follower's serial bus can only be
 opened once), `lerobot.scripts.lerobot_rollout` running as a subprocess
 for clean cancellation. Hub-checkpoint refs are resolved to a local dir
 via huggingface_hub.snapshot_download before we spawn the subprocess.
+
+Two subprocess shapes, chosen by `eval_episodes`:
+
+  1 (the default) — one `lerobot-rollout`, exactly as it has always been.
+      Everything below that mentions "the subprocess" means this one.
+  >1 (EVAL mode)  — one `makermodslab.eval_runner` for the WHOLE session. It
+      loads the policy and connects the bus and cameras once, then runs an
+      episode per `EPISODE` line on its stdin. Spawning a rollout per episode
+      instead re-paid a 15-40 s policy load and a full reconnect every time —
+      5-10 minutes of dead time across a 20-episode eval — so this module
+      keeps ONE process alive and talks to it (`makermodslab.eval_protocol`)
+      rather than starting and killing N of them. Episode boundaries then
+      arrive as stdout events rather than as process exits, which is why eval
+      mode has its own pump (`_pump_runner_stdout`) and why a runner exit is
+      read as a crash to contain, not as an episode that ended.
 """
 
 from __future__ import annotations
@@ -43,6 +58,18 @@ from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 
 from .arm_identity import ArmIdentityError, ArmSlot, verify_devices
 from .camera_preview import camera_preview_manager
+from .eval_protocol import (
+    CMD_EPISODE,
+    CMD_QUIT,
+    CMD_STOP,
+    EVENT_EPISODE_ENDED,
+    EVENT_EPISODE_STARTED,
+    EVENT_ERROR,
+    EVENT_READY,
+    REASON_STOPPED,
+    parse_episode_end_reason,
+    parse_event,
+)
 from .jobs import download_hub_checkpoint_ref, make_snapshot_progress_tqdm
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .record import _DEFAULT_FOURCC
@@ -168,8 +195,12 @@ _ROLLOUT_START_MARKER = "Rollout setup complete"
 # downloads) a dataset. We omit the phase rather than invent one that never
 # fires.
 #
-# EVAL-ONLY phases (eval_episodes > 1). The startup phases above repeat per
-# episode (each episode is its own subprocess), plus:
+# EVAL-ONLY phases (eval_episodes > 1). The setup phases above run ONCE per
+# session, not once per episode: eval mode drives a single long-lived
+# `makermodslab.eval_runner` subprocess that loads the policy and connects the
+# robot one time and then runs episode after episode on command (they DO run
+# again after a crash-respawn, which is a genuine second load). Episode two
+# onwards therefore goes straight from `starting` to `running`. Plus:
 #   resetting — an episode ended, the tally was updated, and the session is
 #       parked waiting for the user to rearrange the scene and POST
 #       /inference-next-episode. Also where a CRASHED episode parks, with
@@ -237,14 +268,19 @@ def classify_episode(
     rollout_started: bool,
     error_text: str | None,
 ) -> str:
-    """Turn one episode's subprocess exit into a verdict.
+    """Turn one episode's ending into a verdict.
+
+    The single classifier for BOTH ways an episode can end under the eval
+    runner, so the two paths can't drift into different semantics:
+      - the runner reported `EPISODE_ENDED` — a clean end, passed rc=0;
+      - the runner DIED mid-episode — passed its non-zero exit code.
 
     `stop_requested` (the user pressed "task succeeded — stop episode") wins
-    outright: we terminated the subprocess ourselves, so its exit code is our own
-    SIGTERM and says nothing about the run.
+    outright: we asked for the ending, so how the episode terminated says
+    nothing about the policy.
 
     Otherwise the episode ended on its own. Reuse `_classify_outcome`:
-      ok / ran_with_warning → the rollout ran its full --duration (a noisy
+      ok / ran_with_warning → the episode ran its full --duration (a noisy
           torque-disable on teardown is not a failed episode) → FAILURE, i.e.
           the policy never got the task done in the time allowed.
       failed → the episode crashed → ERROR, excluded from the accuracy."""
@@ -273,14 +309,33 @@ class _EvalSession:
     # Verdicts in episode order; len(results) is how many episodes have finished,
     # so the CURRENT episode is 1-based index len(results) + 1.
     results: list[str] = field(default_factory=list)
-    # Set by /inference-episode-stop just before it terminates the subprocess, so
-    # the exit finalisation scores the episode a success instead of reading our
-    # own SIGTERM as a crash. Cleared as each episode is scored.
+    # Set by /inference-episode-stop just before it asks the runner to end the
+    # episode, so the finalisation scores it a success instead of reading the
+    # end as a plain timeout. Cleared as each episode is scored.
     stop_requested: bool = False
     # A crashed episode's mined error + plain-language hint, surfaced on the
     # resetting payload and cleared when the user continues.
     error: str | None = None
     hint: str | None = None
+
+    # --- eval-runner bookkeeping (see makermodslab/eval_runner.py) --------------
+    # True from the moment the runner reports EPISODE_STARTED until it reports
+    # the episode's end. THIS, not `_inference_proc`, is what "an episode is in
+    # flight" means now: the runner process spans the whole session, so a live
+    # process no longer implies a live episode (it used to, when every episode
+    # was its own subprocess).
+    episode_running: bool = False
+    # An EPISODE was asked for but hasn't started yet — either the runner is
+    # still doing its one-time load/connect (the READY handler issues the
+    # command when it lands) or the command is in flight. Keeps a READY from a
+    # crash-respawn from starting an episode nobody asked for.
+    episode_pending: bool = False
+    # A QUIT has been written and the runner is winding down. Suppresses the
+    # crash-containment path so an expected exit isn't scored as an error.
+    quitting: bool = False
+    # The runner's own ERROR line. Preferred over log-tail mining when present:
+    # it's the exception message itself rather than a heuristic over a traceback.
+    runner_error: str | None = None
 
     @property
     def episode_index(self) -> int:
@@ -349,10 +404,23 @@ def _set_phase(phase: str) -> None:
             _inference_meta["phase"] = phase
 
 
+def _advance_setup_phase(line: str) -> bool:
+    """Flip to a finer setup sub-phase when `line` is a recognised lerobot setup
+    log. True when one matched. Cheap substring checks."""
+    for fragment, phase in _PHASE_MARKERS:
+        if fragment in line:
+            _set_phase(phase)
+            return True
+    return False
+
+
 def _pump_stdout(proc: subprocess.Popen, log_handle) -> None:
     """Tee the subprocess's stdout to the log file, advance the startup
     sub-phase off recognised lerobot setup lines, and watch for the
-    rollout-start marker."""
+    rollout-start marker.
+
+    The SINGLE-episode path (`eval_episodes == 1`). Eval mode's long-lived
+    runner is pumped by `_pump_runner_stdout` instead."""
     global _inference_rollout_started_at
     try:
         for raw in iter(proc.stdout.readline, b""):
@@ -366,14 +434,10 @@ def _pump_stdout(proc: subprocess.Popen, log_handle) -> None:
             except Exception:
                 pass
             # Advance to a finer setup sub-phase on the first matching line.
-            # Cheap substring checks; only fires before the rollout marker, so
-            # a later line mentioning "Connecting robot" can't drag a running
-            # session backwards.
+            # Only fires before the rollout marker, so a later line mentioning
+            # "Connecting robot" can't drag a running session backwards.
             if _inference_rollout_started_at is None:
-                for fragment, phase in _PHASE_MARKERS:
-                    if fragment in line:
-                        _set_phase(phase)
-                        break
+                _advance_setup_phase(line)
             if _inference_rollout_started_at is None and _ROLLOUT_START_MARKER in line:
                 _inference_rollout_started_at = time.time()
                 _set_phase(PHASE_RUNNING)
@@ -386,6 +450,171 @@ def _pump_stdout(proc: subprocess.Popen, log_handle) -> None:
     finally:
         with contextlib.suppress(Exception):
             log_handle.close()
+
+
+# How long the runner pump waits for the process to be reaped once its stdout
+# hits EOF. EOF means the process is already on its way out, so this is a
+# formality — it only exists so a wedged exit can't hang the pump thread.
+_RUNNER_REAP_TIMEOUT_S = 5.0
+
+
+def _pump_runner_stdout(proc: subprocess.Popen, log_handle) -> None:
+    """Tee the eval runner's output to the log and act on its protocol events.
+
+    The eval-mode counterpart of `_pump_stdout`, and a structurally different
+    job: it lives for the whole SESSION, so it — not a `proc.poll()` in the
+    status endpoint — is what observes episode boundaries. The runner does not
+    exit between episodes, so there is no exit left for a status poll to notice;
+    every episode start and end arrives here as a line on stdout.
+
+    An exit therefore means something went wrong (or the session is over), which
+    is why the EOF path hands off to the crash-containment handler."""
+    try:
+        for raw in iter(proc.stdout.readline, b""):
+            try:
+                line = raw.decode("utf-8", errors="replace")
+            except Exception:
+                continue
+            try:
+                log_handle.write(line)
+                log_handle.flush()
+            except Exception:
+                pass
+            try:
+                _handle_runner_line(line)
+            except Exception:
+                # One malformed event must not take the pump — and with it every
+                # remaining episode boundary — down with it.
+                logger.exception("Eval runner event handling failed for %r", line.strip())
+    except Exception as exc:
+        logger.exception("Eval runner stdout pump failed: %s", exc)
+    finally:
+        with contextlib.suppress(Exception):
+            log_handle.close()
+        rc: int | None = None
+        with contextlib.suppress(Exception):
+            rc = proc.wait(timeout=_RUNNER_REAP_TIMEOUT_S)
+        _handle_runner_exit(proc, rc)
+
+
+def _handle_runner_line(line: str) -> None:
+    """Dispatch one line of runner output.
+
+    Non-protocol lines are lerobot's own logging: during the runner's one-time
+    load/connect those are exactly the fragments `_PHASE_MARKERS` recognises, so
+    the UI still gets to name the wait ("Loading policy…", "Connecting to
+    arm…"). They're only honoured while no episode is in flight — a mid-episode
+    line that happens to mention "Connecting robot" must not drag a running
+    session back to a setup phase."""
+    parsed = parse_event(line)
+    if parsed is None:
+        with _state_lock:
+            ev = _eval_session
+            in_episode = ev is not None and ev.episode_running
+        if not in_episode:
+            _advance_setup_phase(line)
+        return
+    event, payload = parsed
+    if event == EVENT_READY:
+        _on_runner_ready()
+    elif event == EVENT_EPISODE_STARTED:
+        _on_episode_started()
+    elif event == EVENT_EPISODE_ENDED:
+        _on_episode_ended(parse_episode_end_reason(payload))
+    elif event == EVENT_ERROR:
+        _on_runner_error(payload)
+
+
+def _on_runner_ready() -> None:
+    """The runner finished its one-time load + connect: issue the pending episode.
+
+    The runner never starts an episode on its own, so the session's first
+    episode — and the first after a crash-respawn — is issued from here, once
+    the expensive part is behind us. Gated on `episode_pending` so a READY that
+    lands after an abort (or after the user parked without continuing) can't put
+    the arm in motion."""
+    with _state_lock:
+        ev = _eval_session
+        if not inference_active or ev is None or ev.quitting or not ev.episode_pending:
+            logger.info("Eval runner is ready, but no episode is pending — staying idle")
+            return
+        proc = _inference_proc
+        if _inference_meta:
+            _inference_meta["phase"] = PHASE_STARTING
+    if not _send_runner_command(proc, CMD_EPISODE):
+        # The runner died between READY and here; the pump's EOF path scores it.
+        logger.warning("Eval runner is ready but the EPISODE command could not be sent")
+
+
+def _on_episode_started() -> None:
+    """The runner's control loop has taken over for this episode."""
+    global _inference_rollout_started_at
+    with _state_lock:
+        ev = _eval_session
+        if ev is None:
+            return
+        ev.episode_pending = False
+        ev.episode_running = True
+        _inference_rollout_started_at = time.time()
+        if _inference_meta:
+            _inference_meta["phase"] = PHASE_RUNNING
+        setup_s = _inference_rollout_started_at - (_inference_started_at or _inference_rollout_started_at)
+        episode_index = ev.episode_index
+    logger.info("Eval episode %s rollout started after %.1fs of setup", episode_index, setup_s)
+
+
+def _on_episode_ended(reason: str) -> None:
+    """Score the finished episode, then park or finish the session.
+
+    Runs on the pump thread — in eval mode this is the ONLY place an episode
+    boundary is observed. Goes through the single scoring point with rc=0: the
+    runner is alive and healthy, so `classify_episode` sees a clean ending and
+    the verdict falls out of `stop_requested` (the user's success button) versus
+    the episode simply running out its duration."""
+    with _state_lock:
+        ev = _eval_session
+        if ev is None or not ev.episode_running:
+            logger.warning("Eval runner reported an episode end with none in flight (reason=%r)", reason)
+            return
+        if reason == REASON_STOPPED:
+            # The reason IS the STOP we sent, so honour it even if the flag were
+            # somehow lost — the two can't disagree about what the user pressed.
+            ev.stop_requested = True
+        ev.episode_running = False
+        # Captured before finalising: finishing the session clears the global.
+        proc = _inference_proc
+        _finalise_eval_episode_locked(0, ev, keep_runner=True)
+        session_finished = _eval_session is None
+    if session_finished:
+        # That was the last episode — the slot is already released, so the runner
+        # has nothing left to do. Ask it to go home and disconnect. Sent, not
+        # waited on: this thread has to keep draining stdout or the runner's
+        # teardown logging could fill the pipe and wedge its own shutdown.
+        _send_runner_command(proc, CMD_QUIT)
+
+
+def _on_runner_error(message: str) -> None:
+    """Stash the runner's own exception text ahead of its exit.
+
+    Not a verdict — the runner emits this and then dies, so this only makes the
+    crash that follows legible. Preferred over mining the log tail because it is
+    the exception message itself rather than a heuristic over a traceback."""
+    with _state_lock:
+        ev = _eval_session
+        if ev is not None:
+            ev.runner_error = message or None
+
+
+def _handle_runner_exit(proc: subprocess.Popen, rc: int | None) -> None:
+    """Crash containment for a dead eval runner (called from the pump's EOF)."""
+    with _state_lock:
+        ev = _eval_session
+        if ev is None or _inference_proc is not proc:
+            # Either the session is already over (the expected QUIT after the
+            # last episode, or an abort) or this is a stale pump whose runner we
+            # have since replaced. Nothing to score either way.
+            return
+        _finalise_runner_exit_locked(rc, ev)
 
 
 def _detect_device() -> str:
@@ -694,16 +923,18 @@ def _classify_outcome(rc: int | None, rollout_started: bool, error_text: str | N
     return "failed"
 
 
-def _build_rollout_cmd(request: InferenceRequest, policy_path: str, robot_args: list[str]) -> list[str]:
-    """Assemble the full `lerobot-rollout` argv from the robot-specific args.
+def _rollout_cli_args(request: InferenceRequest, policy_path: str, robot_args: list[str]) -> list[str]:
+    """The rollout flags, without the interpreter/module prefix.
 
     `robot_args` is the `--robot.*` block built per mode (single vs bimanual);
     everything else — strategy, policy, task, duration, and the teardown pin —
-    is identical across modes and lives here so both paths stay in sync."""
-    cmd = [
-        sys.executable,
-        "-m",
-        "lerobot.scripts.lerobot_rollout",
+    is identical across modes and lives here so both paths stay in sync.
+
+    Split out from `_build_rollout_cmd` because eval mode points the SAME flags
+    at a different entry point (`makermodslab.eval_runner`, which speaks
+    `lerobot-rollout`'s argv verbatim). One list, two front-ends, so a flag
+    added for one is never missing from the other."""
+    return [
         "--strategy.type=base",
         f"--policy.path={policy_path}",
         f"--policy.device={_detect_device()}",
@@ -718,7 +949,34 @@ def _build_rollout_cmd(request: InferenceRequest, policy_path: str, robot_args: 
         # it. Set it explicitly so the contract is ours, not upstream's.
         "--return_to_initial_position=true",
     ]
-    return cmd
+
+
+def _build_rollout_cmd(request: InferenceRequest, policy_path: str, robot_args: list[str]) -> list[str]:
+    """The full `lerobot-rollout` argv — one rollout, one process.
+
+    The single-episode path (and only it): `eval_episodes == 1` runs exactly the
+    command it always has."""
+    return [
+        sys.executable,
+        "-m",
+        "lerobot.scripts.lerobot_rollout",
+        *_rollout_cli_args(request, policy_path, robot_args),
+    ]
+
+
+def _build_eval_runner_cmd(request: InferenceRequest, policy_path: str, robot_args: list[str]) -> list[str]:
+    """The full `makermodslab.eval_runner` argv — one process, N episodes.
+
+    Identical flags to `_build_rollout_cmd`, different entry point: the runner
+    parses `lerobot-rollout`'s config with lerobot's own parser and then serves
+    episodes off stdin instead of running exactly one and exiting. `--duration`
+    becomes the PER-EPISODE limit."""
+    return [
+        sys.executable,
+        "-m",
+        "makermodslab.eval_runner",
+        *_rollout_cli_args(request, policy_path, robot_args),
+    ]
 
 
 def _single_robot_args(request: InferenceRequest, follower_id: str) -> list[str]:
@@ -840,53 +1098,62 @@ def _fail_startup(error: str) -> None:
     Session-level, not episode-level: this is the download/preflight/first-spawn
     window, so in eval mode there is nothing to score yet — the eval session is
     dropped and the failure is reported the same way a single run's would be."""
+    with _state_lock:
+        _fail_startup_locked(error)
+
+
+def _fail_startup_locked(error: str) -> None:
+    """`_fail_startup`'s body, for callers that already hold `_state_lock`.
+
+    Split out for the eval-runner crash path: a runner that dies before its
+    FIRST episode ever started is a startup failure, not an episode to score,
+    and that determination is made deep inside a locked section."""
     global inference_active, _inference_proc, _inference_started_at
     global _inference_rollout_started_at, _inference_meta, _last_result, _eval_session
-    with _state_lock:
-        if not inference_active:
-            return
-        policy_ref = _inference_meta.get("policy_ref")
-        finished_eval = _eval_session
-        inference_active = False
-        _inference_proc = None
-        _inference_started_at = None
-        _inference_rollout_started_at = None
-        _inference_meta = {}
-        _eval_session = None
-        _last_result = {
-            "inference_active": False,
-            "exited": True,
-            "exit_code": None,
-            "outcome": "failed",
-            "error": error,
-            "hint": friendly_hint(error),
-            "phase": PHASE_ERROR,
-            "policy_ref": policy_ref,
-            "duration_s": None,
-            "log_path": None,
-            "started_at": None,
-            "rollout_started_at": None,
-            "rollout_elapsed_s": 0,
-            "elapsed_s": 0,
-            **_eval_fields(finished_eval),
-        }
+    if not inference_active:
+        return
+    policy_ref = _inference_meta.get("policy_ref")
+    finished_eval = _eval_session
+    inference_active = False
+    _inference_proc = None
+    _inference_started_at = None
+    _inference_rollout_started_at = None
+    _inference_meta = {}
+    _eval_session = None
+    _last_result = {
+        "inference_active": False,
+        "exited": True,
+        "exit_code": None,
+        "outcome": "failed",
+        "error": error,
+        "hint": friendly_hint(error),
+        "phase": PHASE_ERROR,
+        "policy_ref": policy_ref,
+        "duration_s": None,
+        "log_path": None,
+        "started_at": None,
+        "rollout_started_at": None,
+        "rollout_elapsed_s": 0,
+        "elapsed_s": 0,
+        **_eval_fields(finished_eval),
+    }
 
 
-def _launch_rollout_subprocess(
-    request: InferenceRequest,
-    policy_path: str,
-    robot_args: list[str],
+def _spawn_rollout_process(
+    cmd: list[str],
+    stdin_seed: bytes,
+    *,
+    close_stdin: bool,
 ) -> tuple[subprocess.Popen, IO[str], Path]:
-    """Build the argv, open a fresh log file, spawn ONE rollout subprocess and
-    seed its stdin.
+    """Open a fresh log file, spawn `cmd`, and seed its stdin.
 
-    The pure "start a rollout process" step, factored out of the startup worker
-    so eval mode's second-and-later episodes can respawn without re-downloading
-    the model or re-preflighting the arm. Returns (proc, log_handle, log_path);
-    the caller owns committing them to the module state and starting the stdout
-    pump. Raises on spawn failure (after closing the log handle) — the caller
-    decides how to report it, since a first-episode failure fails the session
-    while a later one fails just that episode."""
+    Shared by both entry points (one-shot `lerobot-rollout` and the persistent
+    eval runner) — they differ only in argv and in whether stdin stays open.
+    Returns (proc, log_handle, log_path); the caller owns committing them to the
+    module state and starting the stdout pump. Raises on spawn failure (after
+    closing the log handle) — the caller decides how to report it, since a
+    first-episode failure fails the session while a later one fails just that
+    episode."""
     log_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / "inference_logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{int(time.time())}.log"
@@ -894,19 +1161,9 @@ def _launch_rollout_subprocess(
 
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
-    # Feed a newline into stdin PER follower arm so SOFollower.calibrate()'s
-    # `input("Press ENTER to use the calibration file ...")` returns "" and
-    # writes the existing calibration to the motors instead of hanging
-    # forever waiting for an interactive operator. A BiSO follower connects
-    # its two sub-arms sequentially (left then right), each of which can fire
-    # that prompt once — so seed two newlines for bimanual, one for single.
-    # Any prompt that doesn't fire just leaves an unread newline (harmless);
-    # subsequent input() calls in the recalibration path get EOF and raise —
-    # fine, because we never want to enter that path from the UI.
-    stdin_seed = b"\n\n" if request.mode == "bimanual" else b"\n"
     try:
         proc = subprocess.Popen(
-            _build_rollout_cmd(request, policy_path, robot_args),
+            cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -920,10 +1177,115 @@ def _launch_rollout_subprocess(
         assert proc.stdin is not None
         proc.stdin.write(stdin_seed)
         proc.stdin.flush()
-        proc.stdin.close()
+        if close_stdin:
+            proc.stdin.close()
     except Exception as exc:
         logger.warning("Failed to seed stdin for inference subprocess: %s", exc)
     return proc, log_handle, log_path
+
+
+def _stdin_seed(request: InferenceRequest) -> bytes:
+    """Newlines to pre-answer lerobot's per-arm calibration prompt.
+
+    Feed a newline into stdin PER follower arm so SOFollower.calibrate()'s
+    `input("Press ENTER to use the calibration file ...")` returns "" and
+    writes the existing calibration to the motors instead of hanging
+    forever waiting for an interactive operator. A BiSO follower connects
+    its two sub-arms sequentially (left then right), each of which can fire
+    that prompt once — so seed two newlines for bimanual, one for single.
+    Any prompt that doesn't fire just leaves an unread newline (harmless);
+    for the one-shot path subsequent input() calls in the recalibration path get
+    EOF and raise — fine, because we never want to enter that path from the UI.
+    For the eval runner, whose stdin stays open as a command channel, an
+    unconsumed newline surfaces as a blank command line and is ignored."""
+    return b"\n\n" if request.mode == "bimanual" else b"\n"
+
+
+def _launch_rollout_subprocess(
+    request: InferenceRequest,
+    policy_path: str,
+    robot_args: list[str],
+) -> tuple[subprocess.Popen, IO[str], Path]:
+    """Spawn ONE `lerobot-rollout` process — the single-episode path.
+
+    stdin is closed right after the seed: this process is asked for nothing
+    after it starts, and an open pipe would only be something to leak."""
+    return _spawn_rollout_process(
+        _build_rollout_cmd(request, policy_path, robot_args),
+        _stdin_seed(request),
+        close_stdin=True,
+    )
+
+
+def _launch_eval_runner(
+    request: InferenceRequest,
+    policy_path: str,
+    robot_args: list[str],
+) -> tuple[subprocess.Popen, IO[str], Path]:
+    """Spawn the persistent eval runner — one process for the whole session.
+
+    stdin STAYS OPEN: it is the command channel (`EPISODE` / `STOP` / `QUIT`)
+    that replaces spawning-and-killing a process per episode."""
+    return _spawn_rollout_process(
+        _build_eval_runner_cmd(request, policy_path, robot_args),
+        _stdin_seed(request),
+        close_stdin=False,
+    )
+
+
+# How long a QUIT gets to land before we escalate to SIGTERM. Has to cover
+# lerobot's teardown: the 3 s ease-home interpolation plus the bus and camera
+# disconnects. Escalating early would kill the arm mid-motion — the exact thing
+# the clean-shutdown command exists to avoid.
+_RUNNER_QUIT_TIMEOUT_S = 10.0
+
+
+def _send_runner_command(proc: subprocess.Popen | None, command: str) -> bool:
+    """Write one command line to the eval runner's stdin. True when it landed.
+
+    Never raises: a dead runner (BrokenPipeError) or a closed pipe is a real
+    state the caller has to handle — the crash-containment path — not an
+    exception to unwind an HTTP handler with. Returning False lets the caller
+    say so in a status payload instead."""
+    if proc is None or proc.stdin is None:
+        return False
+    try:
+        proc.stdin.write(f"{command}\n".encode())
+        proc.stdin.flush()
+        return True
+    except Exception as exc:
+        logger.warning("Could not send %s to the eval runner: %s", command, exc)
+        return False
+
+
+def _quit_runner(proc: subprocess.Popen) -> None:
+    """End the eval runner cleanly, escalating only if it doesn't answer.
+
+    QUIT is the happy path: the runner breaks out of any running episode, eases
+    the follower home and disconnects the bus and cameras before exiting — the
+    same teardown a one-shot rollout does at the end of its process. SIGTERM is
+    the fallback for a runner that is wedged (and the runner installs lerobot's
+    signal handler, so even that is asked-nicely first); SIGKILL is the last
+    resort. Blocking, and called off the lock."""
+    _send_runner_command(proc, CMD_QUIT)
+    try:
+        proc.wait(timeout=_RUNNER_QUIT_TIMEOUT_S)
+        return
+    except subprocess.TimeoutExpired:
+        logger.warning("Eval runner did not exit %.0fs after QUIT; terminating", _RUNNER_QUIT_TIMEOUT_S)
+    except Exception as exc:
+        logger.exception("Waiting for the eval runner to quit failed: %s", exc)
+        return
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.warning("Eval runner did not exit 5s after SIGTERM; killing")
+            proc.kill()
+            proc.wait()
+    except Exception as exc:
+        logger.exception("Terminating the eval runner failed: %s", exc)
 
 
 def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Event) -> None:
@@ -973,17 +1335,25 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
         logger.info("Inference startup abandoned after preflight (stop requested)")
         return
 
-    # 3. Spawn the rollout subprocess (episode 1 of 1, or of N in eval mode).
-    #    In eval mode, cache what the later episodes reuse verbatim — the model
-    #    is downloaded once and the arm preflight runs once per SESSION, not per
-    #    episode (which is what makes N episodes cheap to chain).
+    # 3. Spawn the subprocess. Single-episode runs get one `lerobot-rollout`, as
+    #    they always have; eval mode gets ONE `makermodslab.eval_runner` that will
+    #    serve every episode of the session, so the policy load and the bus and
+    #    camera connect are paid once instead of N times. Cache what the later
+    #    episodes reuse verbatim (the resolved path and the preflighted
+    #    `--robot.*` args) so even a crash-respawn skips the download and the
+    #    second arm-identity pass.
     with _state_lock:
+        is_eval = _eval_session is not None
         if _eval_session is not None:
             _eval_session.policy_path = policy_path
             _eval_session.robot_args = list(robot_args)
+            # Episode 1 is issued by the READY handler, once the runner has
+            # finished loading — it is pending from this moment.
+            _eval_session.episode_pending = True
 
+    launch = _launch_eval_runner if is_eval else _launch_rollout_subprocess
     try:
-        proc, log_handle, log_path = _launch_rollout_subprocess(request, policy_path, robot_args)
+        proc, log_handle, log_path = launch(request, policy_path, robot_args)
     except Exception as exc:
         logger.exception("Failed to spawn rollout subprocess")
         _fail_startup(f"Failed to start inference: {exc}")
@@ -1019,12 +1389,22 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
 
     if abandoned:
         # Stopped during/just after the spawn — kill the subprocess we just
-        # started and leave the (already idle) state alone.
+        # started and leave the (already idle) state alone. The SIGTERM is
+        # escalated because both entry points now handle it gracefully, which
+        # means "finish loading the policy first" — a wait that can outlast the
+        # 5 s. Leaving the orphan behind would keep the serial bus open and
+        # block the next session.
         logger.info("Inference startup abandoned after spawn (stop requested); killing subprocess")
         with contextlib.suppress(Exception):
             proc.terminate()
-        with contextlib.suppress(Exception):
+        try:
             proc.wait(timeout=5)
+        except Exception:
+            logger.warning("Abandoned subprocess did not exit in 5s; killing")
+            with contextlib.suppress(Exception):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=5)
         with contextlib.suppress(Exception):
             log_handle.close()
         return
@@ -1032,12 +1412,12 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
     # Start the stdout pump only after committing, so it never advances the phase
     # of a subprocess we might have abandoned above.
     threading.Thread(
-        target=_pump_stdout,
+        target=_pump_runner_stdout if is_eval else _pump_stdout,
         args=(proc, log_handle),
         name="inference-stdout-pump",
         daemon=True,
     ).start()
-    logger.info("Inference started: pid=%s policy=%s", proc.pid, policy_path)
+    logger.info("Inference started: pid=%s policy=%s eval=%s", proc.pid, policy_path, is_eval)
 
 
 def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
@@ -1287,29 +1667,42 @@ def handle_stop_inference() -> dict[str, Any]:
         # terminate/wait below sees "stopping" rather than a stale "running".
         if _inference_meta:
             _inference_meta["phase"] = PHASE_STOPPING
+        if ev is not None:
+            # Suppress crash containment: the runner is about to exit because we
+            # asked it to, and an expected exit must not be scored an error.
+            ev.quitting = True
+            ev.episode_pending = False
 
         if proc is None:
             # Stop pressed with no live subprocess: either before the first one
             # spawned (during the model download / arm preflight — no policy has
             # driven the robot, and the orphaned startup worker bails at its next
-            # cancel check), or, in eval mode, while parked in a reset between
-            # episodes. Either way there's nothing to terminate.
+            # cancel check), or, in eval mode, while parked in a reset after the
+            # runner crashed. Either way there's nothing to terminate.
             if ev is not None:
                 _abort_eval_locked(ev)
                 return {"success": True, "message": "Evaluation aborted"}
             _go_idle_locked()
             return {"success": True, "message": "Inference stopped"}
 
-    try:
-        proc.terminate()
+    if ev is not None:
+        # Eval mode: QUIT rather than SIGTERM. The runner breaks out of the
+        # running episode, eases the follower home and disconnects properly —
+        # a signal would cut that short. The in-flight episode is deliberately
+        # left unscored (see _abort_eval_locked), which is why the runner also
+        # reports no episode end for it.
+        _quit_runner(proc)
+    else:
         try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            logger.warning("Inference did not exit in 5s; killing")
-            proc.kill()
-            proc.wait()
-    except Exception as exc:
-        logger.exception("Stop inference: %s", exc)
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logger.warning("Inference did not exit in 5s; killing")
+                proc.kill()
+                proc.wait()
+        except Exception as exc:
+            logger.exception("Stop inference: %s", exc)
 
     with _state_lock:
         # Re-read: a status poll could have finalised the exit (and, in eval
@@ -1325,62 +1718,67 @@ def handle_stop_inference() -> dict[str, Any]:
 def handle_stop_episode() -> dict[str, Any]:
     """End the CURRENT eval episode early and score it a SUCCESS.
 
-    This is the "the robot did the task — next" button. It terminates the
-    episode's subprocess exactly the way `handle_stop_inference` does (so the
-    follower still eases back to its start pose via
-    `--return_to_initial_position`) but leaves the SESSION standing: the exit
-    finalisation in `handle_inference_status` then parks it in the reset phase
-    (or finishes it, if that was the last episode).
+    This is the "the robot did the task — next" button. It asks the runner to
+    end the episode cleanly — no signal, no kill: the runner breaks out of the
+    control loop and eases the follower back to its start pose, exactly what
+    `--return_to_initial_position` did at each subprocess's teardown — and
+    leaves the SESSION standing. The runner then reports the end on stdout, and
+    the pump parks the session in the reset phase (or finishes it, if that was
+    the last episode).
 
     Eval-only by design: a single-episode run has no tally to record a success
     into, so it gets a 409 rather than a silent no-op."""
     with _state_lock:
-        if not inference_active or _eval_session is None:
+        ev = _eval_session
+        if not inference_active or ev is None or not ev.episode_running:
+            # No session, not an eval, still starting up, or parked in a reset —
+            # in none of those is there a running episode to call a success.
+            # `episode_running` (not a live process) is the test: the runner
+            # outlives every episode, so it is alive between them too.
             return {
                 "success": False,
                 "status_code": 409,
                 "message": "No evaluation episode is running",
             }
         proc = _inference_proc
-        if proc is None:
-            # Either still starting up, or already parked in a reset — there is
-            # no running episode to call a success.
-            return {
-                "success": False,
-                "status_code": 409,
-                "message": "No evaluation episode is running",
-            }
-        # Set BEFORE terminating so the flag is always visible to whichever
-        # thread finalises the exit. If a status poll beats us to the exit (the
-        # episode hit its duration in this exact window) it clears
-        # `_inference_proc` under this same lock, and the guard above turns the
-        # next call into a 409 — the two orders can't both score the episode.
-        _eval_session.stop_requested = True
+        # Set BEFORE the command goes out, so the flag is always visible to the
+        # pump thread that finalises the episode. If the episode hits its
+        # duration in this exact window, the pump clears `episode_running` under
+        # this same lock and the next call 409s — the two orders can't both
+        # score the episode.
+        ev.stop_requested = True
 
-    try:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            logger.warning("Eval episode did not exit in 5s; killing")
-            proc.kill()
-            proc.wait()
-    except Exception as exc:
-        logger.exception("Stop eval episode: %s", exc)
-    # The verdict is recorded in ONE place — the exit finalisation in
-    # handle_inference_status — so a poll that raced us can't double-score.
+    if not _send_runner_command(proc, CMD_STOP):
+        # The runner was already gone when we asked, so this is not a success
+        # the user got to observe — take the flag back, or the crash-containment
+        # path would read it as one ("stop_requested wins outright"). Guarded on
+        # the episode still being in flight so we can't unset a flag that the
+        # pump has meanwhile consumed to score a genuine success.
+        with _state_lock:
+            if _eval_session is ev and ev.episode_running:
+                ev.stop_requested = False
+        return {
+            "success": False,
+            "status_code": 409,
+            "message": "The evaluation runner is no longer responding",
+        }
+    # The verdict is recorded in ONE place — `_finalise_eval_episode_locked`,
+    # driven by the runner's episode-end line — so nothing here can double-score.
     return {"success": True, "message": "Episode recorded as a success"}
 
 
 def handle_next_episode() -> dict[str, Any]:
-    """Leave the reset phase and spawn the next eval episode.
+    """Leave the reset phase and start the next eval episode.
 
     The reset between episodes is explicitly user-ended (no auto-timer, unlike
-    recording's): rearranging a bench scene has no reason to be rushed. Reuses
-    the session's already-resolved policy path and already-preflighted
-    `--robot.*` args, so continuing costs one subprocess spawn — no re-download,
-    no second arm-identity pass, and the cameras stay owned by the session
-    throughout."""
+    recording's): rearranging a bench scene has no reason to be rushed.
+
+    The normal case costs ONE line of stdin: the runner is still up with the
+    policy resident and the bus and cameras open, so continuing is instant —
+    that is the whole point of the runner. The exception is a runner that died
+    (see `_finalise_runner_exit_locked`), where continuing respawns it and pays
+    ONE reload; even then the model isn't re-downloaded and the arm isn't
+    re-preflighted, because both results are cached on the session."""
     global _inference_proc, _inference_started_at, _inference_rollout_started_at, _inference_meta
 
     with _state_lock:
@@ -1404,11 +1802,49 @@ def handle_next_episode() -> dict[str, Any]:
         request, policy_path, robot_args = ev.request, ev.policy_path, list(ev.robot_args)
         carried_ref = _inference_meta.get("policy_ref")
         carried_warning = _inference_meta.get("warning")
+        respawn = _inference_proc is None
+        proc = _inference_proc
+        ev.episode_pending = True
+        # Both timers restart per episode: `elapsed_s` is this episode's setup
+        # time and `rollout_elapsed_s` its rollout time, so the dialog's clock
+        # and the frontend's past-duration safety net both measure the EPISODE,
+        # not the (much longer) session. On the live-runner path the setup time
+        # is now ~0, which is the win.
+        _inference_started_at = time.time()
+        _inference_rollout_started_at = None
+        # Clear the previous episode's crash banner — the user chose to continue.
+        ev.error = None
+        ev.hint = None
+        ev.runner_error = None
+        _inference_meta = {
+            "policy_ref": carried_ref or request.policy_ref,
+            "policy_path": policy_path,
+            "duration_s": request.duration_s,
+            # A respawn opens a fresh log; a live runner keeps writing the one
+            # the session started with.
+            "log_path": _inference_meta.get("log_path"),
+            "phase": PHASE_STARTING,
+            **({"warning": carried_warning} if carried_warning else {}),
+        }
+        episode_index = ev.episode_index
 
+    if not respawn:
+        if not _send_runner_command(proc, CMD_EPISODE):
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "The evaluation runner is no longer responding",
+            }
+        logger.info("Eval episode %s requested from the live runner", episode_index)
+        return {"success": True, "message": f"Episode {episode_index} starting"}
+
+    # The runner died during the previous episode (or during the reset). Respawn
+    # it — one policy load — and let the READY handler issue the episode, the
+    # same way the session's first episode is issued.
     try:
-        proc, log_handle, log_path = _launch_rollout_subprocess(request, policy_path, robot_args)
+        proc, log_handle, log_path = _launch_eval_runner(request, policy_path, robot_args)
     except Exception as exc:
-        logger.exception("Failed to spawn the next eval episode")
+        logger.exception("Failed to respawn the eval runner")
         # Spawning is the cheap part; a failure here is a session-level problem
         # (a broken interpreter/env), not something the next reset can fix.
         _fail_startup(f"Failed to start the next episode: {exc}")
@@ -1418,7 +1854,7 @@ def handle_next_episode() -> dict[str, Any]:
         if not inference_active or _eval_session is None:
             # Aborted while we were spawning — kill what we just started rather
             # than leave a policy driving the arm for a dead session.
-            logger.info("Next eval episode abandoned right after spawn; killing subprocess")
+            logger.info("Eval runner respawn abandoned right after spawn; killing subprocess")
             with contextlib.suppress(Exception):
                 proc.terminate()
             with contextlib.suppress(Exception):
@@ -1427,34 +1863,15 @@ def handle_next_episode() -> dict[str, Any]:
                 log_handle.close()
             return {"success": False, "status_code": 409, "message": "No evaluation is active"}
         _inference_proc = proc
-        # Both timers restart per episode: `elapsed_s` is this episode's setup
-        # time and `rollout_elapsed_s` its rollout time, so the dialog's clock
-        # and the frontend's past-duration safety net both measure the EPISODE,
-        # not the (much longer) session.
-        _inference_started_at = time.time()
-        _inference_rollout_started_at = None
-        # Clear the previous episode's crash banner — the user chose to continue.
-        _eval_session.error = None
-        _eval_session.hint = None
-        meta: dict[str, Any] = {
-            "policy_ref": carried_ref or request.policy_ref,
-            "policy_path": policy_path,
-            "duration_s": request.duration_s,
-            "log_path": str(log_path),
-            "phase": PHASE_STARTING,
-        }
-        if carried_warning:
-            meta["warning"] = carried_warning
-        _inference_meta = meta
-        episode_index = _eval_session.episode_index
+        _inference_meta["log_path"] = str(log_path)
 
     threading.Thread(
-        target=_pump_stdout,
+        target=_pump_runner_stdout,
         args=(proc, log_handle),
         name="inference-stdout-pump",
         daemon=True,
     ).start()
-    logger.info("Eval episode %s started: pid=%s", episode_index, proc.pid)
+    logger.info("Eval runner respawned for episode %s: pid=%s", episode_index, proc.pid)
     return {"success": True, "message": f"Episode {episode_index} starting"}
 
 
@@ -1502,26 +1919,35 @@ def handle_inference_log(max_lines: int = _INFERENCE_LOG_MAX_LINES) -> dict[str,
     return {"logs": "\n".join(tail), "log_path": str(path)}
 
 
-def _finalise_eval_episode_locked(rc: int | None, ev: _EvalSession) -> dict[str, Any]:
+def _finalise_eval_episode_locked(
+    rc: int | None,
+    ev: _EvalSession,
+    *,
+    keep_runner: bool = False,
+    runner_error: str | None = None,
+) -> dict[str, Any]:
     """Score one finished eval episode and either park or finish the session.
 
     Caller must hold `_state_lock`. This is the SINGLE place an episode verdict
-    is recorded — `handle_stop_episode` only sets the flag and terminates, so a
-    status poll racing the stop can't double-score.
+    is recorded, reached from both endings the eval runner can produce: a clean
+    `EPISODE_ENDED` (rc=0, `keep_runner=True` — the runner is alive and will
+    serve the next episode) and an unexpected runner death (its exit code,
+    `keep_runner` left False so the next continue respawns). `handle_stop_episode`
+    only sets a flag and asks the runner to end, so nothing can double-score.
 
     Not finishing the session means keeping `inference_active` True through the
     reset: the session still owns the inference slot (recording/teleop stay
     blocked) and still owns the cameras (previews stay 409'd), which is exactly
-    what lets the next episode spawn straight into a ready rig."""
+    what lets the next episode start straight into a ready rig."""
     global _inference_proc, _inference_rollout_started_at, _inference_meta, _last_result
 
     finished_meta = _inference_meta
     finished_started = _inference_started_at
     rollout_started = _inference_rollout_started_at is not None
-    # Mine the log only when the exit was non-zero; a stop we asked for exits
-    # non-zero via our own SIGTERM, so the snippet is discarded unless the
-    # verdict actually turns out to be a crash.
-    error = _extract_error_from_log(finished_meta.get("log_path")) if rc else None
+    # Mine the error only when the ending was non-clean. `runner_error` is the
+    # runner's own ERROR line when it managed to send one — the exception text
+    # itself, so it beats the log-tail heuristic.
+    error = (runner_error or _extract_error_from_log(finished_meta.get("log_path"))) if rc else None
     verdict = classify_episode(rc, ev.stop_requested, rollout_started, error)
     # Read the index BEFORE appending — the property is derived from the result
     # count, so afterwards it names the NEXT episode.
@@ -1534,6 +1960,7 @@ def _finalise_eval_episode_locked(rc: int | None, ev: _EvalSession) -> dict[str,
     )
     ev.results.append(verdict)
     ev.stop_requested = False
+    ev.runner_error = None
     if verdict == EPISODE_ERROR:
         ev.error = error
         ev.hint = friendly_hint(error)
@@ -1541,7 +1968,8 @@ def _finalise_eval_episode_locked(rc: int | None, ev: _EvalSession) -> dict[str,
         ev.error = None
         ev.hint = None
 
-    _inference_proc = None
+    if not keep_runner:
+        _inference_proc = None
     _inference_rollout_started_at = None
 
     if len(ev.results) < ev.episodes_total:
@@ -1592,6 +2020,58 @@ def _finalise_eval_episode_locked(rc: int | None, ev: _EvalSession) -> dict[str,
     return dict(_last_result)
 
 
+def _finalise_runner_exit_locked(rc: int | None, ev: _EvalSession) -> None:
+    """Absorb an unexpected eval-runner death without losing the session.
+
+    Caller must hold `_state_lock`. The runner is the session's ONE process, so
+    losing it costs a policy reload — but not the run: the tally, the resolved
+    policy path and the already-preflighted `--robot.*` args all live on the
+    `_EvalSession`, so the user's next continue respawns and carries on from
+    where the tally stood (`handle_next_episode`).
+
+    An episode that was in flight is scored `error`, which is excluded from the
+    accuracy denominator — a serial glitch on episode 7 must not be readable as
+    the policy failing. The session then parks in `resetting` with the error on
+    show, which is also the screen the abort button lives on."""
+    global _inference_proc, _inference_meta
+
+    if ev.quitting:
+        # We asked for this exit (an abort is mid-flight). The in-flight episode
+        # of an aborted session is deliberately left unscored, so returning here
+        # is what keeps the abort's partial tally honest.
+        logger.info("Eval runner exited after QUIT rc=%s", rc)
+        _inference_proc = None
+        return
+    logger.warning("Eval runner exited unexpectedly rc=%s", rc)
+    _inference_proc = None
+    if not ev.results and not ev.episode_running:
+        # The runner died before its very FIRST episode ever started — a bad
+        # policy path, a camera that isn't there, a bus another process holds.
+        # That is a startup failure, not an evaluation with a bad episode in it:
+        # parking in a reset would offer a "continue" that can only fail the same
+        # way. Report it exactly as a single run's startup failure is reported.
+        error = ev.runner_error or _extract_error_from_log(_inference_meta.get("log_path"))
+        _fail_startup_locked(error or f"The evaluation runner exited unexpectedly (code {rc}).")
+        return
+    ev.episode_pending = False
+    if ev.episode_running:
+        ev.episode_running = False
+        # Any exit that interrupts an episode is a crash, whatever the code
+        # says: a runner that finished an episode cleanly reports EPISODE_ENDED
+        # and stays alive, so reaching here at all means it didn't.
+        _finalise_eval_episode_locked(rc or 1, ev, runner_error=ev.runner_error)
+        return
+
+    # Died while parked between episodes: there is no episode to score, but the
+    # user still needs to know why continuing will now cost a reload.
+    error = ev.runner_error or _extract_error_from_log(_inference_meta.get("log_path"))
+    ev.error = error
+    ev.hint = friendly_hint(error)
+    ev.runner_error = None
+    if _inference_meta:
+        _inference_meta["phase"] = PHASE_RESETTING
+
+
 def handle_inference_status() -> dict[str, Any]:
     global inference_active, _inference_proc, _inference_started_at
     global _inference_rollout_started_at, _inference_meta, _last_result
@@ -1619,49 +2099,57 @@ def handle_inference_status() -> dict[str, Any]:
         if proc is not None and proc.poll() is not None:
             rc = proc.returncode
             if _eval_session is not None:
-                # Eval mode: this exit ends an EPISODE, which only ends the
-                # SESSION if it was the last one.
-                return _finalise_eval_episode_locked(rc, _eval_session)
-            logger.info("Inference subprocess exited rc=%s", rc)
-            finished_meta = _inference_meta
-            finished_started = _inference_started_at
-            finished_rollout_started = _inference_rollout_started_at
-            # Terminal phase: a clean exit (rc 0, including a stop we asked for)
-            # is `stopped`; any non-zero code is `error`. The prior phase in
-            # `finished_meta` (e.g. "stopping" from a stop request) is
-            # superseded — the subprocess has actually gone now.
-            terminal_phase = PHASE_STOPPED if rc == 0 else PHASE_ERROR
-            inference_active = False
-            _inference_proc = None
-            _inference_started_at = None
-            _inference_rollout_started_at = None
-            _inference_meta = {}
-            # On a non-zero exit, mine the real error out of the log so the UI
-            # can show it directly (hint + snippet) instead of sending the user
-            # digging through the cache. `outcome` further distinguishes a true
-            # failure from a run that worked but tripped a noisy shutdown/cleanup
-            # warning (see _classify_outcome) so the false-failure isn't reported
-            # as a hard error.
-            error = _extract_error_from_log(finished_meta.get("log_path")) if rc else None
-            outcome = _classify_outcome(rc, finished_rollout_started is not None, error)
-            _last_result = {
-                "inference_active": False,
-                "exited": True,
-                "exit_code": rc,
-                "outcome": outcome,
-                "error": error,
-                "hint": friendly_hint(error),
-                "phase": terminal_phase,
-                "policy_ref": finished_meta.get("policy_ref"),
-                "duration_s": finished_meta.get("duration_s"),
-                "log_path": finished_meta.get("log_path"),
-                "started_at": finished_started,
-                "rollout_started_at": finished_rollout_started,
-                "rollout_elapsed_s": 0,
-                "elapsed_s": 0,
-                **_eval_fields(None),
-            }
-            return {**_last_result, "shutting_down": shutting_down}
+                # Eval mode: episode boundaries arrive on the RUNNER's stdout,
+                # so an exit here is the runner dying — a crash, not an episode
+                # end. Backstop for the pump (which normally notices EOF first);
+                # `_finalise_runner_exit_locked` clears `_inference_proc`, so
+                # whichever path gets here second finds nothing to finalise.
+                _finalise_runner_exit_locked(rc, _eval_session)
+                if not inference_active and _last_result is not None:
+                    # The crash landed on the final episode: the session is over.
+                    return {**_last_result, "shutting_down": shutting_down}
+                # Otherwise fall through and report the parked (resetting) state.
+            else:
+                logger.info("Inference subprocess exited rc=%s", rc)
+                finished_meta = _inference_meta
+                finished_started = _inference_started_at
+                finished_rollout_started = _inference_rollout_started_at
+                # Terminal phase: a clean exit (rc 0, including a stop we asked
+                # for) is `stopped`; any non-zero code is `error`. The prior
+                # phase in `finished_meta` (e.g. "stopping" from a stop request)
+                # is superseded — the subprocess has actually gone now.
+                terminal_phase = PHASE_STOPPED if rc == 0 else PHASE_ERROR
+                inference_active = False
+                _inference_proc = None
+                _inference_started_at = None
+                _inference_rollout_started_at = None
+                _inference_meta = {}
+                # On a non-zero exit, mine the real error out of the log so the
+                # UI can show it directly (hint + snippet) instead of sending the
+                # user digging through the cache. `outcome` further distinguishes
+                # a true failure from a run that worked but tripped a noisy
+                # shutdown/cleanup warning (see _classify_outcome) so the
+                # false-failure isn't reported as a hard error.
+                error = _extract_error_from_log(finished_meta.get("log_path")) if rc else None
+                outcome = _classify_outcome(rc, finished_rollout_started is not None, error)
+                _last_result = {
+                    "inference_active": False,
+                    "exited": True,
+                    "exit_code": rc,
+                    "outcome": outcome,
+                    "error": error,
+                    "hint": friendly_hint(error),
+                    "phase": terminal_phase,
+                    "policy_ref": finished_meta.get("policy_ref"),
+                    "duration_s": finished_meta.get("duration_s"),
+                    "log_path": finished_meta.get("log_path"),
+                    "started_at": finished_started,
+                    "rollout_started_at": finished_rollout_started,
+                    "rollout_elapsed_s": 0,
+                    "elapsed_s": 0,
+                    **_eval_fields(None),
+                }
+                return {**_last_result, "shutting_down": shutting_down}
         elapsed = (time.time() - _inference_started_at) if _inference_started_at else 0
         rollout_elapsed = time.time() - _inference_rollout_started_at if _inference_rollout_started_at else 0
         return {

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -147,6 +147,24 @@ _inference_meta: dict[str, Any] = {}
 # dies swallows the outcome/error/hint — the dialog then sees a bare idle
 # status and misreports a crash as a clean finish.
 _last_result: dict[str, Any] | None = None
+# Log file of the most recent run that actually SPAWNED a subprocess, kept until
+# the next start claims the slot. Same lifecycle as `_last_result` above and for
+# the same reason: a finished run's log must stay readable while the dialog is
+# still showing its terminal state.
+#
+# It exists because the log used to be found by globbing the newest `*.log` out
+# of the inference_logs dir whenever the active meta had no path — which is true
+# in two ordinary windows: during a new session's pre-spawn phases (download /
+# preflight), and after a run that FAILED before spawning (the startup error
+# wipes the meta, so no path is ever committed). In both, the glob served a
+# previous run's log as though it were this one, unlabelled. Observed live: a run
+# that failed in `_prepare_robot` on a calibration error produced no log at all,
+# and the user was shown a three-day-old RTC run's output — they reasonably
+# concluded their sync run was executing RTC code.
+#
+# Binding log identity to the session lifecycle instead means the endpoint can
+# only ever return THIS process's own runs, and can say which.
+_last_log_path: str | None = None
 # Set for the CURRENT session at claim time; the background startup worker
 # captures its own reference and stop() sets it. It's the only way to abandon a
 # start that's still in its pre-subprocess window (Hub download / arm preflight),
@@ -1319,7 +1337,7 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
     next cancel check without preflighting or spawning. Terminal download/
     preflight failures flow through _fail_startup into the shared outcome/error/
     hint status machinery."""
-    global _inference_proc, _inference_rollout_started_at, _inference_meta
+    global _inference_proc, _inference_rollout_started_at, _inference_meta, _last_log_path
 
     # 1. Resolve/download the policy. A Hub ref streams byte progress into the
     #    meta; a local dir returns instantly (no downloading_model phase, no
@@ -1403,6 +1421,10 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
             if identity_warnings:
                 meta["warning"] = " ".join(identity_warnings)
             _inference_meta = meta
+            # This run now owns a log file. Recorded outside the meta too, so it
+            # survives the meta being cleared at session end and the endpoint can
+            # still serve THIS run's log (labelled last_run) afterwards.
+            _last_log_path = str(log_path)
 
     if abandoned:
         # Stopped during/just after the spawn — kill the subprocess we just
@@ -1448,7 +1470,7 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
     launch modal; the multi-minute Hub download moves off the request thread so
     the UI lands on the inference page and shows download progress there."""
     global inference_active, _inference_started_at, _inference_meta, _inference_cancel
-    global _last_result, _inference_startup_thread, _eval_session
+    global _last_result, _last_log_path, _inference_startup_thread, _eval_session
 
     # Mutex with every other feature that drives the same serial bus (see
     # CLAUDE.md's "State model & mutual exclusion").
@@ -1522,6 +1544,11 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
         # A new run supersedes the previous run's terminal payload — status
         # polls must reflect THIS session from the first tick.
         _last_result = None
+        # ...and its log. Until THIS session opens its own log file, there is no
+        # log to show: the pre-spawn phases (download / preflight) produce no
+        # subprocess output, and inheriting the previous run's path here is
+        # exactly how a stale log used to be presented as the current one.
+        _last_log_path = None
         # Eval mode is decided once, here, and clamped: episodes > 1 seeds the
         # session bookkeeping so the very first status poll already reports
         # "episode 1 / N". A count of 1 leaves `_eval_session` None, which is
@@ -1797,6 +1824,7 @@ def handle_next_episode() -> dict[str, Any]:
     ONE reload; even then the model isn't re-downloaded and the arm isn't
     re-preflighted, because both results are cached on the session."""
     global _inference_proc, _inference_started_at, _inference_rollout_started_at, _inference_meta
+    global _last_log_path
 
     with _state_lock:
         ev = _eval_session
@@ -1881,6 +1909,10 @@ def handle_next_episode() -> dict[str, Any]:
             return {"success": False, "status_code": 409, "message": "No evaluation is active"}
         _inference_proc = proc
         _inference_meta["log_path"] = str(log_path)
+        # A respawn opens a FRESH log (see _open_log_and_spawn), so this is not a
+        # set-once-per-session value: keep the two in step here as well as at the
+        # session's first launch.
+        _last_log_path = str(log_path)
 
     threading.Thread(
         target=_pump_runner_stdout,
@@ -1897,43 +1929,66 @@ def handle_next_episode() -> dict[str, Any]:
 _INFERENCE_LOG_MAX_LINES = 500
 
 
-def _resolve_inference_log_path() -> Path | None:
-    """Path of the current (or most-recent) run's inference log, or None.
+def _resolve_inference_log_path() -> tuple[Path | None, str | None]:
+    """The log to show and WHOSE it is: (path, "active" | "last_run" | None).
 
-    Prefers the active session's `_inference_meta["log_path"]`; when no session
-    is active (or its meta lacks a path), falls back to the newest `*.log` under
-    the inference_logs dir so a just-finished run's log is still viewable."""
+    Two sources, in order, and nothing else:
+      * the ACTIVE session's `_inference_meta["log_path"]` — this run's own log;
+      * `_last_log_path` — the most recent run of THIS server process to have
+        spawned a subprocess, so a finished run's log stays readable while the
+        dialog shows its terminal state.
+
+    There is deliberately NO directory fallback. Globbing the newest `*.log` out
+    of inference_logs looks like a harmless convenience, but a log file on disk
+    carries no evidence of which run produced it: during a new session's pre-spawn
+    phases, and after a run that failed before spawning, the newest file belongs
+    to some EARLIER run and was served as if it were the current one (see
+    `_last_log_path`). Returning None is the honest answer.
+
+    The cost is that after a server restart the endpoint reports no log even
+    though files exist on disk. That is accepted: those files belong to runs this
+    process never saw, and mislabelling them is worse than not showing them. The
+    path is still printed in the status payload for anyone who wants to open it.
+    """
     with _state_lock:
         meta_path = _inference_meta.get("log_path")
-    if meta_path:
+        active = inference_active
+        last_path = _last_log_path
+    if meta_path and active:
         p = Path(meta_path)
         if p.is_file():
-            return p
-    log_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / "inference_logs"
-    try:
-        logs = sorted(log_dir.glob("*.log"), key=lambda p: p.stat().st_mtime)
-    except OSError:
-        return None
-    return logs[-1] if logs else None
+            return p, "active"
+    if last_path:
+        p = Path(last_path)
+        if p.is_file():
+            return p, "last_run"
+    return None, None
 
 
 def handle_inference_log(max_lines: int = _INFERENCE_LOG_MAX_LINES) -> dict[str, Any]:
-    """Return the tail of the active/most-recent inference log.
+    """Return the tail of this session's (or the last run's) inference log.
 
     Read-only and bounded: at most `max_lines` trailing lines. Never raises —
     a missing/unreadable log yields empty text, so the route stays 200 even
-    before a run has produced any output."""
-    path = _resolve_inference_log_path()
+    before a run has produced any output.
+
+    `belongs_to` tells the caller what it is looking at, so the UI never has to
+    guess: "active" is the running session's own log, "last_run" the most recent
+    finished run of this process, and None means there is no log to show. A live
+    session that reports anything other than "active" has not produced output
+    yet — rendering `logs` in that case is how a stale run's output ends up
+    labelled as the current one."""
+    path, belongs_to = _resolve_inference_log_path()
     if path is None:
-        return {"logs": "", "log_path": None}
+        return {"logs": "", "log_path": None, "belongs_to": None}
     # Bounded read: only the last ~64 KB is decoded (shared with the error-mining
     # path), which holds every line a rollout log this size produces. A
     # missing/unreadable file yields None -> empty text, keeping the route 200.
     lines = _read_log_tail_lines(str(path))
     if lines is None:
-        return {"logs": "", "log_path": str(path)}
+        return {"logs": "", "log_path": str(path), "belongs_to": belongs_to}
     tail = lines[-max_lines:] if max_lines > 0 else lines
-    return {"logs": "\n".join(tail), "log_path": str(path)}
+    return {"logs": "\n".join(tail), "log_path": str(path), "belongs_to": belongs_to}
 
 
 def _finalise_eval_episode_locked(

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -31,10 +31,11 @@ import subprocess
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from pydantic import BaseModel
 
@@ -88,6 +89,12 @@ class InferenceRequest(BaseModel):
     # Escape hatch for the arm-identity guard (see makermodslab/arm_identity.py):
     # when true, run even if the connected arm doesn't match its calibration.
     skip_identity_check: bool = False
+    # Multi-episode EVALUATION mode. 1 (the default) is exactly the historical
+    # single-rollout flow — no episode bookkeeping, no reset phase, no accuracy.
+    # >1 walks N sequential rollout subprocesses inside ONE session (one model
+    # download, one arm preflight, one camera handover), scoring each episode.
+    # Clamped server-side to [1, MAX_EVAL_EPISODES] — see clamp_eval_episodes.
+    eval_episodes: int = 1
 
 
 inference_active: bool = False
@@ -121,8 +128,10 @@ _inference_cancel: threading.Event | None = None
 # orphaned worker is still alive, instead of racing it for the same serial
 # port. None once the worker has exited or before any session has started.
 _inference_startup_thread: threading.Thread | None = None
-# Guards mutations to the globals above; held only for the short critical
-# sections in start/stop/status.
+# Multi-episode evaluation bookkeeping for the CURRENT session lives in
+# `_eval_session`, declared just below the _EvalSession dataclass.
+# Guards mutations to the globals above (and _eval_session); held only for the
+# short critical sections in start/stop/status.
 _state_lock = threading.Lock()
 # Bound on how long a second stop-inference call waits for an orphaned startup
 # worker (see _inference_startup_thread) to exit before giving up and
@@ -158,6 +167,16 @@ _ROLLOUT_START_MARKER = "Rollout setup complete"
 # build passes no --dataset, so build_rollout_context never sets up (or
 # downloads) a dataset. We omit the phase rather than invent one that never
 # fires.
+#
+# EVAL-ONLY phases (eval_episodes > 1). The startup phases above repeat per
+# episode (each episode is its own subprocess), plus:
+#   resetting — an episode ended, the tally was updated, and the session is
+#       parked waiting for the user to rearrange the scene and POST
+#       /inference-next-episode. Also where a CRASHED episode parks, with
+#       `error`/`hint` populated so the user can continue or abort.
+#   finished  — every episode ran; terminal, carries `accuracy`.
+#   aborted   — /stop-inference ended the session early; terminal, partial
+#       tally, NO accuracy claimed.
 PHASE_DOWNLOADING_MODEL = "downloading_model"
 PHASE_STARTING = "starting"
 PHASE_LOADING_POLICY = "loading_policy"
@@ -166,6 +185,147 @@ PHASE_RUNNING = "running"
 PHASE_STOPPING = "stopping"
 PHASE_STOPPED = "stopped"
 PHASE_ERROR = "error"
+PHASE_RESETTING = "resetting"
+PHASE_FINISHED = "finished"
+PHASE_ABORTED = "aborted"
+
+# Per-episode verdicts, in the order the UI tallies them.
+#   success — the user pressed "task succeeded" and we terminated the episode.
+#   failure — the episode ran out its --duration without the user calling it.
+#   error   — the episode crashed (a serial glitch, a camera drop, a policy
+#       blow-up). NEITHER success nor failure: deliberately excluded from the
+#       accuracy denominator so one hardware hiccup can't poison a 20-episode
+#       number.
+EPISODE_SUCCESS = "success"
+EPISODE_FAILURE = "failure"
+EPISODE_ERROR = "error"
+
+# Upper bound on a single eval session. 200 episodes × a 60s duration is
+# already a >3h bench session; anything past this is a typo, not a plan.
+MAX_EVAL_EPISODES = 200
+
+
+def clamp_eval_episodes(value: int | None) -> int:
+    """Coerce a requested episode count into [1, MAX_EVAL_EPISODES].
+
+    Clamps rather than rejects: a nonsensical count (0, -5, 10_000) is a UI slip,
+    and silently running one episode / the cap is friendlier than a 422 that
+    loses the whole configured launch. A non-integer or None falls back to 1."""
+    try:
+        n = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 1
+    return max(1, min(MAX_EVAL_EPISODES, n))
+
+
+def eval_accuracy(results: Sequence[str]) -> float | None:
+    """successes / (successes + failures) over the recorded episode verdicts.
+
+    Crashed episodes (EPISODE_ERROR) are excluded from BOTH numerator and
+    denominator — see EPISODE_ERROR. Returns None when nothing scoreable has
+    happened yet (no episodes, or every episode crashed), so the UI shows
+    "no accuracy" instead of a misleading 0%."""
+    scored = [r for r in results if r in (EPISODE_SUCCESS, EPISODE_FAILURE)]
+    if not scored:
+        return None
+    return round(sum(1 for r in scored if r == EPISODE_SUCCESS) / len(scored), 4)
+
+
+def classify_episode(
+    rc: int | None,
+    stop_requested: bool,
+    rollout_started: bool,
+    error_text: str | None,
+) -> str:
+    """Turn one episode's subprocess exit into a verdict.
+
+    `stop_requested` (the user pressed "task succeeded — stop episode") wins
+    outright: we terminated the subprocess ourselves, so its exit code is our own
+    SIGTERM and says nothing about the run.
+
+    Otherwise the episode ended on its own. Reuse `_classify_outcome`:
+      ok / ran_with_warning → the rollout ran its full --duration (a noisy
+          torque-disable on teardown is not a failed episode) → FAILURE, i.e.
+          the policy never got the task done in the time allowed.
+      failed → the episode crashed → ERROR, excluded from the accuracy."""
+    if stop_requested:
+        return EPISODE_SUCCESS
+    if _classify_outcome(rc, rollout_started, error_text) == "failed":
+        return EPISODE_ERROR
+    return EPISODE_FAILURE
+
+
+@dataclass
+class _EvalSession:
+    """Bookkeeping for ONE multi-episode evaluation session.
+
+    Lives for the whole session (across N subprocesses) — unlike
+    `_inference_meta`, which is per-episode and cleared at each subprocess exit.
+    Mutated only under `_state_lock`. None whenever the session is single-episode
+    or idle, which is what every eval-only endpoint gates on."""
+
+    request: InferenceRequest
+    episodes_total: int
+    # Resolved ONCE by the startup worker and reused verbatim for every episode:
+    # the model is downloaded once and the arm preflight runs once per session.
+    policy_path: str | None = None
+    robot_args: list[str] = field(default_factory=list)
+    # Verdicts in episode order; len(results) is how many episodes have finished,
+    # so the CURRENT episode is 1-based index len(results) + 1.
+    results: list[str] = field(default_factory=list)
+    # Set by /inference-episode-stop just before it terminates the subprocess, so
+    # the exit finalisation scores the episode a success instead of reading our
+    # own SIGTERM as a crash. Cleared as each episode is scored.
+    stop_requested: bool = False
+    # A crashed episode's mined error + plain-language hint, surfaced on the
+    # resetting payload and cleared when the user continues.
+    error: str | None = None
+    hint: str | None = None
+
+    @property
+    def episode_index(self) -> int:
+        """1-based index of the episode currently running (or about to run).
+
+        Clamped to episodes_total so the final payload reads "10 / 10" rather
+        than "11 / 10"."""
+        return min(len(self.results) + 1, self.episodes_total)
+
+
+# Evaluation bookkeeping for the CURRENT session, or None when the session is a
+# plain single rollout (eval_episodes <= 1) or nothing is running. Every
+# eval-only endpoint gates on this being non-None, which is what keeps the
+# single-episode flow bit-for-bit unchanged. Mutated under `_state_lock`.
+_eval_session: _EvalSession | None = None
+
+
+def _eval_fields(
+    ev: _EvalSession | None,
+    *,
+    accuracy: float | None = None,
+) -> dict[str, Any]:
+    """The eval block of an /inference-status payload.
+
+    Emitted on EVERY payload so the shape is stable for the frontend: a
+    single-episode run reports `eval_mode: False` with null/empty companions
+    rather than omitting the keys. `accuracy` is passed in (not derived) because
+    it is claimed ONLY on a session that ran to completion — an aborted session
+    reports its partial tally with accuracy None."""
+    if ev is None:
+        return {
+            "eval_mode": False,
+            "episode_index": None,
+            "episodes_total": None,
+            "episode_results": None,
+            "accuracy": None,
+        }
+    return {
+        "eval_mode": True,
+        "episode_index": ev.episode_index,
+        "episodes_total": ev.episodes_total,
+        "episode_results": list(ev.results),
+        "accuracy": accuracy,
+    }
+
 
 # Stable lerobot setup log fragments (lerobot/rollout/context.py) that mark the
 # transition into a finer sub-phase. Watched in _pump_stdout. These are plain
@@ -675,18 +835,24 @@ def _fail_startup(error: str) -> None:
 
     A no-op when a stop already tore the session down (inference_active False):
     the stop wins, and a download that raised while being abandoned must not
-    resurrect a phantom failure."""
+    resurrect a phantom failure.
+
+    Session-level, not episode-level: this is the download/preflight/first-spawn
+    window, so in eval mode there is nothing to score yet — the eval session is
+    dropped and the failure is reported the same way a single run's would be."""
     global inference_active, _inference_proc, _inference_started_at
-    global _inference_rollout_started_at, _inference_meta, _last_result
+    global _inference_rollout_started_at, _inference_meta, _last_result, _eval_session
     with _state_lock:
         if not inference_active:
             return
         policy_ref = _inference_meta.get("policy_ref")
+        finished_eval = _eval_session
         inference_active = False
         _inference_proc = None
         _inference_started_at = None
         _inference_rollout_started_at = None
         _inference_meta = {}
+        _eval_session = None
         _last_result = {
             "inference_active": False,
             "exited": True,
@@ -702,7 +868,62 @@ def _fail_startup(error: str) -> None:
             "rollout_started_at": None,
             "rollout_elapsed_s": 0,
             "elapsed_s": 0,
+            **_eval_fields(finished_eval),
         }
+
+
+def _launch_rollout_subprocess(
+    request: InferenceRequest,
+    policy_path: str,
+    robot_args: list[str],
+) -> tuple[subprocess.Popen, IO[str], Path]:
+    """Build the argv, open a fresh log file, spawn ONE rollout subprocess and
+    seed its stdin.
+
+    The pure "start a rollout process" step, factored out of the startup worker
+    so eval mode's second-and-later episodes can respawn without re-downloading
+    the model or re-preflighting the arm. Returns (proc, log_handle, log_path);
+    the caller owns committing them to the module state and starting the stdout
+    pump. Raises on spawn failure (after closing the log handle) — the caller
+    decides how to report it, since a first-episode failure fails the session
+    while a later one fails just that episode."""
+    log_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / "inference_logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{int(time.time())}.log"
+    log_handle = log_path.open("w", buffering=1)
+
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    # Feed a newline into stdin PER follower arm so SOFollower.calibrate()'s
+    # `input("Press ENTER to use the calibration file ...")` returns "" and
+    # writes the existing calibration to the motors instead of hanging
+    # forever waiting for an interactive operator. A BiSO follower connects
+    # its two sub-arms sequentially (left then right), each of which can fire
+    # that prompt once — so seed two newlines for bimanual, one for single.
+    # Any prompt that doesn't fire just leaves an unread newline (harmless);
+    # subsequent input() calls in the recalibration path get EOF and raise —
+    # fine, because we never want to enter that path from the UI.
+    stdin_seed = b"\n\n" if request.mode == "bimanual" else b"\n"
+    try:
+        proc = subprocess.Popen(
+            _build_rollout_cmd(request, policy_path, robot_args),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+    except Exception:
+        with contextlib.suppress(Exception):
+            log_handle.close()
+        raise
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(stdin_seed)
+        proc.stdin.flush()
+        proc.stdin.close()
+    except Exception as exc:
+        logger.warning("Failed to seed stdin for inference subprocess: %s", exc)
+    return proc, log_handle, log_path
 
 
 def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Event) -> None:
@@ -752,48 +973,21 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
         logger.info("Inference startup abandoned after preflight (stop requested)")
         return
 
-    # 3. Spawn the rollout subprocess.
-    is_bimanual = request.mode == "bimanual"
-    cmd = _build_rollout_cmd(request, policy_path, robot_args)
+    # 3. Spawn the rollout subprocess (episode 1 of 1, or of N in eval mode).
+    #    In eval mode, cache what the later episodes reuse verbatim — the model
+    #    is downloaded once and the arm preflight runs once per SESSION, not per
+    #    episode (which is what makes N episodes cheap to chain).
+    with _state_lock:
+        if _eval_session is not None:
+            _eval_session.policy_path = policy_path
+            _eval_session.robot_args = list(robot_args)
 
-    log_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / "inference_logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_path = log_dir / f"{int(time.time())}.log"
-    log_handle = log_path.open("w", buffering=1)
-
-    env = os.environ.copy()
-    env["PYTHONUNBUFFERED"] = "1"
-    # Feed a newline into stdin PER follower arm so SOFollower.calibrate()'s
-    # `input("Press ENTER to use the calibration file ...")` returns "" and
-    # writes the existing calibration to the motors instead of hanging
-    # forever waiting for an interactive operator. A BiSO follower connects
-    # its two sub-arms sequentially (left then right), each of which can fire
-    # that prompt once — so seed two newlines for bimanual, one for single.
-    # Any prompt that doesn't fire just leaves an unread newline (harmless);
-    # subsequent input() calls in the recalibration path get EOF and raise —
-    # fine, because we never want to enter that path from the UI.
-    stdin_seed = b"\n\n" if is_bimanual else b"\n"
     try:
-        proc = subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            env=env,
-        )
+        proc, log_handle, log_path = _launch_rollout_subprocess(request, policy_path, robot_args)
     except Exception as exc:
         logger.exception("Failed to spawn rollout subprocess")
-        with contextlib.suppress(Exception):
-            log_handle.close()
         _fail_startup(f"Failed to start inference: {exc}")
         return
-    try:
-        assert proc.stdin is not None
-        proc.stdin.write(stdin_seed)
-        proc.stdin.flush()
-        proc.stdin.close()
-    except Exception as exc:
-        logger.warning("Failed to seed stdin for inference subprocess: %s", exc)
 
     # Commit the subprocess under the lock, re-checking the cancel flag: a stop
     # that raced the spawn must NOT leave a live subprocess driving the arm.
@@ -857,7 +1051,7 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
     launch modal; the multi-minute Hub download moves off the request thread so
     the UI lands on the inference page and shows download progress there."""
     global inference_active, _inference_started_at, _inference_meta, _inference_cancel
-    global _last_result, _inference_startup_thread
+    global _last_result, _inference_startup_thread, _eval_session
 
     # Mutex with every other feature that drives the same serial bus (see
     # CLAUDE.md's "State model & mutual exclusion").
@@ -931,14 +1125,22 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
         # A new run supersedes the previous run's terminal payload — status
         # polls must reflect THIS session from the first tick.
         _last_result = None
+        # Eval mode is decided once, here, and clamped: episodes > 1 seeds the
+        # session bookkeeping so the very first status poll already reports
+        # "episode 1 / N". A count of 1 leaves `_eval_session` None, which is
+        # what keeps the historical single-rollout flow untouched.
+        episodes = clamp_eval_episodes(request.eval_episodes)
+        _eval_session = _EvalSession(request=request, episodes_total=episodes) if episodes > 1 else None
 
     def _release_slot() -> None:
         global inference_active, _inference_started_at, _inference_cancel, _inference_meta
+        global _eval_session
         with _state_lock:
             inference_active = False
             _inference_started_at = None
             _inference_cancel = None
             _inference_meta = {}
+            _eval_session = None
 
     # Arm-count guard: reject a single-arm checkpoint on a bimanual robot (and
     # vice versa) BEFORE spawning the worker, where the shape mismatch would
@@ -994,10 +1196,58 @@ def inference_in_use_path() -> str | None:
         return _inference_meta.get("policy_path")
 
 
-def handle_stop_inference() -> dict[str, Any]:
-    global inference_active, _inference_proc, _inference_started_at
-    global _inference_rollout_started_at, _inference_meta, _inference_cancel
+def _go_idle_locked() -> None:
+    """Drop every per-session global back to the idle shape.
 
+    Caller must hold `_state_lock`. Does NOT touch `_last_result` — whether a
+    teardown leaves a terminal payload behind is the caller's decision."""
+    global inference_active, _inference_proc, _inference_started_at
+    global _inference_rollout_started_at, _inference_meta, _eval_session
+    inference_active = False
+    _inference_proc = None
+    _inference_started_at = None
+    _inference_rollout_started_at = None
+    _inference_meta = {}
+    _eval_session = None
+
+
+def _abort_eval_locked(ev: _EvalSession) -> None:
+    """End an eval session early and leave the ABORTED terminal payload behind.
+
+    Caller must hold `_state_lock`. Partial tally, and deliberately NO accuracy:
+    a session the user cut short says nothing about the policy's success rate
+    over N episodes, so claiming one would be a lie. The episode that was running
+    when the abort landed is simply not scored."""
+    global _last_result
+    finished_meta = _inference_meta
+    finished_started = _inference_started_at
+    _go_idle_locked()
+    _last_result = {
+        "inference_active": False,
+        "exited": True,
+        "exit_code": None,
+        "outcome": "ok",
+        "error": ev.error,
+        "hint": ev.hint,
+        "phase": PHASE_ABORTED,
+        "policy_ref": finished_meta.get("policy_ref"),
+        "duration_s": finished_meta.get("duration_s"),
+        "log_path": finished_meta.get("log_path"),
+        "started_at": finished_started,
+        "rollout_started_at": None,
+        "rollout_elapsed_s": 0,
+        "elapsed_s": 0,
+        **_eval_fields(ev),
+    }
+
+
+def handle_stop_inference() -> dict[str, Any]:
+    """Abort the WHOLE session — single run or eval.
+
+    In eval mode this is the session-level stop, not the per-episode one: it
+    ends the run wherever it is (mid-episode or parked in a reset) and reports
+    the partial tally under the `aborted` phase. Ending only the current episode
+    while keeping the session alive is `handle_stop_episode`."""
     with _state_lock:
         session_active = inference_active
         orphaned_worker = _inference_startup_thread if not session_active else None
@@ -1032,24 +1282,22 @@ def handle_stop_inference() -> dict[str, Any]:
         if _inference_cancel is not None:
             _inference_cancel.set()
         proc = _inference_proc
+        ev = _eval_session
         # Surface the stop as its own phase so a status poll racing the
         # terminate/wait below sees "stopping" rather than a stale "running".
         if _inference_meta:
             _inference_meta["phase"] = PHASE_STOPPING
 
         if proc is None:
-            # Stop pressed before the subprocess spawned (during the model
-            # download or the arm preflight). There's no process to terminate and
-            # no policy has driven the robot. Go straight to idle: the orphaned
-            # startup worker (if any) finishes its in-flight download into the HF
-            # cache and bails at its next cancel check — it never opens the bus
-            # or spawns a subprocess. A download-first ordering guarantees "no
-            # robot touched" here.
-            inference_active = False
-            _inference_proc = None
-            _inference_started_at = None
-            _inference_rollout_started_at = None
-            _inference_meta = {}
+            # Stop pressed with no live subprocess: either before the first one
+            # spawned (during the model download / arm preflight — no policy has
+            # driven the robot, and the orphaned startup worker bails at its next
+            # cancel check), or, in eval mode, while parked in a reset between
+            # episodes. Either way there's nothing to terminate.
+            if ev is not None:
+                _abort_eval_locked(ev)
+                return {"success": True, "message": "Evaluation aborted"}
+            _go_idle_locked()
             return {"success": True, "message": "Inference stopped"}
 
     try:
@@ -1064,12 +1312,150 @@ def handle_stop_inference() -> dict[str, Any]:
         logger.exception("Stop inference: %s", exc)
 
     with _state_lock:
-        inference_active = False
-        _inference_proc = None
-        _inference_started_at = None
-        _inference_rollout_started_at = None
-        _inference_meta = {}
+        # Re-read: a status poll could have finalised the exit (and, in eval
+        # mode, even finished the session) while we were outside the lock.
+        ev = _eval_session
+        if ev is not None:
+            _abort_eval_locked(ev)
+            return {"success": True, "message": "Evaluation aborted"}
+        _go_idle_locked()
     return {"success": True, "message": "Inference stopped"}
+
+
+def handle_stop_episode() -> dict[str, Any]:
+    """End the CURRENT eval episode early and score it a SUCCESS.
+
+    This is the "the robot did the task — next" button. It terminates the
+    episode's subprocess exactly the way `handle_stop_inference` does (so the
+    follower still eases back to its start pose via
+    `--return_to_initial_position`) but leaves the SESSION standing: the exit
+    finalisation in `handle_inference_status` then parks it in the reset phase
+    (or finishes it, if that was the last episode).
+
+    Eval-only by design: a single-episode run has no tally to record a success
+    into, so it gets a 409 rather than a silent no-op."""
+    with _state_lock:
+        if not inference_active or _eval_session is None:
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "No evaluation episode is running",
+            }
+        proc = _inference_proc
+        if proc is None:
+            # Either still starting up, or already parked in a reset — there is
+            # no running episode to call a success.
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "No evaluation episode is running",
+            }
+        # Set BEFORE terminating so the flag is always visible to whichever
+        # thread finalises the exit. If a status poll beats us to the exit (the
+        # episode hit its duration in this exact window) it clears
+        # `_inference_proc` under this same lock, and the guard above turns the
+        # next call into a 409 — the two orders can't both score the episode.
+        _eval_session.stop_requested = True
+
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.warning("Eval episode did not exit in 5s; killing")
+            proc.kill()
+            proc.wait()
+    except Exception as exc:
+        logger.exception("Stop eval episode: %s", exc)
+    # The verdict is recorded in ONE place — the exit finalisation in
+    # handle_inference_status — so a poll that raced us can't double-score.
+    return {"success": True, "message": "Episode recorded as a success"}
+
+
+def handle_next_episode() -> dict[str, Any]:
+    """Leave the reset phase and spawn the next eval episode.
+
+    The reset between episodes is explicitly user-ended (no auto-timer, unlike
+    recording's): rearranging a bench scene has no reason to be rushed. Reuses
+    the session's already-resolved policy path and already-preflighted
+    `--robot.*` args, so continuing costs one subprocess spawn — no re-download,
+    no second arm-identity pass, and the cameras stay owned by the session
+    throughout."""
+    global _inference_proc, _inference_started_at, _inference_rollout_started_at, _inference_meta
+
+    with _state_lock:
+        ev = _eval_session
+        if not inference_active or ev is None:
+            return {"success": False, "status_code": 409, "message": "No evaluation is active"}
+        if _inference_meta.get("phase") != PHASE_RESETTING:
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "The evaluation is not waiting for a reset",
+            }
+        if ev.policy_path is None:
+            # Only reachable if the startup worker never got far enough to cache
+            # the resolved path, which also means no episode ever ran.
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": "The evaluation session has no prepared policy to run",
+            }
+        request, policy_path, robot_args = ev.request, ev.policy_path, list(ev.robot_args)
+        carried_ref = _inference_meta.get("policy_ref")
+        carried_warning = _inference_meta.get("warning")
+
+    try:
+        proc, log_handle, log_path = _launch_rollout_subprocess(request, policy_path, robot_args)
+    except Exception as exc:
+        logger.exception("Failed to spawn the next eval episode")
+        # Spawning is the cheap part; a failure here is a session-level problem
+        # (a broken interpreter/env), not something the next reset can fix.
+        _fail_startup(f"Failed to start the next episode: {exc}")
+        return {"success": False, "status_code": 500, "message": f"Failed to start the next episode: {exc}"}
+
+    with _state_lock:
+        if not inference_active or _eval_session is None:
+            # Aborted while we were spawning — kill what we just started rather
+            # than leave a policy driving the arm for a dead session.
+            logger.info("Next eval episode abandoned right after spawn; killing subprocess")
+            with contextlib.suppress(Exception):
+                proc.terminate()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=5)
+            with contextlib.suppress(Exception):
+                log_handle.close()
+            return {"success": False, "status_code": 409, "message": "No evaluation is active"}
+        _inference_proc = proc
+        # Both timers restart per episode: `elapsed_s` is this episode's setup
+        # time and `rollout_elapsed_s` its rollout time, so the dialog's clock
+        # and the frontend's past-duration safety net both measure the EPISODE,
+        # not the (much longer) session.
+        _inference_started_at = time.time()
+        _inference_rollout_started_at = None
+        # Clear the previous episode's crash banner — the user chose to continue.
+        _eval_session.error = None
+        _eval_session.hint = None
+        meta: dict[str, Any] = {
+            "policy_ref": carried_ref or request.policy_ref,
+            "policy_path": policy_path,
+            "duration_s": request.duration_s,
+            "log_path": str(log_path),
+            "phase": PHASE_STARTING,
+        }
+        if carried_warning:
+            meta["warning"] = carried_warning
+        _inference_meta = meta
+        episode_index = _eval_session.episode_index
+
+    threading.Thread(
+        target=_pump_stdout,
+        args=(proc, log_handle),
+        name="inference-stdout-pump",
+        daemon=True,
+    ).start()
+    logger.info("Eval episode %s started: pid=%s", episode_index, proc.pid)
+    return {"success": True, "message": f"Episode {episode_index} starting"}
 
 
 # Tail cap for the inference-log endpoint: last N lines, bounded so a very long
@@ -1116,6 +1502,96 @@ def handle_inference_log(max_lines: int = _INFERENCE_LOG_MAX_LINES) -> dict[str,
     return {"logs": "\n".join(tail), "log_path": str(path)}
 
 
+def _finalise_eval_episode_locked(rc: int | None, ev: _EvalSession) -> dict[str, Any]:
+    """Score one finished eval episode and either park or finish the session.
+
+    Caller must hold `_state_lock`. This is the SINGLE place an episode verdict
+    is recorded — `handle_stop_episode` only sets the flag and terminates, so a
+    status poll racing the stop can't double-score.
+
+    Not finishing the session means keeping `inference_active` True through the
+    reset: the session still owns the inference slot (recording/teleop stay
+    blocked) and still owns the cameras (previews stay 409'd), which is exactly
+    what lets the next episode spawn straight into a ready rig."""
+    global _inference_proc, _inference_rollout_started_at, _inference_meta, _last_result
+
+    finished_meta = _inference_meta
+    finished_started = _inference_started_at
+    rollout_started = _inference_rollout_started_at is not None
+    # Mine the log only when the exit was non-zero; a stop we asked for exits
+    # non-zero via our own SIGTERM, so the snippet is discarded unless the
+    # verdict actually turns out to be a crash.
+    error = _extract_error_from_log(finished_meta.get("log_path")) if rc else None
+    verdict = classify_episode(rc, ev.stop_requested, rollout_started, error)
+    # Read the index BEFORE appending — the property is derived from the result
+    # count, so afterwards it names the NEXT episode.
+    logger.info(
+        "Eval episode %s/%s exited rc=%s -> %s",
+        ev.episode_index,
+        ev.episodes_total,
+        rc,
+        verdict,
+    )
+    ev.results.append(verdict)
+    ev.stop_requested = False
+    if verdict == EPISODE_ERROR:
+        ev.error = error
+        ev.hint = friendly_hint(error)
+    else:
+        ev.error = None
+        ev.hint = None
+
+    _inference_proc = None
+    _inference_rollout_started_at = None
+
+    if len(ev.results) < ev.episodes_total:
+        # More to go: park in the reset phase and wait for the user to rearrange
+        # the scene and POST /inference-next-episode. No auto-timer.
+        _inference_meta = {**finished_meta, "phase": PHASE_RESETTING}
+        return {
+            **_eval_fields(ev),
+            "inference_active": True,
+            "started_at": finished_started,
+            "rollout_started_at": None,
+            "elapsed_s": 0,
+            "rollout_elapsed_s": 0,
+            "duration_s": finished_meta.get("duration_s"),
+            "policy_ref": finished_meta.get("policy_ref"),
+            "log_path": finished_meta.get("log_path"),
+            "phase": PHASE_RESETTING,
+            "download_bytes_done": None,
+            "download_bytes_total": None,
+            "download_percent": None,
+            "warning": finished_meta.get("warning"),
+            # Populated only for a CRASHED episode — the reset screen doubles as
+            # the "this one broke, continue or abort?" screen.
+            "error": ev.error,
+            "hint": ev.hint,
+        }
+
+    # Last episode: the session is done. Claim the accuracy and release the slot.
+    _go_idle_locked()
+    _last_result = {
+        "inference_active": False,
+        "exited": True,
+        "exit_code": rc,
+        "outcome": "ok",
+        "error": ev.error,
+        "hint": ev.hint,
+        "phase": PHASE_FINISHED,
+        "policy_ref": finished_meta.get("policy_ref"),
+        "duration_s": finished_meta.get("duration_s"),
+        "log_path": finished_meta.get("log_path"),
+        "started_at": finished_started,
+        "rollout_started_at": None,
+        "rollout_elapsed_s": 0,
+        "elapsed_s": 0,
+        **_eval_fields(ev, accuracy=eval_accuracy(ev.results)),
+    }
+    logger.info("Evaluation finished: %s accuracy=%s", ev.results, _last_result["accuracy"])
+    return dict(_last_result)
+
+
 def handle_inference_status() -> dict[str, Any]:
     global inference_active, _inference_proc, _inference_started_at
     global _inference_rollout_started_at, _inference_meta, _last_result
@@ -1142,6 +1618,10 @@ def handle_inference_status() -> dict[str, Any]:
             return {**_last_result, "shutting_down": shutting_down}
         if proc is not None and proc.poll() is not None:
             rc = proc.returncode
+            if _eval_session is not None:
+                # Eval mode: this exit ends an EPISODE, which only ends the
+                # SESSION if it was the last one.
+                return _finalise_eval_episode_locked(rc, _eval_session)
             logger.info("Inference subprocess exited rc=%s", rc)
             finished_meta = _inference_meta
             finished_started = _inference_started_at
@@ -1179,11 +1659,18 @@ def handle_inference_status() -> dict[str, Any]:
                 "rollout_started_at": finished_rollout_started,
                 "rollout_elapsed_s": 0,
                 "elapsed_s": 0,
+                **_eval_fields(None),
             }
             return {**_last_result, "shutting_down": shutting_down}
         elapsed = (time.time() - _inference_started_at) if _inference_started_at else 0
         rollout_elapsed = time.time() - _inference_rollout_started_at if _inference_rollout_started_at else 0
         return {
+            **_eval_fields(_eval_session),
+            # A crashed episode parks the eval session in the reset phase with
+            # its mined error still on show, so the user can decide to continue
+            # or abort. Null on every other live payload.
+            "error": _eval_session.error if _eval_session else None,
+            "hint": _eval_session.hint if _eval_session else None,
             "inference_active": inference_active,
             "started_at": _inference_started_at,
             "rollout_started_at": _inference_rollout_started_at,

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -99,7 +99,9 @@ from .rollout import (
     InferenceRequest,
     handle_inference_log,
     handle_inference_status,
+    handle_next_episode,
     handle_start_inference,
+    handle_stop_episode,
     handle_stop_inference,
 )
 
@@ -539,11 +541,42 @@ def start_inference(request: InferenceRequest):
 
 @app.post("/stop-inference")
 def stop_inference():
+    """Abort the whole session. In evaluation mode (eval_episodes > 1) this ends
+    the run wherever it is and reports the partial tally with NO accuracy — the
+    per-episode control is /inference-episode-stop."""
     result = handle_stop_inference()
     if not result.get("success"):
         raise HTTPException(
             status_code=result.get("status_code", 500),
             detail=result.get("message", "Failed to stop inference"),
+        )
+    return result
+
+
+@app.post("/inference-episode-stop")
+def inference_episode_stop():
+    """Evaluation mode only: end the CURRENT episode early and score it a
+    SUCCESS ("the robot did the task"). The session stays up and moves into its
+    reset phase. 409 when no evaluation episode is running."""
+    result = handle_stop_episode()
+    if not result.get("success"):
+        raise HTTPException(
+            status_code=result.get("status_code", 500),
+            detail=result.get("message", "Failed to stop the episode"),
+        )
+    return result
+
+
+@app.post("/inference-next-episode")
+def inference_next_episode():
+    """Evaluation mode only: leave the reset phase and start the next episode.
+    The reset is user-ended (no auto-timer). 409 unless an evaluation is parked
+    waiting for a reset."""
+    result = handle_next_episode()
+    if not result.get("success"):
+        raise HTTPException(
+            status_code=result.get("status_code", 500),
+            detail=result.get("message", "Failed to start the next episode"),
         )
     return result
 

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -590,8 +590,12 @@ def inference_status():
 def inference_log():
     """Tail of the active/most-recent rollout's log file (read-only, bounded).
 
-    Returns {logs, log_path}; empty logs (not an error) when no run has produced
-    output yet, so the frontend can poll unconditionally."""
+    Returns {logs, log_path, belongs_to}; empty logs (not an error) when no run
+    has produced output yet, so the frontend can poll unconditionally.
+
+    `belongs_to` is "active" (the running session's own log), "last_run" (the
+    most recent finished run of this server process) or null (nothing to show) —
+    the caller must not present a "last_run" log as the live session's output."""
     return handle_inference_log()
 
 

--- a/makermodslab/utils/errors.py
+++ b/makermodslab/utils/errors.py
@@ -96,6 +96,29 @@ def friendly_hint(error_text: str | None) -> str | None:
             "A follower motor isn't responding (often the gripper, id 6). If a skill was holding an object "
             "it likely overloaded — remove it, power-cycle the arm, then try teleoperation first."
         )
+    # Servo bus comms: lerobot's motors_bus raises these as ConnectionError with
+    # a "Failed to <read|write|sync read|sync write> ... [TxRxResult] ..." body
+    # when a servo doesn't answer or answers with a corrupt packet (arm powered
+    # down mid-session, a loose daisy-chain link, a half-seated cable). Keyed on
+    # the bus-specific phrasing, and placed before the Hub branches because the
+    # exception TYPE name is the same "ConnectionError" a download failure has.
+    # `in_download_step` is rollout's own prefix for anything raised inside the
+    # model fetch — the arm has not been touched yet, so the generic
+    # read/write wording below cannot be about a servo there.
+    in_download_step = "failed to download the model" in low
+    if not in_download_step and (
+        "txrxresult" in low
+        or "incorrect status packet" in low
+        or "failed to sync read" in low
+        or "failed to sync write" in low
+        or "failed to write" in low
+        or "failed to read" in low
+    ):
+        return (
+            "A motor stopped answering on the servo bus — usually the arm lost power, or a servo "
+            "cable/daisy-chain link is loose. Power-cycle the arm, re-seat the cables, then try "
+            "teleoperation before inference."
+        )
     # Hub model-download failures (snapshot_download, before the arm is ever
     # touched). Keyed on hub-specific tokens so a network/404/disk error while
     # fetching a checkpoint isn't mistaken for an arm-connection problem below.
@@ -109,7 +132,12 @@ def friendly_hint(error_text: str | None) -> str | None:
         or ("404" in low and ("huggingface" in low or "hf.co" in low or "repo" in low))
     ):
         return "Couldn't find the model on the Hub — check the repo id, and that you have access if it's private or gated."
-    if ("huggingface.co" in low or "hf.co" in low or "max retries" in low or "connectionerror" in low) and (
+    # The trigger tokens must be HUB-specific. A bare "connectionerror" is not:
+    # lerobot's motors bus raises ConnectionError for every serial failure, and
+    # the type name itself contains "connect", so keying on it labelled arm-side
+    # startup crashes "couldn't download the model". `in_download_step` (rollout's
+    # own prefix) is the one marker that says the failure really was the fetch.
+    if ("huggingface.co" in low or "hf.co" in low or "max retries" in low or in_download_step) and (
         "connect" in low or "reach" in low or "retries" in low or "timed out" in low or "timeout" in low
     ):
         return "Couldn't download the model — check your internet connection, then confirm the repo id."

--- a/tests/test_log_endpoints.py
+++ b/tests/test_log_endpoints.py
@@ -15,14 +15,13 @@
 on-disk log file) and recording-log (tail of the in-memory ring buffer).
 
 Both log SOURCES are mocked: the inference log is a temp file monkeypatched into
-the handler's meta / fallback dir, and the recording log is a seeded ring-buffer
+the handler's session state, and the recording log is a seeded ring-buffer
 handler. No real inference or recording is ever started (that would drive the
 arm) — we exercise the pure read paths only."""
 
 from __future__ import annotations
 
 import logging
-import os
 
 import pytest
 
@@ -38,17 +37,25 @@ def _reset_rollout_meta(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_inference_log_empty_when_no_run(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    """No active meta and an empty logs dir → empty text, log_path None, no raise."""
+    """No session state → empty text, log_path None, belongs_to None, no raise.
+
+    Log files on disk are deliberately irrelevant here: the handler only serves a
+    log this process opened, so a populated inference_logs dir must not change
+    the answer (see the removal note below).
+    """
     from makermodslab import rollout
 
-    empty_dir = tmp_path / "inference_logs"
-    empty_dir.mkdir()
-    # Point the fallback glob at an empty dir by faking Path.home().
-    monkeypatch.setattr(rollout.Path, "home", staticmethod(lambda: tmp_path.parent))
-    # tmp_path.parent/.cache/... won't exist; the OSError/empty path both yield "".
+    logs_dir = tmp_path / ".cache" / "huggingface" / "lerobot" / "inference_logs"
+    logs_dir.mkdir(parents=True)
+    (logs_dir / "100.log").write_text("some earlier run\n")
+    monkeypatch.setattr(rollout.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(rollout, "_last_log_path", None)
+
     result = rollout.handle_inference_log()
     assert result["logs"] == ""
     assert result["log_path"] is None
+    assert result["belongs_to"] is None
 
 
 def test_inference_log_tails_active_meta_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -57,11 +64,16 @@ def test_inference_log_tails_active_meta_file(monkeypatch: pytest.MonkeyPatch, t
 
     log_file = tmp_path / "run.log"
     log_file.write_text("line1\nline2\nline3\n")
+    # The meta branch serves the log only for a LIVE session — otherwise a
+    # lingering meta could get labelled "active" after the run ended, which is the
+    # mislabelling the belongs_to contract exists to prevent.
+    monkeypatch.setattr(rollout, "inference_active", True)
     monkeypatch.setattr(rollout, "_inference_meta", {"log_path": str(log_file)})
 
     result = rollout.handle_inference_log()
     assert result["log_path"] == str(log_file)
     assert result["logs"] == "line1\nline2\nline3"
+    assert result["belongs_to"] == "active"
 
 
 def test_inference_log_bounded_to_max_lines(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -70,6 +82,7 @@ def test_inference_log_bounded_to_max_lines(monkeypatch: pytest.MonkeyPatch, tmp
 
     log_file = tmp_path / "run.log"
     log_file.write_text("\n".join(f"line{i}" for i in range(1000)) + "\n")
+    monkeypatch.setattr(rollout, "inference_active", True)
     monkeypatch.setattr(rollout, "_inference_meta", {"log_path": str(log_file)})
 
     result = rollout.handle_inference_log(max_lines=10)
@@ -80,24 +93,21 @@ def test_inference_log_bounded_to_max_lines(monkeypatch: pytest.MonkeyPatch, tmp
     assert lines[-1] == "line999"
 
 
-def test_inference_log_falls_back_to_newest_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    """With no active meta, the newest *.log under the logs dir is tailed."""
-    from makermodslab import rollout
-
-    logs_dir = tmp_path / ".cache" / "huggingface" / "lerobot" / "inference_logs"
-    logs_dir.mkdir(parents=True)
-    old = logs_dir / "100.log"
-    new = logs_dir / "200.log"
-    old.write_text("old-run\n")
-    new.write_text("new-run\n")
-    # Make `new` unambiguously newer regardless of write ordering.
-    os.utime(old, (1000, 1000))
-    os.utime(new, (2000, 2000))
-    monkeypatch.setattr(rollout.Path, "home", staticmethod(lambda: tmp_path))
-
-    result = rollout.handle_inference_log()
-    assert result["log_path"] == str(new)
-    assert result["logs"] == "new-run"
+# REMOVED: test_inference_log_falls_back_to_newest_file.
+#
+# It pinned the "no active meta -> tail the newest *.log in inference_logs"
+# fallback, which is now the DEFECT rather than the contract. A log file on disk
+# carries no evidence of which run wrote it, so during a new session's pre-spawn
+# phases — and after a run that failed before spawning — that glob served an
+# earlier run's output as though it were the current one. Observed live: a run
+# that failed on a calibration error produced no log at all, and the user was
+# shown a three-day-old RTC run's output and concluded their sync run was
+# executing RTC code.
+#
+# The replacement guarantees live in tests/test_rollout.py: the endpoint serves
+# only logs THIS process opened, labelled `belongs_to` ("active" / "last_run" /
+# null), and `test_inference_log_never_globs_the_directory` pins the absence of
+# this fallback directly.
 
 
 # --- Recording log ------------------------------------------------------------

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -41,6 +41,7 @@ def _reset_rollout_globals(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(rollout, "_inference_cancel", None)
     monkeypatch.setattr(rollout, "_last_result", None)
     monkeypatch.setattr(rollout, "_inference_startup_thread", None)
+    monkeypatch.setattr(rollout, "_eval_session", None)
 
 
 class _SyncThread:
@@ -1391,3 +1392,440 @@ def test_run_inference_startup_local_ref_skips_download_phase(monkeypatch, tmp_p
 
     assert rollout.PHASE_DOWNLOADING_MODEL not in phases
     assert rollout._inference_proc is not None
+
+
+# ---------------------------------------------------------------------------
+# Multi-episode EVALUATION mode
+#
+# Pure helpers (clamping, accuracy math, verdict classification), the request
+# schema, the status-payload shape, and the idle/mutex branches of the two new
+# endpoints. The subprocess happy path stays deliberately untested (per
+# CLAUDE.md) — the one exception is a fully-stubbed exit finalisation, which is
+# pure bookkeeping over a fake Popen and touches no hardware.
+# ---------------------------------------------------------------------------
+
+
+class _ExitedProc:
+    """A `subprocess.Popen` stand-in that has already exited with `rc`."""
+
+    def __init__(self, rc: int = 0) -> None:
+        self.returncode = rc
+        self.pid = 4242
+
+    def poll(self) -> int:
+        return self.returncode
+
+
+def _eval_request(episodes: int = 3):
+    from makermodslab.rollout import InferenceRequest
+
+    return InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        eval_episodes=episodes,
+    )
+
+
+def _arm_eval_session(monkeypatch, rollout, episodes: int = 3, *, running: bool = True, rc: int = 0):
+    """Put the module into a mid-eval state with an already-exited subprocess."""
+    session = rollout._EvalSession(request=_eval_request(episodes), episodes_total=episodes)
+    session.policy_path = "/tmp/policy"
+    session.robot_args = ["--robot.type=so101_follower"]
+    monkeypatch.setattr(rollout, "_eval_session", session)
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_started_at", 1000.0)
+    monkeypatch.setattr(rollout, "_inference_rollout_started_at", 1005.0)
+    monkeypatch.setattr(
+        rollout,
+        "_inference_meta",
+        {"phase": rollout.PHASE_RUNNING, "policy_ref": "user/repo@checkpoints/000050", "duration_s": 60},
+    )
+    if running:
+        monkeypatch.setattr(rollout, "_inference_proc", _ExitedProc(rc))
+    return session
+
+
+def test_eval_episodes_defaults_to_one() -> None:
+    """The historical single-rollout request is unchanged: no eval fields set."""
+    from makermodslab.rollout import InferenceRequest
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+    )
+    assert req.eval_episodes == 1
+
+
+def test_inference_request_accepts_eval_episodes() -> None:
+    assert _eval_request(10).eval_episodes == 10
+
+
+def test_clamp_eval_episodes_bounds_and_fallbacks() -> None:
+    from makermodslab.rollout import MAX_EVAL_EPISODES, clamp_eval_episodes
+
+    assert clamp_eval_episodes(1) == 1
+    assert clamp_eval_episodes(10) == 10
+    assert clamp_eval_episodes(0) == 1
+    assert clamp_eval_episodes(-5) == 1
+    assert clamp_eval_episodes(MAX_EVAL_EPISODES) == MAX_EVAL_EPISODES
+    assert clamp_eval_episodes(10_000) == MAX_EVAL_EPISODES
+    # Junk degrades to a single episode rather than raising out of the POST.
+    assert clamp_eval_episodes(None) == 1
+    assert clamp_eval_episodes("nope") == 1
+
+
+def test_eval_accuracy_scores_successes_over_scored_episodes() -> None:
+    from makermodslab.rollout import eval_accuracy
+
+    assert eval_accuracy(["success", "success", "failure", "failure"]) == 0.5
+    assert eval_accuracy(["success"]) == 1.0
+    assert eval_accuracy(["failure", "failure"]) == 0.0
+
+
+def test_eval_accuracy_excludes_errored_episodes_from_the_denominator() -> None:
+    """A serial glitch must not poison the number: an errored episode counts
+    neither for nor against the policy."""
+    from makermodslab.rollout import eval_accuracy
+
+    # 1 success, 1 failure, 2 crashes -> 1/2, not 1/4.
+    assert eval_accuracy(["success", "failure", "error", "error"]) == 0.5
+
+
+def test_eval_accuracy_is_none_when_nothing_scoreable() -> None:
+    from makermodslab.rollout import eval_accuracy
+
+    assert eval_accuracy([]) is None
+    assert eval_accuracy(["error", "error"]) is None
+
+
+def test_classify_episode_early_stop_is_a_success_whatever_the_exit_code() -> None:
+    """We terminated the subprocess ourselves, so its exit code is our own
+    SIGTERM and says nothing about the run."""
+    from makermodslab.rollout import EPISODE_SUCCESS, classify_episode
+
+    assert classify_episode(-15, True, True, None) == EPISODE_SUCCESS
+    assert classify_episode(0, True, True, None) == EPISODE_SUCCESS
+    assert classify_episode(1, True, True, "RuntimeError: boom") == EPISODE_SUCCESS
+
+
+def test_classify_episode_clean_timeout_is_a_failure() -> None:
+    from makermodslab.rollout import EPISODE_FAILURE, classify_episode
+
+    assert classify_episode(0, False, True, None) == EPISODE_FAILURE
+
+
+def test_classify_episode_cleanup_warning_is_a_failure_not_an_error() -> None:
+    """The rollout ran its full duration and only teardown was noisy — the
+    episode legitimately timed out, so it's a failure, not a crash."""
+    from makermodslab.rollout import EPISODE_FAILURE, classify_episode
+
+    # "overload" is one of errors.CLEANUP_MARKERS — a gripper still holding an
+    # object when torque is released at teardown.
+    verdict = classify_episode(1, False, True, "RuntimeError: motor 6 overload during shutdown")
+    assert verdict == EPISODE_FAILURE
+
+
+def test_classify_episode_crash_is_an_error() -> None:
+    from makermodslab.rollout import EPISODE_ERROR, classify_episode
+
+    assert classify_episode(1, False, False, "DeviceNotConnectedError: bus is gone") == EPISODE_ERROR
+
+
+def test_eval_fields_are_null_shaped_for_a_single_episode_run() -> None:
+    """The status shape stays stable: a plain run reports eval_mode False with
+    null companions rather than omitting the keys."""
+    from makermodslab.rollout import _eval_fields
+
+    fields = _eval_fields(None)
+    assert fields["eval_mode"] is False
+    assert fields["episode_index"] is None
+    assert fields["episodes_total"] is None
+    assert fields["episode_results"] is None
+    assert fields["accuracy"] is None
+
+
+def test_idle_status_reports_single_episode_shape() -> None:
+    from makermodslab.rollout import handle_inference_status
+
+    result = handle_inference_status()
+    assert result["eval_mode"] is False
+    assert result["episodes_total"] is None
+    assert result["accuracy"] is None
+
+
+def test_start_inference_seeds_the_eval_session(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(rollout, "_run_inference_startup", lambda *a, **k: None)
+    monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: None)
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
+
+    result = rollout.handle_start_inference(_eval_request(5))
+    assert result["success"] is True
+    assert rollout._eval_session is not None
+    assert rollout._eval_session.episodes_total == 5
+    assert rollout._eval_session.episode_index == 1
+    status = rollout.handle_inference_status()
+    assert status["eval_mode"] is True
+    assert status["episodes_total"] == 5
+    assert status["episode_index"] == 1
+    assert status["episode_results"] == []
+    assert status["accuracy"] is None
+
+
+def test_start_inference_with_one_episode_leaves_eval_session_none(monkeypatch) -> None:
+    """eval_episodes=1 must be bit-for-bit the historical flow."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(rollout, "_run_inference_startup", lambda *a, **k: None)
+    monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: None)
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
+
+    rollout.handle_start_inference(_eval_request(1))
+    assert rollout._eval_session is None
+    assert rollout.handle_inference_status()["eval_mode"] is False
+
+
+def test_start_inference_clamps_the_requested_episode_count(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(rollout, "_run_inference_startup", lambda *a, **k: None)
+    monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: None)
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
+
+    rollout.handle_start_inference(_eval_request(10_000))
+    assert rollout._eval_session.episodes_total == rollout.MAX_EVAL_EPISODES
+
+
+def test_start_inference_guard_failure_clears_the_eval_session(monkeypatch) -> None:
+    """A rejected start must not leave eval bookkeeping behind for the next run."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: False)
+    result = rollout.handle_start_inference(_eval_request(4))
+    assert result["success"] is False
+    assert rollout._eval_session is None
+    assert rollout.inference_active is False
+
+
+def test_episode_timeout_parks_the_session_in_the_reset_phase(monkeypatch) -> None:
+    """A clean exit scores a FAILURE and keeps the session (and its hold on the
+    inference slot + cameras) alive for the reset."""
+    from makermodslab import rollout
+
+    _arm_eval_session(monkeypatch, rollout, episodes=3, rc=0)
+    status = rollout.handle_inference_status()
+
+    assert status["phase"] == rollout.PHASE_RESETTING
+    assert status["inference_active"] is True
+    assert status["episode_results"] == ["failure"]
+    assert status["episode_index"] == 2
+    assert status["accuracy"] is None
+    # The slot stays claimed through the reset — recording/teleop stay blocked.
+    assert rollout.inference_active is True
+    assert rollout._inference_proc is None
+
+
+def test_early_stop_scores_the_episode_a_success(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, rc=-15)
+    session.stop_requested = True
+    status = rollout.handle_inference_status()
+
+    assert status["episode_results"] == ["success"]
+    assert status["phase"] == rollout.PHASE_RESETTING
+    # The flag is one-shot: the next episode starts unstopped.
+    assert session.stop_requested is False
+
+
+def test_crashed_episode_parks_with_the_error_visible(monkeypatch) -> None:
+    """A crash is neither success nor failure: it parks in the reset phase with
+    the mined error so the user can continue or abort."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(
+        rollout,
+        "_extract_error_from_log",
+        lambda p: "DeviceNotConnectedError: could not connect to the follower bus",
+    )
+    _arm_eval_session(monkeypatch, rollout, episodes=3, rc=1)
+    monkeypatch.setattr(rollout, "_inference_rollout_started_at", None)
+
+    status = rollout.handle_inference_status()
+    assert status["episode_results"] == ["error"]
+    assert status["phase"] == rollout.PHASE_RESETTING
+    assert status["inference_active"] is True
+    assert "DeviceNotConnectedError" in status["error"]
+    # The existing error taxonomy still applies to an episode-level crash.
+    assert status["hint"]
+
+
+def test_last_episode_finishes_the_session_with_accuracy(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, rc=0)
+    session.results.extend(["success", "success"])
+    status = rollout.handle_inference_status()
+
+    assert status["phase"] == rollout.PHASE_FINISHED
+    assert status["inference_active"] is False
+    assert status["exited"] is True
+    assert status["episode_results"] == ["success", "success", "failure"]
+    assert status["episodes_total"] == 3
+    assert status["episode_index"] == 3
+    assert status["accuracy"] == pytest.approx(2 / 3, rel=1e-3)
+    # The slot is released for the next session.
+    assert rollout.inference_active is False
+    assert rollout._eval_session is None
+
+
+def test_finished_eval_payload_is_idempotent_across_polls(monkeypatch) -> None:
+    """Several surfaces poll concurrently; the summary must survive every one."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=2, rc=0)
+    session.results.append("success")
+    first = rollout.handle_inference_status()
+    second = rollout.handle_inference_status()
+    third = rollout.handle_inference_status()
+
+    assert first["accuracy"] == second["accuracy"] == third["accuracy"] == 0.5
+    assert second["episode_results"] == third["episode_results"] == ["success", "failure"]
+    assert third["phase"] == rollout.PHASE_FINISHED
+
+
+def test_accuracy_excludes_errors_in_the_finished_payload(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, rc=0)
+    session.results.extend(["success", "error"])
+    status = rollout.handle_inference_status()
+
+    assert status["episode_results"] == ["success", "error", "failure"]
+    # 1 success out of 2 scored episodes, not out of 3.
+    assert status["accuracy"] == 0.5
+
+
+def test_stop_episode_when_idle_returns_409() -> None:
+    from makermodslab.rollout import handle_stop_episode
+
+    result = handle_stop_episode()
+    assert result["success"] is False
+    assert result["status_code"] == 409
+
+
+def test_stop_episode_refuses_outside_eval_mode(monkeypatch) -> None:
+    """A single-episode run has no tally to record a success into."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_proc", _ExitedProc(0))
+    result = rollout.handle_stop_episode()
+    assert result["success"] is False
+    assert result["status_code"] == 409
+
+
+def test_stop_episode_refuses_while_parked_in_a_reset(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    _arm_eval_session(monkeypatch, rollout, episodes=3, running=False)
+    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_RESETTING})
+    result = rollout.handle_stop_episode()
+    assert result["success"] is False
+    assert result["status_code"] == 409
+
+
+def test_next_episode_when_idle_returns_409() -> None:
+    from makermodslab.rollout import handle_next_episode
+
+    result = handle_next_episode()
+    assert result["success"] is False
+    assert result["status_code"] == 409
+
+
+def test_next_episode_refuses_while_an_episode_is_still_running(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    _arm_eval_session(monkeypatch, rollout, episodes=3)
+    # Phase is `running`, not `resetting` — there is nothing to continue from.
+    result = rollout.handle_next_episode()
+    assert result["success"] is False
+    assert result["status_code"] == 409
+
+
+def test_next_episode_spawns_with_the_cached_policy_and_robot_args(monkeypatch) -> None:
+    """Continuing costs one spawn: no re-download and no second arm preflight,
+    so the session's resolved path + `--robot.*` args are reused verbatim."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False)
+    session.results.append("failure")
+    session.error = "old crash"
+    session.hint = "old hint"
+    monkeypatch.setattr(
+        rollout,
+        "_inference_meta",
+        {"phase": rollout.PHASE_RESETTING, "policy_ref": "user/repo@checkpoints/000050", "duration_s": 60},
+    )
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+
+    launched = {}
+
+    def _fake_launch(request, policy_path, robot_args):
+        launched["policy_path"] = policy_path
+        launched["robot_args"] = robot_args
+        proc = _ExitedProc(0)
+        proc.stdout = _EmptyStdout()
+        return proc, io.StringIO(), __import__("pathlib").Path("/tmp/ep2.log")
+
+    monkeypatch.setattr(rollout, "_launch_rollout_subprocess", _fake_launch)
+
+    result = rollout.handle_next_episode()
+    assert result["success"] is True
+    assert launched["policy_path"] == "/tmp/policy"
+    assert launched["robot_args"] == ["--robot.type=so101_follower"]
+    # The previous episode's crash banner is cleared on continue.
+    assert session.error is None
+    assert session.hint is None
+    assert rollout._inference_meta["phase"] == rollout.PHASE_STARTING
+    # Both timers restart so the dialog clocks the EPISODE, not the session.
+    assert rollout._inference_rollout_started_at is None
+
+
+def test_stop_inference_aborts_an_eval_parked_in_a_reset(monkeypatch) -> None:
+    """Abort reports the partial tally and deliberately claims NO accuracy."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=5, running=False)
+    session.results.extend(["success", "failure"])
+    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_RESETTING})
+
+    result = rollout.handle_stop_inference()
+    assert result["success"] is True
+
+    status = rollout.handle_inference_status()
+    assert status["phase"] == rollout.PHASE_ABORTED
+    assert status["inference_active"] is False
+    assert status["episode_results"] == ["success", "failure"]
+    assert status["episodes_total"] == 5
+    assert status["accuracy"] is None
+    assert rollout._eval_session is None
+
+
+def test_stop_inference_still_ends_a_single_run_the_old_way(monkeypatch) -> None:
+    """No eval session -> the historical idle-with-no-payload teardown."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_DOWNLOADING_MODEL})
+
+    result = rollout.handle_stop_inference()
+    assert result["success"] is True
+    assert rollout.inference_active is False
+    assert rollout._last_result is None

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import io
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -2412,3 +2413,171 @@ def test_runner_death_before_the_first_episode_fails_the_session(monkeypatch) ->
     assert rollout._eval_session is None
     # Idempotent, like every other terminal payload.
     assert rollout.handle_inference_status()["phase"] == rollout.PHASE_ERROR
+
+
+# ---------------------------------------------------------------------------
+# /inference-log identity: the endpoint may only ever serve a log this PROCESS
+# opened, and must say whose it is.
+#
+# The old resolver fell back to "newest *.log in inference_logs" whenever the
+# active meta had no path — true during a new session's pre-spawn phases, and
+# after a run that failed before spawning. Both windows served an earlier run's
+# log unlabelled. Live incident: a run that failed in _prepare_robot on a
+# calibration error produced no log at all, and the user was shown a three-day-old
+# RTC run's output, concluding their sync run was executing RTC code.
+# ---------------------------------------------------------------------------
+
+
+def _seed_log_dir(monkeypatch, tmp_path, *, stale_text: str = "STALE RTC RUN") -> Path:
+    """An inference_logs dir holding an old log from some previous run."""
+    log_dir = tmp_path / "inference_logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stale = log_dir / "1000.log"
+    stale.write_text(stale_text + "\n")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    return stale
+
+
+def test_inference_log_ignores_stale_files_during_startup(monkeypatch, tmp_path) -> None:
+    """THE INCIDENT: a session in its pre-spawn phases has no log of its own.
+
+    `log_path` is only committed once the subprocess is launched, so during the
+    download/preflight window the endpoint must report nothing rather than the
+    newest file on disk.
+    """
+    from makermodslab import rollout
+
+    stale = _seed_log_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_DOWNLOADING_MODEL})
+    monkeypatch.setattr(rollout, "_last_log_path", None)
+
+    result = rollout.handle_inference_log()
+
+    assert result["belongs_to"] is None
+    assert result["logs"] == "" and result["log_path"] is None
+    assert stale.is_file(), "the stale file is still there — it is simply not ours to show"
+
+
+def test_inference_log_after_a_startup_failure_is_empty(monkeypatch, tmp_path) -> None:
+    """A run that failed BEFORE spawning never opened a log.
+
+    `_fail_startup` wipes the meta, so nothing points anywhere — and the previous
+    run's file must not fill the gap. This is the shape of the live incident: the
+    user's calibration error produced no log, and they were shown someone else's.
+    """
+    from makermodslab import rollout
+
+    _seed_log_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(rollout, "_inference_meta", {})
+    monkeypatch.setattr(rollout, "_last_log_path", None)
+
+    result = rollout.handle_inference_log()
+
+    assert result == {"logs": "", "log_path": None, "belongs_to": None}
+
+
+def test_inference_log_serves_the_active_sessions_own_log(monkeypatch, tmp_path) -> None:
+    from makermodslab import rollout
+
+    _seed_log_dir(monkeypatch, tmp_path)
+    mine = tmp_path / "inference_logs" / "2000.log"
+    mine.write_text("MY RUN\n")
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_meta", {"log_path": str(mine)})
+    monkeypatch.setattr(rollout, "_last_log_path", str(mine))
+
+    result = rollout.handle_inference_log()
+
+    assert result["belongs_to"] == "active"
+    assert "MY RUN" in result["logs"]
+
+
+def test_inference_log_serves_a_finished_run_as_last_run(monkeypatch, tmp_path) -> None:
+    """The legitimate case the glob fallback existed for, now explicit.
+
+    A finished run's log stays readable — `_go_idle_locked` clears the meta but
+    not `_last_log_path` — and is labelled so the UI can say it is not live.
+    """
+    from makermodslab import rollout
+
+    _seed_log_dir(monkeypatch, tmp_path)
+    mine = tmp_path / "inference_logs" / "2000.log"
+    mine.write_text("MY FINISHED RUN\n")
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(rollout, "_inference_meta", {})
+    monkeypatch.setattr(rollout, "_last_log_path", str(mine))
+
+    result = rollout.handle_inference_log()
+
+    assert result["belongs_to"] == "last_run"
+    assert "MY FINISHED RUN" in result["logs"]
+    assert result["log_path"] == str(mine)
+
+
+def test_inference_log_never_globs_the_directory(monkeypatch, tmp_path) -> None:
+    """The fallback is gone, not merely deprioritised.
+
+    Pinned directly: with a populated log dir and no session state at all, the
+    answer is None. If someone reintroduces a "be helpful, show the newest file"
+    shortcut, this fails.
+    """
+    from makermodslab import rollout
+
+    log_dir = tmp_path / "inference_logs"
+    log_dir.mkdir(parents=True)
+    for name in ("1000.log", "2000.log", "3000.log"):
+        (log_dir / name).write_text(f"run {name}\n")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(rollout, "_inference_meta", {})
+    monkeypatch.setattr(rollout, "_last_log_path", None)
+
+    assert rollout._resolve_inference_log_path() == (None, None)
+
+
+def test_inference_log_does_not_serve_a_previous_runs_log_to_a_new_session(monkeypatch, tmp_path) -> None:
+    """A new claim clears the pointer, so run N+1 cannot inherit run N's log."""
+    from makermodslab import rollout
+
+    previous = tmp_path / "inference_logs" / "2000.log"
+    previous.parent.mkdir(parents=True)
+    previous.write_text("PREVIOUS RUN\n")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(rollout, "_last_log_path", str(previous))
+
+    # What handle_start_inference does when it claims the slot.
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_STARTING})
+    monkeypatch.setattr(rollout, "_last_log_path", None)
+
+    result = rollout.handle_inference_log()
+    assert result["belongs_to"] is None and result["logs"] == ""
+
+
+def test_start_inference_clears_the_previous_runs_log_pointer(monkeypatch, tmp_path) -> None:
+    """The clear happens in the real claim path, not just in test setup.
+
+    Driven through `handle_start_inference` so the lifecycle wiring itself is
+    covered; the start is failed immediately after the claim (arm-count mismatch)
+    so nothing spawns.
+    """
+    from makermodslab import rollout
+    from makermodslab.rollout import InferenceRequest
+
+    monkeypatch.setattr(rollout, "_last_log_path", "/tmp/some-previous-run.log")
+    monkeypatch.setattr(rollout, "_arm_count_mismatch", lambda mode, dim: "nope")
+
+    # Built inline rather than via a shared helper so this case stays
+    # self-contained on this branch.
+    request = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        checkpoint_state_dim=12,
+    )
+    result = rollout.handle_start_inference(request)
+
+    assert result["success"] is False
+    assert rollout._last_log_path is None, "a new claim must not inherit the previous run's log"

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -140,6 +140,35 @@ def test_inference_request_accepts_bimanual_block() -> None:
     assert req.checkpoint_state_dim == 12
 
 
+def test_inference_request_defaults_to_sync_engine() -> None:
+    """Absent an explicit choice the request pins lerobot's own default, so
+    adding the A/B knob can't change what an existing caller gets."""
+    from makermodslab.rollout import InferenceRequest
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+    )
+    assert req.inference_engine == "sync"
+
+
+def test_inference_request_rejects_unknown_engine() -> None:
+    """The field is a Literal, so a typo is a 422 at the API edge rather than a
+    draccus parse crash inside the rollout subprocess."""
+    from pydantic import ValidationError
+
+    from makermodslab.rollout import InferenceRequest
+
+    with pytest.raises(ValidationError):
+        InferenceRequest(
+            follower_port="/dev/ttyUSB0",
+            follower_config="robot_a",
+            policy_ref="user/repo@checkpoints/000050",
+            inference_engine="async",
+        )
+
+
 # ---------------------------------------------------------------------------
 # _arm_count_mismatch — the pre-spawn checkpoint/robot arm-count guard
 # ---------------------------------------------------------------------------
@@ -485,6 +514,40 @@ def test_handle_start_inference_pins_return_to_initial_position(monkeypatch, tmp
     # Sanity: the core rollout invocation is intact around our pinned flag.
     assert "lerobot.scripts.lerobot_rollout" in cmd
     assert "--strategy.type=base" in cmd
+
+
+def test_rollout_cli_args_emits_sync_engine_by_default() -> None:
+    """`inference` is a draccus ChoiceRegistry field defaulting to sync
+    upstream; we name it explicitly so an upstream flip can't silently change
+    which engine drives the arm."""
+    from makermodslab.rollout import _rollout_cli_args
+
+    args = _rollout_cli_args(_stub_request(), "/tmp/pretrained_model", [])
+    assert "--inference.type=sync" in args
+
+
+def test_rollout_cli_args_forwards_the_engine_to_both_front_ends() -> None:
+    """_rollout_cli_args is shared by the single-episode command and the eval
+    runner — guard against the eval path drifting away from the rollout path."""
+    from makermodslab.rollout import (
+        InferenceRequest,
+        _build_eval_runner_cmd,
+        _build_rollout_cmd,
+    )
+
+    request = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        inference_engine="rtc",
+        eval_episodes=5,
+    )
+    single = _build_rollout_cmd(request, "/tmp/pretrained_model", [])
+    evalrun = _build_eval_runner_cmd(request, "/tmp/pretrained_model", [])
+    assert "--inference.type=rtc" in single
+    assert "--inference.type=rtc" in evalrun
+    assert "--inference.type=sync" not in single
+    assert "--inference.type=sync" not in evalrun
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -1211,6 +1211,53 @@ def test_friendly_hint_maps_common_failures() -> None:
     assert friendly_hint(None) is None
 
 
+def test_friendly_hint_servo_bus_error_is_not_a_download_failure() -> None:
+    """A servo that stops answering must read as an ARM problem.
+
+    lerobot's motors bus raises every serial failure as `ConnectionError`, and
+    the type name itself contains "connect" — keying the Hub-download hint on
+    that token labelled arm-side startup crashes "couldn't download the model"
+    (observed 2026-08-03: a `Failed to write 'Lock' ... [TxRxResult] Incorrect
+    status packet!` at robot.connect() reported as a failed model download)."""
+    from makermodslab.utils.errors import friendly_hint
+
+    for text in (
+        "ConnectionError: Failed to write 'Lock' on id_=3 with '1' after 1 tries. "
+        "[TxRxResult] Incorrect status packet!",
+        "Failed to start inference: ConnectionError: Failed to sync read 'Present_Position' "
+        "on ids=[1, 2, 3] after 1 tries. [TxRxResult] There is no status packet!",
+    ):
+        hint = friendly_hint(text) or ""
+        assert "motor" in hint.lower()
+        assert "download" not in hint.lower()
+
+
+def test_friendly_hint_still_names_real_download_failures() -> None:
+    """The other side of the tightening: a genuine fetch failure keeps its Hub
+    hint. Download-step failures reach here with rollout's own
+    "Failed to download the model: …" prefix (see _inference_startup_thread)."""
+    from makermodslab.utils.errors import friendly_hint
+
+    network = friendly_hint(
+        "Failed to download the model: (MaxRetryError(\"HTTPSConnectionPool(host='huggingface.co', "
+        'port=443): Max retries exceeded with url: /api/models/user/repo"))'
+    )
+    assert network is not None and "download the model" in network.lower()
+    # No hub host in the text at all — rollout's prefix is what identifies it.
+    offline = friendly_hint(
+        "Failed to download the model: An error happened while trying to locate the file on the Hub "
+        "and we cannot find the requested files in the local cache. Please check your connection."
+    )
+    assert offline is not None and "download the model" in offline.lower()
+    missing = friendly_hint(
+        "Failed to download the model: RepositoryNotFoundError: 404 Client Error. "
+        "Repository Not Found for url: https://huggingface.co/api/models/user/repo"
+    )
+    assert missing is not None and "hub" in missing.lower()
+    full = friendly_hint("Failed to download the model: OSError: [Errno 28] No space left on device")
+    assert full is not None and "disk space" in full.lower()
+
+
 def test_extract_error_from_log_pulls_exception_tail(tmp_path) -> None:
     from makermodslab.rollout import _extract_error_from_log
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -26,6 +26,14 @@ import threading
 
 import pytest
 
+from makermodslab.eval_protocol import (
+    CMD_EPISODE,
+    CMD_QUIT,
+    CMD_STOP,
+    REASON_DURATION,
+    REASON_STOPPED,
+)
+
 
 @pytest.fixture(autouse=True)
 def _reset_rollout_globals(monkeypatch: pytest.MonkeyPatch):
@@ -1397,11 +1405,13 @@ def test_run_inference_startup_local_ref_skips_download_phase(monkeypatch, tmp_p
 # ---------------------------------------------------------------------------
 # Multi-episode EVALUATION mode
 #
-# Pure helpers (clamping, accuracy math, verdict classification), the request
-# schema, the status-payload shape, and the idle/mutex branches of the two new
-# endpoints. The subprocess happy path stays deliberately untested (per
-# CLAUDE.md) — the one exception is a fully-stubbed exit finalisation, which is
-# pure bookkeeping over a fake Popen and touches no hardware.
+# Pure helpers (clamping, accuracy math, verdict classification, protocol
+# parsing), the request schema, the status-payload shape, the orchestrator state
+# machine driven over a fake runner pipe, and the idle/mutex branches of the two
+# new endpoints. Nothing here spawns a process or touches hardware: the eval
+# runner is never executed, only stood in for. Per CLAUDE.md the subprocess
+# happy path stays untested — what IS tested is the bookkeeping either side of
+# it, which is where the verdicts and the crash containment live.
 # ---------------------------------------------------------------------------
 
 
@@ -1411,8 +1421,46 @@ class _ExitedProc:
     def __init__(self, rc: int = 0) -> None:
         self.returncode = rc
         self.pid = 4242
+        # A dead process has no usable command pipe — writing to it is exactly
+        # how the orchestrator discovers the runner is gone.
+        self.stdin = None
 
     def poll(self) -> int:
+        return self.returncode
+
+
+class _CommandPipe:
+    """A subprocess `stdin` that records the command lines written to it."""
+
+    def __init__(self, sink: list[str]) -> None:
+        self._sink = sink
+
+    def write(self, data: bytes) -> None:
+        self._sink.append(data.decode().strip())
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeRunner:
+    """A live `makermodslab.eval_runner` subprocess stand-in.
+
+    Unlike `_ExitedProc` it is ALIVE (`poll()` → None) and stays alive across
+    episodes, which is the property the redesign turns on: a live process no
+    longer implies a live episode, so the tests drive episode boundaries through
+    the protocol handlers rather than by pretending a process exited. Every
+    command the orchestrator sends lands in `.commands`."""
+
+    def __init__(self, rc: int | None = None) -> None:
+        self.pid = 4242
+        self.returncode = rc
+        self.commands: list[str] = []
+        self.stdin = _CommandPipe(self.commands)
+
+    def poll(self) -> int | None:
         return self.returncode
 
 
@@ -1427,22 +1475,37 @@ def _eval_request(episodes: int = 3):
     )
 
 
-def _arm_eval_session(monkeypatch, rollout, episodes: int = 3, *, running: bool = True, rc: int = 0):
-    """Put the module into a mid-eval state with an already-exited subprocess."""
+def _arm_eval_session(
+    monkeypatch,
+    rollout,
+    episodes: int = 3,
+    *,
+    running: bool = True,
+    proc=None,
+):
+    """Put the module into a mid-eval state with a live runner.
+
+    `running` is whether an EPISODE is in flight, which is now independent of
+    whether the runner process is up — pass `proc=None` for the (recoverable)
+    state left behind by a runner that died."""
     session = rollout._EvalSession(request=_eval_request(episodes), episodes_total=episodes)
     session.policy_path = "/tmp/policy"
     session.robot_args = ["--robot.type=so101_follower"]
+    session.episode_running = running
     monkeypatch.setattr(rollout, "_eval_session", session)
     monkeypatch.setattr(rollout, "inference_active", True)
     monkeypatch.setattr(rollout, "_inference_started_at", 1000.0)
-    monkeypatch.setattr(rollout, "_inference_rollout_started_at", 1005.0)
+    monkeypatch.setattr(rollout, "_inference_rollout_started_at", 1005.0 if running else None)
     monkeypatch.setattr(
         rollout,
         "_inference_meta",
-        {"phase": rollout.PHASE_RUNNING, "policy_ref": "user/repo@checkpoints/000050", "duration_s": 60},
+        {
+            "phase": rollout.PHASE_RUNNING if running else rollout.PHASE_RESETTING,
+            "policy_ref": "user/repo@checkpoints/000050",
+            "duration_s": 60,
+        },
     )
-    if running:
-        monkeypatch.setattr(rollout, "_inference_proc", _ExitedProc(rc))
+    monkeypatch.setattr(rollout, "_inference_proc", _FakeRunner() if (proc is None and running) else proc)
     return session
 
 
@@ -1614,11 +1677,14 @@ def test_start_inference_guard_failure_clears_the_eval_session(monkeypatch) -> N
 
 
 def test_episode_timeout_parks_the_session_in_the_reset_phase(monkeypatch) -> None:
-    """A clean exit scores a FAILURE and keeps the session (and its hold on the
-    inference slot + cameras) alive for the reset."""
+    """An episode that runs out its duration scores a FAILURE and keeps the
+    session — and its hold on the inference slot, the cameras AND the loaded
+    policy — alive for the reset."""
     from makermodslab import rollout
 
-    _arm_eval_session(monkeypatch, rollout, episodes=3, rc=0)
+    _arm_eval_session(monkeypatch, rollout, episodes=3)
+    runner = rollout._inference_proc
+    rollout._on_episode_ended(REASON_DURATION)
     status = rollout.handle_inference_status()
 
     assert status["phase"] == rollout.PHASE_RESETTING
@@ -1628,14 +1694,27 @@ def test_episode_timeout_parks_the_session_in_the_reset_phase(monkeypatch) -> No
     assert status["accuracy"] is None
     # The slot stays claimed through the reset — recording/teleop stay blocked.
     assert rollout.inference_active is True
-    assert rollout._inference_proc is None
+    # And so does the runner: the whole point is that the next episode does not
+    # re-pay the policy load. It is only told to QUIT once the session is over.
+    assert rollout._inference_proc is runner
+    assert runner.commands == []
 
 
 def test_early_stop_scores_the_episode_a_success(monkeypatch) -> None:
+    """The success button asks the runner to end the episode — no signal, no
+    kill — and the verdict lands when the runner reports the end."""
     from makermodslab import rollout
 
-    session = _arm_eval_session(monkeypatch, rollout, episodes=3, rc=-15)
-    session.stop_requested = True
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3)
+    runner = rollout._inference_proc
+
+    assert rollout.handle_stop_episode()["success"] is True
+    assert runner.commands == [CMD_STOP]
+    assert session.stop_requested is True
+    # Still running until the runner says otherwise — nothing was scored yet.
+    assert session.results == []
+
+    rollout._on_episode_ended(REASON_STOPPED)
     status = rollout.handle_inference_status()
 
     assert status["episode_results"] == ["success"]
@@ -1644,9 +1723,29 @@ def test_early_stop_scores_the_episode_a_success(monkeypatch) -> None:
     assert session.stop_requested is False
 
 
-def test_crashed_episode_parks_with_the_error_visible(monkeypatch) -> None:
-    """A crash is neither success nor failure: it parks in the reset phase with
-    the mined error so the user can continue or abort."""
+def test_episode_end_reason_stopped_scores_a_success_without_the_flag(monkeypatch) -> None:
+    """The reason IS the STOP we sent, so it stands on its own — a lost flag
+    can't turn the user's success into a timeout."""
+    from makermodslab import rollout
+
+    _arm_eval_session(monkeypatch, rollout, episodes=3)
+    rollout._on_episode_ended(REASON_STOPPED)
+    assert rollout.handle_inference_status()["episode_results"] == ["success"]
+
+
+def test_episode_end_with_no_episode_in_flight_is_ignored(monkeypatch) -> None:
+    """A duplicate/late end line must not append a phantom verdict."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=_FakeRunner())
+    rollout._on_episode_ended(REASON_DURATION)
+    assert session.results == []
+
+
+def test_crashed_runner_parks_the_episode_with_the_error_visible(monkeypatch) -> None:
+    """A crash is neither success nor failure: the in-flight episode is scored
+    `error` and the session parks in the reset phase with the error on show, so
+    the user can continue (paying one reload) or abort."""
     from makermodslab import rollout
 
     monkeypatch.setattr(
@@ -1654,8 +1753,11 @@ def test_crashed_episode_parks_with_the_error_visible(monkeypatch) -> None:
         "_extract_error_from_log",
         lambda p: "DeviceNotConnectedError: could not connect to the follower bus",
     )
-    _arm_eval_session(monkeypatch, rollout, episodes=3, rc=1)
+    _arm_eval_session(monkeypatch, rollout, episodes=3)
+    runner = rollout._inference_proc
     monkeypatch.setattr(rollout, "_inference_rollout_started_at", None)
+
+    rollout._handle_runner_exit(runner, 1)
 
     status = rollout.handle_inference_status()
     assert status["episode_results"] == ["error"]
@@ -1664,13 +1766,65 @@ def test_crashed_episode_parks_with_the_error_visible(monkeypatch) -> None:
     assert "DeviceNotConnectedError" in status["error"]
     # The existing error taxonomy still applies to an episode-level crash.
     assert status["hint"]
+    # The dead runner is dropped, which is what makes the continue respawn.
+    assert rollout._inference_proc is None
+
+
+def test_crashed_runner_prefers_its_own_error_line(monkeypatch) -> None:
+    """The runner's ERROR event is the exception itself; log mining is a
+    heuristic over a traceback, so the event wins when both exist."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "_extract_error_from_log", lambda p: "mined from the log tail")
+    _arm_eval_session(monkeypatch, rollout, episodes=3)
+    runner = rollout._inference_proc
+
+    rollout._on_runner_error("RuntimeError: the gripper stalled")
+    rollout._handle_runner_exit(runner, 1)
+
+    assert rollout.handle_inference_status()["error"] == "RuntimeError: the gripper stalled"
+
+
+def test_runner_death_during_a_reset_keeps_the_session_recoverable(monkeypatch) -> None:
+    """Nothing to score — but the user has to learn that continuing now costs a
+    reload, and the tally must survive."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "_extract_error_from_log", lambda p: "OSError: the port vanished")
+    session = _arm_eval_session(monkeypatch, rollout, episodes=4, running=False, proc=_FakeRunner())
+    session.results.extend(["success", "failure"])
+    runner = rollout._inference_proc
+
+    rollout._handle_runner_exit(runner, 1)
+    status = rollout.handle_inference_status()
+
+    assert status["episode_results"] == ["success", "failure"]  # no phantom verdict
+    assert status["phase"] == rollout.PHASE_RESETTING
+    assert status["inference_active"] is True
+    assert "OSError" in status["error"]
+    assert rollout._inference_proc is None
+
+
+def test_expected_runner_exit_after_quit_is_not_scored(monkeypatch) -> None:
+    """An abort asks the runner to quit; that exit must not be read as a crash
+    and score the episode the abort deliberately left unscored."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3)
+    runner = rollout._inference_proc
+    session.quitting = True
+
+    rollout._handle_runner_exit(runner, 0)
+    assert session.results == []
 
 
 def test_last_episode_finishes_the_session_with_accuracy(monkeypatch) -> None:
     from makermodslab import rollout
 
-    session = _arm_eval_session(monkeypatch, rollout, episodes=3, rc=0)
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3)
+    runner = rollout._inference_proc
     session.results.extend(["success", "success"])
+    rollout._on_episode_ended(REASON_DURATION)
     status = rollout.handle_inference_status()
 
     assert status["phase"] == rollout.PHASE_FINISHED
@@ -1683,14 +1837,17 @@ def test_last_episode_finishes_the_session_with_accuracy(monkeypatch) -> None:
     # The slot is released for the next session.
     assert rollout.inference_active is False
     assert rollout._eval_session is None
+    # And the runner is sent home rather than left holding the bus and cameras.
+    assert runner.commands == [CMD_QUIT]
 
 
 def test_finished_eval_payload_is_idempotent_across_polls(monkeypatch) -> None:
     """Several surfaces poll concurrently; the summary must survive every one."""
     from makermodslab import rollout
 
-    session = _arm_eval_session(monkeypatch, rollout, episodes=2, rc=0)
+    session = _arm_eval_session(monkeypatch, rollout, episodes=2)
     session.results.append("success")
+    rollout._on_episode_ended(REASON_DURATION)
     first = rollout.handle_inference_status()
     second = rollout.handle_inference_status()
     third = rollout.handle_inference_status()
@@ -1703,8 +1860,9 @@ def test_finished_eval_payload_is_idempotent_across_polls(monkeypatch) -> None:
 def test_accuracy_excludes_errors_in_the_finished_payload(monkeypatch) -> None:
     from makermodslab import rollout
 
-    session = _arm_eval_session(monkeypatch, rollout, episodes=3, rc=0)
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3)
     session.results.extend(["success", "error"])
+    rollout._on_episode_ended(REASON_DURATION)
     status = rollout.handle_inference_status()
 
     assert status["episode_results"] == ["success", "error", "failure"]
@@ -1732,10 +1890,22 @@ def test_stop_episode_refuses_outside_eval_mode(monkeypatch) -> None:
 
 
 def test_stop_episode_refuses_while_parked_in_a_reset(monkeypatch) -> None:
+    """The runner is still ALIVE between episodes, so a live process is no
+    longer proof an episode is running — `episode_running` is."""
     from makermodslab import rollout
 
-    _arm_eval_session(monkeypatch, rollout, episodes=3, running=False)
-    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_RESETTING})
+    _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=_FakeRunner())
+    result = rollout.handle_stop_episode()
+    assert result["success"] is False
+    assert result["status_code"] == 409
+
+
+def test_stop_episode_reports_a_dead_runner_instead_of_claiming_success(monkeypatch) -> None:
+    """A success can't be recorded against a runner that isn't there to end the
+    episode — the crash path will score it an error instead."""
+    from makermodslab import rollout
+
+    _arm_eval_session(monkeypatch, rollout, episodes=3, proc=_ExitedProc(1))
     result = rollout.handle_stop_episode()
     assert result["success"] is False
     assert result["status_code"] == 409
@@ -1759,37 +1929,28 @@ def test_next_episode_refuses_while_an_episode_is_still_running(monkeypatch) -> 
     assert result["status_code"] == 409
 
 
-def test_next_episode_spawns_with_the_cached_policy_and_robot_args(monkeypatch) -> None:
-    """Continuing costs one spawn: no re-download and no second arm preflight,
-    so the session's resolved path + `--robot.*` args are reused verbatim."""
+def test_next_episode_on_a_live_runner_costs_one_command(monkeypatch) -> None:
+    """The headline of the redesign: continuing does NOT spawn anything. The
+    policy is still resident and the bus and cameras are still open, so the
+    whole cost is one line on the runner's stdin."""
     from makermodslab import rollout
 
-    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False)
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=_FakeRunner())
+    runner = rollout._inference_proc
     session.results.append("failure")
     session.error = "old crash"
     session.hint = "old hint"
-    monkeypatch.setattr(
-        rollout,
-        "_inference_meta",
-        {"phase": rollout.PHASE_RESETTING, "policy_ref": "user/repo@checkpoints/000050", "duration_s": 60},
-    )
-    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
 
-    launched = {}
+    def _explode(*a, **k):
+        raise AssertionError("continuing must not spawn a process")
 
-    def _fake_launch(request, policy_path, robot_args):
-        launched["policy_path"] = policy_path
-        launched["robot_args"] = robot_args
-        proc = _ExitedProc(0)
-        proc.stdout = _EmptyStdout()
-        return proc, io.StringIO(), __import__("pathlib").Path("/tmp/ep2.log")
-
-    monkeypatch.setattr(rollout, "_launch_rollout_subprocess", _fake_launch)
+    monkeypatch.setattr(rollout, "_launch_eval_runner", _explode)
+    monkeypatch.setattr(rollout, "_launch_rollout_subprocess", _explode)
 
     result = rollout.handle_next_episode()
     assert result["success"] is True
-    assert launched["policy_path"] == "/tmp/policy"
-    assert launched["robot_args"] == ["--robot.type=so101_follower"]
+    assert runner.commands == [CMD_EPISODE]
+    assert rollout._inference_proc is runner
     # The previous episode's crash banner is cleared on continue.
     assert session.error is None
     assert session.hint is None
@@ -1798,13 +1959,111 @@ def test_next_episode_spawns_with_the_cached_policy_and_robot_args(monkeypatch) 
     assert rollout._inference_rollout_started_at is None
 
 
+def test_next_episode_respawns_a_dead_runner_and_carries_the_tally(monkeypatch) -> None:
+    """Crash containment: a runner that died costs ONE reload, not the session.
+    The resolved policy path and preflighted `--robot.*` args are reused
+    verbatim — no re-download, no second arm-identity pass — and the tally so
+    far is carried forward."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=None)
+    session.results.append("error")
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+
+    launched = {}
+
+    def _fake_launch(request, policy_path, robot_args):
+        launched["policy_path"] = policy_path
+        launched["robot_args"] = robot_args
+        proc = _FakeRunner()
+        proc.stdout = _EmptyStdout()
+        return proc, io.StringIO(), __import__("pathlib").Path("/tmp/ep2.log")
+
+    monkeypatch.setattr(rollout, "_launch_eval_runner", _fake_launch)
+    # The pump would otherwise reap the fake proc and fire crash containment.
+    monkeypatch.setattr(rollout, "_handle_runner_exit", lambda proc, rc: None)
+
+    result = rollout.handle_next_episode()
+    assert result["success"] is True
+    assert launched["policy_path"] == "/tmp/policy"
+    assert launched["robot_args"] == ["--robot.type=so101_follower"]
+    assert session.results == ["error"]
+    # The episode is PENDING, not started: the respawned runner has to finish
+    # loading first, and its READY is what issues the command.
+    assert session.episode_pending is True
+    assert rollout._inference_meta["log_path"] == "/tmp/ep2.log"
+
+
+def test_runner_ready_issues_the_pending_episode(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=_FakeRunner())
+    runner = rollout._inference_proc
+    session.episode_pending = True
+
+    rollout._on_runner_ready()
+    assert runner.commands == [CMD_EPISODE]
+    assert rollout._inference_meta["phase"] == rollout.PHASE_STARTING
+
+
+def test_runner_ready_stays_idle_when_no_episode_is_pending(monkeypatch) -> None:
+    """A READY from a respawn the user hasn't continued from — or one that lands
+    after an abort — must not put the arm in motion."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=_FakeRunner())
+    runner = rollout._inference_proc
+    session.episode_pending = False
+    rollout._on_runner_ready()
+    assert runner.commands == []
+
+    session.episode_pending = True
+    session.quitting = True
+    rollout._on_runner_ready()
+    assert runner.commands == []
+
+
+def test_episode_started_flips_the_phase_to_running(monkeypatch) -> None:
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=_FakeRunner())
+    session.episode_pending = True
+
+    rollout._on_episode_started()
+    assert session.episode_running is True
+    assert session.episode_pending is False
+    assert rollout._inference_meta["phase"] == rollout.PHASE_RUNNING
+    assert rollout._inference_rollout_started_at is not None
+
+
+def test_stop_inference_quits_the_runner_instead_of_signalling_it(monkeypatch) -> None:
+    """Abort mid-episode: the runner is asked to wind down so the follower still
+    eases home, and the in-flight episode stays deliberately unscored."""
+    from makermodslab import rollout
+
+    session = _arm_eval_session(monkeypatch, rollout, episodes=5)
+    session.results.extend(["success", "failure"])
+    runner = rollout._inference_proc
+    quit_calls = []
+    monkeypatch.setattr(rollout, "_quit_runner", lambda proc: quit_calls.append(proc))
+
+    result = rollout.handle_stop_inference()
+    assert result["success"] is True
+    assert quit_calls == [runner]
+    assert session.quitting is True
+
+    status = rollout.handle_inference_status()
+    assert status["phase"] == rollout.PHASE_ABORTED
+    assert status["episode_results"] == ["success", "failure"]  # the cut episode isn't scored
+    assert status["accuracy"] is None
+
+
 def test_stop_inference_aborts_an_eval_parked_in_a_reset(monkeypatch) -> None:
     """Abort reports the partial tally and deliberately claims NO accuracy."""
     from makermodslab import rollout
 
-    session = _arm_eval_session(monkeypatch, rollout, episodes=5, running=False)
+    session = _arm_eval_session(monkeypatch, rollout, episodes=5, running=False, proc=None)
     session.results.extend(["success", "failure"])
-    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_RESETTING})
 
     result = rollout.handle_stop_inference()
     assert result["success"] is True
@@ -1829,3 +2088,217 @@ def test_stop_inference_still_ends_a_single_run_the_old_way(monkeypatch) -> None
     assert result["success"] is True
     assert rollout.inference_active is False
     assert rollout._last_result is None
+
+
+# ---------------------------------------------------------------------------
+# Eval-runner line protocol + argv (makermodslab/eval_protocol.py)
+#
+# Pure string handling, no process anywhere near it. The runner itself is NEVER
+# executed by the suite — it drives real servos.
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_round_trips_an_event_and_its_payload() -> None:
+    from makermodslab.eval_protocol import format_event, parse_event
+
+    line = format_event("EPISODE_ENDED", "reason=duration")
+    assert parse_event(line) == ("EPISODE_ENDED", "reason=duration")
+    assert parse_event(format_event("READY")) == ("READY", "")
+
+
+def test_protocol_collapses_a_multiline_payload_onto_one_line() -> None:
+    """A traceback in an ERROR payload must not split one event across several
+    lines — the reader is line-oriented and would read the tail as junk."""
+    from makermodslab.eval_protocol import format_event, parse_event
+
+    line = format_event("ERROR", "RuntimeError: boom\n  File 'x.py', line 3\n")
+    assert "\n" not in line
+    event, payload = parse_event(line)
+    assert event == "ERROR"
+    assert payload.startswith("RuntimeError: boom")
+
+
+def test_protocol_ignores_ordinary_log_lines() -> None:
+    from makermodslab.eval_protocol import parse_event
+
+    assert parse_event("INFO 2026-07-31 Connecting robot (so101_follower)...\n") is None
+    assert parse_event("") is None
+
+
+def test_protocol_finds_an_event_appended_to_a_log_line() -> None:
+    """The runner's logging handler shares the pipe; a record flushed without
+    its newline must not swallow the event behind it."""
+    from makermodslab.eval_protocol import parse_event
+
+    assert parse_event("INFO some log MAKERMODSLAB-EVAL EPISODE_STARTED") == ("EPISODE_STARTED", "")
+
+
+def test_protocol_reason_parsing_is_conservative() -> None:
+    """An unrecognised (or renamed) reason yields "" rather than a guess: the
+    orchestrator must not score an episode off a reason it doesn't understand."""
+    from makermodslab.eval_protocol import parse_episode_end_reason
+
+    assert parse_episode_end_reason("reason=stopped") == "stopped"
+    assert parse_episode_end_reason("elapsed=30 reason=duration") == "duration"
+    assert parse_episode_end_reason("") == ""
+    assert parse_episode_end_reason("something-else") == ""
+
+
+def test_unknown_episode_end_reason_scores_a_failure_not_a_success(monkeypatch) -> None:
+    """Degrade the way the pre-runner code did — an episode that ended without
+    the user calling it a success is a failure — rather than inventing a verdict."""
+    from makermodslab import rollout
+
+    _arm_eval_session(monkeypatch, rollout, episodes=3)
+    rollout._on_episode_ended("")
+    assert rollout.handle_inference_status()["episode_results"] == ["failure"]
+
+
+def test_eval_runner_and_rollout_argv_share_every_flag() -> None:
+    """One flag list, two entry points. A flag added for the single-episode path
+    must never be missing from the eval runner's."""
+    from makermodslab.rollout import _build_eval_runner_cmd, _build_rollout_cmd
+
+    request = _eval_request(4)
+    args = ("/local/pretrained_model", ["--robot.type=so101_follower", "--robot.port=/dev/ttyUSB0"])
+    rollout_cmd = _build_rollout_cmd(request, *args)
+    runner_cmd = _build_eval_runner_cmd(request, *args)
+
+    assert rollout_cmd[1:3] == ["-m", "lerobot.scripts.lerobot_rollout"]
+    assert runner_cmd[1:3] == ["-m", "makermodslab.eval_runner"]
+    assert rollout_cmd[3:] == runner_cmd[3:]
+    assert "--return_to_initial_position=true" in runner_cmd
+    assert "--strategy.type=base" in runner_cmd
+
+
+def test_eval_start_spawns_the_runner_with_stdin_left_open(monkeypatch, tmp_path) -> None:
+    """Eval mode gets ONE long-lived runner whose stdin is the command channel;
+    the single-episode path still gets `lerobot-rollout` with stdin closed."""
+    from makermodslab import rollout
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(rollout, "_preflight_arm_identity", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "_preflight_motor_registers", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda name: name)
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: "/local/model")
+    monkeypatch.setattr(rollout, "_detect_device", lambda: "cpu")
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
+    monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: None)
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(rollout, "_pump_runner_stdout", lambda proc, log: None)
+
+    captured: dict = {}
+
+    class _FakeStdin:
+        def __init__(self) -> None:
+            self.written = b""
+            self.closed = False
+
+        def write(self, data: bytes) -> None:
+            self.written += data
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _FakeProc:
+        pid = 9999
+
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            self.stdin = _FakeStdin()
+            self.stdout = _EmptyStdout()
+            captured["stdin"] = self.stdin
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(rollout.subprocess, "Popen", _FakeProc)
+
+    assert rollout.handle_start_inference(_eval_request(6))["success"] is True
+    assert captured["cmd"][1:3] == ["-m", "makermodslab.eval_runner"]
+    # The command channel has to stay open — closing it is what a one-shot
+    # rollout does, and it would make every later EPISODE unsendable.
+    assert captured["stdin"].closed is False
+    assert captured["stdin"].written == b"\n"
+    # Episode 1 is pending: it is issued when the runner reports READY, after
+    # the one-time policy load.
+    assert rollout._eval_session.episode_pending is True
+    assert rollout._eval_session.episode_running is False
+
+
+def test_single_episode_start_still_spawns_lerobot_rollout(monkeypatch, tmp_path) -> None:
+    """`eval_episodes == 1` is untouched by the redesign: same module, and stdin
+    closed straight after the calibration seed."""
+    from makermodslab import rollout
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(rollout, "_preflight_arm_identity", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "_preflight_motor_registers", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda name: name)
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: "/local/model")
+    monkeypatch.setattr(rollout, "_detect_device", lambda: "cpu")
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
+    monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: None)
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+
+    captured: dict = {}
+
+    class _FakeStdin:
+        def __init__(self) -> None:
+            self.written = b""
+            self.closed = False
+
+        def write(self, data: bytes) -> None:
+            self.written += data
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _FakeProc:
+        pid = 9999
+
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            self.stdin = _FakeStdin()
+            self.stdout = _EmptyStdout()
+            captured["stdin"] = self.stdin
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(rollout.subprocess, "Popen", _FakeProc)
+
+    assert rollout.handle_start_inference(_eval_request(1))["success"] is True
+    assert captured["cmd"][1:3] == ["-m", "lerobot.scripts.lerobot_rollout"]
+    assert captured["stdin"].closed is True
+    assert rollout._eval_session is None
+
+
+def test_runner_death_before_the_first_episode_fails_the_session(monkeypatch) -> None:
+    """A bad policy path / missing camera / busy bus kills the runner before any
+    episode starts. That is a startup failure, not an evaluation with one bad
+    episode — parking in a reset would offer a continue that can only fail the
+    same way."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "_extract_error_from_log", lambda p: "FileNotFoundError: no such checkpoint")
+    session = _arm_eval_session(monkeypatch, rollout, episodes=4, running=False, proc=_FakeRunner())
+    session.episode_pending = True
+    runner = rollout._inference_proc
+
+    rollout._handle_runner_exit(runner, 1)
+
+    status = rollout.handle_inference_status()
+    assert status["phase"] == rollout.PHASE_ERROR
+    assert status["outcome"] == "failed"
+    assert status["inference_active"] is False
+    assert "FileNotFoundError" in status["error"]
+    assert rollout._eval_session is None
+    # Idempotent, like every other terminal payload.
+    assert rollout.handle_inference_status()["phase"] == rollout.PHASE_ERROR


### PR DESCRIPTION
Five commits that turn single-shot inference into a usable evaluation workflow, plus two fixes the first real-hardware passes surfaced. Eval mode and the RTC engine were both exercised on real hardware this week.

**1. Multi-episode evaluation mode.** Run N episodes in one session — model download, arm preflight and camera handover happen once. "Task succeeded — end episode" scores a success; running out the time limit scores a failure; a crashed episode scores as an error *excluded from the accuracy denominator*, so a glitch can't poison the number. Between episodes the session parks in a human-gated reset phase that doubles as the crash continue-or-abort screen. Additive API (`eval_episodes`, `/inference-episode-stop`, `/inference-next-episode`); single-run behavior unchanged.

**2. Persistent eval runner.** Episodes previously spawned a fresh `lerobot-rollout` per episode, reloading the policy (~15–40s SmolVLA on MPS) and reconnecting the bus and cameras every time — minutes of dead time over a 20-episode eval. Episodes now run inside one `makermodslab.eval_runner` process serving them over a line protocol. Deliberate behavior deltas: the follower stays energized holding its eased-home pose between episodes, and the home pose is captured once per session instead of drifting. (Includes the squashed fix keeping `from __future__ import annotations` out of `eval_runner.py` — lerobot's `parser.wrap()` reads the raw annotation, and PEP 563 breaks draccus at CLI parse.)

**3. Selectable RTC inference engine.** `inference_engine` ("sync" | "rtc") on the request. Sync stays the default; RTC is labelled experimental — it routes flow-matching through a different action-generation path than a checkpoint was evaluated under, so A/B per run.

**4. Servo-bus errors get an arm hint.** lerobot raises every serial failure as `ConnectionError`, and the Hub-network branch matched the bare token `connectionerror` — whose second conjunct was self-satisfied by the word itself. A `robot.connect()` torque/ID failure surfaced as "couldn't download the model." Adds a servo-bus branch keyed on motors-bus phrasing and requires a Hub-specific token for the download hint.

**5. Honest inference-log identity.** `/inference-log` served the newest `*.log` on disk whenever the active session had no log yet — true during pre-spawn phases and after a startup that failed before spawning. A three-day-old RTC run's log was shown as a live sync run's output, and the user concluded the wrong policy was executing. Identity now follows the session lifecycle, the directory glob is gone, and the endpoint labels its answer `belongs_to: active | last_run | null` so the dialog says "No log yet for this run" instead of ever showing a stale file. After a server restart old logs are deliberately not served — mislabelling is worse than not showing.

Carved from the `rig` integration branch. Piece 5 is a slice of a three-concern rig commit; the F6 weights probe and the P0-3 follower-port release are **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)