### PR TITLE
feat(models,inference): never download the same model twice (F6)

### DIFF
--- a/makermodslab/models.py
+++ b/makermodslab/models.py
@@ -42,7 +42,9 @@ import time
 from pathlib import Path
 from typing import Any
 
-from huggingface_hub import metadata_update, snapshot_download
+from huggingface_hub import constants as hf_constants, metadata_update, snapshot_download
+from huggingface_hub.file_download import repo_folder_name
+from huggingface_hub.utils import filter_repo_objects
 
 from .datasets import (
     DownloadManager,
@@ -338,6 +340,41 @@ def _downloaded_model_dir(repo_id: str) -> Path | None:
     if not path.is_dir() or _resolve_pretrained_dir(path) is None:
         return None
     return path
+
+
+def _hub_cache_has_repo(repo_id: str) -> bool:
+    """True when the shared HF hub cache already holds a snapshot of `repo_id`.
+
+    The hub-cache twin of `_downloaded_model_dir` above: that one answers "is it
+    in OUR models store", this one "is it in the cache huggingface_hub itself
+    manages". Both callers of this are about not downloading the same bytes
+    twice — `_fetch_model_snapshot` below (serve a Models-page download from the
+    cache) and `rollout._local_store_policy_path` (the mirror image: serve
+    inference from our store when the cache is empty). It lives HERE, and
+    rollout imports it, so the two directions can never disagree about what
+    "already cached" means; models.py must not import from rollout (cycle).
+
+    huggingface_hub 1.21.0 has no public "is this repo cached at all?" call:
+    ``try_to_load_from_cache`` answers per FILE and per revision (so it says
+    "no" for a repo cached under a different revision), and ``scan_cache_dir``
+    walks the ENTIRE cache — every dataset too — to answer one question about
+    one repo. So probe the documented on-disk layout directly, which is exactly
+    the question we want: ``<HF_HUB_CACHE>/models--<user>--<repo>/snapshots/``.
+    A repo dir with no snapshot in it (an interrupted or wiped entry) counts as
+    absent. HF_HUB_CACHE is read off the module at call time, not bound at
+    import, so an env override (or a test) is honoured.
+
+    A malformed repo id answers "not cached" rather than raising: `policy_ref`
+    is user input and the hub-ref regex accepts any ``[^@]+``, so
+    `repo_folder_name`'s validation can reject it (HFValidationError is a
+    ValueError). Reporting False just routes it to snapshot_download, which
+    produces the canonical, already-handled error message for a bad repo id."""
+    try:
+        folder = Path(hf_constants.HF_HUB_CACHE) / repo_folder_name(repo_id=repo_id, repo_type="model")
+        snapshots = folder / "snapshots"
+        return snapshots.is_dir() and any(snapshots.iterdir())
+    except (OSError, ValueError):
+        return False
 
 
 def is_model_available_locally(repo_id: str) -> bool:
@@ -1281,6 +1318,98 @@ def delete_local_model(model_id: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+# Optimizer/scheduler state, excluded from everything the Models page pulls.
+# Two patterns because huggingface_hub filters with fnmatch, NOT path-aware
+# globbing: `training_state/**` catches the root one a flat push leaves, and
+# `*/training_state/**` catches the per-step ones (fnmatch's `*` spans `/`, so
+# it covers `checkpoints/<step>/training_state/...` at any depth).
+_TRAINING_STATE_IGNORE = ["training_state/**", "*/training_state/**"]
+
+
+def _copy_snapshot_into_store(snapshot: Path, target: Path) -> None:
+    """Copy a hub-cache snapshot dir into the local models store.
+
+    Two things this must NOT do naively:
+
+    * **Symlinks.** A cache snapshot is a farm of symlinks into the sibling
+      ``blobs/`` dir; copying them as links would leave the store pointing at
+      files `huggingface_hub` may garbage-collect (``delete_revisions``) or that
+      simply vanish if the user clears their hub cache. Every file is
+      dereferenced (``shutil.copyfile`` copies CONTENT through a symlink), so
+      the store stays the self-contained directory the rest of models.py
+      assumes. It also leaves dest mtimes at "now", which is what the listing's
+      `_dir_mtime_iso` should report for a just-downloaded model — a blob's own
+      mtime could be months old.
+    * **training_state.** A cache entry can predate this exclusion (inference's
+      @root fetch, or a plain `hf_hub_download`, may have populated it), so the
+      snapshot on disk can hold optimizer state even though we asked
+      snapshot_download to skip it. Filtering is delegated to huggingface_hub's
+      OWN `filter_repo_objects` — the same function snapshot_download filters
+      with — so the copied tree is byte-for-byte the tree the local_dir download
+      would have produced, rather than a hand-rolled guess at fnmatch semantics.
+
+    Copies IN PLACE into `target` rather than staging in a temp dir and swapping:
+    it matches what the local_dir download does (write over whatever is there),
+    keeps a re-download of an already-present model from ever having a window
+    where the model is missing, and a half-finished copy is handled the same way
+    a half-finished download is — the caller falls back to the network path,
+    which rewrites these very paths, and `_cleanup_partial_model` removes the
+    dir if the result still doesn't resolve."""
+    rel_paths = [p.relative_to(snapshot).as_posix() for p in snapshot.rglob("*") if p.is_file()]
+    for rel in filter_repo_objects(rel_paths, ignore_patterns=_TRAINING_STATE_IGNORE):
+        dest = target / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(snapshot / rel, dest)
+
+
+def _fetch_via_hub_cache(repo_id: str, target: Path) -> bool:
+    """Materialize `repo_id` into `target` from the shared hub cache, or return
+    False to say "not applicable — do the normal download".
+
+    Closes the second half of design-debt F6. `_fetch_model_snapshot` downloads
+    with ``local_dir=``, and huggingface_hub 1.21.0's local_dir mode neither
+    reads nor populates the shared cache (it is the deliberate "give me a plain
+    directory, no cache machinery" mode). So a repo inference had already pulled
+    into the cache was downloaded a SECOND time, in full, the moment the user
+    clicked Download on the Models page. (`rollout._local_store_policy_path`
+    covers the opposite order: Models page first, inference second.)
+
+    Deliberately routed through a cache-mode ``snapshot_download`` — no
+    ``local_dir`` — rather than copying the newest snapshot dir straight out of
+    the cache. That call dedupes against the cache and pulls only what is
+    missing or changed, which means:
+
+      * a PARTIAL cache entry (someone `hf_hub_download`-ed a single file, so
+        `_hub_cache_has_repo` says yes but the snapshot is one symlink) gets
+        COMPLETED rather than copied as a broken tree, and
+      * the result is revision-correct — we get `main` as it is now, not
+        whatever stale revision happens to sit in the cache.
+
+    It is an optimization and must never become a new failure mode, so ANY
+    failure (HF error, a cache entry mutated out from under us, a copy that runs
+    out of disk) returns False and lets the caller do the plain download. The
+    exception is logged, not swallowed silently — a cache path that always fails
+    would otherwise just look like "downloads are slow"."""
+    if not _hub_cache_has_repo(repo_id):
+        return False
+    try:
+        snapshot = snapshot_download(
+            repo_id,
+            repo_type="model",
+            ignore_patterns=_TRAINING_STATE_IGNORE,
+        )
+        _copy_snapshot_into_store(Path(snapshot), target)
+    except Exception as exc:  # noqa: BLE001 - optimization only; the caller re-downloads
+        logger.warning(
+            "Could not serve %s from the HF hub cache (%s) — falling back to a full download",
+            repo_id,
+            exc,
+        )
+        return False
+    logger.info("Served %s from the HF hub cache instead of re-downloading it", repo_id)
+    return True
+
+
 def _fetch_model_snapshot(repo_id: str) -> None:
     """Snapshot a Hub model repo into ``<local models root>/<repo_id>/``.
 
@@ -1288,9 +1417,31 @@ def _fetch_model_snapshot(repo_id: str) -> None:
     (_resolve_pretrained_dir) — a repo with no config.json / checkpoints tree is
     not a policy and is rejected (the manager's cleanup then removes it).
     Invalidates the /models listing cache so the source flips to "both"
-    immediately."""
+    immediately.
+
+    Optimizer/scheduler state is excluded. A training repo carries a
+    ``training_state/`` dir next to every ``pretrained_model/`` (and one at the
+    repo root for a flat push), which exists only to RESUME training — nothing
+    that reads a downloaded model here (inference, the checkpoint browser,
+    _resolve_pretrained_dir) ever opens it, and it is hundreds of MB per step.
+    Observed: a 5.6 GB local model dir of which ~3.5 GB was training_state.
+    ``rollout._resolve_policy_path``'s @root fetch already dropped exactly these
+    for exactly this reason; the two call sites now agree. The
+    ``checkpoints/<step>/pretrained_model`` trees are deliberately KEPT — the
+    checkpoint browser lists and inference selects individual steps from them.
+
+    When the shared hub cache ALREADY holds the repo, the bytes are taken from
+    there instead of off the network — see `_fetch_via_hub_cache`, which is a
+    pure optimization and falls back to the download below on any failure.
+    """
     target = _local_models_root() / repo_id
-    snapshot_download(repo_id, repo_type="model", local_dir=str(target))
+    if not _fetch_via_hub_cache(repo_id, target):
+        snapshot_download(
+            repo_id,
+            repo_type="model",
+            local_dir=str(target),
+            ignore_patterns=_TRAINING_STATE_IGNORE,
+        )
     if _resolve_pretrained_dir(target) is None:
         raise ModelError(
             400,

--- a/makermodslab/models.py
+++ b/makermodslab/models.py
@@ -304,6 +304,53 @@ def _local_models_root() -> Path:
     return root
 
 
+# The weights file lerobot's loader actually opens, and the one alternative
+# layout it accepts. Derived from the PINNED lerobot (v0.6.0), not guessed:
+#
+#   * Standard policy — `PreTrainedPolicy.from_pretrained` on a LOCAL dir does
+#     exactly `os.path.join(model_id, SAFETENSORS_SINGLE_FILE)` and hands it
+#     straight to `_load_as_safetensor` (policies/pretrained.py:195-198).
+#     `SAFETENSORS_SINGLE_FILE` is huggingface_hub's "model.safetensors".
+#   * SHARDED weights are deliberately NOT accepted. That local-dir branch has no
+#     index-file handling at all, and the save side pins `max_shard_size` above
+#     the total size specifically "so the output stays a single
+#     `model.safetensors`" (pretrained.py:157-159). Treating
+#     `model-00001-of-...` as usable would recreate this very bug — a tree we
+#     call loadable that lerobot then fails to open.
+#   * ADAPTER (PEFT/LoRA) repos are accepted, because `make_policy` has a real
+#     branch for them: with `use_peft`, it reads `PeftConfig.from_pretrained(dir)`
+#     and calls `PeftModel.from_pretrained(policy, dir)` (policies/factory.py:
+#     616-638), loading the BASE weights from the adapter config's
+#     `base_model_name_or_path`. So an adapter dir is complete without
+#     `model.safetensors`; what it must have is PEFT's own pair.
+#
+# NOT sufficient, and the trap this exists to close: "some *.safetensors is
+# present". A policy checkpoint also ships pre/post-processor safetensors, so an
+# interrupted download can carry several .safetensors files and still have no
+# policy weights at all.
+_POLICY_WEIGHTS_FILE = "model.safetensors"
+_ADAPTER_WEIGHTS_FILES = ("adapter_config.json", "adapter_model.safetensors")
+
+
+def _has_loadable_weights(pretrained_dir: Path) -> bool:
+    """True when `pretrained_dir` holds weights lerobot can actually load.
+
+    A `config.json` alone proves only that a download STARTED. An interrupted
+    `local_dir` download leaves a tree that looks complete to a config-only check
+    — config.json, train_config.json, both processor safetensors — and then dies
+    with FileNotFoundError on `model.safetensors` the moment inference runs. That
+    happened live: a 68 KB store entry served by the F6 short-circuit turned a
+    silently-partial download into a hard crash, where the pre-F6 path would have
+    re-downloaded and worked.
+    """
+    try:
+        if (pretrained_dir / _POLICY_WEIGHTS_FILE).is_file():
+            return True
+        return all((pretrained_dir / name).is_file() for name in _ADAPTER_WEIGHTS_FILES)
+    except OSError:
+        return False
+
+
 def _resolve_pretrained_dir(path: Path) -> Path | None:
     """The pretrained_model dir inside a downloaded/imported checkpoint dir, or
     None when `path` isn't a usable policy checkpoint.
@@ -314,12 +361,31 @@ def _resolve_pretrained_dir(path: Path) -> Path | None:
     ``config.json`` (the shape ``upload_local_model`` pushes). The returned dir
     is EXACTLY what rollout._resolve_policy_path consumes verbatim for a local
     ref, so `path` rows built from it are directly usable for inference.
+
+    "Usable" requires the POLICY WEIGHTS, not just a config (see
+    `_has_loadable_weights`). This is the single definition every consumer shares
+    — the /models listing, `is_model_available_locally`, `_fetch_model_snapshot`'s
+    post-download validation, `_cleanup_partial_model`, `import_local_model` and
+    the F6 local-store short-circuit in rollout all ask this one question — so a
+    weights-less tree is uniformly invisible rather than usable-here-and-broken-
+    there. A partial download therefore drops out of the listing instead of being
+    offered and then crashing mid-run.
+
+    In the checkpoints layout the scan walks from the highest step DOWN and takes
+    the first checkpoint with weights: a checkpoint still being written by a live
+    training run must not hide the last complete one. The returned path names its
+    own step, so there is no risk of the UI labelling one step's weights as
+    another's.
     """
     try:
         checkpoints = _list_local_checkpoints(str(path))
+        for checkpoint in reversed(checkpoints):
+            candidate = Path(checkpoint.ref)
+            if _has_loadable_weights(candidate):
+                return candidate
         if checkpoints:
-            return Path(checkpoints[-1].ref)
-        if (path / "config.json").is_file():
+            return None
+        if (path / "config.json").is_file() and _has_loadable_weights(path):
             return path
     except OSError:
         return None

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -71,7 +71,12 @@ from .eval_protocol import (
     parse_event,
 )
 from .jobs import download_hub_checkpoint_ref, make_snapshot_progress_tqdm
-from .models import _downloaded_model_dir, _hub_cache_has_repo, _resolve_pretrained_dir
+from .models import (
+    _downloaded_model_dir,
+    _has_loadable_weights,
+    _hub_cache_has_repo,
+    _resolve_pretrained_dir,
+)
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .record import _DEFAULT_FOURCC
 from .utils.config import (
@@ -722,7 +727,13 @@ def _local_store_policy_path(repo_id: str, step_dir: str | None) -> str | None:
     resolved: Path | None = None
     if step_dir is not None:
         candidate = model_dir / "checkpoints" / step_dir / "pretrained_model"
-        if (candidate / "config.json").is_file():
+        # config.json alone is NOT enough: an interrupted local_dir download
+        # leaves the config and the processor safetensors behind but no policy
+        # weights, and serving that turns a silently-partial store entry into a
+        # FileNotFoundError deep inside lerobot. This branch addresses a specific
+        # step directly (it never goes through _resolve_pretrained_dir), so it
+        # has to ask the weights question itself.
+        if (candidate / "config.json").is_file() and _has_loadable_weights(candidate):
             resolved = candidate
     elif _resolve_pretrained_dir(model_dir) == model_dir:
         resolved = model_dir

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -71,6 +71,7 @@ from .eval_protocol import (
     parse_event,
 )
 from .jobs import download_hub_checkpoint_ref, make_snapshot_progress_tqdm
+from .models import _downloaded_model_dir, _hub_cache_has_repo, _resolve_pretrained_dir
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .record import _DEFAULT_FOURCC
 from .utils.config import (
@@ -687,28 +688,89 @@ def _policy_ref_is_valid(policy_ref: str) -> bool:
     )
 
 
+def _local_store_policy_path(repo_id: str, step_dir: str | None) -> str | None:
+    """A ready-to-run pretrained_model dir for a Hub ref, taken from MakerMods
+    Lab's own models store instead of the Hub — or None to go download.
+
+    The Models page downloads with ``local_dir=<makermodslab_models>/<repo_id>``,
+    and huggingface_hub's local_dir mode neither reads nor populates the shared
+    hub cache. So a model the user already pulled on the Models page was, until
+    this check, downloaded a SECOND time the first time inference ran on it
+    (see design-debt F6). When the hub cache has no entry for the repo there is
+    nothing for snapshot_download to dedupe against, so a usable local copy is
+    strictly better: same bytes, zero network, no downloading_model phase.
+
+    Deliberately does NOT pre-empt a populated hub cache: snapshot_download IS
+    the hub-cache path, it is revision-aware and only fetches changed files, so
+    once the repo is cached letting it run keeps the user on `main` rather than
+    pinning them to a possibly stale local copy.
+
+    `step_dir` is the zero-padded step of a ``@checkpoints/<step>`` ref, or None
+    for a ``@root`` ref. Usability is judged with models.py's own helpers, so
+    the tree that comes back is one the Models page would also call usable:
+    ``_downloaded_model_dir`` for the traversal guard + a first usability probe,
+    then the ref-shape-specific check. For ``@root`` the ROOT itself must be the
+    pretrained dir (what a flat repo resolves to) — a local copy that resolves
+    to a checkpoints sub-tree is not what the Hub path would have returned, so
+    it falls through to the download rather than quietly substituting a
+    different tree."""
+    if _hub_cache_has_repo(repo_id):
+        return None
+    model_dir = _downloaded_model_dir(repo_id)
+    if model_dir is None:
+        return None
+    resolved: Path | None = None
+    if step_dir is not None:
+        candidate = model_dir / "checkpoints" / step_dir / "pretrained_model"
+        if (candidate / "config.json").is_file():
+            resolved = candidate
+    elif _resolve_pretrained_dir(model_dir) == model_dir:
+        resolved = model_dir
+    if resolved is None:
+        return None
+    logger.info(
+        "Using the local models store for %s (nothing cached for it in the HF hub cache): %s",
+        repo_id,
+        resolved,
+    )
+    return str(resolved)
+
+
 def _resolve_policy_path(policy_ref: str, report: Callable[[int, int | None], None] | None = None) -> str:
     """Turn a checkpoints API ref into a local path that lerobot accepts.
 
     Local refs are already absolute paths to a pretrained_model dir.
-    Hub refs look like 'user/repo@checkpoints/<step_dir>' where
-    <step_dir> is lerobot's zero-padded directory name (e.g. 000050) — we
-    forward it verbatim into snapshot_download's allow_patterns and the
-    resolved local path.
-    A 'user/repo@root' ref means the whole repo IS the pretrained_model
-    (no checkpoints sub-tree); the full repo is downloaded via
-    snapshot_download and its root is returned directly.
-
-    When ``report`` is given, snapshot_download streams byte progress through it
-    (see make_snapshot_progress_tqdm) so the inference page can show a real
-    download bar. Local refs never download, so they never report and never flip
-    the phase.
+    Hub refs look like 'user/repo@checkpoints/<step_dir>' (where <step_dir> is
+    lerobot's zero-padded directory name, e.g. 000050) and resolve to that
+    step's pretrained_model dir; a 'user/repo@root' ref means the whole repo IS
+    the pretrained_model and resolves to its root.
 
     The download itself (which patterns each ref shape pulls, and what path it
     yields) lives in jobs.download_hub_checkpoint_ref, shared with the fine-tune
     path so a ref resolves to the same weights whoever asks. This wrapper owns
-    only what is inference-specific: the local-dir short-circuit, the
-    downloading_model phase, and the progress hook."""
+    only what is inference-specific: the local-dir short-circuit, the local
+    models-store short-circuit, the downloading_model phase, and the progress
+    hook.
+
+    Before delegating, `_local_store_policy_path` gets a chance to serve the ref
+    out of MakerMods Lab's own models store (what the Models page downloads
+    into) — that store is invisible to the hub cache, so without the check a
+    model already on disk is downloaded a second time (design-debt F6).
+
+    That short-circuit deliberately lives HERE and not inside
+    jobs.download_hub_checkpoint_ref, even though the duplicate-download problem
+    is the same for every caller: the shared helper also feeds fine-tune/resume
+    downloads, and the models store is written by `models._fetch_model_snapshot`,
+    which strips ``training_state/`` (optimizer + scheduler state — dead weight
+    for inference, often the bulk of a checkpoint). Serving the store from the
+    shared helper would therefore hand a *resume* a checkpoint with no optimizer
+    state to resume from. Inference only ever loads the policy weights, so it is
+    the one caller for which the stripped tree is equivalent.
+
+    When ``report`` is given, snapshot_download streams byte progress through it
+    (see make_snapshot_progress_tqdm) so the inference page can show a real
+    download bar. Local refs — on disk or in the models store — never download,
+    so they never report and never flip the phase."""
     if Path(policy_ref).is_dir():
         # A local checkpoint — nothing to fetch, so no downloading_model phase.
         return policy_ref
@@ -721,6 +783,22 @@ def _resolve_policy_path(policy_ref: str, report: Callable[[int, int | None], No
     # the download paths (not the local branch above), and only when a session is
     # live (_set_phase no-ops otherwise), so this helper stays safe to call from
     # the unit tests.
+    # …but first: the ref may already be sitting in our own models store, in
+    # which case there is nothing to announce. Match the ref shape here (rather
+    # than inside the helper) because the two shapes ask a different question of
+    # the store — a specific step's pretrained_model dir, or the repo root.
+    m = _HUB_REF_RE.match(policy_ref)
+    if m:
+        local = _local_store_policy_path(m.group("repo"), m.group("step_dir"))
+    else:
+        m = _HUB_ROOT_REF_RE.match(policy_ref)
+        local = _local_store_policy_path(m.group("repo"), None) if m else None
+    if local is not None:
+        # Already on disk in our own models store and nothing in the hub cache
+        # to dedupe against — no fetch, so (like the local-ref branch above) no
+        # downloading_model phase and no progress reporting.
+        return local
+
     _set_phase(PHASE_DOWNLOADING_MODEL)
     tqdm_class = make_snapshot_progress_tqdm(report) if report is not None else None
     return download_hub_checkpoint_ref(policy_ref, tqdm_class=tqdm_class)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -95,8 +95,12 @@ def _seed_run(
     pretrained = run_dir / "checkpoints" / str(steps) / "pretrained_model"
     if with_checkpoint:
         pretrained.mkdir(parents=True)
-        # _list_local_checkpoints requires pretrained_model/config.json.
+        # _list_local_checkpoints requires pretrained_model/config.json, and
+        # _resolve_pretrained_dir additionally requires the policy weights lerobot
+        # actually loads (model.safetensors) — a config-only tree is a partial
+        # download, not a checkpoint.
         (pretrained / "config.json").write_text(json.dumps({"type": policy_type}))
+        (pretrained / "model.safetensors").write_text("weights")
         (pretrained / "train_config.json").write_text(
             json.dumps(
                 {
@@ -1010,15 +1014,21 @@ def _make_model_checkpoint(
 ) -> Path:
     """Fabricate a checkpoint dir in one of the two recognized shapes: a root
     config.json ("root", what upload_local_model pushes) or a
-    checkpoints/<step>/pretrained_model tree ("tree")."""
+    checkpoints/<step>/pretrained_model tree ("tree").
+
+    Both shapes carry `model.safetensors`: `_resolve_pretrained_dir` requires the
+    weights lerobot actually loads, so a config-only tree is deliberately NOT a
+    usable checkpoint (it is what an interrupted download leaves behind)."""
     d = root / repo_id
     if shape == "root":
         d.mkdir(parents=True)
         (d / "config.json").write_text(json.dumps({"type": policy_type}))
+        (d / "model.safetensors").write_text("weights")
     else:
         p = d / "checkpoints" / str(step) / "pretrained_model"
         p.mkdir(parents=True)
         (p / "config.json").write_text(json.dumps({"type": policy_type}))
+        (p / "model.safetensors").write_text("weights")
     return d
 
 
@@ -1254,6 +1264,7 @@ def test_model_download_manager_completes_and_lands_locally(
         d = Path(local_dir)
         d.mkdir(parents=True)
         (d / "config.json").write_text(json.dumps({"type": "act"}))
+        (d / "model.safetensors").write_text("weights")
 
     monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
 
@@ -1496,6 +1507,7 @@ def test_model_download_uses_the_network_when_the_cache_is_empty(
         d = Path(local_dir)
         d.mkdir(parents=True, exist_ok=True)
         (d / "config.json").write_text(json.dumps({"type": "act"}))
+        (d / "model.safetensors").write_text("weights")
 
     monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
 
@@ -2127,3 +2139,61 @@ def test_delete_succeeds_when_inference_reads_other_path(
 
     result = delete_local_model("user/idle_policy")
     assert result["deleted"] is True
+
+
+def test_model_download_rejects_a_fetch_that_lands_without_weights(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A download that ends weights-less is a FAILURE, not a usable model.
+
+    Reproduces the live incident at the download boundary: the fetch lands
+    config.json, train_config.json and both processor safetensors but no
+    model.safetensors — the 68 KB interrupted-download shape. The post-download
+    validation must catch it so the partial is cleaned up and the user is told,
+    rather than the entry sitting in the library until inference dies on
+    FileNotFoundError deep inside lerobot.
+    """
+    import makermodslab.models as m
+
+    def _fake_snapshot(repo_id, repo_type, local_dir, ignore_patterns=None):  # noqa: ARG001
+        d = Path(local_dir)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(json.dumps({"type": "act"}))
+        (d / "train_config.json").write_text(json.dumps({"type": "act"}))
+        # Present, and deliberately NOT policy weights.
+        (d / "preprocessor.safetensors").write_text("processor")
+        (d / "postprocessor.safetensors").write_text("processor")
+
+    monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
+
+    mgr = _model_download_manager()
+    mgr.start("user/partial")
+    _join_download(mgr)
+
+    status = mgr.get_status()
+    assert status["state"] == "error"
+    assert not m.is_model_available_locally("user/partial")
+    # The partial dir is cleaned up, so it can't be mistaken for a complete copy.
+    assert not (tmp_lerobot_home / "makermodslab_models" / "user" / "partial").exists()
+
+
+def test_resolve_pretrained_dir_skips_a_half_written_newest_checkpoint(tmp_lerobot_home: Path) -> None:
+    """A checkpoint still being written must not hide the last complete one.
+
+    Training writes checkpoints/<step>/pretrained_model incrementally, so the
+    highest step can exist with a config and no weights for a while. The scan
+    walks down to the newest COMPLETE checkpoint instead of reporting the run
+    unusable.
+    """
+    import makermodslab.models as m
+
+    root = tmp_lerobot_home / "makermodslab_models" / "user" / "run"
+    good = root / "checkpoints" / "000100" / "pretrained_model"
+    good.mkdir(parents=True)
+    (good / "config.json").write_text(json.dumps({"type": "act"}))
+    (good / "model.safetensors").write_text("weights")
+    partial = root / "checkpoints" / "000200" / "pretrained_model"
+    partial.mkdir(parents=True)
+    (partial / "config.json").write_text(json.dumps({"type": "act"}))
+
+    assert m._resolve_pretrained_dir(root) == good.resolve()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -1249,7 +1250,7 @@ def test_model_download_manager_completes_and_lands_locally(
 ) -> None:
     import makermodslab.models as m
 
-    def _fake_snapshot(repo_id, repo_type, local_dir):  # noqa: ARG001
+    def _fake_snapshot(repo_id, repo_type, local_dir, ignore_patterns=None):  # noqa: ARG001
         d = Path(local_dir)
         d.mkdir(parents=True)
         (d / "config.json").write_text(json.dumps({"type": "act"}))
@@ -1274,7 +1275,7 @@ def test_model_download_manager_rejects_non_policy_repo(
     not a policy — the fetch errors and the partial dir is cleaned up."""
     import makermodslab.models as m
 
-    def _fake_snapshot(repo_id, repo_type, local_dir):  # noqa: ARG001
+    def _fake_snapshot(repo_id, repo_type, local_dir, ignore_patterns=None):  # noqa: ARG001
         Path(local_dir).mkdir(parents=True)
         (Path(local_dir) / "README.md").write_text("not a model")
 
@@ -1288,6 +1289,313 @@ def test_model_download_manager_rejects_non_policy_repo(
     assert status["state"] == "error"
     assert "doesn't look like a policy checkpoint" in status["message"]
     assert not (tmp_lerobot_home / "makermodslab_models" / "user" / "notapolicy").exists()
+
+
+def test_model_download_skips_training_state_but_keeps_checkpoints(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Models-page download must not pull optimizer/scheduler state.
+
+    `training_state/` exists only to RESUME training — nothing that reads a
+    downloaded model here ever opens it, and it is hundreds of MB per checkpoint
+    step (a real 5.6 GB local model dir was ~3.5 GB of it). The
+    `checkpoints/<step>/pretrained_model` trees must survive: the checkpoint
+    browser lists them and inference selects individual steps from them.
+
+    The fake snapshot runs the captured ignore_patterns through huggingface_hub's
+    OWN filter, so this asserts the real matching semantics (fnmatch, not
+    path-aware globbing) rather than a hand-rolled guess — and it does it with no
+    network."""
+    from huggingface_hub.utils import filter_repo_objects
+
+    import makermodslab.models as m
+
+    repo_files = [
+        "README.md",
+        "config.json",
+        "model.safetensors",
+        "train_config.json",
+        "training_state/optimizer_state.safetensors",
+        "checkpoints/000050/pretrained_model/config.json",
+        "checkpoints/000050/pretrained_model/model.safetensors",
+        "checkpoints/000050/training_state/optimizer_state.safetensors",
+        "checkpoints/last/training_state/scheduler_state.json",
+    ]
+    seen: dict = {}
+
+    def _fake_snapshot(repo_id, repo_type, local_dir, ignore_patterns=None):  # noqa: ARG001
+        seen["ignore_patterns"] = ignore_patterns
+        for rel in filter_repo_objects(repo_files, ignore_patterns=ignore_patterns):
+            path = Path(local_dir) / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({"type": "act"}) if rel.endswith(".json") else "weights")
+
+    monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
+
+    mgr = _model_download_manager()
+    mgr.start("user/policy")
+    _join_download(mgr)
+    assert mgr.get_status()["state"] == "done"
+
+    assert seen["ignore_patterns"] == ["training_state/**", "*/training_state/**"]
+    target = tmp_lerobot_home / "makermodslab_models" / "user" / "policy"
+    # Both the root-level and the per-checkpoint optimizer state are gone...
+    assert not (target / "training_state").exists()
+    assert not (target / "checkpoints" / "000050" / "training_state").exists()
+    assert not (target / "checkpoints" / "last").exists()
+    # ...while everything a downloaded model is actually read for survives.
+    assert (target / "config.json").is_file()
+    assert (target / "model.safetensors").is_file()
+    assert (target / "checkpoints" / "000050" / "pretrained_model" / "model.safetensors").is_file()
+    # And the trimmed tree still resolves the way the listing/inference expect.
+    assert (
+        m._resolve_pretrained_dir(target)
+        == (target / "checkpoints" / "000050" / "pretrained_model").resolve()
+    )
+    assert m.is_model_available_locally("user/policy")
+
+
+# ---------------------------------------------------------------------------
+# Models-page download → served from the shared HF hub cache (design-debt F6,
+# the other direction).
+#
+# `_fetch_model_snapshot` downloads with local_dir=, and huggingface_hub 1.21.0's
+# local_dir mode neither reads nor populates the shared cache — so a repo
+# inference had already cached was pulled over the network a SECOND time. The
+# fetch now goes through the cache when it holds the repo. No network anywhere:
+# snapshot_download is monkeypatched, and the "cache" is a tmp dir built to the
+# real on-disk layout (blobs/ + a snapshots/<rev>/ symlink farm).
+# ---------------------------------------------------------------------------
+
+
+def _seed_hub_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    cached_repo: str | None = None,
+    with_snapshot: bool = True,
+) -> Path:
+    """Redirect HF_HUB_CACHE at a tmp dir, optionally holding one model repo.
+
+    Returns the cache root. Deliberately redirected in every test here rather
+    than relying on the developer's real cache being empty of the fake repo id."""
+    from huggingface_hub import constants as hf_constants
+    from huggingface_hub.file_download import repo_folder_name
+
+    cache = tmp_path / "hub"
+    cache.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(hf_constants, "HF_HUB_CACHE", str(cache))
+    if cached_repo is not None:
+        snapshots = cache / repo_folder_name(repo_id=cached_repo, repo_type="model") / "snapshots"
+        snapshots.mkdir(parents=True)
+        if with_snapshot:
+            (snapshots / "deadbeef").mkdir()
+    return cache
+
+
+def _build_cache_snapshot(cache: Path, repo_id: str) -> Path:
+    """Write a realistic cache snapshot for `repo_id`: a blobs/ dir plus a
+    snapshots/<rev>/ tree whose entries are SYMLINKS into it, which is what
+    huggingface_hub actually leaves on disk. Includes a training_state file
+    (a cache entry can predate our exclusion) and a nested checkpoint tree."""
+    from huggingface_hub.file_download import repo_folder_name
+
+    repo_root = cache / repo_folder_name(repo_id=repo_id, repo_type="model")
+    blobs = repo_root / "blobs"
+    blobs.mkdir(parents=True, exist_ok=True)
+    snapshot = repo_root / "snapshots" / "deadbeef"
+    snapshot.mkdir(parents=True, exist_ok=True)
+
+    contents = {
+        "config.json": json.dumps({"type": "act"}),
+        "model.safetensors": "root-weights",
+        "training_state/optimizer_state.safetensors": "optimizer-junk",
+        "checkpoints/000050/pretrained_model/config.json": json.dumps({"type": "act"}),
+        "checkpoints/000050/pretrained_model/model.safetensors": "step-weights",
+        "checkpoints/000050/training_state/optimizer_state.safetensors": "optimizer-junk",
+    }
+    for i, (rel, text) in enumerate(contents.items()):
+        blob = blobs / f"blob{i}"
+        blob.write_text(text)
+        link = snapshot / rel
+        link.parent.mkdir(parents=True, exist_ok=True)
+        # Relative link, exactly as huggingface_hub writes them.
+        link.symlink_to(Path(os.path.relpath(blob, link.parent)))
+    return snapshot
+
+
+def test_model_download_serves_a_cached_repo_without_re_downloading(
+    tmp_lerobot_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The repo is already in the shared hub cache, so the Models-page download
+    must NOT pull it over the network a second time (design-debt F6).
+
+    Asserts the whole contract of the cache path at once: no local_dir download
+    happens, the symlink farm lands DEREFERENCED (the store must not point into
+    blobs/, which huggingface_hub may garbage-collect), training_state is still
+    excluded even though the cache entry has it, and the download manager still
+    reaches "done" normally."""
+    import makermodslab.models as m
+
+    cache = _seed_hub_cache(monkeypatch, tmp_path, cached_repo="user/policy")
+    snapshot = _build_cache_snapshot(cache, "user/policy")
+    calls: list[dict] = []
+
+    def _fake_snapshot(repo_id, repo_type=None, local_dir=None, ignore_patterns=None):
+        calls.append({"repo_id": repo_id, "local_dir": local_dir, "ignore_patterns": ignore_patterns})
+        if local_dir is not None:
+            raise AssertionError("a cached repo must not be re-downloaded with local_dir=")
+        return str(snapshot)
+
+    monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
+
+    mgr = _model_download_manager()
+    mgr.start("user/policy")
+    _join_download(mgr)
+
+    assert mgr.get_status()["state"] == "done"
+    # Cache mode: no local_dir, and the exclusion is still requested so missing
+    # files aren't fetched as optimizer state.
+    assert len(calls) == 1
+    assert calls[0]["local_dir"] is None
+    assert calls[0]["ignore_patterns"] == ["training_state/**", "*/training_state/**"]
+
+    target = tmp_lerobot_home / "makermodslab_models" / "user" / "policy"
+    weights = target / "model.safetensors"
+    assert weights.is_file()
+    assert not weights.is_symlink()
+    assert weights.read_text() == "root-weights"
+    nested = target / "checkpoints" / "000050" / "pretrained_model" / "model.safetensors"
+    assert nested.is_file()
+    assert not nested.is_symlink()
+    assert nested.read_text() == "step-weights"
+    # A cache entry predating the exclusion still must not leak optimizer state.
+    assert not (target / "training_state").exists()
+    assert not (target / "checkpoints" / "000050" / "training_state").exists()
+    # And the copied tree passes the same validation the download path does.
+    assert (
+        m._resolve_pretrained_dir(target)
+        == (target / "checkpoints" / "000050" / "pretrained_model").resolve()
+    )
+    assert m.is_model_available_locally("user/policy")
+
+
+def test_model_download_uses_the_network_when_the_cache_is_empty(
+    tmp_lerobot_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing cached for the repo → the plain local_dir download, unchanged.
+    The cache path is an optimization, not a precondition."""
+    import makermodslab.models as m
+
+    _seed_hub_cache(monkeypatch, tmp_path)
+    calls: list[dict] = []
+
+    def _fake_snapshot(repo_id, repo_type=None, local_dir=None, ignore_patterns=None):
+        calls.append({"local_dir": local_dir})
+        assert local_dir is not None, "an uncached repo has nothing to serve from the cache"
+        d = Path(local_dir)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(json.dumps({"type": "act"}))
+
+    monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
+
+    mgr = _model_download_manager()
+    mgr.start("user/policy")
+    _join_download(mgr)
+
+    assert mgr.get_status()["state"] == "done"
+    assert len(calls) == 1 and calls[0]["local_dir"] is not None
+    assert m.is_model_available_locally("user/policy")
+
+
+def test_hub_cache_has_repo_requires_an_actual_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both sides of the rule: a repo dir whose snapshots/ is empty (an
+    interrupted or wiped entry) has nothing to dedupe against and counts as
+    ABSENT, so the caller downloads instead of copying a broken tree."""
+    import makermodslab.models as m
+
+    _seed_hub_cache(monkeypatch, tmp_path, cached_repo="user/policy")
+    assert m._hub_cache_has_repo("user/policy") is True
+    assert m._hub_cache_has_repo("user/other") is False
+
+    _seed_hub_cache(monkeypatch, tmp_path / "b", cached_repo="user/policy", with_snapshot=False)
+    assert m._hub_cache_has_repo("user/policy") is False
+    # A repo id the hub's own validation rejects answers "not cached" rather
+    # than raising — snapshot_download then produces the canonical error.
+    assert m._hub_cache_has_repo("../../etc") is False
+
+
+def test_model_download_falls_back_when_the_cache_fetch_errors(
+    tmp_lerobot_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cache path must never become a NEW failure mode: an HF error on the
+    cache-mode call falls back to the plain local_dir download and the download
+    still succeeds."""
+    import makermodslab.models as m
+
+    _seed_hub_cache(monkeypatch, tmp_path, cached_repo="user/policy")
+    calls: list[dict] = []
+
+    def _fake_snapshot(repo_id, repo_type=None, local_dir=None, ignore_patterns=None):
+        calls.append({"local_dir": local_dir})
+        if local_dir is None:
+            raise OSError("cache entry vanished mid-fetch")
+        d = Path(local_dir)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(json.dumps({"type": "act"}))
+        (d / "model.safetensors").write_text("downloaded")
+
+    monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
+
+    mgr = _model_download_manager()
+    mgr.start("user/policy")
+    _join_download(mgr)
+
+    assert mgr.get_status()["state"] == "done"
+    # Tried the cache first, then fell back to the network.
+    assert [c["local_dir"] is None for c in calls] == [True, False]
+    target = tmp_lerobot_home / "makermodslab_models" / "user" / "policy"
+    assert (target / "model.safetensors").read_text() == "downloaded"
+    assert m.is_model_available_locally("user/policy")
+
+
+def test_model_download_falls_back_when_the_snapshot_copy_errors(
+    tmp_lerobot_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same guarantee for the other half of the cache path — a copy that dies
+    (out of disk, a blob yanked out from under us) also falls back."""
+    import makermodslab.models as m
+
+    cache = _seed_hub_cache(monkeypatch, tmp_path, cached_repo="user/policy")
+    snapshot = _build_cache_snapshot(cache, "user/policy")
+    calls: list[dict] = []
+
+    def _fake_snapshot(repo_id, repo_type=None, local_dir=None, ignore_patterns=None):
+        calls.append({"local_dir": local_dir})
+        if local_dir is None:
+            return str(snapshot)
+        d = Path(local_dir)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(json.dumps({"type": "act"}))
+        (d / "model.safetensors").write_text("downloaded")
+
+    def _boom(_snapshot, _target):
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(m, "snapshot_download", _fake_snapshot)
+    monkeypatch.setattr(m, "_copy_snapshot_into_store", _boom)
+
+    mgr = _model_download_manager()
+    mgr.start("user/policy")
+    _join_download(mgr)
+
+    assert mgr.get_status()["state"] == "done"
+    assert [c["local_dir"] is None for c in calls] == [True, False]
+    assert (
+        tmp_lerobot_home / "makermodslab_models" / "user" / "policy" / "model.safetensors"
+    ).read_text() == ("downloaded")
 
 
 def test_models_download_endpoint_rejects_bad_repo_id(client) -> None:

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -331,6 +331,199 @@ def test_resolve_policy_path_resolves_hub_root_ref(monkeypatch, tmp_path) -> Non
     assert result == str(fake_root)
 
 
+# ---------------------------------------------------------------------------
+# Hub ref → MakerMods Lab's own models store (design-debt F6).
+#
+# The Models page downloads with `local_dir=<makermodslab_models>/<repo_id>`, which
+# huggingface_hub keeps entirely outside the shared hub cache — so a model the
+# user already pulled there used to be downloaded a SECOND time on first
+# inference. _resolve_policy_path now checks the local store first, but ONLY
+# when the hub cache holds nothing for the repo (with a cache entry,
+# snapshot_download is the revision-aware, self-deduping path and must win).
+# No network anywhere: snapshot_download is monkeypatched to explode.
+# ---------------------------------------------------------------------------
+
+_FAKE_POLICY_CONFIG = '{"type": "act"}'
+
+
+def _seed_models_store(monkeypatch, tmp_path, repo_id: str, *, step: str | None = None, flat: bool = False):
+    """Point models._local_models_root at a tmp dir and populate one repo in it.
+
+    `step` writes a `checkpoints/<step>/pretrained_model/config.json` tree (what
+    a training repo download looks like); `flat` writes a root `config.json`
+    (what a `@root` repo looks like). Both may be set, to build the ambiguous
+    tree the `@root` branch deliberately refuses. Returns the repo dir,
+    RESOLVED — _downloaded_model_dir resolves, and tmp_path is behind a symlink
+    on macOS."""
+    import makermodslab.models as m
+
+    store = tmp_path / "makermodslab_models"
+    monkeypatch.setattr(m, "_local_models_root", lambda: store)
+    repo_dir = store / repo_id
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    if step is not None:
+        pretrained = repo_dir / "checkpoints" / step / "pretrained_model"
+        pretrained.mkdir(parents=True)
+        (pretrained / "config.json").write_text(_FAKE_POLICY_CONFIG)
+    if flat:
+        (repo_dir / "config.json").write_text(_FAKE_POLICY_CONFIG)
+    return repo_dir.resolve()
+
+
+def _seed_hub_cache(monkeypatch, tmp_path, *, cached_repo: str | None = None, with_snapshot: bool = True):
+    """Redirect HF_HUB_CACHE at a tmp dir, optionally holding one model repo."""
+    from huggingface_hub import constants as hf_constants
+    from huggingface_hub.file_download import repo_folder_name
+
+    cache = tmp_path / "hub"
+    cache.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(hf_constants, "HF_HUB_CACHE", str(cache))
+    if cached_repo is not None:
+        snapshots = cache / repo_folder_name(repo_id=cached_repo, repo_type="model") / "snapshots"
+        snapshots.mkdir(parents=True)
+        if with_snapshot:
+            (snapshots / "deadbeef").mkdir()
+    return cache
+
+
+def _explode_snapshot_download(monkeypatch) -> None:
+    """Any snapshot_download call in these tests is the bug under test."""
+
+    def _boom(**kwargs):
+        raise AssertionError(f"snapshot_download must not be called: {kwargs}")
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _boom)
+
+
+def test_resolve_policy_path_uses_local_store_for_checkpoint_ref(monkeypatch, tmp_path) -> None:
+    """A `@checkpoints/<step>` ref whose repo is already in the local models
+    store (and nowhere in the hub cache) resolves with zero network."""
+    from makermodslab import rollout
+
+    repo_dir = _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path)
+    _explode_snapshot_download(monkeypatch)
+
+    result = rollout._resolve_policy_path("user/repo@checkpoints/000050")
+
+    assert result == str(repo_dir / "checkpoints" / "000050" / "pretrained_model")
+
+
+def test_resolve_policy_path_uses_local_store_for_root_ref(monkeypatch, tmp_path) -> None:
+    """Same for a flat `@root` repo — the store's repo dir IS the pretrained
+    dir, so it is returned verbatim."""
+    from makermodslab import rollout
+
+    repo_dir = _seed_models_store(monkeypatch, tmp_path, "user/flat", flat=True)
+    _seed_hub_cache(monkeypatch, tmp_path)
+    _explode_snapshot_download(monkeypatch)
+
+    assert rollout._resolve_policy_path("user/flat@root") == str(repo_dir)
+
+
+def test_resolve_policy_path_local_store_hit_leaves_phase_untouched(monkeypatch, tmp_path) -> None:
+    """Nothing is fetched, so the UI must not be told it is downloading a model
+    — the same contract the plain local-dir branch has."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path)
+    _explode_snapshot_download(monkeypatch)
+    monkeypatch.setattr(rollout, "_inference_meta", {"phase": rollout.PHASE_STARTING})
+
+    rollout._resolve_policy_path("user/repo@checkpoints/000050")
+
+    assert rollout._inference_meta["phase"] == rollout.PHASE_STARTING
+
+
+def test_resolve_policy_path_prefers_hub_when_repo_is_cached(monkeypatch, tmp_path) -> None:
+    """With the repo in the hub cache, snapshot_download is the right call even
+    though a local-store copy exists: it is revision-aware and only pulls what
+    changed, so the user stays on `main` instead of being pinned to a possibly
+    stale local copy."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path, cached_repo="user/repo")
+    fake_root = tmp_path / "snapshot"
+    fake_root.mkdir()
+    seen: dict = {}
+
+    def fake_snapshot_download(**kwargs):
+        seen.update(kwargs)
+        return str(fake_root)
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_snapshot_download)
+
+    result = rollout._resolve_policy_path("user/repo@checkpoints/000050")
+
+    assert seen["repo_id"] == "user/repo"
+    assert result == str(fake_root / "checkpoints" / "000050" / "pretrained_model")
+
+
+def test_resolve_policy_path_downloads_when_requested_step_is_missing(monkeypatch, tmp_path) -> None:
+    """The local store has the repo but not the step the user picked — that is a
+    miss, not a substitution: fall through to the Hub."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path)
+    fake_root = tmp_path / "snapshot"
+    fake_root.mkdir()
+    monkeypatch.setattr("huggingface_hub.snapshot_download", lambda **kw: str(fake_root))
+
+    result = rollout._resolve_policy_path("user/repo@checkpoints/000100")
+
+    assert result == str(fake_root / "checkpoints" / "000100" / "pretrained_model")
+
+
+def test_local_store_root_ref_refuses_a_checkpoints_tree(monkeypatch, tmp_path) -> None:
+    """`@root` means "the repo root IS the pretrained_model". A local copy that
+    resolves to a checkpoints sub-tree is a DIFFERENT tree than the Hub path
+    would return, so the shortcut declines rather than substituting it."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path)
+
+    assert rollout._local_store_policy_path("user/repo", None) is None
+
+
+def test_local_store_declines_unknown_repo(monkeypatch, tmp_path) -> None:
+    """Nothing in the store for this repo → no shortcut."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path)
+
+    assert rollout._local_store_policy_path("someone/else", "000050") is None
+
+
+def test_local_store_refuses_traversal_repo_id(monkeypatch, tmp_path) -> None:
+    """`policy_ref` is user input and the hub-ref regex accepts any `[^@]+`, so
+    a repo id that escapes the models root must never resolve (the guard comes
+    from models._downloaded_model_dir)."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path)
+
+    assert rollout._local_store_policy_path("../../etc", None) is None
+
+
+def test_hub_cache_has_repo_reads_the_on_disk_layout(monkeypatch, tmp_path) -> None:
+    """A repo dir whose snapshots/ is empty (an interrupted or wiped entry) has
+    nothing to dedupe against, so it counts as absent."""
+    from makermodslab import rollout
+
+    _seed_hub_cache(monkeypatch, tmp_path, cached_repo="user/repo")
+    assert rollout._hub_cache_has_repo("user/repo") is True
+    assert rollout._hub_cache_has_repo("user/other") is False
+
+    _seed_hub_cache(monkeypatch, tmp_path / "b", cached_repo="user/repo", with_snapshot=False)
+    assert rollout._hub_cache_has_repo("user/repo") is False
+
+
 def test_format_cameras_arg_empty_yields_empty_braces() -> None:
     from makermodslab.rollout import _format_cameras_arg
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -346,27 +346,50 @@ def test_resolve_policy_path_resolves_hub_root_ref(monkeypatch, tmp_path) -> Non
 _FAKE_POLICY_CONFIG = '{"type": "act"}'
 
 
-def _seed_models_store(monkeypatch, tmp_path, repo_id: str, *, step: str | None = None, flat: bool = False):
+def _seed_models_store(
+    monkeypatch,
+    tmp_path,
+    repo_id: str,
+    *,
+    step: str | None = None,
+    flat: bool = False,
+    weights: bool = True,
+):
     """Point models._local_models_root at a tmp dir and populate one repo in it.
 
-    `step` writes a `checkpoints/<step>/pretrained_model/config.json` tree (what
-    a training repo download looks like); `flat` writes a root `config.json`
-    (what a `@root` repo looks like). Both may be set, to build the ambiguous
-    tree the `@root` branch deliberately refuses. Returns the repo dir,
-    RESOLVED — _downloaded_model_dir resolves, and tmp_path is behind a symlink
-    on macOS."""
+    `step` writes a `checkpoints/<step>/pretrained_model` tree (what a training
+    repo download looks like); `flat` writes a root config (what a `@root` repo
+    looks like). Both may be set, to build the ambiguous tree the `@root` branch
+    deliberately refuses. Returns the repo dir, RESOLVED — _downloaded_model_dir
+    resolves, and tmp_path is behind a symlink on macOS.
+
+    `weights=False` reproduces an INTERRUPTED local_dir download: config plus the
+    pre/post-processor safetensors, but no `model.safetensors`. That is the exact
+    shape that bit the user — note it does contain `.safetensors` files, so any
+    check looking merely for "some safetensors" would still be fooled.
+    """
     import makermodslab.models as m
 
     store = tmp_path / "makermodslab_models"
     monkeypatch.setattr(m, "_local_models_root", lambda: store)
     repo_dir = store / repo_id
     repo_dir.mkdir(parents=True, exist_ok=True)
+
+    def _populate(d):
+        (d / "config.json").write_text(_FAKE_POLICY_CONFIG)
+        (d / "train_config.json").write_text(_FAKE_POLICY_CONFIG)
+        # Processor weights land early in a download and are NOT policy weights.
+        (d / "preprocessor.safetensors").write_text("processor")
+        (d / "postprocessor.safetensors").write_text("processor")
+        if weights:
+            (d / "model.safetensors").write_text("weights")
+
     if step is not None:
         pretrained = repo_dir / "checkpoints" / step / "pretrained_model"
         pretrained.mkdir(parents=True)
-        (pretrained / "config.json").write_text(_FAKE_POLICY_CONFIG)
+        _populate(pretrained)
     if flat:
-        (repo_dir / "config.json").write_text(_FAKE_POLICY_CONFIG)
+        _populate(repo_dir)
     return repo_dir.resolve()
 
 
@@ -2774,3 +2797,140 @@ def test_start_inference_clears_the_previous_runs_log_pointer(monkeypatch, tmp_p
 
     assert result["success"] is False
     assert rollout._last_log_path is None, "a new claim must not inherit the previous run's log"
+
+
+# ---------------------------------------------------------------------------
+# F6 store entries must hold LOADABLE WEIGHTS, not just a config.
+#
+# Live incident: the user's sock ACT model had a 68 KB store entry — an
+# interrupted local_dir download with config.json, train_config.json and both
+# processor safetensors, but no model.safetensors. F6's short-circuit served it,
+# and lerobot died with FileNotFoundError on the weights. Pre-F6 the hub path
+# would have downloaded and worked, so the short-circuit converted a silent
+# partial into a hard failure.
+# ---------------------------------------------------------------------------
+
+
+def test_local_store_refuses_a_weightless_checkpoint_ref(monkeypatch, tmp_path) -> None:
+    """The incident, at the `@checkpoints/<step>` branch that hit it."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050", weights=False)
+    _seed_hub_cache(monkeypatch, tmp_path)
+
+    assert rollout._local_store_policy_path("user/repo", "000050") is None, (
+        "a store entry with a config but no model.safetensors must fall through to the "
+        "download instead of being served as a usable checkpoint"
+    )
+
+
+def test_local_store_refuses_a_weightless_root_ref(monkeypatch, tmp_path) -> None:
+    """Same for the flat `@root` shape."""
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/flat", flat=True, weights=False)
+    _seed_hub_cache(monkeypatch, tmp_path)
+
+    assert rollout._local_store_policy_path("user/flat", None) is None
+
+
+def test_weightless_store_entry_falls_through_to_the_hub(monkeypatch, tmp_path) -> None:
+    """End-to-end: the partial entry must not break inference, just be skipped.
+
+    This is the behaviour the incident should have had — resolve via the Hub, as
+    it did before F6 existed.
+    """
+    from makermodslab import rollout
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050", weights=False)
+    _seed_hub_cache(monkeypatch, tmp_path)
+    fake_root = tmp_path / "snapshot"
+    fake_root.mkdir()
+    monkeypatch.setattr("huggingface_hub.snapshot_download", lambda **kw: str(fake_root))
+
+    result = rollout._resolve_policy_path("user/repo@checkpoints/000050")
+
+    assert result == str(fake_root / "checkpoints" / "000050" / "pretrained_model")
+
+
+def test_processor_safetensors_alone_do_not_count_as_weights(monkeypatch, tmp_path) -> None:
+    """The trap, pinned explicitly.
+
+    The broken tree DOES contain .safetensors files (pre/post-processor), so a
+    check for "any safetensors present" would have served it just the same. The
+    requirement is the POLICY weights specifically.
+    """
+    from makermodslab import models
+
+    _seed_models_store(monkeypatch, tmp_path, "user/repo", flat=True, weights=False)
+    repo_dir = tmp_path / "makermodslab_models" / "user" / "repo"
+
+    assert list(repo_dir.glob("*.safetensors")), "fixture precondition: safetensors ARE present"
+    assert models._has_loadable_weights(repo_dir) is False
+    assert models._resolve_pretrained_dir(repo_dir) is None
+
+
+def test_complete_store_entry_is_still_served(monkeypatch, tmp_path) -> None:
+    """Control: the fix must not stop F6 serving a COMPLETE local copy."""
+    from makermodslab import rollout
+
+    repo_dir = _seed_models_store(monkeypatch, tmp_path, "user/repo", step="000050")
+    _seed_hub_cache(monkeypatch, tmp_path)
+    _explode_snapshot_download(monkeypatch)
+
+    assert rollout._local_store_policy_path("user/repo", "000050") == str(
+        repo_dir / "checkpoints" / "000050" / "pretrained_model"
+    )
+
+
+def test_adapter_shaped_checkpoint_counts_as_loadable(tmp_path) -> None:
+    """A PEFT/LoRA adapter dir has no model.safetensors and is still loadable.
+
+    `make_policy`'s use_peft branch reads the adapter config and calls
+    `PeftModel.from_pretrained(policy, dir)`, pulling the BASE weights from the
+    adapter config's `base_model_name_or_path` — so requiring model.safetensors
+    unconditionally would make the user's pi05 LoRA repos vanish.
+    """
+    from makermodslab import models
+
+    d = tmp_path / "adapter"
+    d.mkdir()
+    (d / "config.json").write_text("{}")
+    (d / "adapter_config.json").write_text('{"base_model_name_or_path": "lerobot/pi05"}')
+    (d / "adapter_model.safetensors").write_text("lora")
+
+    assert models._has_loadable_weights(d) is True
+    assert models._resolve_pretrained_dir(d) == d
+
+
+def test_partial_adapter_dir_is_not_loadable(tmp_path) -> None:
+    """Half an adapter is not an adapter: PeftConfig.from_pretrained needs the
+    config, and there is nothing to load without the adapter weights."""
+    from makermodslab import models
+
+    d = tmp_path / "half_adapter"
+    d.mkdir()
+    (d / "config.json").write_text("{}")
+    (d / "adapter_model.safetensors").write_text("lora")  # no adapter_config.json
+
+    assert models._has_loadable_weights(d) is False
+
+
+def test_sharded_weights_are_not_accepted(tmp_path) -> None:
+    """The pinned lerobot cannot load sharded weights from a local dir.
+
+    `from_pretrained` joins SAFETENSORS_SINGLE_FILE and opens it — there is no
+    index-file branch — and the save side pins max_shard_size above the total so
+    output stays one file. Accepting shards would recreate this very bug: a tree
+    we call usable that lerobot then fails to open.
+    """
+    from makermodslab import models
+
+    d = tmp_path / "sharded"
+    d.mkdir()
+    (d / "config.json").write_text("{}")
+    (d / "model-00001-of-00002.safetensors").write_text("shard")
+    (d / "model-00002-of-00002.safetensors").write_text("shard")
+    (d / "model.safetensors.index.json").write_text("{}")
+
+    assert models._has_loadable_weights(d) is False


### PR DESCRIPTION
> ⚠️ **Stacked PR — base branch is `feat/inference-eval-suite` (#63), not `main`.**
> **Do not merge before #63.** After #63 merges (squash), this branch needs a rebase onto `main` and a retarget of this PR's base to `main`. The diff below is F6 only; everything else in the file view belongs to #63.

The Models-page store and the shared HF hub cache were invisible to each other, so the same model downloaded twice: once when the user pulled it in-app, again the first time inference ran on it — and vice versa. This closes both directions.

**Direction 1 — inference serves from our store.** `rollout._local_store_policy_path` returns a ready-to-run `pretrained_model` dir out of the Models-page store when the hub cache holds nothing for the repo: zero network, no `downloading_model` phase. A *populated* hub cache still wins, deliberately — `snapshot_download` **is** the hub-cache path, it is revision-aware and fetches only changed files, so once a repo is cached, letting it run keeps the user on `main` rather than pinning them to a possibly stale local copy. That precedence rule is the whole design: the store is a fallback for "nothing to dedupe against", never a substitute for a live revision check.

**Direction 2 — the Models page serves from the hub cache.** `_fetch_via_hub_cache` materializes an already-cached repo by running a *cache-mode* `snapshot_download` (no `local_dir`) and copying the snapshot into the store with symlinks dereferenced. Routing through `snapshot_download` rather than copying the newest snapshot dir straight out means a **partial** cache entry gets *completed* rather than copied as a broken tree, and the result is revision-correct. It is a pure optimization: any failure logs a warning and falls back to the plain download.

`_hub_cache_has_repo` lives in `models.py` and `rollout` imports it, so the two directions can never disagree about what "already cached" means.

**`training_state/` is excluded from everything the Models page pulls.** A training repo carries a `training_state/` dir next to every `pretrained_model/`, and it exists only to *resume* training — nothing that reads a downloaded model here ever opens it. Observed: **3.5 GB of a 5.6 GB model dir**. The `checkpoints/<step>/pretrained_model` trees are deliberately kept.

This short-circuit deliberately does **not** live inside `jobs.download_hub_checkpoint_ref`, even though the duplicate-download problem is the same for every caller: that shared helper also feeds fine-tune/resume, and the store strips `training_state/` — serving the store from there would hand a *resume* a checkpoint with no optimizer state to resume from. Inference is the one caller for which the stripped tree is equivalent.

**Weights-probe hardening (second commit).** The first real-hardware pass found the store-usability probe accepting `config.json` as proof of a model. An interrupted `local_dir` download leaves exactly that shape — `config.json`, `train_config.json`, both processor safetensors, no `model.safetensors` — and the short-circuit served it, crashing lerobot with `FileNotFoundError`. Live: a **68 KB** store entry for an ACT model. Pre-F6 the hub path would have re-downloaded and worked, so the short-circuit converted a silent partial into a hard failure.

`_has_loadable_weights` is now the single shared definition, derived from the **pinned lerobot's loader** rather than guessed:

- `model.safetensors` **required** — `from_pretrained` on a local dir joins `SAFETENSORS_SINGLE_FILE` and hands it straight to `_load_as_safetensor`.
- **PEFT adapter pair accepted** (`adapter_config.json` + `adapter_model.safetensors`) — `make_policy`'s `use_peft` branch reads the adapter config and pulls base weights from `base_model_name_or_path`, so an adapter dir is complete without `model.safetensors`.
- **Sharded weights rejected** — that local-dir branch has no index-file handling at all, and the save side pins `max_shard_size` above the total so output stays one file. Accepting shards would recreate this very bug.

"Some `*.safetensors` is present" is explicitly *not* sufficient, and there's a test pinning that: the broken tree contains processor safetensors. Because `_resolve_pretrained_dir` asks the same question, partials are uniformly invisible — they drop out of the listing, fail download validation, get cleaned up, and are skipped by the short-circuit. The checkpoint scan also walks highest-step-**down**, so a checkpoint still being written by a live training run can't hide the last complete one.

**Both directions were verified on real hardware today.** Direction 2: partial-cache completion observed. Direction 1: no download phase, no cache entry created, store-served run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)