### PR TITLE
feat(train): cross-runner training resume (F7) — cloud→local and local→cloud

### DIFF
--- a/frontend/src/components/training/ConfigurationTab.tsx
+++ b/frontend/src/components/training/ConfigurationTab.tsx
@@ -13,10 +13,6 @@ interface ConfigurationTabProps extends ConfigComponentProps {
   /** True when a base skill (fine-tune) or resume seed fixes the policy —
    * the run must train the source checkpoint's architecture. */
   policyLocked?: boolean;
-  /** True when a resume seed fixes the compute target — a resume can only
-   * continue on the parent run's runner (F7). Only about WHERE the
-   * continuation executes; it leaves the cloud flavor editable. */
-  runnerLocked?: boolean;
 }
 
 const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
@@ -27,7 +23,6 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
   hardwareLoading,
   policyLocked,
   resumeLocked,
-  runnerLocked,
 }) => {
   return (
     // Order matters: Policy answers "what am I training" and so belongs with
@@ -46,7 +41,6 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
         flavors={flavors}
         loading={hardwareLoading}
         resumeLocked={resumeLocked}
-        runnerLocked={runnerLocked}
       />
       <EssentialsCard
         config={config}

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -12,6 +12,7 @@ import TrainingExtraGate from "@/components/training/TrainingExtraGate";
 import PolicyExtraDialog from "@/components/training/PolicyExtraDialog";
 import HfAuthBanner from "@/components/landing/HfAuthBanner";
 import LocalDatasetCloudNotice from "@/components/training/config/LocalDatasetCloudNotice";
+import LocalCheckpointCloudNotice from "@/components/training/config/LocalCheckpointCloudNotice";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -43,12 +44,14 @@ export type ResumeSeed = {
   sourceSteps: number; // the source run's configured total, for a sane prefill
   logFreq?: number; // the source run's log cadence, to preserve on resume
   saveFreq?: number; // the source run's checkpoint cadence, to preserve on resume
-  // The parent run's runner + flavor. A resume ALWAYS continues on the parent's
-  // runner — the form pins Compute to this value and disables it (see F7) —
-  // so `runner` is the lock's source of truth, not just a cloud convenience.
-  // Omitted ⇒ treated as "local". When "hf_cloud", the launched run targets the
-  // same flavor and continues into the parent's Hub output repo; `flavor` stays
-  // editable, since which GPU the continuation rents is a real per-launch choice.
+  // The parent run's runner + flavor. A resume DEFAULTS to the parent's runner
+  // but may cross to the other one (F7), so `runner` is the form's starting
+  // point AND its record of where the parent actually ran — which is what tells
+  // the form that continuing on the cloud has to upload a local checkpoint
+  // first. Omitted ⇒ treated as "local". When "hf_cloud", the launched run
+  // targets the same flavor and continues into the parent's Hub output repo;
+  // `flavor` stays editable, since which GPU the continuation rents is a real
+  // per-launch choice.
   runner?: "local" | "hf_cloud";
   flavor?: string;
 };
@@ -86,7 +89,10 @@ interface TrainingConfiguratorProps {
   actionsContainer?: HTMLElement | null;
 }
 
-function configToRequest(c: TrainingConfig): TrainingRequest {
+function configToRequest(
+  c: TrainingConfig,
+  needsCheckpointUpload: boolean,
+): TrainingRequest {
   // The backend's TrainingRequest has more optional fields; the form covers
   // the user-meaningful subset.
   return {
@@ -104,6 +110,11 @@ function configToRequest(c: TrainingConfig): TrainingRequest {
     resume: c.resume,
     resume_from_job_id: c.resume_from_job_id,
     resume_from_step: c.resume_from_step,
+    // Consent, not a mode: sent only for the one combination that has to push
+    // bytes to the Hub (a local parent continued on cloud compute), and the
+    // backend refuses that combination without it. Left undefined otherwise so
+    // no other launch carries an upload permission it has no use for.
+    upload_resume_checkpoint: needsCheckpointUpload ? true : undefined,
     finetune_from_job_id: c.finetune_from_job_id,
     finetune_from_step: c.finetune_from_step,
     wandb_enable: c.wandb_enable,
@@ -158,12 +169,13 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
   const { openJobMonitor } = useStudio();
 
   const [trainingConfig, setTrainingConfig] = useState<TrainingConfig>({
-    // A resume inherits the parent run's runner — a cloud one so the
+    // A resume DEFAULTS to the parent run's runner — a cloud one so the
     // continuation runs on the same flavor and pushes into the same Hub repo, a
     // local one so it reads the parent's on-disk checkpoint. The Compute
-    // control is then pinned to it (`runnerLocked` below), because neither
-    // cross-runner direction works: see F7. Everything else defaults to a fresh
-    // local run.
+    // control stays editable: either cross-runner direction works now (F7), it
+    // just moves the checkpoint first — down from the Hub for a cloud→local
+    // continuation, up to it for a local→cloud one. Everything else defaults to
+    // a fresh local run.
     target:
       resumeSeed?.runner === "hf_cloud"
         ? { runner: "hf_cloud", flavor: resumeSeed.flavor }
@@ -301,6 +313,15 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
   const datasetLocalOnly = selectedDatasetItem?.source === "local";
   const needsUpload = isCloud && datasetLocalOnly;
 
+  // A resume whose parent ran locally, retargeted at cloud compute: the pod
+  // can't read this machine's disk, so the parent's checkpoint has to be
+  // uploaded to a private Hub repo before the job is submitted (F7). Derived
+  // from the seed's runner rather than from the config, because the config's
+  // `target` is now the user's live choice — the seed is the only record of
+  // where the parent actually ran.
+  const needsCheckpointUpload =
+    resumeSeed != null && resumeSeed.runner !== "hf_cloud" && isCloud;
+
   // Approximate on-disk size for the notice (cheap detail endpoint; local only).
   const [datasetSizeBytes, setDatasetSizeBytes] = useState<number | null>(null);
   useEffect(() => {
@@ -331,7 +352,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
       const job = await startTrainingJob(
         baseUrl,
         fetchWithHeaders,
-        configToRequest(config),
+        configToRequest(config, needsCheckpointUpload),
       );
       toast({ title: "Training Started", description: job.name });
       onStarted?.(job.id);
@@ -358,6 +379,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     baseUrl,
     fetchWithHeaders,
     config,
+    needsCheckpointUpload,
     toast,
     navigate,
     location.pathname,
@@ -480,6 +502,10 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
   // in offline mode, in which case uploads are impossible and Start is a hard
   // block. (needsUpload is already gated on isCloud.)
   const uploadBlockedOffline = needsUpload && offline;
+  // A local run continued on the cloud has to push its checkpoint to the Hub
+  // first, which offline mode makes impossible — a hard block, exactly like the
+  // dataset case above.
+  const checkpointUploadBlockedOffline = needsCheckpointUpload && offline;
   const startDisabled =
     isStarting ||
     uploading ||
@@ -488,6 +514,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     (targetRequiresAuth && !authenticated) ||
     targetMissingFlavor ||
     uploadBlockedOffline ||
+    checkpointUploadBlockedOffline ||
     resumeStepError != null;
   const startTooltip = localBlocked
     ? "Another local training is already running"
@@ -497,7 +524,9 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
         ? "Select a hardware flavor"
         : uploadBlockedOffline
           ? "Offline mode is on — the dataset can't be uploaded to the Hub"
-          : undefined;
+          : checkpointUploadBlockedOffline
+            ? "Offline mode is on — the checkpoint can't be uploaded to the Hub"
+            : undefined;
 
   return (
     <div className="w-full">
@@ -547,15 +576,6 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
         // will discard. configToRequest still sends the form's values, keeping
         // the new JobRecord's persisted config truthful about what was asked.
         resumeLocked={resumeSeed != null}
-        // Compute is pinned to the parent's runner on a resume. Cross-runner
-        // resume isn't implemented (F7) and both directions fail badly —
-        // cloud→local dies at startup on a host path that never existed,
-        // local→cloud silently restarts from step 0 wearing a resume label —
-        // so the control is disabled rather than left to fail late. The
-        // backend refuses a mismatch too (JobRegistry.start). The cloud
-        // flavor and job timeout stay editable: those a continuation can
-        // genuinely change.
-        runnerLocked={resumeSeed != null}
       />
       {needsUpload ? (
         <div className="mt-6">
@@ -565,6 +585,19 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
             offline={offline}
             uploading={uploading}
             errorMessage={uploadError}
+          />
+        </div>
+      ) : null}
+      {/* Compute is editable on a resume now (F7), so the user can retarget a
+          local run's continuation at the cloud. That direction moves the
+          parent's checkpoint to the Hub first, which is a disclosure — hence a
+          notice before the click, and a Start button that says "Upload". */}
+      {needsCheckpointUpload && resumeSeed ? (
+        <div className="mt-6">
+          <LocalCheckpointCloudNotice
+            runName={resumeSeed.name}
+            step={resumeSeed.step}
+            offline={offline}
           />
         </div>
       ) : null}
@@ -602,7 +635,9 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
                       TrainPanel and Collect's / Run's Start buttons — these
                       used to flip to Title Case the moment the form opened. */}
                   {resumeSeed
-                    ? "Continue training"
+                    ? needsCheckpointUpload
+                      ? "Upload & continue training"
+                      : "Continue training"
                     : finetuneSeed
                       ? "Start fine-tuning"
                       : needsUpload

--- a/frontend/src/components/training/config/LocalCheckpointCloudNotice.tsx
+++ b/frontend/src/components/training/config/LocalCheckpointCloudNotice.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { AlertTriangle, Lock, UploadCloud, WifiOff } from "lucide-react";
+
+interface LocalCheckpointCloudNoticeProps {
+  /** The run being continued, for a notice that names what moves. */
+  runName: string;
+  /** The checkpoint step the continuation resumes from; null ⇒ the latest. */
+  step: number | null;
+  /** Backend is in HF_HUB_OFFLINE mode: nothing can be uploaded, so this
+   * continuation can't run on the cloud at all. */
+  offline: boolean;
+}
+
+/**
+ * Amber notice shown when a run that trained LOCALLY is being continued on
+ * Hugging Face Cloud. The pod resumes from the Hub, so the parent's checkpoint
+ * — weights AND optimizer state — has to be uploaded first (F7's local→cloud
+ * direction).
+ *
+ * The twin of LocalDatasetCloudNotice, and deliberately louder about privacy
+ * than its dataset sibling: a dataset upload is public by default because a
+ * dataset is a thing people share, while this is an intermediate artifact of
+ * someone's own run that the user never asked to publish. It goes to a private
+ * repo, and the notice says so before the click rather than after — an upload
+ * is a disclosure, so it is never a silent side effect of Continue. The backend
+ * enforces the same rule: it refuses this launch unless the request carries the
+ * consent this notice is asking for.
+ */
+const LocalCheckpointCloudNotice: React.FC<LocalCheckpointCloudNoticeProps> = ({
+  runName,
+  step,
+  offline,
+}) => {
+  const stepLabel =
+    step != null ? `step ${step.toLocaleString()}` : "its latest checkpoint";
+
+  if (offline) {
+    return (
+      <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-100">
+        <div className="flex items-start gap-2">
+          <WifiOff className="w-4 h-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-300" />
+          <div>
+            <div className="font-semibold">
+              This checkpoint is only on this machine
+            </div>
+            <p className="mt-1 text-amber-700/80 dark:text-amber-200/80">
+              Hugging Face Cloud continues from the Hub, but the server is in
+              offline mode (
+              <code className="text-amber-700 dark:text-amber-100">
+                HF_HUB_OFFLINE
+              </code>
+              ), so {stepLabel} of{" "}
+              <span className="font-medium">{runName}</span> can't be uploaded.
+              Switch off offline mode, or continue this run locally.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-100">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-300" />
+        <div className="w-full">
+          <div className="font-semibold">
+            This checkpoint is only on this machine
+          </div>
+          <p className="mt-1 text-amber-700/80 dark:text-amber-200/80">
+            Hugging Face Cloud continues from the Hub, so {stepLabel} of{" "}
+            <span className="font-medium">{runName}</span> — its weights and
+            optimizer state — will be uploaded to a{" "}
+            <span className="font-medium">private</span> repo in your account
+            before the job starts. Continuing the same checkpoint again reuses
+            that upload.
+          </p>
+          <p className="mt-2 flex items-center gap-2 text-amber-700/70 dark:text-amber-200/70">
+            <Lock className="w-4 h-4" />
+            Private to your account — nothing is published.
+          </p>
+          <p className="mt-1 flex items-center gap-2 text-amber-700/70 dark:text-amber-200/70">
+            <UploadCloud className="w-4 h-4" />
+            Use “Upload &amp; continue training” below to upload, then launch.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LocalCheckpointCloudNotice;

--- a/frontend/src/components/training/config/TargetCard.tsx
+++ b/frontend/src/components/training/config/TargetCard.tsx
@@ -15,9 +15,6 @@ interface TargetCardProps extends ConfigComponentProps {
   authenticated: boolean;
   flavors: RunnerFlavor[];
   loading: boolean;
-  /** True on a resume: the runner toggle is pinned to the parent run's runner
-   * and disabled (F7). The hardware flavor below it stays live. */
-  runnerLocked?: boolean;
 }
 
 const formatHourly = (unitCostUsd: number, unitLabel: string): string => {
@@ -35,12 +32,13 @@ const formatFlavorLine = (f: RunnerFlavor): string => {
  * no "Compute target" eyebrow above them, which used to restate the "Run
  * training on" label directly beneath it.
  *
- * Which HARDWARE a run rents is genuinely chosen per launch, so the cloud
- * flavor stays live on a resume. WHICH RUNNER does not: a resume can only
- * continue on the parent's runner (`runnerLocked`, F7), so the toggle is pinned
- * and disabled there. `policy_device` is locked too, for a different reason:
- * the resume branch emits no --policy.device, so lerobot uses whatever the
- * checkpoint's train_config.json recorded. */
+ * Both the runner and the hardware are genuinely chosen per launch, including
+ * on a resume: a continuation may cross runners in either direction (F7 — the
+ * parent's checkpoint is fetched from the Hub for a cloud→local one, and
+ * uploaded to it for a local→cloud one), so the toggle stays live and merely
+ * DEFAULTS to the parent's runner. `policy_device` is still locked on a resume,
+ * for an unrelated reason: the resume branch emits no --policy.device, so
+ * lerobot uses whatever the checkpoint's train_config.json recorded. */
 const TargetCard: React.FC<TargetCardProps> = ({
   config,
   updateConfig,
@@ -48,12 +46,10 @@ const TargetCard: React.FC<TargetCardProps> = ({
   flavors,
   loading,
   resumeLocked,
-  runnerLocked,
 }) => {
   const target = config.target;
 
   const setRunner = (runner: "local" | "hf_cloud") => {
-    if (runnerLocked) return;
     if (runner === target.runner) return;
     if (runner === "local") {
       updateConfig("target", { runner: "local" });
@@ -73,28 +69,21 @@ const TargetCard: React.FC<TargetCardProps> = ({
               key={r}
               type="button"
               onClick={() => setRunner(r)}
-              disabled={runnerLocked}
-              // When pinned, the picked half keeps its fill — the inherited
-              // runner should read as the answer, not as disabled chrome —
-              // while the unpicked half dims and stops inviting a click it
-              // would refuse.
               className={cn(
                 "px-3 py-1.5 transition-colors",
                 target.runner === r
                   ? "bg-primary text-primary-foreground"
-                  : runnerLocked
-                    ? "bg-background text-muted-foreground opacity-50 cursor-not-allowed"
-                    : "bg-background text-muted-foreground hover:text-foreground",
+                  : "bg-background text-muted-foreground hover:text-foreground",
               )}
             >
               {r === "local" ? "Local — your machine" : "Hugging Face Cloud"}
             </button>
           ))}
         </div>
-        {runnerLocked ? (
+        {resumeLocked ? (
           <p className="text-xs text-muted-foreground">
-            Continues on the parent's runner — cross-runner resume isn't
-            supported yet.
+            Defaults to the runner this run started on — switch it to continue
+            somewhere else.
           </p>
         ) : null}
       </div>

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -42,6 +42,12 @@ export interface TrainingRequest {
   // resume from. The backend resolves these into the checkpoint's config_path.
   resume_from_job_id?: string;
   resume_from_step?: number;
+  // Consent for the one resume shape that has to publish something: continuing
+  // a LOCAL run on cloud compute uploads its checkpoint to a private Hub repo
+  // first, because the pod can't read this machine's disk (F7). The backend
+  // refuses that combination unless this is true, so it can never be a silent
+  // side effect of Continue.
+  upload_resume_checkpoint?: boolean;
   // Set by the "Fine-tune" flow: start a fresh run whose weights are init'd
   // from an imported/existing checkpoint. The backend resolves these into
   // policy_pretrained_path (which it also accepts directly).

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -43,7 +43,7 @@ from tqdm.auto import tqdm as _base_tqdm
 from .datasets import CAMERA_FEATURE_PREFIX, read_dataset_features
 from .train import TrainingRequest
 from .utils.config import is_valid_robot_name
-from .utils.hf_auth import shared_hf_api
+from .utils.hf_auth import LOGIN_COMMAND, cached_whoami, hf_hub_offline, shared_hf_api
 from .utils.naming import (
     dedupe_display_names,
     derive_imported_title,
@@ -108,6 +108,16 @@ class JobRecord(BaseModel):
     # Number of checkpoints currently visible (local: filesystem; cloud:
     # Hub repo). Filled in by JobRegistry.list/get; persisted as zero.
     checkpoint_count: int = 0
+    # Where THIS run's on-disk checkpoints were uploaded so a cloud
+    # continuation could read them (local runner only; F7's local→cloud
+    # direction). Distinct from `hf_repo_id`, which is a cloud run's own output
+    # repo: this one is a staging repo MakerMods Lab creates, private, holding
+    # only the steps listed below. Recorded on the PARENT record so a second
+    # cross-runner resume of the same step re-uses the upload instead of
+    # pushing the same GBs again.
+    checkpoints_hub_repo_id: str | None = None
+    # Step dirs known to be present under checkpoints/ in that repo.
+    checkpoints_hub_steps: list[str] = []
 
 
 class JobCheckpoint(BaseModel):
@@ -746,17 +756,48 @@ _HUB_TRAINING_STATE_FILE = "training_state/training_step.json"
 _RUNNER_LABELS = {"local": "Local — your machine", "hf_cloud": "Hugging Face Cloud"}
 
 
-def _resolve_cloud_resume(source: JobRecord, step: int | None) -> tuple[str, str]:
-    """Return (repo_id, step_dir) identifying the Hub checkpoint a cloud run
-    should resume from (`step` = None ⇒ the latest available on the Hub).
+def hub_checkpoint_has_training_state(api, repo_id: str, step_dir: str) -> bool:
+    """Is checkpoints/<step_dir>/ on `repo_id` resumable — i.e. did its
+    training_state/ (optimizer + step counter) reach the Hub?
 
-    The cloud container downloads checkpoints/<step_dir>/ (both pretrained_model/
-    and training_state/) from `repo_id` and hands lerobot the reconstructed
-    output-dir layout, so resume restores the optimizer and step counter — true
-    resume, not a weights-only re-init.
+    Reads the repo's file listing (no bytes), so an unresumable checkpoint can
+    be refused before anything is downloaded or a GPU is rented.
+    `_HUB_TRAINING_STATE_FILE` is the cheapest existence probe for that subtree,
+    the same one the cloud runner's uploader uses.
+
+    Shared by every consumer of a Hub checkpoint's completeness so they agree:
+    the cloud→cloud resolver, the cloud→local resolver, and the re-use check
+    that decides whether a local checkpoint still sits on the Hub from an
+    earlier local→cloud resume.
+
+    Raises ValueError when the listing itself can't be read — an unverifiable
+    checkpoint is refused rather than assumed good (that assumption is MT4's
+    failure mode: the run dies inside the trainer instead of at the form).
+    """
+    try:
+        files = set(api.list_repo_files(repo_id, repo_type="model"))
+    except Exception as exc:
+        raise ValueError(
+            f"Could not read {repo_id!r} to verify its checkpoint at step {step_dir}: {exc}"
+        ) from exc
+    return f"checkpoints/{step_dir}/{_HUB_TRAINING_STATE_FILE}" in files
+
+
+def _resolve_cloud_resume(source: JobRecord, step: int | None) -> tuple[str, str]:
+    """Return (repo_id, step_dir) identifying the Hub checkpoint a run continuing
+    a CLOUD parent resumes from (`step` = None ⇒ the latest available on the Hub).
+
+    Whoever runs the trainer downloads checkpoints/<step_dir>/ (both
+    pretrained_model/ and training_state/) from `repo_id` and hands lerobot the
+    reconstructed output-dir layout, so resume restores the optimizer and step
+    counter — true resume, not a weights-only re-init. That download happens
+    pod-side for a cloud→cloud continuation (the HF Jobs wrapper) and host-side
+    for a cloud→local one (download_hub_resume_checkpoint); this resolver only
+    NAMES the checkpoint, identically for both, which is why the cross-runner
+    direction needs no second resolver.
 
     Raises ValueError (→ HTTP 400) with a user-facing message when the source
-    can't be resumed on the cloud: not a cloud run, no output repo, no
+    can't be resumed from the Hub: not a cloud run, no output repo, no
     checkpoints at all (the run died before its first save), an unknown step, or
     a checkpoint whose training_state/ never made it to the Hub.
     """
@@ -784,14 +825,7 @@ def _resolve_cloud_resume(source: JobRecord, step: int | None) -> tuple[str, str
     if not m:
         raise ValueError(f"Unexpected checkpoint ref for cloud run {source.id!r}: {chosen.ref!r}")
     step_dir = m.group("step_dir")
-    try:
-        files = set(api.list_repo_files(source.hf_repo_id, repo_type="model"))
-    except Exception as exc:
-        raise ValueError(
-            f"Could not read cloud run {source.id!r}'s repo to verify the "
-            f"checkpoint at step {chosen.step}: {exc}"
-        ) from exc
-    if f"checkpoints/{step_dir}/{_HUB_TRAINING_STATE_FILE}" not in files:
+    if not hub_checkpoint_has_training_state(api, source.hf_repo_id, step_dir):
         raise ValueError(
             f"Checkpoint at step {chosen.step} has no optimizer/step state "
             "(training_state/) on the Hub, so it can't be resumed."
@@ -800,8 +834,16 @@ def _resolve_cloud_resume(source: JobRecord, step: int | None) -> tuple[str, str
 
 
 def _resolve_resume_config_path(source: JobRecord, step: int | None) -> str:
-    """Return the train_config.json path lerobot needs to resume `source` from
-    `step` (or its latest checkpoint if step is None).
+    """Return the train_config.json path lerobot needs to resume a LOCAL
+    `source` from `step` (or its latest checkpoint if step is None).
+
+    The path names a real directory on this machine, so it is what a local
+    continuation passes as --config_path. A CLOUD continuation of the same
+    local parent uses it differently: `<path>.parent.parent` is the
+    checkpoints/<step>/ directory whose bytes get uploaded to the Hub (see
+    JobRegistry._resolve_upload_resume), because the pod cannot see this disk.
+    Either way the validation below is the gate, which is why both directions
+    come through here.
 
     Raises ValueError (→ HTTP 400) with a user-facing message when the source
     can't be resumed: not a local run, no checkpoints, unknown step, or a
@@ -809,9 +851,16 @@ def _resolve_resume_config_path(source: JobRecord, step: int | None) -> str:
     needed to continue.
     """
     if source.runner != "local":
+        # Not a claim about lerobot — the pin resumes from a Hub repo id just
+        # fine (TrainPipelineConfig._resolve_resume_checkpoint downloads the
+        # LATEST checkpoint of `--config_path=<repo id>`). It's a claim about
+        # THIS function: a cloud parent's checkpoints are on the Hub, so it is
+        # _resolve_cloud_resume that names them, and the chosen step is
+        # materialized explicitly rather than left to lerobot's latest-only
+        # rule (which would silently ignore the step the user picked).
         raise ValueError(
-            "Only local training runs can be resumed — lerobot doesn't support "
-            "resuming from the Hub."
+            "This resume path is for local runs; a cloud run's checkpoints live "
+            "on the Hub and are resolved from there instead."
         )
     checkpoints = _list_local_checkpoints(source.output_dir)
     if not checkpoints:
@@ -1114,7 +1163,7 @@ class _DownloadProgressLogger:
             self._emit(message)
 
 
-def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None) -> str:
+def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None, with_training_state: bool = False) -> str:
     """Download the model a hub checkpoint ref names; return its local dir.
 
     THE resolution rule for a hub ref, shared by every consumer so a ref means
@@ -1129,6 +1178,13 @@ def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None) -> str:
       * 'repo@root' → the whole repo IS the pretrained_model; ``checkpoints/**``
         and ``training_state/**`` are excluded because neither is needed to load
         the policy and both can be multi-GB.
+
+    ``with_training_state`` widens the step-ref case to the WHOLE
+    checkpoints/<step_dir>/ tree — the optimizer/rng/step state a RESUME needs
+    and a deploy or fine-tune never reads (hundreds of MB per step, so it stays
+    opt-in). The return value is unchanged (still the ``pretrained_model/``
+    dir); its parent is then the reconstructed checkpoint dir. See
+    download_hub_resume_checkpoint, the only caller that wants it.
 
     ``tqdm_class`` is forwarded to snapshot_download for byte-progress reporting
     (the inference page's download bar). This function itself has no session or
@@ -1150,10 +1206,11 @@ def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None) -> str:
     m = _HUB_CKPT_REF_RE.match(ref)
     if m:
         repo_id, step_dir = m.group("repo"), m.group("step_dir")
+        subtree = "" if with_training_state else f"/{_HUB_CKPT_SUBDIR}"
         local_root = snapshot_download(
             repo_id=repo_id,
             repo_type="model",
-            allow_patterns=[f"checkpoints/{step_dir}/{_HUB_CKPT_SUBDIR}/*"],
+            allow_patterns=[f"checkpoints/{step_dir}{subtree}/*"],
             **dl_kwargs,
         )
         return str(Path(local_root) / "checkpoints" / step_dir / _HUB_CKPT_SUBDIR)
@@ -1166,6 +1223,97 @@ def download_hub_checkpoint_ref(ref: str, *, tqdm_class=None) -> str:
             **dl_kwargs,
         )
     raise ValueError(f"Unrecognised policy ref: {ref!r}")
+
+
+def download_hub_resume_checkpoint(ref: str, *, tqdm_class=None) -> str:
+    """Materialize a Hub checkpoint HERE so a local trainer can resume from it,
+    and return the --config_path lerobot wants (its train_config.json).
+
+    The host-side port of the HF Jobs wrapper's resume block (F7, cloud→local):
+    pull checkpoints/<step_dir>/ whole — pretrained_model/ AND training_state/ —
+    so lerobot finds the optimizer, scheduler, rng and step counter where its own
+    resume path looks for them. lerobot reads `config_path.parent.parent` as the
+    checkpoint dir, which the snapshot's own layout already satisfies, so unlike
+    the wrapper this does NOT copy the tree into the run's output dir:
+
+      * the trainer only READS the resumed checkpoint (lerobot_train's
+        load_training_state; update_last_checkpoint runs on the checkpoints it
+        WRITES, under --output_dir), so a shared-cache path is enough;
+      * the weights half then stays in the shared HF cache where a later deploy
+        of the same checkpoint reuses it instead of pulling it again;
+      * and the child's own checkpoints/ tree stays free of a step it did not
+        produce.
+
+    Refuses (ValueError → the job's error_message) a checkpoint that arrives
+    incomplete, rather than letting the trainer die on a missing training_state/
+    halfway through startup — MT4's failure mode. The Hub listing is checked
+    before this runs (hub_checkpoint_has_training_state); this second check is on
+    the bytes that actually landed.
+
+    Downloads GBs: never call it while holding a lock others need.
+    """
+    pretrained_dir = Path(download_hub_checkpoint_ref(ref, tqdm_class=tqdm_class, with_training_state=True))
+    checkpoint_dir = pretrained_dir.parent
+    train_config = pretrained_dir / _TRAIN_CONFIG_NAME
+    missing = [
+        name
+        for name, path in (
+            (_TRAIN_CONFIG_NAME, train_config),
+            (_HUB_TRAINING_STATE_FILE, checkpoint_dir / _HUB_TRAINING_STATE_FILE),
+        )
+        if not path.is_file()
+    ]
+    if missing:
+        raise ValueError(
+            f"The downloaded checkpoint {hub_ref_step_label(ref)} from "
+            f"{hub_ref_repo_id(ref)} is incomplete — missing {', '.join(missing)}. "
+            "Resume an earlier checkpoint, or fine-tune from its weights instead."
+        )
+    return str(train_config)
+
+
+def upload_local_checkpoint(checkpoint_dir: Path, repo_id: str, step_dir: str, *, api=None) -> None:
+    """Push one local checkpoints/<step_dir>/ tree to `repo_id` on the Hub.
+
+    F7's local→cloud direction: a pod cannot see this machine's disk, so the
+    parent's checkpoint has to exist on the Hub before the continuation is
+    submitted. The whole tree goes up (pretrained_model/ AND training_state/) —
+    a resume without the optimizer state is a fine-tune wearing a resume label.
+
+    PRIVATE at creation, deliberately and unlike the dataset uploader: this is a
+    by-product of clicking Continue, not a model the user chose to publish, and
+    `exist_ok` never downgrades an existing repo's visibility. The caller is
+    responsible for having asked first (see JobRegistry's consent gate) — this
+    function only moves the bytes.
+
+    Laid out to match what _list_hub_checkpoints/_resolve_cloud_resume expect to
+    find, so the uploaded step reads back as an ordinary Hub checkpoint.
+    """
+    api = api or shared_hf_api()
+    api.create_repo(repo_id=repo_id, repo_type="model", private=True, exist_ok=True)
+    api.upload_folder(
+        repo_id=repo_id,
+        repo_type="model",
+        folder_path=str(checkpoint_dir),
+        path_in_repo=f"checkpoints/{step_dir}",
+        commit_message=f"checkpoint {step_dir} (uploaded for a cloud continuation)",
+    )
+
+
+def checkpoints_staging_repo_id(username: str, job_id: str) -> str:
+    """The Hub repo a LOCAL run's checkpoints are staged in for a cloud resume.
+
+    Follows hf_cloud's own minting convention for a run's repo
+    (`f"{username}/{job_id}"`) plus a `_checkpoints` suffix, which keeps two
+    things true that matter:
+
+      * it can never collide with the output repo of a cloud run of the same
+        name, so a staging upload can't land in a repo full of someone else's
+        lineage; and
+      * the continuation it feeds pushes to its OWN output repo rather than back
+        into this one, so parent and child checkpoints stay distinguishable.
+    """
+    return f"{username}/{job_id}_checkpoints"
 
 
 def needs_local_materialization(pretrained_path: str) -> bool:
@@ -1963,7 +2111,17 @@ class JobRegistry:
                 source, config.finetune_from_step
             )
 
+        # The three things that can still have to MOVE before a trainer starts,
+        # each resolved (and refused) synchronously below but carried out in the
+        # preparing thread because each is potentially GBs over the network:
+        #   * a local fine-tune's base checkpoint, downloaded here;
+        #   * a cloud parent's checkpoint, downloaded here for a local resume;
+        #   * a local parent's checkpoint, uploaded to the Hub for a cloud one.
+        # At most one is ever set: fine-tune and resume are mutually exclusive
+        # (refused above), and a resume moves bytes in one direction only.
         deferred_hub_ref: str | None = None
+        deferred_resume_ref: str | None = None
+        deferred_resume_upload: tuple[Path, str, str] | None = None
         if config.policy_pretrained_path and not config.resume:
             # Deliberately BEFORE the materialization: this reads only the
             # checkpoint's config.json (a few KB), so a contradicting pair is
@@ -2025,41 +2183,71 @@ class JobRegistry:
                             "continuation would train at the schedule's floor. Fine-tune from "
                             "its final checkpoint instead."
                         )
-                    # A resume continues on the PARENT'S runner, full stop.
-                    # Neither cross direction works today (F7): cloud→local
-                    # points --config_path at a host directory that only ever
-                    # existed inside the pod, so the run dies at startup; and
-                    # local→cloud is worse — the pod has no access to the host
-                    # checkpoint, so it silently restarts from step 0 while the
-                    # record calls itself a resume. The form pins the Compute
-                    # control on a resume; this is the defense-in-depth half,
-                    # for a direct API call that flips it anyway.
+                    # A resume may continue on EITHER runner (F7). What changes
+                    # across the four combinations is only where the parent's
+                    # checkpoint has to end up before the trainer can read it —
+                    # the pod cannot see this disk, and this disk does not have
+                    # the pod's. Each branch below either points the trainer at
+                    # bytes that already exist where it runs, or records the one
+                    # move that has to happen first. What NEVER happens is a
+                    # launch that couldn't find the checkpoint: every branch
+                    # refuses (or fails the job) instead, because a resume that
+                    # quietly starts at step 0 while the record calls itself a
+                    # continuation is MT42, the worst outcome available here.
                     #
                     # Only local/hf_cloud parents reach here: an imported record
                     # is created with state="done", so the refusal above already
                     # took it (imported models are fine-tune sources, never
                     # resume sources).
-                    if source.runner != target.runner:
-                        raise ValueError(
-                            "Cross-runner resume isn't supported yet — this run continues on "
-                            f"{_RUNNER_LABELS.get(source.runner, source.runner)}. (F7)"
-                        )
                     if source.runner == "hf_cloud":
-                        # An HF Job is immutable once ended: resuming a cloud run
-                        # launches a NEW cloud job that continues from the parent's
-                        # Hub checkpoint. Record the source repo + step dir; the
-                        # HfCloudJobRunner turns them into an in-container download
-                        # + reconstruct + --config_path. The dataset-on-Hub guard
-                        # (target.runner == hf_cloud above) still applies, so a
-                        # run whose dataset vanished fails the same way a fresh
-                        # cloud run would.
+                        # The parent's checkpoints are on the Hub. Naming the
+                        # chosen one is the same job for both targets, and
+                        # _resolve_cloud_resume refuses an incomplete or absent
+                        # one here — synchronously, as a 400, before any record
+                        # or GPU exists.
                         repo_id, step_dir = _resolve_cloud_resume(source, config.resume_from_step)
-                        config.resume_from_hub_repo = repo_id
-                        config.resume_from_hub_step = step_dir
-                    else:
+                        if target.runner == "hf_cloud":
+                            # An HF Job is immutable once ended: resuming a cloud
+                            # run launches a NEW cloud job that continues from the
+                            # parent's Hub checkpoint. The HfCloudJobRunner turns
+                            # these two into an in-container download +
+                            # reconstruct + --config_path. The dataset-on-Hub
+                            # guard (target.runner == hf_cloud above) still
+                            # applies, so a run whose dataset vanished fails the
+                            # same way a fresh cloud run would.
+                            config.resume_from_hub_repo = repo_id
+                            config.resume_from_hub_step = step_dir
+                        else:
+                            # cloud → Local: the same download the wrapper does
+                            # pod-side, done here instead — but off-request (GBs),
+                            # so config_path is filled in by the preparing thread.
+                            # `resume_from_step` is pinned to the resolved step so
+                            # the record's progress is rebased from the inherited
+                            # step immediately, rather than reading 0 until the
+                            # download finishes and the first tqdm frame lands
+                            # (see _initial_metrics / _resume_start_step).
+                            deferred_resume_ref = f"{repo_id}@checkpoints/{step_dir}"
+                            config.resume_from_step = int(step_dir)
+                    elif target.runner == "local":
                         config.config_path = _resolve_resume_config_path(
                             source, config.resume_from_step
                         )
+                    else:
+                        # local → Cloud: the parent's checkpoint exists only on
+                        # this machine, so it must reach the Hub before the pod
+                        # starts. Resolve + validate it here (the same gate a
+                        # local→local resume passes), then either reuse an
+                        # upload a previous continuation already made or defer a
+                        # fresh, consented one.
+                        (
+                            deferred_resume_upload,
+                            hub_repo,
+                            hub_step,
+                        ) = self._resolve_upload_resume(source, config)
+                        config.resume_from_hub_repo = hub_repo
+                        config.resume_from_hub_step = hub_step
+                        config.resume_from_uploaded_checkpoint = True
+                        config.resume_from_step = int(hub_step)
                 elif not config.config_path:
                     raise ValueError(
                         "Resume is on but no source checkpoint was selected. Use "
@@ -2096,13 +2284,17 @@ class JobRegistry:
 
             log_path = _job_log_path(self._output_root, job_id)
 
-            if deferred_hub_ref is not None:
-                # The base checkpoint still has to be downloaded (GBs, minutes).
-                # Hand the caller its job id NOW — the record exists, is
-                # "running", and has a log file — and do the download in a
-                # thread, which then starts the real trainer. The monitor opens
-                # immediately and tails the download instead of the request
-                # hanging with nothing on screen.
+            deferred = (
+                deferred_hub_ref is not None
+                or deferred_resume_ref is not None
+                or deferred_resume_upload is not None
+            )
+            if deferred:
+                # Something still has to move (GBs, minutes). Hand the caller its
+                # job id NOW — the record exists, is "running", and has a log
+                # file — and do the transfer in a thread, which then starts the
+                # real trainer. The monitor opens immediately and tails the
+                # transfer instead of the request hanging with nothing on screen.
                 #
                 # No new JobState for this window: the job is "running" from the
                 # user's point of view (they asked for a run and one is being
@@ -2113,14 +2305,33 @@ class JobRegistry:
                 # and Stop find a runner from the first request onwards.
                 prep = PreparingJobRunner(log_file_path=log_path)
                 self._runners[job_id] = prep
-                prep.emit(
-                    f"Preparing fine-tune: downloading base checkpoint "
-                    f"{hub_ref_step_label(deferred_hub_ref)} from "
-                    f"{hub_ref_repo_id(deferred_hub_ref)}…"
-                )
+                if deferred_hub_ref is not None:
+                    prep.emit(
+                        f"Preparing fine-tune: downloading base checkpoint "
+                        f"{hub_ref_step_label(deferred_hub_ref)} from "
+                        f"{hub_ref_repo_id(deferred_hub_ref)}…"
+                    )
+                    thread_target: Callable[..., None] = self._materialize_then_start
+                    thread_args: tuple = (job_id, deferred_hub_ref, lerobot_output_dir, prep)
+                elif deferred_resume_ref is not None:
+                    prep.emit(
+                        f"Preparing continuation: downloading checkpoint "
+                        f"{hub_ref_step_label(deferred_resume_ref)} from "
+                        f"{hub_ref_repo_id(deferred_resume_ref)} to this machine…"
+                    )
+                    thread_target = self._download_resume_then_start
+                    thread_args = (job_id, deferred_resume_ref, lerobot_output_dir, prep)
+                else:
+                    ckpt_dir, upload_repo, upload_step = deferred_resume_upload
+                    prep.emit(
+                        f"Preparing continuation: uploading checkpoint {upload_step} "
+                        f"to the private repo {upload_repo} so the cloud job can read it…"
+                    )
+                    thread_target = self._upload_resume_then_start
+                    thread_args = (job_id, ckpt_dir, upload_repo, upload_step, target, prep)
                 thread = threading.Thread(
-                    target=self._materialize_then_start,
-                    args=(job_id, deferred_hub_ref, lerobot_output_dir, prep),
+                    target=thread_target,
+                    args=thread_args,
                     name=f"job-{job_id}-prepare",
                     daemon=True,
                 )
@@ -2200,10 +2411,176 @@ class JobRegistry:
             )
         except Exception as exc:
             logger.exception("Base-checkpoint download failed for job %s", job_id)
-            message = str(exc)
-            prep.emit(message)
-            self._finalize_prepare(job_id, "failed", message)
+            self._fail_prepare(job_id, prep, str(exc))
             return
+
+        self._start_after_prepare(
+            job_id,
+            output_dir,
+            prep,
+            JobTarget(runner="local"),
+            lambda config: setattr(config, "policy_pretrained_path", local_path),
+            "Base checkpoint ready — starting the trainer.",
+        )
+
+    def _download_resume_then_start(
+        self,
+        job_id: str,
+        ref: str,
+        output_dir: str,
+        prep: PreparingJobRunner,
+    ) -> None:
+        """Bring a CLOUD parent's checkpoint to this machine, then resume locally.
+
+        F7's cloud→local direction, and the twin of _materialize_then_start: same
+        thread, same failure vocabulary, different cargo — the whole
+        checkpoints/<step>/ tree rather than weights alone, because a resume
+        needs the optimizer state (see download_hub_resume_checkpoint).
+
+        The step was already chosen and verified against the Hub's file listing
+        before the record existed, so an unresumable selection is still a
+        synchronous 400. What is left here can only fail on the transfer itself,
+        which belongs on the record: a failed or incomplete download finalises
+        the job `failed` with the message naming the checkpoint, and NO trainer
+        is spawned. That is the MT4 lesson — the old behaviour handed lerobot a
+        --config_path that never existed and let it die at startup.
+        """
+        reporter = _DownloadProgressLogger(prep.emit, hub_ref_step_label(ref))
+        try:
+            config_path = download_hub_resume_checkpoint(
+                ref, tqdm_class=make_snapshot_progress_tqdm(reporter)
+            )
+        except Exception as exc:
+            logger.exception("Resume-checkpoint download failed for job %s", job_id)
+            self._fail_prepare(
+                job_id,
+                prep,
+                f"Could not download the checkpoint {hub_ref_step_label(ref)} from "
+                f"{hub_ref_repo_id(ref)} to continue from: {exc}",
+            )
+            return
+
+        self._start_after_prepare(
+            job_id,
+            output_dir,
+            prep,
+            JobTarget(runner="local"),
+            lambda config: setattr(config, "config_path", config_path),
+            "Checkpoint ready — starting the trainer.",
+        )
+
+    def _upload_resume_then_start(
+        self,
+        job_id: str,
+        checkpoint_dir: Path,
+        repo_id: str,
+        step_dir: str,
+        target: JobTarget,
+        prep: PreparingJobRunner,
+    ) -> None:
+        """Push a LOCAL parent's checkpoint to the Hub, then resume on the cloud.
+
+        F7's local→cloud direction. The pod downloads its resume checkpoint from
+        the Hub, so these bytes have to be there before the job is submitted —
+        and the request already carries the user's explicit consent for this
+        upload (see _resolve_upload_resume).
+
+        The upload is re-verified from the Hub's own file listing before anything
+        is submitted, and the job is finalised `failed` if it can't be confirmed.
+        That is the MT42 guarantee stated as code: a run recorded as a resume
+        either continues from the checkpoint it names or does not start at all —
+        it never becomes a fresh run that quietly begins at step 0 on rented
+        hardware.
+
+        On success the upload is recorded on the PARENT's record, so continuing
+        the same step again reuses it instead of pushing the same GBs twice.
+        """
+        try:
+            prep.emit(f"Uploading {step_dir} from {checkpoint_dir}…")
+            upload_local_checkpoint(checkpoint_dir, repo_id, step_dir)
+            if not hub_checkpoint_has_training_state(shared_hf_api(), repo_id, step_dir):
+                raise ValueError(
+                    f"the upload finished but {repo_id} is still missing {_HUB_TRAINING_STATE_FILE}"
+                )
+        except Exception as exc:
+            logger.exception("Resume-checkpoint upload failed for job %s", job_id)
+            self._fail_prepare(
+                job_id,
+                prep,
+                f"Could not upload the checkpoint at step {step_dir} to {repo_id}, "
+                f"so this continuation cannot run on the cloud: {exc}",
+            )
+            return
+
+        self._remember_uploaded_checkpoint(job_id, repo_id, step_dir)
+        self._start_after_prepare(
+            job_id,
+            # A cloud runner ignores the host output dir (its pod writes to a
+            # container path); pass it anyway so the callers stay identical.
+            str(_job_dir(self._output_root, job_id) / "run"),
+            prep,
+            target,
+            None,
+            f"Checkpoint {step_dir} is on the Hub — submitting the cloud job.",
+        )
+
+    def _remember_uploaded_checkpoint(self, job_id: str, repo_id: str, step_dir: str) -> None:
+        """Record on the PARENT run where its checkpoint was uploaded.
+
+        Keyed off the child's `resume_from_job_id` rather than passed in, so the
+        note always lands on the record whose bytes were actually pushed. A
+        missing parent (deleted mid-upload) is not an error: the upload still
+        happened and the child still runs; only the re-use shortcut is lost."""
+        with self._lock:
+            child = self._records.get(job_id)
+            parent_id = child.config.resume_from_job_id if child else None
+            parent = self._records.get(parent_id) if parent_id else None
+            if parent is None:
+                return
+            parent.checkpoints_hub_repo_id = repo_id
+            if step_dir not in parent.checkpoints_hub_steps:
+                parent.checkpoints_hub_steps = [*parent.checkpoints_hub_steps, step_dir]
+            self._persist(parent, force=True)
+
+    def _fail_prepare(self, job_id: str, prep: PreparingJobRunner, message: str) -> None:
+        """Finalise a preparing job whose transfer failed, with the message on
+        both the log and the record — the wording that used to reach the user as
+        an HTTP 400 back when the transfer happened inside the request."""
+        prep.emit(message)
+        self._finalize_prepare(job_id, "failed", message)
+
+    def _start_after_prepare(
+        self,
+        job_id: str,
+        output_dir: str,
+        prep: PreparingJobRunner,
+        target: JobTarget,
+        apply_to_config: Callable[[TrainingRequest], None] | None,
+        ready_message: str,
+    ) -> None:
+        """The locked handoff every deferred preparation ends with: apply what
+        the transfer produced to the job's config, spawn the real runner, and
+        replace the PreparingJobRunner with it.
+
+        Shared by all three preparations so the stop/delete/spawn-failure
+        semantics can't drift between them. `apply_to_config` is whatever the
+        slow step learned (a materialized path, a config_path) and is applied
+        under the lock, immediately before the runner reads the config; None when
+        the transfer taught the config nothing new (the upload path resolved its
+        repo + step up front, so the record described the run correctly from the
+        moment it was created).
+
+        A Stop pressed while bytes were moving takes effect HERE — neither a
+        huggingface_hub download nor an upload can be interrupted mid-flight, so
+        the cancel is read after the transfer returns and before anything is
+        spawned. The bytes are already moved (and cached for the next attempt);
+        what the user gets is a run that never starts training, which is what
+        they asked for. Reading `_stop_requested` under the same lock
+        JobRegistry.stop records it in — with the spawn and runner handoff in the
+        same critical section — is what keeps a stop from being missed (spawning
+        a trainer nobody will signal) or landing on an already-replaced runner.
+        """
+        from .runners.hf_cloud import HfCloudJobRunner  # lazy import to avoid circular import
 
         notify = False
         try:
@@ -2221,12 +2598,14 @@ class JobRegistry:
                     # moved. Nothing to start, nothing to report.
                     self._runners.pop(job_id, None)
                     return
-                prep.emit("Base checkpoint ready — starting the trainer.")
-                record.config.policy_pretrained_path = local_path
-                runner = LocalJobRunner(
-                    record.metrics,
-                    log_file_path=_job_log_path(self._output_root, job_id),
-                )
+                prep.emit(ready_message)
+                if apply_to_config is not None:
+                    apply_to_config(record.config)
+                log_path = _job_log_path(self._output_root, job_id)
+                if target.runner == "local":
+                    runner = LocalJobRunner(record.metrics, log_file_path=log_path)
+                else:
+                    runner = HfCloudJobRunner(record.metrics, log_path, target.flavor)
                 try:
                     runner.start(job_id, record.config, output_dir)
                 except Exception as exc:
@@ -2236,13 +2615,85 @@ class JobRegistry:
                     )
                     notify = True
                     return
-                record.process_pid = runner.pid()
+                if target.runner == "local":
+                    record.process_pid = runner.pid()
+                else:
+                    record.hf_job_id = runner.hf_job_id()
+                    record.hf_job_url = runner.hf_job_url()
+                    # config was mutated by HfCloudJobRunner.start to set
+                    # policy_repo_id; mirror it onto the record for the UI.
+                    record.hf_repo_id = record.config.policy_repo_id
                 self._runners[job_id] = runner
                 self._persist(record, force=True)
                 notify = True
         finally:
             if notify:
                 self._notify_change()
+
+    def _resolve_upload_resume(
+        self, source: JobRecord, config: TrainingRequest
+    ) -> tuple[tuple[Path, str, str] | None, str, str]:
+        """Plan the Hub side of a LOCAL parent → CLOUD continuation.
+
+        Returns (pending_upload, repo_id, step_dir): `pending_upload` is
+        (checkpoint dir, repo id, step dir) when bytes still have to be pushed,
+        or None when a previous continuation already pushed this exact step and
+        the Hub still has it — re-resuming a step must not re-upload GBs.
+
+        Called with the registry lock HELD (from the resume block in `start`),
+        like the cloud→cloud resolver beside it — both read the Hub, and both do
+        so before any record exists so a bad selection leaves nothing behind.
+
+        Every refusal below is a ValueError (→ HTTP 400) raised before a record
+        exists, because each one describes something the user has to change:
+          * the checkpoint isn't resumable at all (delegated wholesale to
+            _resolve_resume_config_path, so local→local and local→cloud can't
+            disagree about what "resumable" means);
+          * the upload wasn't consented to — an upload is a disclosure, so it is
+            never a silent side effect of clicking Continue;
+          * there is no Hub identity to upload as, or the server is offline.
+        """
+        # The same validation a local→local resume passes: complete checkpoint,
+        # known step, real training_state/. Its train_config.json is
+        # <dir>/checkpoints/<step>/pretrained_model/train_config.json, so the
+        # checkpoint dir to upload — and the step dir naming it — come straight
+        # back out of the path.
+        train_config = Path(_resolve_resume_config_path(source, config.resume_from_step))
+        checkpoint_dir = train_config.parent.parent
+        step_dir = checkpoint_dir.name
+
+        # Already on the Hub from an earlier continuation? Trust the record only
+        # as far as the Hub confirms it: a deleted repo (or a half-finished push)
+        # must produce a fresh upload, not a job that dies looking for bytes.
+        if source.checkpoints_hub_repo_id and step_dir in source.checkpoints_hub_steps:
+            with contextlib.suppress(Exception):
+                if hub_checkpoint_has_training_state(
+                    shared_hf_api(), source.checkpoints_hub_repo_id, step_dir
+                ):
+                    return None, source.checkpoints_hub_repo_id, step_dir
+
+        if not config.upload_resume_checkpoint:
+            raise ValueError(
+                f"Continuing this run on {_RUNNER_LABELS['hf_cloud']} needs its "
+                f"checkpoint at step {int(step_dir)} on the Hub, and it is only on "
+                "this machine. Confirm the upload in the training form (it goes to "
+                "a private repo), or continue the run locally instead."
+            )
+        if hf_hub_offline():
+            raise ValueError(
+                "Offline mode is on, so this run's checkpoint can't be uploaded to "
+                "the Hub — continue it locally, or switch offline mode off."
+            )
+        whoami = cached_whoami()
+        username = (whoami or {}).get("name")
+        if not username:
+            raise ValueError(
+                "Continuing a local run on the cloud uploads its checkpoint to your "
+                f"Hugging Face account, so you have to be signed in. Run '{LOGIN_COMMAND}' "
+                "or paste a token in the app, then try again."
+            )
+        repo_id = checkpoints_staging_repo_id(username, source.id)
+        return (checkpoint_dir, repo_id, step_dir), repo_id, step_dir
 
     def _finalize_prepare(self, job_id: str, state: JobState, error_message: str) -> None:
         """Lock-taking wrapper around _finalize_prepare_locked."""

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -206,6 +206,19 @@ def localize_config_for_cloud(config: TrainingRequest, flavor: str) -> None:
             "source checkpoint's train_config.json lives on this machine, not in "
             "the container. Resume a cloud run from its Hub output instead."
         )
+    # MT42, stated as an invariant rather than a hope: a cloud run that CALLS
+    # itself a resume must name the Hub checkpoint it continues from. Without
+    # one, build_training_command falls through to its fresh-run branch and the
+    # pod starts a brand-new run at step 0 while every UI surface reports a
+    # continuation. Refuse instead — the registry only reaches this point after
+    # the checkpoint is confirmed on the Hub (its own resume resolvers), so this
+    # can only fire for a request that bypassed them.
+    if config.resume and not config.resume_from_hub_repo:
+        raise ValueError(
+            "This cloud run is marked as a continuation but names no Hub checkpoint "
+            "to continue from, so it would silently start over at step 0. Resume "
+            "from a run's checkpoint via Continue rather than setting resume by hand."
+        )
     # A fine-tune base is allowed to be a HUB ref — either a bare repo id (whose
     # root lerobot resolves itself) or the step-suffixed 'repo@checkpoints/<step>'
     # form, which the wrapper materializes pod-side before launching the trainer
@@ -655,12 +668,24 @@ class HfCloudJobRunner:
         # The mutated config is what gets persisted in JobRecord.config, so
         # the historical record reflects what actually ran.
         config.policy_push_to_hub = True
-        # Resume continues the SAME output repo as the parent run so the whole
-        # lineage lives in one place; a fresh run gets its own repo named after
-        # its unique job id slug (e.g. "act_dataset_2026-05-04_10-22-03").
+        # A fresh run gets its own repo named after its unique job id slug (e.g.
+        # "act_dataset_2026-05-04_10-22-03"); a continuation picks between that
+        # and the parent's repo — see the branch below.
         resume_directive: str | None = None
         if config.resume and config.resume_from_hub_repo:
-            config.policy_repo_id = config.resume_from_hub_repo
+            # Where this run PUBLISHES is not always where it resumes FROM. A
+            # cloud→cloud continuation keeps the parent's output repo so the
+            # lineage lives in one place. A local→cloud one (F7) resumes from a
+            # private staging repo that exists only to carry the local parent's
+            # uploaded checkpoint, so it publishes to its own repo instead —
+            # otherwise the staging repo would accumulate the child's
+            # checkpoints too and parent and child would again be
+            # indistinguishable inside one tree.
+            config.policy_repo_id = (
+                f"{username}/{job_id}"
+                if config.resume_from_uploaded_checkpoint
+                else config.resume_from_hub_repo
+            )
             step_dir = config.resume_from_hub_step or "last"
             # The wrapper downloads checkpoints/<step_dir>/ into this exact path;
             # lerobot's resume reads config_path.parent.parent as the checkpoint

--- a/makermodslab/train.py
+++ b/makermodslab/train.py
@@ -200,6 +200,22 @@ class TrainingRequest(BaseModel):
     # resume source is a cloud run; never set for local runs.
     resume_from_hub_repo: str | None = None
     resume_from_hub_step: str | None = None
+    # Cross-runner resume, local parent → cloud target (F7). The parent's
+    # checkpoint is on THIS machine, so it has to be uploaded to the Hub before
+    # a pod can read it. That upload is a deliberate act, not a side effect of
+    # clicking Continue: the client must say yes here, and the registry refuses
+    # the launch otherwise (naming the control that grants it). Ignored on every
+    # other path — nothing is uploaded when the checkpoint is already on the Hub,
+    # including a re-resume of a step a previous continuation already pushed.
+    upload_resume_checkpoint: bool = False
+    # Set by the registry (never by a client) when `resume_from_hub_repo` is the
+    # staging repo above rather than a cloud parent's own output repo. It tells
+    # the cloud runner not to adopt the source repo as this run's OUTPUT repo:
+    # a cloud→cloud continuation shares its parent's repo on purpose (one
+    # lineage, one place), but a local→cloud one must not publish into a staging
+    # repo that exists only to carry the parent's bytes. Defaults False so
+    # configs persisted before F7 — all of them cloud→cloud — keep their meaning.
+    resume_from_uploaded_checkpoint: bool = False
 
     # Weights & Biases
     wandb_enable: bool = False

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1350,15 +1350,23 @@ def test_start_leaves_a_fresh_records_progress_at_zero(tmp_path) -> None:
 # decision — no per-policy exceptions.
 
 
-def _hub_checkpoint_files(step_dir: str) -> list[str]:
-    """The repo paths a complete cloud checkpoint publishes."""
-    return [
+def _hub_checkpoint_files(step_dir: str, *, with_state: bool = True) -> list[str]:
+    """The repo paths a complete cloud checkpoint publishes.
+
+    `with_state=False` is the weights-only shape — an interrupted upload, or a
+    staging repo that lost its training_state/ — which is exactly what every
+    resume path has to refuse."""
+    files = [
         f"checkpoints/{step_dir}/pretrained_model/config.json",
         f"checkpoints/{step_dir}/pretrained_model/model.safetensors",
         f"checkpoints/{step_dir}/pretrained_model/train_config.json",
-        f"checkpoints/{step_dir}/training_state/training_step.json",
-        f"checkpoints/{step_dir}/training_state/optimizer_state.safetensors",
     ]
+    if with_state:
+        files += [
+            f"checkpoints/{step_dir}/training_state/training_step.json",
+            f"checkpoints/{step_dir}/training_state/optimizer_state.safetensors",
+        ]
+    return files
 
 
 def _resumable_source(tmp_path, state: str, *, job_id: str = "src", steps: int = 200):
@@ -1458,12 +1466,16 @@ def test_start_still_resumes_a_run_that_stopped_short(tmp_path, state) -> None:
     assert "checkpoints/100" in record.config.config_path
 
 
-# ── …and only on the runner it stopped on ────────────────────────────────────
-# Cross-runner resume isn't implemented (F7) and both directions fail badly:
-# cloud→local hands lerobot a --config_path that only ever existed inside the
-# pod (MT4), local→cloud silently restarts from step 0 while recording itself as
-# a resume (MT42). The form pins the Compute control; these cover the
-# defense-in-depth half, which catches a direct API call that flips it anyway.
+# ── …and on either runner, once the checkpoint can get there (F7) ───────────
+# A continuation may cross runners in both directions now. What each direction
+# has to do first is move the parent's checkpoint to wherever the trainer will
+# run: DOWN from the Hub for a cloud parent continued locally (MT4 — the old
+# code pointed --config_path at a pod path that never existed here), and UP to
+# the Hub for a local parent continued on the cloud (MT42 — the old code let the
+# pod start a fresh run at step 0 while the record called itself a resume).
+# Both transfers happen off-request in the preparing thread, so these join it
+# the way the fine-tune materialization tests do.
+#
 # Reuses the section's helpers above; a cloud parent is the same record with its
 # runner/repo flipped, exactly as the done-source pair does it.
 
@@ -1475,51 +1487,458 @@ def _cloud_parent(reg, *, job_id: str = "src"):
     return reg
 
 
-def test_start_refuses_a_local_parent_resumed_on_the_cloud(tmp_path, monkeypatch) -> None:
-    """local parent → Cloud target (MT42). The refusal must name the parent's
-    runner, and must leave no record behind."""
+def _fake_resume_snapshot(tmp_path, seen: dict, *, complete: bool = True):
+    """A snapshot_download stand-in that lays down a real checkpoint tree.
+
+    Mirrors what the Hub returns for `allow_patterns=['checkpoints/<step>/*']`:
+    a snapshot root holding the whole step directory, zero-padded the way the
+    Hub names it. `complete=False` is the interrupted-upload shape — weights but
+    no training_state/ — which a resume must refuse rather than hand to the
+    trainer."""
+
+    def _download(**kwargs):
+        seen.update(kwargs)
+        root = tmp_path / "snapshot"
+        ck = root / "checkpoints" / "000100"
+        pretrained = ck / "pretrained_model"
+        pretrained.mkdir(parents=True, exist_ok=True)
+        (pretrained / "config.json").write_text("{}")
+        (pretrained / "train_config.json").write_text("{}")
+        (ck / "training_state").mkdir(exist_ok=True)
+        if complete:
+            (ck / "training_state" / "training_step.json").write_text("{}")
+        return str(root)
+
+    return _download
+
+
+class _FakeUploadApi:
+    """HfApi stand-in for the upload path: records the calls, moves no bytes.
+
+    `list_repo_files` answers from whatever has been "uploaded" so far, so the
+    post-upload verification in _upload_resume_then_start exercises the real
+    completeness rule instead of a stub that always says yes."""
+
+    def __init__(self, files: list[str] | None = None) -> None:
+        self._files = list(files or [])
+        self.created: list[dict] = []
+        self.uploaded: list[dict] = []
+        self.upload_error: Exception | None = None
+
+    def create_repo(self, **kwargs):
+        self.created.append(kwargs)
+
+    def upload_folder(self, **kwargs):
+        if self.upload_error is not None:
+            raise self.upload_error
+        self.uploaded.append(kwargs)
+        step_dir = kwargs["path_in_repo"].rsplit("/", 1)[-1]
+        self._files.extend(_hub_checkpoint_files(step_dir))
+
+    def list_repo_files(self, repo_id, repo_type):
+        return self._files
+
+
+def _local_to_cloud_request(*, consent: bool = True, job_id: str = "src"):
+    from makermodslab.train import TrainingRequest
+
+    return TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        resume_from_job_id=job_id,
+        upload_resume_checkpoint=consent,
+    )
+
+
+@pytest.fixture
+def cloud_preflight(monkeypatch):
+    """Keep the cloud dataset preflight off the network — it sits ahead of the
+    resume block, so without this it, not the code under test, is what fails."""
+    monkeypatch.setattr("makermodslab.datasets.get_hub_status", lambda repo_id: {"status": "on_hub"})
+
+
+# ── cloud parent → Local ─────────────────────────────────────────────────────
+
+
+def test_cloud_parent_resumed_locally_downloads_the_chosen_step(tmp_path, monkeypatch) -> None:
+    """The parent's Hub checkpoint is materialized HERE — whole, including
+    training_state/ — and config_path points into it, exactly as a local→local
+    resume would. The step is the one the resolver chose, not lerobot's
+    latest-only Hub rule."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _cloud_parent(_resumable_source(tmp_path, "interrupted"))
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api",
+        lambda: _FakeHubApi(_hub_checkpoint_files("000100")),
+    )
+    seen: dict = {}
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_resume_snapshot(tmp_path, seen))
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_resume_request(), JobTarget(runner="local"))
+        _join_prepare(reg, record.id)
+
+    # The WHOLE step tree, not just pretrained_model/ — a resume without the
+    # optimizer state is a fine-tune wearing a resume label.
+    assert seen["allow_patterns"] == ["checkpoints/000100/*"]
+    record = reg._records[record.id]
+    assert record.config.config_path.endswith("checkpoints/000100/pretrained_model/train_config.json")
+    assert Path(record.config.config_path).is_file()
+    assert record.state == "running"
+    assert fake_runner.start.called
+
+
+def test_cloud_parent_resumed_locally_seeds_progress_from_the_inherited_step(tmp_path, monkeypatch) -> None:
+    """The record's metrics start at the checkpoint's step, not at 0 — and they
+    do so from the moment it is created, i.e. before the (minutes-long) download
+    finishes. A 0 there is what wipes the seeded loss chart."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _cloud_parent(_resumable_source(tmp_path, "interrupted"))
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api",
+        lambda: _FakeHubApi(_hub_checkpoint_files("000100")),
+    )
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_resume_snapshot(tmp_path, {}))
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()):
+        # `resume_from_step` left unset: "the latest checkpoint", which the
+        # resolver has to pin to a real step for the seeding to work at all.
+        record = reg.start(_resume_request(), JobTarget(runner="local"))
+        assert record.metrics.current_step == 100
+        assert record.metrics.total_steps == record.config.steps
+        assert record.config.resume_from_step == 100
+        _join_prepare(reg, record.id)
+
+
+def test_cloud_parent_resumed_locally_refuses_an_incomplete_hub_checkpoint(tmp_path, monkeypatch) -> None:
+    """Refused synchronously, from the repo's file listing, before a record or a
+    single byte exists — the completeness gate is the same one cloud→cloud uses."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _cloud_parent(_resumable_source(tmp_path, "interrupted"))
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api",
+        lambda: _FakeHubApi(_hub_checkpoint_files("000100", with_state=False)),
+    )
+
+    def _no_downloads(**kwargs):
+        raise AssertionError("an incomplete checkpoint must be refused before downloading")
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _no_downloads)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="optimizer/step state"),
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+    assert list(reg._records) == ["src"]
+    _assert_nothing_was_created(reg)
+
+
+def test_cloud_parent_resumed_locally_fails_the_job_on_an_incomplete_download(tmp_path, monkeypatch) -> None:
+    """MT4's failure mode, closed: if the bytes that land are short of a
+    resumable checkpoint, the job fails with a message naming it and NO trainer
+    is spawned — rather than lerobot dying on a missing optimizer file minutes
+    into startup."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _cloud_parent(_resumable_source(tmp_path, "interrupted"))
+    # The listing says complete; the bytes that arrive are not (the uploader
+    # race). Only the on-disk check can catch that.
+    monkeypatch.setattr(
+        "makermodslab.jobs.shared_hf_api",
+        lambda: _FakeHubApi(_hub_checkpoint_files("000100")),
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download", _fake_resume_snapshot(tmp_path, {}, complete=False)
+    )
+    fake_runner = MagicMock()
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_resume_request(), JobTarget(runner="local"))
+        _join_prepare(reg, record.id)
+
+    failed = reg._records[record.id]
+    assert failed.state == "failed"
+    assert "training_state" in failed.error_message
+    assert not fake_runner.start.called
+
+
+# ── local parent → Cloud ─────────────────────────────────────────────────────
+
+
+def test_local_parent_resumed_on_the_cloud_uploads_then_submits(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """The checkpoint goes up first — whole tree, PRIVATE repo — and only then
+    is the cloud job submitted, pointed at what was just uploaded."""
     from unittest.mock import MagicMock, patch
 
     from makermodslab.jobs import JobTarget
 
     reg = _resumable_source(tmp_path, "interrupted")
-    # The cloud dataset preflight sits ahead of the resume block; keep it happy
-    # (and off the network) so the cross-runner refusal is what we observe.
-    monkeypatch.setattr("makermodslab.datasets.get_hub_status", lambda repo_id: {"status": "on_hub"})
-    with (
-        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
-        pytest.raises(ValueError, match="Cross-runner resume isn't supported yet") as excinfo,
-    ):
-        reg.start(_resume_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    fake_runner.hf_job_id.return_value = "hfjob-1"
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
 
-    assert "Local" in str(excinfo.value)
-    assert [r.id for r in reg.list(limit=10)] == ["src"]
-    _assert_nothing_was_created(reg)
+    assert api.created == [
+        {"repo_id": "alice/src_checkpoints", "repo_type": "model", "private": True, "exist_ok": True}
+    ]
+    assert api.uploaded[0]["path_in_repo"] == "checkpoints/100"
+    assert api.uploaded[0]["folder_path"].endswith("checkpoints/100")
+    record = reg._records[record.id]
+    assert record.config.resume_from_hub_repo == "alice/src_checkpoints"
+    assert record.config.resume_from_hub_step == "100"
+    assert record.config.resume_from_uploaded_checkpoint is True
+    # Never a host path: that is what the pod cannot resolve.
+    assert record.config.config_path is None
+    assert record.metrics.current_step == 100
+    assert fake_runner.start.called
 
 
-def test_start_refuses_a_cloud_parent_resumed_locally(tmp_path, monkeypatch) -> None:
-    """cloud parent → Local target (MT4). Refused BEFORE _resolve_cloud_resume
-    would go to the Hub — the exploding api stand-in is the assertion that the
-    guard lands first."""
+def test_local_parent_resumed_on_the_cloud_records_the_upload_on_the_parent(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """Where the bytes went is remembered on the PARENT, and survives a reload —
+    that record is what stops the next continuation of the same step from
+    pushing the same GBs again."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()):
+        record = reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
+
+    parent = reg._records["src"]
+    assert parent.checkpoints_hub_repo_id == "alice/src_checkpoints"
+    assert parent.checkpoints_hub_steps == ["100"]
+    # The parent record is persisted, so a fresh registry over the same root
+    # reads the same answer.
+    reloaded = JobRegistry(reg._output_root)._records["src"]
+    assert reloaded.checkpoints_hub_repo_id == "alice/src_checkpoints"
+    assert reloaded.checkpoints_hub_steps == ["100"]
+
+
+def test_local_parent_resumed_on_the_cloud_reuses_an_earlier_upload(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """Second continuation of the same step: the checkpoint is already on the
+    Hub and confirmed there, so nothing is uploaded — and no consent is asked
+    for, because nothing new is disclosed."""
     from unittest.mock import MagicMock, patch
 
     from makermodslab.jobs import JobTarget
 
-    def _no_hub():
-        raise AssertionError("cross-runner resume reached the Hub")
+    reg = _resumable_source(tmp_path, "interrupted")
+    reg._records["src"].checkpoints_hub_repo_id = "alice/src_checkpoints"
+    reg._records["src"].checkpoints_hub_steps = ["100"]
+    api = _FakeUploadApi(_hub_checkpoint_files("100"))
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(
+            _local_to_cloud_request(consent=False),
+            JobTarget(runner="hf_cloud", flavor="t4-small"),
+        )
 
-    reg = _cloud_parent(_resumable_source(tmp_path, "interrupted"))
-    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", _no_hub)
+    assert api.uploaded == []
+    assert record.config.resume_from_hub_repo == "alice/src_checkpoints"
+    assert record.config.resume_from_hub_step == "100"
+    # Nothing had to move, so the job went straight to the runner — no
+    # preparing thread at all.
+    assert record.id not in reg._prepare_threads
+    assert fake_runner.start.called
+
+
+def test_local_parent_resumed_on_the_cloud_re_uploads_when_the_hub_lost_it(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """The record is a hint, not the truth: a staging repo that has since been
+    deleted (or was half-pushed) produces a fresh upload rather than a job that
+    dies looking for bytes."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    reg._records["src"].checkpoints_hub_repo_id = "alice/src_checkpoints"
+    reg._records["src"].checkpoints_hub_steps = ["100"]
+    api = _FakeUploadApi(_hub_checkpoint_files("100", with_state=False))
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()):
+        record = reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
+
+    assert [u["path_in_repo"] for u in api.uploaded] == ["checkpoints/100"]
+
+
+def test_local_parent_resumed_on_the_cloud_refuses_without_consent(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """An upload is a disclosure, so it never happens as a side effect of
+    Continue: without the form's explicit consent the launch is refused, nothing
+    is uploaded, and no record is left behind."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
     with (
-        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
-        pytest.raises(ValueError, match="Cross-runner resume isn't supported yet") as excinfo,
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="only on this machine"),
     ):
-        reg.start(_resume_request(), JobTarget(runner="local"))
+        reg.start(
+            _local_to_cloud_request(consent=False),
+            JobTarget(runner="hf_cloud", flavor="t4-small"),
+        )
 
-    assert "Hugging Face Cloud" in str(excinfo.value)
-    # Read the registry directly: `list` counts a cloud record's checkpoints,
-    # which would itself call the stand-in above.
+    assert api.created == [] and api.uploaded == []
     assert list(reg._records) == ["src"]
+    _assert_nothing_was_created(reg)
+
+
+def test_local_parent_resumed_on_the_cloud_refuses_without_hf_auth(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """No Hub identity ⇒ no namespace to upload into. Refused with the login
+    instruction rather than failing later inside the runner."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: None)
+    with (
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="signed in"),
+    ):
+        reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    assert api.uploaded == []
+    _assert_nothing_was_created(reg)
+
+
+def test_local_parent_resumed_on_the_cloud_refuses_when_offline(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """Offline mode disables every Hub write, so the upload this continuation
+    depends on is impossible — say so instead of trying."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: _FakeUploadApi())
+    monkeypatch.setattr("makermodslab.jobs.hf_hub_offline", lambda: True)
+    with (
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="Offline mode"),
+    ):
+        reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    _assert_nothing_was_created(reg)
+
+
+def test_local_parent_resumed_on_the_cloud_never_starts_a_fresh_run(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """MT42, as an invariant: when the checkpoint cannot be put where the pod
+    will look for it, the job FAILS — it does not quietly become a fresh run at
+    step 0 on rented hardware while the record calls itself a continuation."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    api = _FakeUploadApi()
+    api.upload_error = RuntimeError("413 payload too large")
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
+
+    failed = reg._records[record.id]
+    assert failed.state == "failed"
+    assert "413 payload too large" in failed.error_message
+    # The one assertion that matters: no cloud job was ever submitted.
+    assert not fake_runner.start.called
+
+
+def test_local_parent_resumed_on_the_cloud_fails_when_the_upload_cannot_be_confirmed(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """An upload that reports success but leaves the repo short of a resumable
+    checkpoint is the same failure as one that raised — verified from the Hub's
+    own listing, before anything is submitted."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+
+    class _SilentlyPartialApi(_FakeUploadApi):
+        def upload_folder(self, **kwargs):
+            self.uploaded.append(kwargs)
+            self._files.extend(_hub_checkpoint_files("100", with_state=False))
+
+    api = _SilentlyPartialApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
+
+    failed = reg._records[record.id]
+    assert failed.state == "failed"
+    assert "training_step.json" in failed.error_message
+    assert not fake_runner.start.called
+    assert reg._records["src"].checkpoints_hub_steps == []
+
+
+def test_cross_runner_resume_still_refuses_a_completed_parent(tmp_path, monkeypatch, cloud_preflight) -> None:
+    """Only the runner-mismatch refusal went away. A parent that spent its LR
+    schedule is still unresumable — on either runner, in either direction."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    with (
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="already reached its step target"),
+    ):
+        reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
     _assert_nothing_was_created(reg)
 
 
@@ -1607,6 +2026,50 @@ def test_download_hub_checkpoint_ref_rejects_a_non_ref() -> None:
 
     with pytest.raises(ValueError, match="Unrecognised policy ref"):
         download_hub_checkpoint_ref("just-a-repo-id")
+
+
+def test_download_hub_checkpoint_ref_widens_to_the_whole_step_for_a_resume(monkeypatch, tmp_path) -> None:
+    """`with_training_state` is the one difference between "load these weights"
+    and "continue this run": the optimizer state comes along. Opt-in because it
+    is hundreds of MB per step that a deploy or fine-tune never reads."""
+    from makermodslab.jobs import download_hub_checkpoint_ref
+
+    seen: dict = {}
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_snapshot(tmp_path, seen))
+
+    out = download_hub_checkpoint_ref("user/repo@checkpoints/000500", with_training_state=True)
+
+    assert seen["allow_patterns"] == ["checkpoints/000500/*"]
+    # The return value is still the pretrained_model dir, so the two modes agree
+    # about what a ref resolves TO; its parent is the checkpoint dir.
+    assert out.endswith("/checkpoints/000500/pretrained_model")
+
+
+def test_download_hub_resume_checkpoint_returns_the_train_config(monkeypatch, tmp_path) -> None:
+    """The value lerobot's --config_path wants, inside a tree whose parent
+    directory is the checkpoint (which is how lerobot finds training_state/)."""
+    from makermodslab.jobs import download_hub_resume_checkpoint
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_resume_snapshot(tmp_path, {}))
+
+    out = Path(download_hub_resume_checkpoint("user/repo@checkpoints/000100"))
+
+    assert out.name == "train_config.json" and out.is_file()
+    assert (out.parent.parent / "training_state" / "training_step.json").is_file()
+
+
+def test_download_hub_resume_checkpoint_refuses_an_incomplete_download(monkeypatch, tmp_path) -> None:
+    """Checked on the bytes that actually landed, not just on the repo listing:
+    an interrupted upload passes the listing check and then dies inside the
+    trainer, which is precisely MT4."""
+    from makermodslab.jobs import download_hub_resume_checkpoint
+
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download", _fake_resume_snapshot(tmp_path, {}, complete=False)
+    )
+
+    with pytest.raises(ValueError, match="training_state"):
+        download_hub_resume_checkpoint("user/repo@checkpoints/000100")
 
 
 def test_localize_pretrained_path_passes_through_non_step_values(monkeypatch, tmp_path) -> None:

--- a/tests/test_runners_hf_cloud.py
+++ b/tests/test_runners_hf_cloud.py
@@ -241,6 +241,18 @@ def test_localize_allows_cloud_resume_from_hub() -> None:
     assert config.policy_device == "cuda"
 
 
+def test_localize_rejects_a_resume_that_names_no_hub_checkpoint() -> None:
+    """MT42's invariant at the cloud submission boundary: `resume` with nothing
+    to resume FROM would fall through build_training_command's fresh-run branch
+    and start over at step 0 on rented hardware while every UI surface reported a
+    continuation. Refuse instead — silence is the failure mode here."""
+    from makermodslab.runners.hf_cloud import localize_config_for_cloud
+
+    config = _request(resume=True)
+    with pytest.raises(ValueError, match="step 0"):
+        localize_config_for_cloud(config, "t4-small")
+
+
 def test_localize_rejects_local_pretrained_path_but_allows_hub_id() -> None:
     from makermodslab.runners.hf_cloud import localize_config_for_cloud
 
@@ -537,6 +549,56 @@ def test_cloud_resume_argv_keeps_lineage_in_parent_repo() -> None:
     # Inherited from the checkpoint — never re-passed on resume.
     assert "--dataset.repo_id" not in cmd
     assert "--policy.type" not in cmd
+
+
+def _submitted_command(config, tmp_path, monkeypatch, job_id: str = "child_run"):
+    """Drive HfCloudJobRunner.start with the Hub stubbed out; return the argv it
+    submitted. No token, no network, no job — the run_job stand-in records and
+    the worker threads are stubbed off."""
+    from unittest.mock import MagicMock
+
+    from makermodslab.jobs import TrainingMetrics
+    from makermodslab.runners.hf_cloud import HfCloudJobRunner
+
+    monkeypatch.setattr("makermodslab.runners.hf_cloud.get_token", lambda: "hf_fake")
+    monkeypatch.setattr("makermodslab.runners.hf_cloud.cached_whoami", lambda: {"name": "alice"})
+    runner = HfCloudJobRunner(TrainingMetrics(), tmp_path / "log.jsonl", "t4-small")
+    api = MagicMock()
+    api.run_job.return_value = MagicMock(id="hfjob-1", url="https://hf/jobs/1")
+    runner._api = api
+    monkeypatch.setattr(runner, "_ensure_dataset_on_hub", lambda repo_id: None)
+    monkeypatch.setattr(runner, "_start_worker_threads", lambda label: None)
+    runner.start(job_id, config, "/host/out")
+    return api.run_job.call_args.kwargs["command"]
+
+
+def test_cloud_resume_from_a_cloud_parent_publishes_into_the_parents_repo(tmp_path, monkeypatch) -> None:
+    """Unchanged behaviour, pinned: a cloud→cloud continuation keeps the whole
+    lineage in one repo."""
+    config = _request(resume=True, resume_from_hub_repo="user/parent-run", resume_from_hub_step="005000")
+    command = _submitted_command(config, tmp_path, monkeypatch)
+
+    assert config.policy_repo_id == "user/parent-run"
+    assert "--resume-from=user/parent-run@checkpoints/005000" in command
+
+
+def test_cloud_resume_from_an_uploaded_local_checkpoint_gets_its_own_repo(tmp_path, monkeypatch) -> None:
+    """F7, local→cloud: the source repo is a private STAGING repo holding the
+    local parent's uploaded checkpoint, not an output repo. Publishing into it
+    would put parent and child checkpoints in one tree again, so the run takes
+    its own repo — while still resuming from the staged step."""
+    config = _request(
+        resume=True,
+        resume_from_hub_repo="alice/src_checkpoints",
+        resume_from_hub_step="000100",
+        resume_from_uploaded_checkpoint=True,
+    )
+    command = _submitted_command(config, tmp_path, monkeypatch)
+
+    assert config.policy_repo_id == "alice/child_run"
+    assert "--resume-from=alice/src_checkpoints@checkpoints/000100" in command
+    assert "--policy.repo_id" in command
+    assert command[command.index("--policy.repo_id") + 1] == "alice/child_run"
 
 
 def test_wrapper_source_inlines_the_tested_install_plan() -> None:


### PR DESCRIPTION
Resuming a training run is no longer pinned to the compute target it started on. This implements F7 from the feature list: a cloud run can be continued on the local machine, and a local run can be continued on HF Jobs.

## What it does

**Cloud parent → local target.** The chosen checkpoint step — not just the latest — is downloaded from the parent's Hub repo including `training_state/`, and the resume launches with `config_path` pointing into the HF snapshot cache (no multi-GB copy into the child's run dir; the weights half lives in the shared cache, per F7's cache policy). An incomplete Hub checkpoint refuses loudly before any job record or trainer process exists, closing MT4's failure mode. lerobot v0.6.0's native Hub-resume path is deliberately not used: it is latest-only and would silently ignore the step the user picked (the stale "lerobot doesn't support resuming from the Hub" comment is corrected to say exactly this).

**Local parent → cloud target.** With explicit consent (a new `upload_resume_checkpoint` request field, surfaced as a notice in the panel and an "Upload & continue training" start button), the parent's `checkpoints/<step>/` uploads to a **private** staging repo `<user>/<parent_job_id>_checkpoints`, and the upload is re-verified against the Hub's own listing before the job is submitted — the MT42 silent-restart-at-step-0 path is impossible by construction, and `localize_config_for_cloud` now raises on any resume without a Hub source as a belt-and-braces invariant. The upload location is persisted on the parent (`checkpoints_hub_repo_id` / `checkpoints_hub_steps`), so re-resuming the same step skips the upload; the record is treated as a hint and re-confirmed against the Hub. The cloud child publishes to its **own** repo rather than adopting the staging repo, so the new path does not inherit MT12's parent/child repo conflation.

**Refusals that stay:** done parent (its LR schedule is finished), resume+finetune exclusivity, incomplete checkpoint, missing consent, offline, no HF identity.

**Frontend:** the compute selector unlocks on resume — the parent's runner becomes the default, not a lock ("Defaults to the runner this run started on — switch it to continue somewhere else"). Local-parent + cloud-target shows the consent notice, relabels Start, and hard-blocks offline, mirroring the existing local-dataset upload-first pattern.

## Verified

- +18 tests (both directions end-to-end with mocked Hub, every refusal path, the no-silent-restart guarantee, upload-metadata round-trip and reuse). Full suite on this branch: 1120 passed with only main's 7 pre-existing `test_models.py` sandbox failures, unchanged. `tsc -p tsconfig.app.json` byte-identical to main's baseline (5 pre-existing errors); lint unchanged; build green; `frontend/dist` untouched.
- **Live smoke tests passed on the identical implementation** (rig build, same semantics): cloud→local resumed a real cloud parent from chosen step 10,000 on MPS with `config_path` in the snapshot cache, training to step 10,093 before deliberate stop; local→cloud uploaded a real 591 MB checkpoint to its staging repo, the pod resumed at step 10 and ran to `done` at 100/100, publishing to the child's own repo, with the parent's upload metadata persisted and verified.

## Notes for review

- **Interplay with #42:** both touch `jobs.py`'s resume path. Whichever lands second does the reconciliation; the touchpoints here are the `JobRegistry.start` resume branch, the deferred-prepare helpers, and the two new `TrainingRequest` fields.
- One adaptation vs. the rig implementation: completeness of a Hub checkpoint is judged by main's existing single-file rule (`training_state/training_step.json`), applied consistently via a new shared helper. A stricter file-by-file completeness check exists on rig and would be a separate hardening follow-up — as-is, a checkpoint missing `optimizer_state.safetensors` but having `training_step.json` would pass the probe (pre-existing main behavior, not widened by this PR).
- The `_start_after_prepare` refactor consolidates the three deferred-preparation paths' stop/delete/spawn-failure semantics in one place; behavior for the existing fine-tune materialization path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)