### PR TITLE
feat(cameras): the robot record is the single source of session cameras

### DIFF
--- a/frontend/src/components/landing/InferenceModal.tsx
+++ b/frontend/src/components/landing/InferenceModal.tsx
@@ -31,11 +31,10 @@ import {
 } from "@/lib/checkpointsApi";
 import { startInference } from "@/lib/inferenceApi";
 import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
-import {
-  AvailableCamera,
-  useAvailableCameras,
-} from "@/hooks/useAvailableCameras";
+import { useAvailableCameras } from "@/hooks/useAvailableCameras";
 import BackendCameraStream from "@/components/BackendCameraStream";
+import type { CameraConfig } from "@/components/recording/CameraConfiguration";
+import { isCameraConnected, resolveCameraIndex } from "@/lib/cameraResolve";
 
 interface Props {
   open: boolean;
@@ -44,10 +43,6 @@ interface Props {
   jobId: string;
   initialStep: number | null;
 }
-
-const DEFAULT_FPS = 30;
-
-const cameraKey = (cam: AvailableCamera) => String(cam.index);
 
 /** Small preview for verifying which physical camera a role binds to.
  *
@@ -173,10 +168,14 @@ const InferenceModal: React.FC<Props> = ({
   const [policyConfigLoading, setPolicyConfigLoading] = useState(false);
   const [policyConfigError, setPolicyConfigError] = useState<string | null>(null);
 
-  // Per camera DISPLAY name → user-selected physical camera key (the raw cv2
-  // index string). Keyed by the stripped display name (== requestKey), not the
-  // checkpoint feature key — see `cameraMappings` / the CameraMapping doc for
-  // the round-trip.
+  // Per camera DISPLAY name → the NAME of one of the selected robot's cameras.
+  // Keyed by the stripped display name (== requestKey), not the checkpoint
+  // feature key — see `cameraMappings` / the CameraMapping doc for the
+  // round-trip. Sent verbatim as the request's `camera_bindings`: only the name
+  // pairing travels, and the server reads which device and how to open it out
+  // of the robot record (see makermodslab/utils/config.py bind_robot_cameras).
+  // Capture resolution is the exception — forwarded from the checkpoint as
+  // `camera_dims`, because the rollout doesn't resize frames.
   const [cameraBindings, setCameraBindings] = useState<Record<string, string | null>>({});
   const { cameras: availableCameras } = useAvailableCameras({ enabled: open });
 
@@ -194,12 +193,27 @@ const InferenceModal: React.FC<Props> = ({
     [policyConfig, isBimanual],
   );
 
-  const liveCameraByKey = React.useCallback(
-    (key: string | null | undefined) =>
-      key == null
-        ? undefined
-        : availableCameras.find((cam) => cameraKey(cam) === key),
-    [availableCameras],
+  const robotCameras: CameraConfig[] = React.useMemo(
+    () => robot?.cameras ?? [],
+    [robot],
+  );
+
+  /** The robot's camera a binding names, or undefined once the record no
+   * longer has it (camera removed in Robot settings, or another robot). */
+  const recordCameraByName = React.useCallback(
+    (name: string | null | undefined) =>
+      name == null ? undefined : robotCameras.find((cam) => cam.name === name),
+    [robotCameras],
+  );
+
+  /** Bound AND physically present — a stored camera_index goes stale on
+   * replug, so presence is judged by unique_id against the live enumeration. */
+  const cameraIsReady = React.useCallback(
+    (name: string | null | undefined) => {
+      const cam = recordCameraByName(name);
+      return cam != null && isCameraConnected(cam, availableCameras);
+    },
+    [recordCameraByName, availableCameras],
   );
 
   // Re-arm Start on reopen. The success path closes the modal with
@@ -274,56 +288,44 @@ const InferenceModal: React.FC<Props> = ({
   // If the selected robot has cameras whose names match a policy-expected
   // camera, auto-bind them. Match against the DISPLAY name (the bare name the
   // user chose at record time — that's what the robot record stores), not the
-  // `left_`-prefixed checkpoint feature. Prefer the stored browser device_id,
-  // then the saved camera_index fallback.
+  // `left_`-prefixed checkpoint feature. No device enumeration is involved: the
+  // binding names a RECORD camera, and the record is what the server resolves.
   useEffect(() => {
-    if (!policyConfig) return;
-    const robotCams = robot?.cameras ?? [];
-    if (robotCams.length === 0 || availableCameras.length === 0) return;
+    if (!policyConfig || robotCameras.length === 0) return;
     setCameraBindings((prev) => {
       let changed = false;
       const next = { ...prev };
       for (const m of cameraMap) {
         if (next[m.requestKey] != null) continue;
-        const robotCam = robotCams.find(
+        const robotCam = robotCameras.find(
           (c) => c.name.toLowerCase() === m.display.toLowerCase(),
         );
-        if (!robotCam) continue;
-        // Resolve by unique_id first: it names the physical device exactly.
-        // device_id is a coin flip when two cameras share a name (the browser
-        // match is by localizedName), and camera_index goes stale on replug —
-        // both are fallbacks for records saved before unique_id was stored.
-        const live =
-          (robotCam.unique_id
-            ? availableCameras.find((c) => c.uniqueId === robotCam.unique_id)
-            : undefined) ??
-          (robotCam.device_id
-            ? availableCameras.find((c) => c.deviceId === robotCam.device_id)
-            : undefined) ??
-          availableCameras.find((c) => c.index === robotCam.camera_index);
-        if (live) {
-          next[m.requestKey] = cameraKey(live);
+        if (robotCam) {
+          next[m.requestKey] = robotCam.name;
           changed = true;
         }
       }
       return changed ? next : prev;
     });
-  }, [policyConfig, robot, availableCameras, cameraMap]);
+  }, [policyConfig, robotCameras, cameraMap]);
 
+  // Drop a binding the robot record no longer backs (camera removed in Robot
+  // settings, or another robot selected). A merely UNPLUGGED camera keeps its
+  // binding — the tile says disconnected and Start stays disabled.
   useEffect(() => {
-    if (!policyConfig || availableCameras.length === 0) return;
+    if (!policyConfig) return;
     setCameraBindings((prev) => {
       let changed = false;
       const next = { ...prev };
-      for (const [name, key] of Object.entries(prev)) {
-        if (key != null && !liveCameraByKey(key)) {
+      for (const [name, boundTo] of Object.entries(prev)) {
+        if (boundTo != null && !recordCameraByName(boundTo)) {
           next[name] = null;
           changed = true;
         }
       }
       return changed ? next : prev;
     });
-  }, [policyConfig, availableCameras, liveCameraByKey]);
+  }, [policyConfig, recordCameraByName]);
 
   const selectedRef =
     selectedStep != null
@@ -356,8 +358,8 @@ const InferenceModal: React.FC<Props> = ({
     checkpointArms != null &&
     checkpointIsBimanual !== isBimanual;
 
-  const allCamerasBound = cameraMap.every(
-    (m) => liveCameraByKey(cameraBindings[m.requestKey]) != null,
+  const allCamerasBound = cameraMap.every((m) =>
+    cameraIsReady(cameraBindings[m.requestKey]),
   );
 
   // Inference drives the follower(s) only — gate on follower_ready, not
@@ -384,31 +386,25 @@ const InferenceModal: React.FC<Props> = ({
     // same camera index via OpenCV without colliding on the device.
     setSubmitting(true);
     await new Promise((r) => setTimeout(r, 300));
-    // Emit camera dict keys under the DISPLAY/request name (bare in bimanual
-    // mode). The rollout hands these to the BiSO left_arm_config, which
-    // re-prefixes with `left_` — reconstructing the checkpoint's `left_<name>`
-    // feature. Resolution still comes from the checkpoint feature's dims.
-    const cameraDict: Record<string, {
-      type: string;
-      camera_index?: number;
-      width: number;
-      height: number;
-      fps?: number;
-      fourcc?: string;
-    }> = {};
+    // Emit binding keys under the DISPLAY/request name (bare in bimanual
+    // mode). The rollout hands the resolved cameras to the BiSO
+    // left_arm_config, which re-prefixes with `left_` — reconstructing the
+    // checkpoint's `left_<name>` feature. The VALUES are robot-record camera
+    // names; every setting behind them is read server-side from the record.
+    const cameraBindingPayload: Record<string, string> = {};
+    // ...except capture RESOLUTION, which comes from the checkpoint: lerobot's
+    // rollout doesn't resize frames to the policy's input shape, so the camera
+    // must capture at the size the policy was trained on. Forwarded the same
+    // way `checkpoint_state_dim` is.
+    const cameraDimsPayload: Record<string, { width: number; height: number }> = {};
     for (const m of cameraMap) {
-      const key = cameraBindings[m.requestKey];
-      if (key == null) continue;
-      const live = liveCameraByKey(key);
-      if (!live) continue;
+      const boundTo = cameraBindings[m.requestKey];
+      if (boundTo == null || !recordCameraByName(boundTo)) continue;
+      cameraBindingPayload[m.requestKey] = boundTo;
       const dims = policyConfig.image_features[m.feature];
-      cameraDict[m.requestKey] = {
-        type: "opencv",
-        camera_index: live.index,
-        width: dims.width,
-        height: dims.height,
-        fps: DEFAULT_FPS,
-      };
+      if (dims?.width && dims?.height) {
+        cameraDimsPayload[m.requestKey] = { width: dims.width, height: dims.height };
+      }
     }
     try {
       // The POST now returns immediately (it only validates cheaply, then the
@@ -421,7 +417,8 @@ const InferenceModal: React.FC<Props> = ({
         follower_config: robot.follower_config,
         policy_ref: selectedRef,
         task,
-        cameras: cameraDict,
+        camera_bindings: cameraBindingPayload,
+        camera_dims: cameraDimsPayload,
         duration_s: durationS,
         // Bimanual: forward the mode + right-arm follower so the server builds a
         // `bi_so_follower` command staging both follower calibrations. In single
@@ -608,13 +605,18 @@ const InferenceModal: React.FC<Props> = ({
             ) : (
               <div className="space-y-3">
                 <p className="text-xs text-muted-foreground">
-                  Bind a physical camera to each name the policy was trained
-                  with. Resolution comes from the checkpoint.
+                  Bind one of this robot's cameras to each name the policy was
+                  trained with. Which camera and how it's opened come from the
+                  robot (edit in Robot settings); the capture resolution comes
+                  from the checkpoint.
                 </p>
                 {cameraMap.map((m) => {
                   const dims = policyConfig.image_features[m.feature];
                   const value = cameraBindings[m.requestKey];
-                  const selectedCamera = liveCameraByKey(value);
+                  const boundCamera = recordCameraByName(value);
+                  const connected =
+                    boundCamera != null &&
+                    isCameraConnected(boundCamera, availableCameras);
                   return (
                     <div key={m.requestKey} className="flex items-center gap-3">
                       <div className="flex-1">
@@ -622,8 +624,22 @@ const InferenceModal: React.FC<Props> = ({
                           {m.display}
                         </Label>
                         <p className="text-xs text-muted-foreground">
-                          {dims.width}×{dims.height}
+                          Captures at {dims.width}×{dims.height} — the policy's
+                          resolution
                         </p>
+                        {boundCamera &&
+                        (boundCamera.width !== dims.width ||
+                          boundCamera.height !== dims.height) ? (
+                          <p className="text-xs text-muted-foreground">
+                            ({boundCamera.name} is set to {boundCamera.width}×
+                            {boundCamera.height} in Robot settings)
+                          </p>
+                        ) : null}
+                        {boundCamera && !connected ? (
+                          <p className="text-xs text-destructive">
+                            Disconnected — reconnect it before starting
+                          </p>
+                        ) : null}
                       </div>
                       <Select
                         value={value ?? undefined}
@@ -633,17 +649,15 @@ const InferenceModal: React.FC<Props> = ({
                           <SelectValue placeholder="Select a camera" />
                         </SelectTrigger>
                         <SelectContent>
-                          {availableCameras.length === 0 ? (
+                          {robotCameras.length === 0 ? (
                             <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                              No cameras detected
+                              This robot has no cameras — add them in Robot
+                              settings
                             </div>
                           ) : (
-                            availableCameras.map((cam) => (
-                              <SelectItem
-                                key={cameraKey(cam)}
-                                value={cameraKey(cam)}
-                              >
-                                #{cam.index} — {cam.name}
+                            robotCameras.map((cam) => (
+                              <SelectItem key={cam.name} value={cam.name}>
+                                {cam.name} — {cam.width}×{cam.height}
                               </SelectItem>
                             ))
                           )}
@@ -652,8 +666,12 @@ const InferenceModal: React.FC<Props> = ({
                       {/* Backend preview at the exact cv2 index this role
                           binds to, so the tile can't disagree with the run. */}
                       <CameraThumbnail
-                        cameraIndex={selectedCamera?.index}
-                        uniqueId={selectedCamera?.uniqueId}
+                        cameraIndex={
+                          boundCamera && connected
+                            ? resolveCameraIndex(boundCamera, availableCameras)
+                            : undefined
+                        }
+                        uniqueId={boundCamera?.unique_id}
                         paused={submitting}
                       />
                     </div>

--- a/frontend/src/components/recording/CameraConfiguration.tsx
+++ b/frontend/src/components/recording/CameraConfiguration.tsx
@@ -19,7 +19,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { useAvailableCameras } from "@/hooks/useAvailableCameras";
 import BackendCameraStream from "@/components/BackendCameraStream";
-import { isCameraConnected } from "@/lib/cameraResolve";
+import { isCameraConnected, resolveCameraIndex } from "@/lib/cameraResolve";
 
 // Sentinels distinguish "leave unset" (auto-detect / platform default) from an
 // explicit choice. Radix Select disallows an empty-string value, so we map these
@@ -184,6 +184,26 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
       return;
     }
 
+    // Names must be unique within a robot: they key the session camera dict
+    // server-side (dataset feature keys when recording, binding targets when
+    // deploying), so two cameras sharing one would be ambiguous — the backend
+    // now refuses to start such a record rather than silently dropping one of
+    // them. Block it here, at the only place a name is ever assigned, so the
+    // user can't save a robot that fails at start. Compared case-insensitively
+    // because the inference auto-binder matches names that way.
+    const nameTaken = cameras.some(
+      (cam) =>
+        cam.name.trim().toLowerCase() === cameraName.trim().toLowerCase(),
+    );
+    if (nameTaken) {
+      toast({
+        title: "Name Already Used",
+        description: `Another camera on this robot is already named "${cameraName.trim()}". Pick a different name.`,
+        variant: "destructive",
+      });
+      return;
+    }
+
     const newCamera: CameraConfig = {
       id: `camera_${Date.now()}`,
       name: cameraName.trim(),
@@ -331,15 +351,24 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
                     <SelectValue placeholder="Select a name" />
                   </SelectTrigger>
                   <SelectContent className="bg-popover border-border">
-                    {CAMERA_NAME_PRESETS.map((name) => (
-                      <SelectItem
-                        key={name}
-                        value={name}
-                        className="text-foreground"
-                      >
-                        {name}
-                      </SelectItem>
-                    ))}
+                    {CAMERA_NAME_PRESETS.map((name) => {
+                      // Same treatment the camera dropdown gives an
+                      // already-added device: shown, labelled, not selectable.
+                      const nameTaken = cameras.some(
+                        (cam) => cam.name.trim().toLowerCase() === name,
+                      );
+                      return (
+                        <SelectItem
+                          key={name}
+                          value={name}
+                          className="text-foreground"
+                          disabled={nameTaken}
+                        >
+                          {name}
+                          {nameTaken && " · already used"}
+                        </SelectItem>
+                      );
+                    })}
                     <SelectItem
                       value={CAMERA_NAME_CUSTOM}
                       className="text-foreground"
@@ -616,6 +645,107 @@ const CameraPreview: React.FC<CameraPreviewProps> = ({
           </CollapsibleContent>
         </Collapsible>
       </div>
+    </div>
+  );
+};
+
+interface SessionCameraListProps {
+  /** The selected robot record's cameras, exactly as stored. */
+  cameras: CameraConfig[];
+  /** Filled with a function that drops every preview stream, so the caller can
+   * hand the devices to cv2 before a session starts (same contract as
+   * CameraConfiguration's prop of the same name). */
+  releaseStreamsRef?: React.MutableRefObject<(() => void) | null>;
+  /** Shown when the robot has no cameras. */
+  emptyLabel?: string;
+}
+
+/**
+ * READ-ONLY view of the cameras a session will open — name, settings, and a
+ * live preview per camera, with no add/remove/edit controls.
+ *
+ * Sessions no longer carry their own camera set: the backend resolves the
+ * cameras from the robot record named in the start request (see
+ * makermodslab/utils/config.py's load_robot_cameras / bind_robot_cameras). A
+ * per-session editable copy could only ever diverge from what actually runs —
+ * edits made here were silently discarded, and the panel could show a set the
+ * server would not use. Cameras are therefore edited in exactly one place, the
+ * robot settings dialog (which still renders the full CameraConfiguration
+ * above), and shown here only to confirm what is about to be recorded.
+ *
+ * Previews stream from the backend by cv2 index, re-anchored to each camera's
+ * unique_id against the live enumeration — a stored index goes stale on
+ * replug, and showing the wrong device is exactly the confusion this list
+ * exists to prevent.
+ */
+export const SessionCameraList: React.FC<SessionCameraListProps> = ({
+  cameras,
+  releaseStreamsRef,
+  emptyLabel = "No cameras on this robot.",
+}) => {
+  // Same handover as the editable component: pausing unmounts the streams AND
+  // stops the enumeration probe, so cv2 can open the devices exclusively.
+  const [streamsPaused, setStreamsPaused] = useState(false);
+  const { cameras: availableCameras } = useAvailableCameras({
+    enabled: !streamsPaused,
+  });
+
+  const releaseAllCameraStreams = useCallback(() => setStreamsPaused(true), []);
+  useEffect(() => {
+    if (releaseStreamsRef) {
+      releaseStreamsRef.current = releaseAllCameraStreams;
+    }
+  }, [releaseStreamsRef, releaseAllCameraStreams]);
+
+  return (
+    <div className="space-y-4">
+      {/* Cameras is a repeater, not a single labelled control, so it keeps an
+          eyebrow heading — matching the editable component. */}
+      <h3 className="eyebrow">Cameras</h3>
+      <p className="text-xs text-muted-foreground">
+        Cameras come from the selected robot. Add, remove, or adjust them in
+        Robot settings.
+      </p>
+
+      {cameras.length === 0 ? (
+        <div className="py-6 text-center text-muted-foreground">
+          <Camera className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+          <p className="text-sm">{emptyLabel}</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {cameras.map((camera) => {
+            const connected = isCameraConnected(camera, availableCameras);
+            return (
+              <div
+                key={camera.id ?? camera.name}
+                className="overflow-hidden rounded-lg border border-border bg-card"
+              >
+                <CameraStreamBox
+                  cameraIndex={
+                    connected
+                      ? resolveCameraIndex(camera, availableCameras)
+                      : undefined
+                  }
+                  uniqueId={camera.unique_id}
+                  paused={streamsPaused}
+                  emptyLabel="Camera disconnected — reconnect it or check Robot settings"
+                />
+                <div className="space-y-0.5 p-3">
+                  <h5 className="truncate font-medium text-foreground">
+                    {camera.name}
+                  </h5>
+                  <p className="text-xs text-muted-foreground">
+                    {camera.width}×{camera.height}
+                    {camera.fps ? ` · ${camera.fps} fps` : ""}
+                    {camera.fourcc ? ` · ${camera.fourcc}` : ""}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -71,8 +71,13 @@ const CollectPanel: React.FC = () => {
     resetTimeS,
     streamingEncoding,
     pushToHub,
-    cameras,
   } = collectForm;
+
+  // The session's cameras ARE the selected robot's cameras — the backend
+  // resolves them from the robot record and the start request carries none.
+  // Read straight off the record so the panel can't show (or hold on to) a set
+  // the server wouldn't use; edits live in the robot settings dialog.
+  const cameras = selectedRecord?.cameras ?? [];
 
   // The record-new form slides open in place; the library folds to its header
   // while the form is open (still expandable by hand).
@@ -102,20 +107,6 @@ const CollectPanel: React.FC = () => {
   };
 
   const releaseStreamsRef = useRef<(() => void) | null>(null);
-
-  // Seed the camera config from the selected robot whenever the robot changes
-  // (mirrors the old openRecordingModal seeding). Keyed on the robot name so a
-  // user's in-form camera edits aren't clobbered on every render — the marker
-  // persists in the draft so a panel remount doesn't re-seed either.
-  useEffect(() => {
-    const name = selectedRecord?.name ?? null;
-    if (name !== collectForm.camerasSeededFor) {
-      updateCollectForm({
-        camerasSeededFor: name,
-        cameras: selectedRecord ? [...(selectedRecord.cameras ?? [])] : [],
-      });
-    }
-  }, [selectedRecord, collectForm.camerasSeededFor, updateCollectForm]);
 
   // Release camera streams when the panel unmounts (e.g. navigating to the
   // recording session), so cv2 can grab the devices exclusively.
@@ -206,33 +197,6 @@ const CollectPanel: React.FC = () => {
       });
     }
 
-    const cameraDict = cameras.reduce(
-      (acc, cam) => {
-        acc[cam.name] = {
-          type: cam.type,
-          camera_index: cam.camera_index,
-          width: cam.width,
-          height: cam.height,
-          fps: cam.fps,
-          ...(cam.fourcc ? { fourcc: cam.fourcc } : {}),
-          ...(cam.backend ? { backend: cam.backend } : {}),
-        };
-        return acc;
-      },
-      {} as Record<
-        string,
-        {
-          type: string;
-          camera_index?: number;
-          width: number;
-          height: number;
-          fps?: number;
-          fourcc?: string;
-          backend?: string;
-        }
-      >,
-    );
-
     const recordingConfig = {
       leader_port: robot.leader_port,
       follower_port: robot.follower_port,
@@ -244,8 +208,10 @@ const CollectPanel: React.FC = () => {
       right_follower_port: robot.right_follower_port,
       right_leader_config: robot.right_leader_config,
       right_follower_config: robot.right_follower_config,
-      // Robot name → BiSO staging base id (bimanual). Names the per-session
-      // staging dir; does not affect which calibration drives which arm.
+      // Robot name → the record the backend resolves this session's CAMERAS
+      // from (the request carries no camera payload). Bimanual also uses it as
+      // the BiSO staging base id, naming the per-session staging dir; it does
+      // not affect which calibration drives which arm.
       robot_name: robot.name,
       dataset_repo_id: datasetRepoId,
       single_task: singleTask,
@@ -257,7 +223,8 @@ const CollectPanel: React.FC = () => {
       push_to_hub: false,
       resume: false,
       streaming_encoding: streamingEncoding,
-      cameras: cameraDict,
+      // No `cameras` here on purpose: the backend resolves this session's
+      // cameras from the robot record named above.
     };
 
     setActiveRecording(recordingConfig);
@@ -326,8 +293,6 @@ const CollectPanel: React.FC = () => {
             }
             pushToHub={pushToHub}
             setPushToHub={(v) => updateCollectForm({ pushToHub: v })}
-            cameras={cameras}
-            setCameras={(v) => updateCollectForm({ cameras: v })}
             releaseStreamsRef={releaseStreamsRef}
           />
         </CollapsibleContent>

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -741,26 +741,21 @@ const DeployPanel: React.FC = () => {
             Run this skill on your robot, then start inference.
           </p>
 
-          {/* Robot readiness — a status line, not a parameter, so no eyebrow. */}
+          {/* Robot readiness — a warning, not a parameter, so no eyebrow. A
+              ready robot renders nothing: the robot menu already names the
+              selection and its arm layout. */}
           <RobotStatus ready={!!robot && robot.follower_ready}>
             {!robot ? (
               <>
                 Select a robot to run on — use the robot menu in the top-right
                 corner of this window.
               </>
-            ) : !robot.follower_ready ? (
+            ) : (
               <>
                 <strong>{robot.name}</strong> {robotSetupGap(robot, "follower")}.
                 Open Robot settings before running inference. (Inference only
                 uses the follower arm{isBimanual ? "s" : ""} — leader setup
                 isn't needed.)
-              </>
-            ) : (
-              <>
-                <span className="text-foreground">{robot.name}</span>
-                <span className="rounded border border-border px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                  {isBimanual ? "bimanual — both followers" : "single arm"}
-                </span>
               </>
             )}
           </RobotStatus>

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -53,11 +53,10 @@ import {
   RobotStatus,
 } from "@/components/studio/panel/primitives";
 import { cn } from "@/lib/utils";
-import {
-  AvailableCamera,
-  useAvailableCameras,
-} from "@/hooks/useAvailableCameras";
+import { useAvailableCameras } from "@/hooks/useAvailableCameras";
 import BackendCameraStream from "@/components/BackendCameraStream";
+import type { CameraConfig } from "@/components/recording/CameraConfiguration";
+import { isCameraConnected, resolveCameraIndex } from "@/lib/cameraResolve";
 
 /**
  * Studio panel 3 · Deploy — run a skill (local trained checkpoint or an
@@ -74,10 +73,7 @@ import BackendCameraStream from "@/components/BackendCameraStream";
  * the husk-repo messaging is identical, not re-implemented.
  */
 
-const DEFAULT_FPS = 30;
 const JOB_SCAN_LIMIT = 200;
-
-const cameraKey = (cam: AvailableCamera) => String(cam.index);
 
 /** Small preview for verifying which physical camera a role binds to.
  *
@@ -197,8 +193,14 @@ const DeployPanel: React.FC = () => {
     null,
   );
 
-  // Per camera DISPLAY name → user-selected physical camera key (raw cv2 index
-  // string). Keyed by the stripped display name (== requestKey).
+  // Per camera DISPLAY name → the NAME of one of the selected robot's cameras.
+  // Keyed by the stripped display name (== requestKey), and sent verbatim as
+  // the request's `camera_bindings`. The binding is a name pairing only: the
+  // server reads which device and how to open it (index, unique_id, fps,
+  // fourcc, backend) out of the robot record, so a run can never open a camera
+  // set the saved robot doesn't have. Capture resolution is the exception —
+  // it's forwarded from the checkpoint as `camera_dims`, because the rollout
+  // doesn't resize frames. Cameras are edited in Robot settings.
   const [cameraBindings, setCameraBindings] = useState<
     Record<string, string | null>
   >({});
@@ -221,12 +223,30 @@ const DeployPanel: React.FC = () => {
     [policyConfig, isBimanual],
   );
 
-  const liveCameraByKey = useCallback(
-    (key: string | null | undefined) =>
-      key == null
-        ? undefined
-        : availableCameras.find((cam) => cameraKey(cam) === key),
-    [availableCameras],
+  const robotCameras: CameraConfig[] = useMemo(
+    () => robot?.cameras ?? [],
+    [robot],
+  );
+
+  /** The robot's camera a binding names, or undefined once the record no
+   * longer has it (camera removed in Robot settings, or another robot
+   * selected). */
+  const recordCameraByName = useCallback(
+    (name: string | null | undefined) =>
+      name == null ? undefined : robotCameras.find((cam) => cam.name === name),
+    [robotCameras],
+  );
+
+  /** Bound AND physically present. A stored camera_index goes stale on replug,
+   * so presence is judged by unique_id against the live enumeration — the same
+   * check the preview tiles use, and the same strictness Start had when
+   * bindings pointed straight at an enumerated device. */
+  const cameraIsReady = useCallback(
+    (name: string | null | undefined) => {
+      const cam = recordCameraByName(name);
+      return cam != null && isCameraConnected(cam, availableCameras);
+    },
+    [recordCameraByName, availableCameras],
   );
 
   // Load the skill listing (local runs + Hub models) when the studio opens.
@@ -411,58 +431,48 @@ const DeployPanel: React.FC = () => {
     };
   }, [open, baseUrl, fetchWithHeaders, jobId, selectedStep, isBimanual]);
 
-  // Auto-bind robot cameras whose names match a policy-expected camera. Match
-  // against the DISPLAY name (bare name), preferring stored device_id then
-  // camera_index. (Ported verbatim.)
+  // Auto-bind robot cameras whose names match a policy-expected camera, by
+  // name against the DISPLAY name (the bare name the user chose at record
+  // time — that's what the robot record stores). No device enumeration is
+  // involved any more: the binding names a RECORD camera, and the record is
+  // what the server resolves against.
   useEffect(() => {
-    if (!policyConfig) return;
-    const robotCams = robot?.cameras ?? [];
-    if (robotCams.length === 0 || availableCameras.length === 0) return;
+    if (!policyConfig || robotCameras.length === 0) return;
     setCameraBindings((prev) => {
       let changed = false;
       const next = { ...prev };
       for (const m of cameraMap) {
         if (next[m.requestKey] != null) continue;
-        const robotCam = robotCams.find(
+        const robotCam = robotCameras.find(
           (c) => c.name.toLowerCase() === m.display.toLowerCase(),
         );
-        if (!robotCam) continue;
-        // Resolve by unique_id first: it names the physical device exactly.
-        // device_id is a coin flip when two cameras share a name (the browser
-        // match is by localizedName), and camera_index goes stale on replug —
-        // both are fallbacks for records saved before unique_id was stored.
-        const live =
-          (robotCam.unique_id
-            ? availableCameras.find((c) => c.uniqueId === robotCam.unique_id)
-            : undefined) ??
-          (robotCam.device_id
-            ? availableCameras.find((c) => c.deviceId === robotCam.device_id)
-            : undefined) ??
-          availableCameras.find((c) => c.index === robotCam.camera_index);
-        if (live) {
-          next[m.requestKey] = cameraKey(live);
+        if (robotCam) {
+          next[m.requestKey] = robotCam.name;
           changed = true;
         }
       }
       return changed ? next : prev;
     });
-  }, [policyConfig, robot, availableCameras, cameraMap]);
+  }, [policyConfig, robotCameras, cameraMap]);
 
-  // Drop a binding whose physical camera has vanished. (Ported verbatim.)
+  // Drop a binding the robot record no longer backs — the camera was removed
+  // in Robot settings, or another robot was selected. (A binding to a camera
+  // that is merely UNPLUGGED is kept: the tile says "disconnected" and Start
+  // stays disabled, so reconnecting it doesn't cost the user the binding.)
   useEffect(() => {
-    if (!policyConfig || availableCameras.length === 0) return;
+    if (!policyConfig) return;
     setCameraBindings((prev) => {
       let changed = false;
       const next = { ...prev };
-      for (const [name, key] of Object.entries(prev)) {
-        if (key != null && !liveCameraByKey(key)) {
+      for (const [name, boundTo] of Object.entries(prev)) {
+        if (boundTo != null && !recordCameraByName(boundTo)) {
           next[name] = null;
           changed = true;
         }
       }
       return changed ? next : prev;
     });
-  }, [policyConfig, availableCameras, liveCameraByKey]);
+  }, [policyConfig, recordCameraByName]);
 
   // Poll inference status while visible so ⏹ Stop reflects a live rollout.
   useEffect(() => {
@@ -505,8 +515,8 @@ const DeployPanel: React.FC = () => {
     checkpointArms != null &&
     checkpointIsBimanual !== isBimanual;
 
-  const allCamerasBound = cameraMap.every(
-    (m) => liveCameraByKey(cameraBindings[m.requestKey]) != null,
+  const allCamerasBound = cameraMap.every((m) =>
+    cameraIsReady(cameraBindings[m.requestKey]),
   );
 
   const inferenceActive = status?.inference_active === true;
@@ -536,34 +546,30 @@ const DeployPanel: React.FC = () => {
     // open the same camera index via OpenCV without colliding on the device.
     setSubmitting(true);
     await new Promise((r) => setTimeout(r, 300));
-    // Emit camera dict keys under the DISPLAY/request name (bare in bimanual
-    // mode). The rollout hands these to the BiSO left_arm_config, which
-    // re-prefixes with `left_` — reconstructing the checkpoint's `left_<name>`
-    // feature. Resolution comes from the checkpoint feature's dims.
-    const cameraDict: Record<
-      string,
-      {
-        type: string;
-        camera_index?: number;
-        width: number;
-        height: number;
-        fps?: number;
-        fourcc?: string;
-      }
-    > = {};
+    // Emit binding keys under the DISPLAY/request name (bare in bimanual
+    // mode). The rollout hands the resolved cameras to the BiSO
+    // left_arm_config, which re-prefixes with `left_` — reconstructing the
+    // checkpoint's `left_<name>` feature. The VALUES are robot-record camera
+    // names; every setting behind them is read server-side from the record.
+    const cameraBindingPayload: Record<string, string> = {};
+    // ...except capture RESOLUTION, which comes from the checkpoint: lerobot's
+    // rollout doesn't resize frames to the policy's input shape, so the camera
+    // must capture at the size the policy was trained on. Forwarded the same
+    // way `checkpoint_state_dim` is — the client already read these dims off
+    // /policy-config, the server applies them.
+    const cameraDimsPayload: Record<string, { width: number; height: number }> =
+      {};
     for (const m of cameraMap) {
-      const key = cameraBindings[m.requestKey];
-      if (key == null) continue;
-      const live = liveCameraByKey(key);
-      if (!live) continue;
+      const boundTo = cameraBindings[m.requestKey];
+      if (boundTo == null || !recordCameraByName(boundTo)) continue;
+      cameraBindingPayload[m.requestKey] = boundTo;
       const dims = policyConfig.image_features[m.feature];
-      cameraDict[m.requestKey] = {
-        type: "opencv",
-        camera_index: live.index,
-        width: dims.width,
-        height: dims.height,
-        fps: DEFAULT_FPS,
-      };
+      if (dims?.width && dims?.height) {
+        cameraDimsPayload[m.requestKey] = {
+          width: dims.width,
+          height: dims.height,
+        };
+      }
     }
     try {
       await startInference(baseUrl, fetchWithHeaders, {
@@ -571,7 +577,8 @@ const DeployPanel: React.FC = () => {
         follower_config: robot.follower_config,
         policy_ref: selectedRef,
         task,
-        cameras: cameraDict,
+        camera_bindings: cameraBindingPayload,
+        camera_dims: cameraDimsPayload,
         duration_s: durationS,
         mode: robot.mode,
         right_follower_port: robot.right_follower_port,
@@ -856,20 +863,39 @@ const DeployPanel: React.FC = () => {
               ) : (
                 <div className="space-y-3">
                   <p className="text-xs text-muted-foreground">
-                    Bind a physical camera to each name the policy was trained with.
-                    Resolution comes from the checkpoint.
+                    Bind one of this robot's cameras to each name the policy was
+                    trained with. Which camera and how it's opened come from the
+                    robot (edit in Robot settings); the capture resolution comes
+                    from the checkpoint.
                   </p>
                   {cameraMap.map((m) => {
                     const dims = policyConfig.image_features[m.feature];
                     const value = cameraBindings[m.requestKey];
-                    const selectedCamera = liveCameraByKey(value);
+                    const boundCamera = recordCameraByName(value);
+                    const connected =
+                      boundCamera != null &&
+                      isCameraConnected(boundCamera, availableCameras);
                     return (
                       <div key={m.requestKey} className="flex items-center gap-3">
                         <div className="flex-1">
                           <Label className="text-sm font-medium">{m.display}</Label>
                           <p className="text-xs text-muted-foreground">
-                            {dims.width}×{dims.height}
+                            Captures at {dims.width}×{dims.height} — the
+                            policy's resolution
                           </p>
+                          {boundCamera &&
+                          (boundCamera.width !== dims.width ||
+                            boundCamera.height !== dims.height) ? (
+                            <p className="text-xs text-muted-foreground">
+                              ({boundCamera.name} is set to {boundCamera.width}×
+                              {boundCamera.height} in Robot settings)
+                            </p>
+                          ) : null}
+                          {boundCamera && !connected ? (
+                            <p className="text-xs text-destructive">
+                              Disconnected — reconnect it before starting
+                            </p>
+                          ) : null}
                         </div>
                         <Select
                           value={value ?? undefined}
@@ -879,25 +905,27 @@ const DeployPanel: React.FC = () => {
                             <SelectValue placeholder="Select a camera" />
                           </SelectTrigger>
                           <SelectContent>
-                            {availableCameras.length === 0 ? (
+                            {robotCameras.length === 0 ? (
                               <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                                No cameras detected
+                                This robot has no cameras — add them in Robot
+                                settings
                               </div>
                             ) : (
-                              availableCameras.map((cam) => (
-                                <SelectItem
-                                  key={cameraKey(cam)}
-                                  value={cameraKey(cam)}
-                                >
-                                  #{cam.index} — {cam.name}
+                              robotCameras.map((cam) => (
+                                <SelectItem key={cam.name} value={cam.name}>
+                                  {cam.name} — {cam.width}×{cam.height}
                                 </SelectItem>
                               ))
                             )}
                           </SelectContent>
                         </Select>
                         <CameraThumbnail
-                          cameraIndex={selectedCamera?.index}
-                          uniqueId={selectedCamera?.uniqueId}
+                          cameraIndex={
+                            boundCamera && connected
+                              ? resolveCameraIndex(boundCamera, availableCameras)
+                              : undefined
+                          }
+                          uniqueId={boundCamera?.unique_id}
                           paused={submitting || inferenceActive}
                         />
                       </div>

--- a/frontend/src/components/studio/RecordingForm.tsx
+++ b/frontend/src/components/studio/RecordingForm.tsx
@@ -74,22 +74,19 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
         on the selected robot.
       </p>
 
-      {/* Robot readiness — a status line, not a parameter, so no eyebrow. */}
+      {/* Robot readiness — a warning, not a parameter, so no eyebrow. A ready
+          robot renders nothing: the robot menu already names the selection. */}
       <RobotStatus ready={!!robot && robot.is_clean}>
         {!robot ? (
           <>
             Select or create a robot before recording — use the robot menu in
             the top-right corner of this window.
           </>
-        ) : !robot.is_clean ? (
+        ) : (
           <>
             <strong>{robot.name}</strong> {robotSetupGap(robot)}. Open Robot
             settings before recording.
           </>
-        ) : (
-          <span className="text-foreground">
-            Recording with <strong>{robot.name}</strong>
-          </span>
         )}
       </RobotStatus>
 

--- a/frontend/src/components/studio/RecordingForm.tsx
+++ b/frontend/src/components/studio/RecordingForm.tsx
@@ -3,9 +3,7 @@ import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
-import CameraConfiguration, {
-  CameraConfig,
-} from "@/components/recording/CameraConfiguration";
+import { SessionCameraList } from "@/components/recording/CameraConfiguration";
 import {
   AdvancedSection,
   RobotStatus,
@@ -30,15 +28,16 @@ interface RecordingFormProps {
   setStreamingEncoding: (value: boolean) => void;
   pushToHub: boolean;
   setPushToHub: (value: boolean) => void;
-  cameras: CameraConfig[];
-  setCameras: (cameras: CameraConfig[]) => void;
   releaseStreamsRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 /**
  * The recording configuration form — ported from the old landing
  * RecordingModal (its logic is preserved verbatim: name validation +
- * namespace-prefix hint, camera config, streaming-encoding toggle). Lifted
+ * namespace-prefix hint, streaming-encoding toggle). Cameras are no longer
+ * part of the form: the session records the selected robot's cameras, resolved
+ * server-side from the robot record, so they are shown read-only here and
+ * edited only in the robot settings dialog. Lifted
  * out of the dialog into the studio Collect panel and restyled to Layout D
  * tokens. Every session records a NEW dataset — appending to an existing one
  * was removed in favor of merging datasets. The Start button lives in
@@ -60,8 +59,6 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
   setStreamingEncoding,
   pushToHub,
   setPushToHub,
-  cameras,
-  setCameras,
   releaseStreamsRef,
 }) => {
   const { auth } = useHfAuth();
@@ -181,11 +178,17 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
         </div>
       </div>
 
-      {/* Cameras */}
-      <CameraConfiguration
-        cameras={cameras}
-        onCamerasChange={setCameras}
+      {/* Cameras — read-only. The session records the SELECTED ROBOT's
+          cameras (the backend resolves them from the robot record), so this
+          confirms what will be captured; editing happens in Robot settings. */}
+      <SessionCameraList
+        cameras={robot?.cameras ?? []}
         releaseStreamsRef={releaseStreamsRef}
+        emptyLabel={
+          robot
+            ? "This robot has no cameras. Add them in Robot settings to record video."
+            : "Select a robot to see its cameras."
+        }
       />
 
       {/* Advanced */}

--- a/frontend/src/components/studio/panel/primitives.tsx
+++ b/frontend/src/components/studio/panel/primitives.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AlertTriangle, CheckCircle, ChevronDown } from "lucide-react";
+import { AlertTriangle, ChevronDown } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Collapsible,
@@ -141,22 +141,19 @@ export const AdvancedSection: React.FC<{
 );
 
 /**
- * The robot-readiness line that opens the Collect and Deploy forms. One
+ * The robot-readiness warning that opens the Collect and Deploy forms. One
  * implementation of a block the two panels used to render differently (Collect
  * hand-rolled amber divs, Deploy used <Alert> with warn tokens) — the caller
- * owns the copy, this owns the look. Rendered without an eyebrow: it reports
+ * owns the copy, this owns the look. Warnings only: a ready robot renders
+ * nothing, because the robot menu already names the selection and a green
+ * "ready" line just restates it. Rendered without an eyebrow: it reports
  * state, it isn't a parameter.
  */
 export const RobotStatus: React.FC<{
   ready: boolean;
   children: React.ReactNode;
 }> = ({ ready, children }) =>
-  ready ? (
-    <div className="flex items-center gap-2 text-sm">
-      <CheckCircle className="h-4 w-4 shrink-0 text-ok" />
-      {children}
-    </div>
-  ) : (
+  ready ? null : (
     <Alert className="border-warn/40 text-warn [&>svg]:text-warn">
       <AlertTriangle className="h-4 w-4" />
       <AlertDescription>{children}</AlertDescription>

--- a/frontend/src/contexts/StudioContext.tsx
+++ b/frontend/src/contexts/StudioContext.tsx
@@ -5,7 +5,6 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import type { CameraConfig } from "@/components/recording/CameraConfiguration";
 
 export type StudioPanel = "collect" | "train" | "deploy";
 
@@ -24,11 +23,11 @@ export interface CollectFormState {
    * session ends (via the background UploadManager, not the recorder's
    * blocking in-session push). Consumed by CollectHandoff. */
   pushToHub: boolean;
-  cameras: CameraConfig[];
-  /** Robot name the cameras were last seeded from (null = seeded with no
-   * robot; undefined = never seeded). Kept here so a panel remount doesn't
-   * re-seed and clobber the user's camera edits. */
-  camerasSeededFor: string | null | undefined;
+  // Cameras are deliberately NOT part of this draft. A session records the
+  // selected robot's cameras, resolved server-side from the robot record, so a
+  // session-local editable copy could only diverge from what actually runs —
+  // its edits were never written back and never sent. The Collect panel now
+  // shows the record's cameras read-only; they're edited in Robot settings.
 }
 
 const DEFAULT_COLLECT_FORM: CollectFormState = {
@@ -40,8 +39,6 @@ const DEFAULT_COLLECT_FORM: CollectFormState = {
   resetTimeS: 15,
   streamingEncoding: true,
   pushToHub: true,
-  cameras: [],
-  camerasSeededFor: undefined,
 };
 
 /** Pre-fills the Deploy panel when a skill card / job row says "Run on robot".

--- a/frontend/src/lib/inferenceApi.ts
+++ b/frontend/src/lib/inferenceApi.ts
@@ -5,14 +5,21 @@ export interface StartInferenceRequest {
   follower_config: string;
   policy_ref: string;
   task: string;
-  cameras: Record<string, {
-    type: string;
-    camera_index?: number;
-    width: number;
-    height: number;
-    fps?: number;
-    fourcc?: string;
-  }>;
+  // Which of the ROBOT RECORD's cameras plays each camera role the checkpoint
+  // was trained with: { policy-expected camera name: robot-record camera name }.
+  // Only the name pairing is sent — which device, and how it's opened (index,
+  // unique_id, fps, fourcc, backend), is read out of the record named by
+  // `robot_name`, so a run can never open a camera set the saved robot doesn't
+  // have. (Capture resolution is the exception — see `camera_dims`.) A binding
+  // naming a camera the record lacks is a 400.
+  camera_bindings: Record<string, string>;
+  // Capture resolution per policy-expected camera name, read off the
+  // checkpoint's `image_features` (same forward-the-checkpoint's-own-metadata
+  // pattern as `checkpoint_state_dim`). The ONE camera setting not taken from
+  // the robot record: lerobot's rollout does not resize frames to the policy's
+  // input shape, so a camera must capture at the resolution the policy was
+  // trained on. Omitted entries fall back to the record's own width/height.
+  camera_dims?: Record<string, { width: number; height: number }>;
   duration_s: number;
   // Bimanual: "single" (default) drives one follower; "bimanual" drives two.
   // In bimanual mode follower_port/follower_config above is the LEFT arm and
@@ -20,7 +27,9 @@ export interface StartInferenceRequest {
   mode?: "single" | "bimanual";
   right_follower_port?: string;
   right_follower_config?: string;
-  // Robot record name — the BiSO calibration-staging base id (bimanual only).
+  // Robot record name. Names the record `camera_bindings` resolve against
+  // (required whenever any binding is set), and — bimanual only — the BiSO
+  // calibration-staging base id.
   robot_name?: string;
   // Checkpoint's flat state width (6 = single arm, 12 = bimanual). Lets the
   // server reject an arm-count mismatch before spawning the rollout subprocess.

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -44,6 +44,8 @@ from .motor_power import clear_goal_velocity, reset_torque_limit
 from .rest_pose import RETURN_CEILING_S, capture_rest_pose
 from .teleoperate import _device_buses, _return_followers_to_rest, force_disable_torque
 from .utils.config import (
+    CameraResolutionError,
+    load_robot_cameras,
     validate_dataset_repo_id,
     with_makermodslab_tag,
 )
@@ -340,9 +342,17 @@ class RecordingRequest(BaseModel):
     right_follower_port: str = ""
     right_leader_config: str = ""
     right_follower_config: str = ""
-    # Robot record name — used only as the BiSO staging base id (bimanual). It
-    # decides the on-disk staging dir, not which calibration drives which arm.
-    # Blank/invalid falls back to DEFAULT_BIMANUAL_BASE.
+    # Robot record name. Two jobs:
+    #   1. The session's CAMERAS are resolved from this record, server-side
+    #      (utils/config.load_robot_cameras) — the request carries no camera
+    #      payload at all. Blank ⇒ a camera-less recording; a non-blank name
+    #      with no record on disk is a 400, never a silent camera-less run.
+    #   2. Bimanual only: the BiSO staging base id — it decides the on-disk
+    #      staging dir, not which calibration drives which arm. Blank/invalid
+    #      falls back to DEFAULT_BIMANUAL_BASE.
+    # A `cameras` dict used to live on this model. It was removed (the panel is
+    # read-only now); pydantic ignores unknown fields, so an older frontend's
+    # payload still parses and its stale camera set is correctly ignored.
     robot_name: str = ""
     dataset_repo_id: str
     single_task: str
@@ -356,7 +366,6 @@ class RecordingRequest(BaseModel):
     private: bool = False
     resume: bool = False
     streaming_encoding: bool = True
-    cameras: dict = {}
     test_mode: bool = False  # Skip robot connection for testing
     # Escape hatch for the arm-identity guard (see makermodslab/arm_identity.py):
     # when true, record even if the connected arms don't match their calibrations.
@@ -395,7 +404,10 @@ def _platform_backend():
 
 
 def _build_camera_configs(cameras: dict, default_backend) -> dict:
-    """Convert the frontend camera dict into OpenCVCameraConfig objects.
+    """Convert the session camera dict into OpenCVCameraConfig objects.
+
+    The dict is `{camera name: settings}` as resolved from the robot record by
+    utils/config.load_robot_cameras — it never comes from the request.
 
     `backend` (a Cv2Backends name) and `fourcc` (a 4-char code) are optional per
     camera; when omitted `backend` falls back to `default_backend` and `fourcc`
@@ -435,11 +447,19 @@ def _build_camera_configs(cameras: dict, default_backend) -> dict:
     return camera_configs
 
 
-def create_record_config(request: RecordingRequest) -> RecordConfig:
-    """Create a RecordConfig from the recording request"""
-    # Convert the frontend camera dict into OpenCVCameraConfig objects. Backend
-    # defaults to the platform pin unless the request overrides it per camera.
-    camera_configs = _build_camera_configs(request.cameras, _platform_backend())
+def create_record_config(request: RecordingRequest, cameras: dict | None = None) -> RecordConfig:
+    """Create a RecordConfig from the recording request.
+
+    `cameras` is the session camera dict already resolved from the robot record
+    (handle_start_recording resolves it inside its lock so a bad robot name is a
+    400 before the session claims anything). Left None it is resolved here from
+    `request.robot_name`, so a direct caller gets the same record-driven set.
+    """
+    # Convert the session camera dict into OpenCVCameraConfig objects. Backend
+    # defaults to the platform pin unless the record pins one per camera.
+    if cameras is None:
+        cameras = load_robot_cameras(request.robot_name)
+    camera_configs = _build_camera_configs(cameras, _platform_backend())
 
     if request.mode == "bimanual":
         # Build a lerobot BiSO leader+follower pair (config assembly + calibration
@@ -599,6 +619,16 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
                 name_reason,
             )
             return {"success": False, "status_code": 400, "message": name_reason}
+        # Resolve the session's cameras from the robot record NAMED BY THE
+        # REQUEST — the request itself carries no camera payload. Done here,
+        # before the flag is claimed, so a wrong robot name or an ambiguous
+        # camera set is a plain 400 instead of a session that starts and
+        # silently records no video.
+        try:
+            session_cameras = load_robot_cameras(request.robot_name)
+        except CameraResolutionError as exc:
+            logger.warning("Rejected recording start: %s", exc)
+            return {"success": False, "status_code": 400, "message": str(exc)}
         # Per-session state reset, under the same lock that claims the active
         # flag: a stale _release_now from a previous session's double-stop
         # would otherwise cut EVERY later release grace short until the server
@@ -655,7 +685,7 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
             "paused": False,  # Reset-phase pause/resume (mouse-only, no keyboard shortcut)
         }
 
-        record_config = create_record_config(request)
+        record_config = create_record_config(request, cameras=session_cameras)
 
         def recording_worker():
             global \
@@ -687,10 +717,10 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
 
                 # Give the frontend's camera streams time to release the
                 # underlying devices before lerobot tries to open them.
-                if request.cameras:
+                if session_cameras:
                     logger.info(
                         "Waiting for camera resources to be released (cameras: %s)",
-                        list(request.cameras.keys()),
+                        list(session_cameras.keys()),
                     )
                     time.sleep(2.0)
 

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -46,7 +46,9 @@ from .jobs import download_hub_checkpoint_ref, make_snapshot_progress_tqdm
 from .motor_power import clear_goal_velocity, reset_torque_limit
 from .record import _DEFAULT_FOURCC
 from .utils.config import (
+    CameraResolutionError,
     bimanual_base_id,
+    bind_robot_cameras,
     list_robot_records,
     setup_follower_calibration_file,
     stage_bimanual_follower_calibrations,
@@ -63,12 +65,43 @@ logger = logging.getLogger(__name__)
 _SINGLE_ARM_STATE_DIM = 6
 
 
+class PolicyCameraDims(BaseModel):
+    """The frame size one of the checkpoint's cameras was trained on.
+
+    Forwarded from /policy-config's `image_features` by the launch UI, in the
+    same spirit as `checkpoint_state_dim` below: the client already has the
+    checkpoint's metadata, and echoing it lets the server apply it
+    authoritatively instead of guessing. See bind_robot_cameras for why capture
+    resolution must come from the checkpoint rather than the robot record.
+    """
+
+    width: int
+    height: int
+
+
 class InferenceRequest(BaseModel):
     follower_port: str
     follower_config: str
     policy_ref: str  # opaque ref returned by /jobs/{id}/checkpoints
     task: str = ""
-    cameras: dict[str, dict[str, Any]] = {}
+    # Which of the ROBOT RECORD's cameras plays each camera role the checkpoint
+    # was trained with: {policy-expected camera name: robot-record camera name}.
+    # Only the name pairing travels in the request — which device, and how it's
+    # opened (index, unique_id, fps, fourcc, backend), is read server-side from
+    # the record, so a run can never open a camera set the saved robot doesn't
+    # have. (Capture resolution is the one exception: see `camera_dims` below.)
+    # Empty ⇒ a camera-less policy. Replaces the former `cameras`
+    # dict of full per-camera configs; pydantic ignores unknown fields, so an
+    # older frontend's payload parses and its camera configs are ignored.
+    camera_bindings: dict[str, str] = {}
+    # Capture resolution per policy-expected camera name, from the checkpoint's
+    # image_features. The one camera setting NOT taken from the robot record:
+    # lerobot's standard rollout does not resize frames to the policy's input
+    # shape, so capturing at the record's configured size would silently feed
+    # the policy frames it was never trained on. Keyed to match camera_bindings;
+    # a camera with no entry here (older client, or a checkpoint that doesn't
+    # expose image dims) falls back to the record's own width/height.
+    camera_dims: dict[str, PolicyCameraDims] = {}
     duration_s: int = 60
     # Bimanual: the follower_port/follower_config above is the LEFT arm; these
     # add the RIGHT arm. Inference has no leader arms — only the two followers
@@ -76,9 +109,12 @@ class InferenceRequest(BaseModel):
     mode: str = "single"
     right_follower_port: str = ""
     right_follower_config: str = ""
-    # Robot record name — used only as the BiSO staging base id (bimanual). It
-    # decides the on-disk staging dir, not which calibration drives which arm.
-    # Blank/invalid falls back to DEFAULT_BIMANUAL_BASE.
+    # Robot record name. Two jobs:
+    #   1. It names the record `camera_bindings` resolve against (required
+    #      whenever any binding is set — a missing record is a 400).
+    #   2. Bimanual only: the BiSO staging base id — it decides the on-disk
+    #      staging dir, not which calibration drives which arm. Blank/invalid
+    #      falls back to DEFAULT_BIMANUAL_BASE.
     robot_name: str = ""
     # Flat state width of the selected checkpoint (6 = single SO-101 arm, 12 =
     # bimanual), forwarded from /policy-config so the server can reject an
@@ -447,19 +483,25 @@ def _preflight_motor_registers(port: str, follower_id: str) -> list[str]:
 
 def _format_cameras_arg(cameras: dict[str, dict[str, Any]]) -> str:
     """Convert {name: {type, camera_index, width, height, fps}} into
-    lerobot's CLI dict syntax. The frontend key `camera_index` is
-    remapped to lerobot's `index_or_path`.
+    lerobot's CLI dict syntax. `cameras` is the record-resolved session dict
+    (see _session_cameras), keyed by the POLICY-expected camera names. The
+    stored key `camera_index` is remapped to lerobot's `index_or_path`; the
+    identity key `unique_id` is dropped — it is the robot record's own handle
+    on the physical device (see makermodslab/camera_identity.py), and lerobot's
+    OpenCVCameraConfig would reject it as an unknown field.
 
     Like recording (`record._build_camera_configs`), opencv cameras default to
-    MJPG when the request doesn't pin a fourcc: without it, Linux/V4L2
+    MJPG when the record doesn't pin a fourcc: without it, Linux/V4L2
     negotiates raw YUYV and a 3-camera rig exhausts the USB bus at STREAMON —
     the third camera fails during inference only, since recording already
-    defaults to MJPG. An explicit fourcc from the UI still wins.
+    defaults to MJPG. An explicit fourcc from the record still wins.
     """
     parts = []
     for name, cfg in cameras.items():
         remapped = {
-            ("index_or_path" if k == "camera_index" else k): v for k, v in cfg.items() if v is not None
+            ("index_or_path" if k == "camera_index" else k): v
+            for k, v in cfg.items()
+            if v is not None and k != "unique_id"
         }
         if cfg.get("type") == "opencv" and not cfg.get("fourcc"):
             remapped["fourcc"] = _DEFAULT_FOURCC
@@ -561,6 +603,22 @@ def _build_rollout_cmd(request: InferenceRequest, policy_path: str, robot_args: 
     return cmd
 
 
+def _session_cameras(request: InferenceRequest) -> dict[str, dict[str, Any]]:
+    """This run's cameras, keyed by the policy-expected name.
+
+    Camera identity and transport settings are resolved from the robot record
+    every time they're needed rather than carried on the request: the record is
+    the only place they live, and the lookup is one small JSON read. Capture
+    resolution is overlaid from the checkpoint (see PolicyCameraDims /
+    bind_robot_cameras). Raises CameraResolutionError, which
+    handle_start_inference turns into a 400 before the session starts."""
+    return bind_robot_cameras(
+        request.robot_name,
+        request.camera_bindings,
+        dims={name: dims.model_dump() for name, dims in request.camera_dims.items()},
+    )
+
+
 def _single_robot_args(request: InferenceRequest, follower_id: str) -> list[str]:
     """`--robot.*` args for a single SO-101 follower."""
     args = [
@@ -568,8 +626,9 @@ def _single_robot_args(request: InferenceRequest, follower_id: str) -> list[str]
         f"--robot.port={request.follower_port}",
         f"--robot.id={follower_id}",
     ]
-    if request.cameras:
-        args.append(f"--robot.cameras={_format_cameras_arg(request.cameras)}")
+    cameras = _session_cameras(request)
+    if cameras:
+        args.append(f"--robot.cameras={_format_cameras_arg(cameras)}")
     return args
 
 
@@ -591,8 +650,9 @@ def _bimanual_robot_args(request: InferenceRequest, base: str, follower_staging:
         f"--robot.left_arm_config.port={request.follower_port}",
         f"--robot.right_arm_config.port={request.right_follower_port}",
     ]
-    if request.cameras:
-        args.append(f"--robot.left_arm_config.cameras={_format_cameras_arg(request.cameras)}")
+    cameras = _session_cameras(request)
+    if cameras:
+        args.append(f"--robot.left_arm_config.cameras={_format_cameras_arg(cameras)}")
     return args
 
 
@@ -958,6 +1018,17 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
             "status_code": 400,
             "message": f"Unrecognised policy ref: {request.policy_ref!r}",
         }
+
+    # Resolve the camera bindings against the robot record now (one small JSON
+    # read, no hardware). A binding that names a camera the record doesn't have
+    # must 4xx in the panel; deferring it to the startup worker would surface
+    # the same mistake as a mid-startup failure after the model download.
+    try:
+        _session_cameras(request)
+    except CameraResolutionError as exc:
+        _release_slot()
+        logger.warning("Rejected inference start: %s", exc)
+        return {"success": False, "status_code": 400, "message": str(exc)}
 
     # Backend camera previews hold the cv2 devices the rollout subprocess is about
     # to open. Released here — after the cheap guards above, so a rejected request

--- a/makermodslab/utils/config.py
+++ b/makermodslab/utils/config.py
@@ -471,6 +471,175 @@ def rename_robot_record(old_name: str, new_name: str) -> tuple[bool, str]:
     return True, ""
 
 
+# ---------------------------------------------------------------------------
+# Session cameras — resolved from the robot record, never from the request
+# ---------------------------------------------------------------------------
+#
+# The robot record is the single source of truth for which cameras a session
+# opens. Recording and inference used to carry their own camera dicts in the
+# start request, so a session could run against a camera set that no longer
+# matched (or never matched) the saved robot — and edits made on the panel were
+# silently discarded. Both flows now name a robot and let the server resolve
+# the cameras; cameras are edited in one place only (the robot settings dialog).
+
+
+class CameraResolutionError(ValueError):
+    """A session's cameras could not be resolved from its robot record.
+
+    Carries a user-facing message: the route layer turns it into a 400 with
+    this text, so it must say what to fix and where (robot settings), not name
+    internals.
+    """
+
+
+# The subset of a stored camera entry a SESSION needs. `id`/`device_id`/`name`
+# are record-keeping and UI concerns: `name` becomes the dict key, and the other
+# two must not leak into the camera config (rollout's `--robot.cameras=` CLI
+# serializer forwards every key it is handed straight to lerobot's
+# OpenCVCameraConfig, which would reject them).
+_SESSION_CAMERA_KEYS = (
+    "type",
+    "camera_index",
+    "unique_id",
+    "width",
+    "height",
+    "fps",
+    "fourcc",
+    "backend",
+)
+
+
+def session_camera_config(entry: dict) -> dict:
+    """One stored camera entry → the per-camera dict a session consumes.
+
+    That shape is what `record._build_camera_configs` and
+    `rollout._format_cameras_arg` already take (both of which keep their own
+    hardening: platform backend pin and the MJPG fourcc default).
+
+    Keys the entry doesn't carry are omitted rather than sent as None, so the
+    consumers' own defaults still apply. `type` defaults to "opencv" — records
+    written before the field existed have no other kind of camera.
+    """
+    config = {key: entry[key] for key in _SESSION_CAMERA_KEYS if entry.get(key) is not None}
+    config.setdefault("type", "opencv")
+    return config
+
+
+def record_cameras_by_name(cameras: list) -> dict[str, dict]:
+    """Every camera of a robot record, keyed by its name.
+
+    Names are the record's own user-facing labels and become the dataset's
+    camera keys (recording) or the binding targets (inference), so a duplicate
+    is ambiguous rather than merely untidy: keying a dict by name would
+    silently drop one of the two. Raises CameraResolutionError instead.
+    Non-dict entries in a hand-edited record are skipped.
+    """
+    by_name: dict[str, dict] = {}
+    for entry in cameras or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            raise CameraResolutionError(
+                "A camera in this robot's configuration has no name. "
+                "Open Robot settings and name it before starting."
+            )
+        if name in by_name:
+            raise CameraResolutionError(
+                f"This robot has two cameras named '{name}'. "
+                "Rename one in Robot settings so each camera is unambiguous."
+            )
+        by_name[name] = session_camera_config(entry)
+    return by_name
+
+
+def load_robot_cameras(robot_name: str) -> dict[str, dict]:
+    """The named robot record's cameras, keyed by camera name.
+
+    A blank name means a camera-less session ({}) — recording without cameras
+    is legitimate. A NON-blank name that doesn't resolve to a record on disk
+    raises: recording camera-less because the robot name was wrong is a silent
+    data loss (a whole session with no video), so it must fail loudly.
+    """
+    name = (robot_name or "").strip()
+    if not name:
+        return {}
+    record = get_robot_record(name) if is_valid_robot_name(name) else None
+    if record is None:
+        raise CameraResolutionError(
+            f"No saved configuration found for robot '{name}'. "
+            "Select an existing robot (or save this one in Robot settings) before starting."
+        )
+    return record_cameras_by_name(record.get("cameras") or [])
+
+
+def _positive_int(value: object) -> int | None:
+    """`value` as a usable pixel dimension, or None. bool is excluded (it is an
+    int subclass, and `True` as a width is always a bug, never a 1-pixel frame)."""
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def bind_robot_cameras(
+    robot_name: str,
+    bindings: dict[str, str],
+    dims: dict[str, dict] | None = None,
+) -> dict[str, dict]:
+    """Resolve {policy-expected camera name: robot-record camera name} bindings
+    into the session camera dict, keyed by the POLICY-expected names.
+
+    Inference needs the checkpoint's own camera names, which rarely match the
+    labels on the robot — hence the indirection. The request carries only the
+    name pairing; the camera's IDENTITY and transport settings (index,
+    unique_id, fps, fourcc, backend) come from the record.
+
+    CAPTURE RESOLUTION is the one exception, supplied by `dims`
+    ({policy camera name: {"width": w, "height": h}}, from the checkpoint's
+    image_features). lerobot's standard rollout pipeline does NOT resize frames
+    to the policy's input shape — only the HIL path has a resize processor — so
+    the frames a policy sees at deployment must be captured at the resolution it
+    was trained on. Taking width/height from the robot record instead would
+    silently change policy behaviour whenever the record's configured capture
+    size differs from the checkpoint's. Overlaid per camera and only for sane
+    positive values, so a checkpoint that omits image dims (or an older client
+    that sends none) gracefully falls back to the record's own width/height.
+
+    Empty bindings mean a camera-less policy ({}). Raises
+    CameraResolutionError when no robot is named, when the record is missing,
+    or when a binding points at a camera the record doesn't have (the message
+    lists what it does have).
+    """
+    if not bindings:
+        return {}
+    if not (robot_name or "").strip():
+        raise CameraResolutionError(
+            "No robot selected, so the bound cameras can't be resolved. Select a robot before starting."
+        )
+    available = load_robot_cameras(robot_name)
+    resolved: dict[str, dict] = {}
+    for policy_name, camera_name in bindings.items():
+        key = str(camera_name or "").strip()
+        entry = available.get(key)
+        if entry is None:
+            listing = ", ".join(sorted(available)) if available else "none"
+            raise CameraResolutionError(
+                f"This robot has no camera named '{key}' (bound to '{policy_name}'). "
+                f"Cameras on this robot: {listing}. Fix the binding, or add the camera in Robot settings."
+            )
+        config = dict(entry)
+        override = (dims or {}).get(policy_name) or {}
+        width = _positive_int(override.get("width"))
+        height = _positive_int(override.get("height"))
+        # Both or neither: a half-applied override would capture at a mixed
+        # policy/record aspect, which is worse than either source alone.
+        if width is not None and height is not None:
+            config["width"] = width
+            config["height"] = height
+        resolved[policy_name] = config
+    return resolved
+
+
 def is_robot_record_clean(record: dict, arms: str = "all") -> bool:
     """
     A record is 'clean' when every operational field for its mode is populated AND

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -189,10 +189,14 @@ def test_create_record_config_pins_dshow_on_windows(monkeypatch: pytest.MonkeyPa
         follower_config="follower",
         dataset_repo_id="user/dataset",
         single_task="pick up the cube",
-        cameras={"wrist": {"type": "opencv", "camera_index": 0, "width": 640, "height": 480, "fps": 30}},
     )
 
-    config = record.create_record_config(request)
+    # Cameras come from the robot record, resolved by the caller; passing them
+    # in explicitly is the same path handle_start_recording takes.
+    config = record.create_record_config(
+        request,
+        cameras={"wrist": {"type": "opencv", "camera_index": 0, "width": 640, "height": 480, "fps": 30}},
+    )
     assert config.robot.cameras["wrist"].backend == Cv2Backends.DSHOW
 
 
@@ -231,7 +235,9 @@ def test_create_record_config_builds_biso_for_bimanual(monkeypatch: pytest.Monke
         single_task="pick up the cube",
     )
 
-    config = record.create_record_config(request)
+    # No cameras for this session — passed explicitly so the bimanual assembly
+    # is exercised without needing a "mybot" record on disk.
+    config = record.create_record_config(request, cameras={})
     assert isinstance(config.robot, BiSOFollowerConfig)
     assert isinstance(config.teleop, BiSOLeaderConfig)
     # BiSO id + calibration_dir come from the staging helper (base = robot name).
@@ -1063,7 +1069,7 @@ def test_record_start_clears_stale_release_state_from_previous_double_stop(
     monkeypatch.setattr(teleop, "teleoperation_thread", None)
 
     # Fail fast AFTER the locked reset, before any hardware is touched.
-    def _boom(request):
+    def _boom(request, cameras=None):
         raise RuntimeError("stop before hardware")
 
     monkeypatch.setattr(record, "create_record_config", _boom)
@@ -1868,7 +1874,7 @@ def test_start_recording_resume_skips_timestamp_stamp(monkeypatch: pytest.Monkey
 
     # Fail fast AFTER the stamp point (create_record_config runs right after),
     # before any hardware is touched.
-    def _boom(request):
+    def _boom(request, cameras=None):
         raise RuntimeError("stop before hardware")
 
     monkeypatch.setattr(record, "create_record_config", _boom)
@@ -1997,6 +2003,139 @@ def test_start_recording_rejects_with_400_for_invalid_dataset_name(
 
 
 # ---------------------------------------------------------------------------
+# Session cameras come from the ROBOT RECORD named by the request, never from
+# the request itself. The resolution helpers are covered in
+# tests/test_utils_config.py; these are the start-path rejection branches.
+# ---------------------------------------------------------------------------
+
+
+def _idle_mutexes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import makermodslab.record as record
+    import makermodslab.rollout as rollout
+    import makermodslab.teleoperate as teleop
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr(record, "recording_thread", None)
+    monkeypatch.setattr(record, "releasing", False)
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(teleop, "teleoperation_thread", None)
+    monkeypatch.setattr(rollout, "inference_active", False)
+
+
+def test_start_recording_rejects_with_400_when_the_robot_record_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """A named robot with no record on disk must 400 — recording camera-less
+    because the name was wrong throws away a whole session's video silently."""
+    import makermodslab.record as record
+    from makermodslab.utils import config as cfg
+
+    _idle_mutexes(monkeypatch)
+    monkeypatch.setattr(cfg, "ROBOTS_PATH", str(tmp_lerobot_home / "robots"))
+
+    result = record.handle_start_recording(_stub_recording_request(robot_name="ghost"))
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "ghost" in result["message"]
+    # The rejection happens BEFORE the active flag is claimed.
+    assert record.recording_active is False
+
+
+def test_start_recording_rejects_with_400_on_duplicate_camera_names(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """Keying the session cameras by name would drop one of a duplicate pair —
+    a camera missing from every episode. Refuse the start instead."""
+    import makermodslab.record as record
+    from makermodslab.utils import config as cfg
+
+    _idle_mutexes(monkeypatch)
+    robots_dir = tmp_lerobot_home / "robots"
+    robots_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cfg, "ROBOTS_PATH", str(robots_dir))
+    cfg.save_robot_record(
+        "twins",
+        {
+            "cameras": [
+                {"name": "wrist", "type": "opencv", "camera_index": 0, "width": 640, "height": 480},
+                {"name": "wrist", "type": "opencv", "camera_index": 1, "width": 640, "height": 480},
+            ]
+        },
+        allow_create=True,
+    )
+
+    result = record.handle_start_recording(_stub_recording_request(robot_name="twins"))
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "wrist" in result["message"]
+    assert record.recording_active is False
+
+
+def test_start_recording_ignores_a_stale_cameras_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """An older frontend still posts `cameras`. The field is gone from the
+    model, so pydantic drops it — the request must not carry it forward."""
+    import makermodslab.record as record
+
+    request = record.RecordingRequest(
+        leader_port="/dev/leader",
+        follower_port="/dev/follower",
+        leader_config="leader",
+        follower_config="follower",
+        dataset_repo_id="tester/ds",
+        single_task="pick",
+        cameras={"wrist": {"type": "opencv", "camera_index": 0}},
+    )
+
+    assert not hasattr(request, "cameras")
+
+
+def test_create_record_config_resolves_cameras_from_the_robot_record(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """Called without an explicit set, the config builder reads the record —
+    the request has no camera payload to fall back on."""
+    import makermodslab.record as record
+    from makermodslab.utils import config as cfg
+
+    robots_dir = tmp_lerobot_home / "robots"
+    robots_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cfg, "ROBOTS_PATH", str(robots_dir))
+    cfg.save_robot_record(
+        "lab1",
+        {
+            "cameras": [
+                {
+                    "id": "camera_1",
+                    "name": "wrist",
+                    "type": "opencv",
+                    "camera_index": 0,
+                    "device_id": "browser-id",
+                    "width": 640,
+                    "height": 480,
+                    "fps": 30,
+                }
+            ]
+        },
+        allow_create=True,
+    )
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files",
+        lambda leader, follower: ("leader", "follower"),
+    )
+
+    config = record.create_record_config(
+        _stub_recording_request(robot_name="lab1", dataset_repo_id="tester/ds")
+    )
+
+    assert list(config.robot.cameras) == ["wrist"]
+    assert config.robot.cameras["wrist"].width == 640
+
+
+# ---------------------------------------------------------------------------
 # Session error taxonomy — outcome / error / hint (in-process twin of the
 # rollout exited payload). The worker's catch site holds the actual exception,
 # so the error text is formatted from the object (no log forensics); the
@@ -2094,7 +2233,7 @@ def _start_session_with_fake_work(monkeypatch: pytest.MonkeyPatch, fake_work):
     monkeypatch.setattr(teleop, "teleoperation_active", False)
     monkeypatch.setattr(teleop, "teleoperation_thread", None)
     monkeypatch.setattr(rollout, "inference_active", False)
-    monkeypatch.setattr(record, "create_record_config", lambda request: None)
+    monkeypatch.setattr(record, "create_record_config", lambda request, cameras=None: None)
     monkeypatch.setattr(record, "record_with_web_events", fake_work)
 
     result = record.handle_start_recording(

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import io
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -90,7 +91,8 @@ def test_inference_request_has_expected_defaults() -> None:
         policy_ref="user/repo@checkpoints/000050",
     )
     assert req.task == ""
-    assert req.cameras == {}
+    assert req.camera_bindings == {}
+    assert req.camera_dims == {}
     assert req.duration_s == 60
 
 
@@ -479,8 +481,42 @@ def test_handle_start_inference_pins_return_to_initial_position(monkeypatch, tmp
 
 
 # ---------------------------------------------------------------------------
-# --robot.* arg construction — single vs bimanual (pure, no I/O)
+# --robot.* arg construction — single vs bimanual
+#
+# Cameras are no longer carried on the request: it names a robot record and
+# binds each policy-expected camera name to one of that record's cameras, so
+# the camera-bearing cases need a record on disk (via `_robot_record_with_cam`).
 # ---------------------------------------------------------------------------
+
+
+def _robot_record_with_cam(tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Write a one-camera robot record into a redirected ROBOTS_PATH.
+
+    ROBOTS_PATH is a module-level constant not covered by `tmp_lerobot_home`
+    (same pattern as tests/test_utils_config.py's autouse fixture)."""
+    from makermodslab.utils import config as cfg
+
+    robots_dir = tmp_lerobot_home / "robots"
+    robots_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cfg, "ROBOTS_PATH", str(robots_dir))
+    cfg.save_robot_record(
+        name,
+        {
+            "cameras": [
+                {
+                    "id": "camera_1",
+                    "name": "wrist",
+                    "type": "opencv",
+                    "camera_index": 0,
+                    "device_id": "browser-device-id",
+                    "width": 640,
+                    "height": 480,
+                    "fps": 30,
+                }
+            ]
+        },
+        allow_create=True,
+    )
 
 
 def _bimanual_request():
@@ -508,18 +544,56 @@ def test_single_robot_args_uses_so101_follower_type() -> None:
     assert not any(a.startswith("--robot.cameras=") for a in args)
 
 
-def test_single_robot_args_appends_cameras_when_present() -> None:
+def test_single_robot_args_appends_bound_record_cameras(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The binding names a RECORD camera ("wrist"); the CLI arg is keyed by the
+    POLICY-expected name ("front") and carries the record's own settings."""
     from makermodslab.rollout import InferenceRequest, _single_robot_args
 
+    _robot_record_with_cam(tmp_lerobot_home, monkeypatch, "solo")
     req = InferenceRequest(
         follower_port="/dev/ttyUSB0",
         follower_config="robot_a",
         policy_ref="user/repo@checkpoints/000050",
-        cameras={"front": {"type": "opencv", "camera_index": 0, "width": 640, "height": 480}},
+        robot_name="solo",
+        camera_bindings={"front": "wrist"},
     )
     args = _single_robot_args(req, "robot_a")
     cam_arg = next(a for a in args if a.startswith("--robot.cameras="))
     assert "front:" in cam_arg
+    assert "wrist" not in cam_arg
+    assert "index_or_path: 0" in cam_arg
+    assert "width: 640" in cam_arg
+    # Record-keeping keys never reach lerobot's config parser, and neither does
+    # the record's own device identity (lerobot has no `unique_id` field).
+    assert "device_id" not in cam_arg
+    assert "id:" not in cam_arg
+    assert "unique_id" not in cam_arg
+
+
+def test_single_robot_args_captures_at_the_checkpoints_resolution(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rollout pipeline doesn't resize frames to the policy's input shape,
+    so `camera_dims` (from the checkpoint) must win over the record's own
+    configured size — while identity still comes from the record."""
+    from makermodslab.rollout import InferenceRequest, _single_robot_args
+
+    _robot_record_with_cam(tmp_lerobot_home, monkeypatch, "solo")
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        robot_name="solo",
+        camera_bindings={"front": "wrist"},
+        camera_dims={"front": {"width": 320, "height": 240}},
+    )
+    cam_arg = next(a for a in _single_robot_args(req, "robot_a") if a.startswith("--robot.cameras="))
+
+    assert "width: 320" in cam_arg
+    assert "height: 240" in cam_arg
+    assert "width: 640" not in cam_arg
     assert "index_or_path: 0" in cam_arg
 
 
@@ -534,9 +608,12 @@ def test_bimanual_robot_args_uses_bi_so_follower_with_both_ports() -> None:
     assert "--robot.right_arm_config.port=/dev/right" in args
 
 
-def test_bimanual_robot_args_puts_cameras_on_left_arm_only() -> None:
+def test_bimanual_robot_args_puts_cameras_on_left_arm_only(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from makermodslab.rollout import InferenceRequest, _bimanual_robot_args
 
+    _robot_record_with_cam(tmp_lerobot_home, monkeypatch, "dual_arm")
     req = InferenceRequest(
         follower_port="/dev/left",
         follower_config="left_cal",
@@ -544,7 +621,8 @@ def test_bimanual_robot_args_puts_cameras_on_left_arm_only() -> None:
         mode="bimanual",
         right_follower_port="/dev/right",
         right_follower_config="right_cal",
-        cameras={"front": {"type": "opencv", "camera_index": 0, "width": 640, "height": 480}},
+        robot_name="dual_arm",
+        camera_bindings={"front": "wrist"},
     )
     args = _bimanual_robot_args(req, "dual_arm", "/staging/follower")
     assert any(a.startswith("--robot.left_arm_config.cameras=") for a in args)
@@ -619,6 +697,73 @@ def test_handle_start_inference_arm_count_guard_releases_slot() -> None:
     )
     rollout.handle_start_inference(req)
     assert rollout.inference_active is False
+
+
+# ---------------------------------------------------------------------------
+# handle_start_inference — camera bindings resolve against the ROBOT RECORD
+# (cheap: one JSON read, no hardware, no subprocess). The pure resolution
+# helpers are covered in tests/test_utils_config.py.
+# ---------------------------------------------------------------------------
+
+
+def test_handle_start_inference_rejects_a_binding_with_no_robot() -> None:
+    """Bindings name a record camera, so they're meaningless without a record."""
+    from makermodslab import rollout
+
+    req = rollout.InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        camera_bindings={"front": "wrist"},
+    )
+    result = rollout.handle_start_inference(req)
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "No robot selected" in result["message"]
+    # A rejected start must not wedge the slot.
+    assert rollout.inference_active is False
+
+
+def test_handle_start_inference_rejects_a_binding_to_an_unknown_camera(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 400 names what the robot actually has, so the panel can say which
+    camera to pick — this is the whole point of resolving server-side."""
+    from makermodslab import rollout
+
+    _robot_record_with_cam(tmp_lerobot_home, monkeypatch, "solo")
+    req = rollout.InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        robot_name="solo",
+        camera_bindings={"front": "gone"},
+    )
+    result = rollout.handle_start_inference(req)
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "'gone'" in result["message"]
+    assert "wrist" in result["message"]
+    assert rollout.inference_active is False
+
+
+def test_handle_start_inference_ignores_a_stale_cameras_payload() -> None:
+    """An older frontend still posts full `cameras` configs. The field is gone
+    from the model, so pydantic drops them rather than letting a request-side
+    camera set drive the run."""
+    from makermodslab import rollout
+
+    req = rollout.InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        cameras={"front": {"type": "opencv", "camera_index": 0, "width": 640, "height": 480}},
+    )
+
+    assert not hasattr(req, "cameras")
+    assert req.camera_bindings == {}
 
 
 def test_handle_start_inference_bimanual_builds_bi_so_follower_command(monkeypatch, tmp_path) -> None:

--- a/tests/test_utils_config.py
+++ b/tests/test_utils_config.py
@@ -895,3 +895,227 @@ def test_prune_dismissed_hub_jobs_drops_ids_gone_from_listing(tmp_lerobot_home: 
     # Pruning against a listing that contains everything is a no-op.
     cfg.prune_dismissed_hub_jobs({"job-live"})
     assert cfg.get_dismissed_hub_jobs() == {"job-live"}
+
+
+# --- Session cameras resolved from the robot record -------------------------
+#
+# The robot record is the only source of a session's cameras — recording and
+# inference requests no longer carry camera configs. These cover the pure
+# shaping/lookup helpers; the 400 paths that consume them live in
+# tests/test_record.py and tests/test_rollout.py.
+
+
+def _camera_entry(name: str, **overrides) -> dict:
+    """A camera entry in the shape RobotConfigDialog saves."""
+    entry = {
+        "id": f"camera_{name}",
+        "name": name,
+        "type": "opencv",
+        "camera_index": 1,
+        "device_id": "browser-device-id",
+        "unique_id": "0x1400000005ac8600",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_session_camera_config_keeps_only_session_keys() -> None:
+    """`id`/`device_id`/`name` are record-keeping: forwarding them would reach
+    lerobot's OpenCVCameraConfig (via rollout's `--robot.cameras=`) as unknown
+    fields. Everything a session actually needs survives."""
+    config = cfg.session_camera_config(_camera_entry("wrist", fourcc="MJPG", backend="AVFOUNDATION"))
+
+    assert config == {
+        "type": "opencv",
+        "camera_index": 1,
+        "unique_id": "0x1400000005ac8600",
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+        "fourcc": "MJPG",
+        "backend": "AVFOUNDATION",
+    }
+
+
+def test_session_camera_config_omits_absent_keys_and_defaults_type() -> None:
+    """Absent keys are dropped rather than sent as None, so the consumers' own
+    defaults (platform backend pin, MJPG fourcc) still apply. A record written
+    before `type` existed is an opencv camera."""
+    config = cfg.session_camera_config({"name": "top", "camera_index": 0})
+
+    assert config == {"type": "opencv", "camera_index": 0}
+
+
+def test_record_cameras_by_name_keys_on_the_camera_name() -> None:
+    cameras = cfg.record_cameras_by_name([_camera_entry("wrist"), _camera_entry("top", camera_index=2)])
+
+    assert sorted(cameras) == ["top", "wrist"]
+    assert cameras["top"]["camera_index"] == 2
+
+
+def test_record_cameras_by_name_rejects_duplicate_names() -> None:
+    """Two cameras under one name would silently collapse to one in the dict —
+    an entire camera missing from a recording. Refuse instead."""
+    with pytest.raises(cfg.CameraResolutionError) as exc:
+        cfg.record_cameras_by_name([_camera_entry("wrist"), _camera_entry("wrist", camera_index=2)])
+
+    assert "two cameras named 'wrist'" in str(exc.value)
+
+
+def test_record_cameras_by_name_rejects_unnamed_camera() -> None:
+    with pytest.raises(cfg.CameraResolutionError):
+        cfg.record_cameras_by_name([{**_camera_entry("wrist"), "name": "   "}])
+
+
+def test_record_cameras_by_name_skips_non_dict_entries() -> None:
+    """A hand-edited record shouldn't crash the start path on a stray value."""
+    assert cfg.record_cameras_by_name(["nonsense", None, _camera_entry("wrist")]).keys() == {"wrist"}
+
+
+def test_load_robot_cameras_reads_the_named_record(tmp_lerobot_home: Path) -> None:
+    cfg.save_robot_record("lab1", {"cameras": [_camera_entry("wrist")]}, allow_create=True)
+
+    cameras = cfg.load_robot_cameras("lab1")
+
+    assert list(cameras) == ["wrist"]
+    assert cameras["wrist"]["camera_index"] == 1
+
+
+def test_load_robot_cameras_blank_name_is_a_camera_less_session(tmp_lerobot_home: Path) -> None:
+    assert cfg.load_robot_cameras("") == {}
+    assert cfg.load_robot_cameras("   ") == {}
+
+
+def test_load_robot_cameras_rejects_a_name_with_no_record(tmp_lerobot_home: Path) -> None:
+    """Recording camera-less because the robot name was wrong loses a whole
+    session's video silently — fail loudly instead."""
+    with pytest.raises(cfg.CameraResolutionError) as exc:
+        cfg.load_robot_cameras("ghost")
+
+    assert "ghost" in str(exc.value)
+
+
+def test_load_robot_cameras_rejects_a_path_traversal_name(tmp_lerobot_home: Path) -> None:
+    with pytest.raises(cfg.CameraResolutionError):
+        cfg.load_robot_cameras("../escape")
+
+
+def test_load_robot_cameras_empty_for_a_record_with_no_cameras(tmp_lerobot_home: Path) -> None:
+    cfg.save_robot_record("lab1", {"leader_port": "/dev/a"}, allow_create=True)
+
+    assert cfg.load_robot_cameras("lab1") == {}
+
+
+def test_bind_robot_cameras_keys_on_the_policy_name(tmp_lerobot_home: Path) -> None:
+    """The checkpoint's camera names rarely match the labels on the robot, so
+    the binding renames: settings come from the record, the key from the policy."""
+    cfg.save_robot_record("lab1", {"cameras": [_camera_entry("wrist")]}, allow_create=True)
+
+    bound = cfg.bind_robot_cameras("lab1", {"observation.images.front": "wrist"})
+
+    assert list(bound) == ["observation.images.front"]
+    assert bound["observation.images.front"]["camera_index"] == 1
+
+
+def test_bind_robot_cameras_empty_bindings_need_no_robot(tmp_lerobot_home: Path) -> None:
+    """A camera-less policy binds nothing, so it must not require a record."""
+    assert cfg.bind_robot_cameras("", {}) == {}
+
+
+def test_bind_robot_cameras_rejects_bindings_without_a_robot(tmp_lerobot_home: Path) -> None:
+    with pytest.raises(cfg.CameraResolutionError) as exc:
+        cfg.bind_robot_cameras("", {"front": "wrist"})
+
+    assert "No robot selected" in str(exc.value)
+
+
+def test_bind_robot_cameras_rejects_an_unknown_camera_and_lists_the_options(
+    tmp_lerobot_home: Path,
+) -> None:
+    cfg.save_robot_record(
+        "lab1",
+        {"cameras": [_camera_entry("wrist"), _camera_entry("top", camera_index=2)]},
+        allow_create=True,
+    )
+
+    with pytest.raises(cfg.CameraResolutionError) as exc:
+        cfg.bind_robot_cameras("lab1", {"front": "gone"})
+
+    message = str(exc.value)
+    assert "'gone'" in message
+    assert "top, wrist" in message
+
+
+def test_bind_robot_cameras_overlays_checkpoint_capture_dims(tmp_lerobot_home: Path) -> None:
+    """lerobot's standard rollout does NOT resize frames to the policy's input
+    shape, so a camera must CAPTURE at the resolution the checkpoint was
+    trained on. The record still supplies identity and transport settings."""
+    cfg.save_robot_record("lab1", {"cameras": [_camera_entry("wrist")]}, allow_create=True)
+
+    bound = cfg.bind_robot_cameras(
+        "lab1",
+        {"front": "wrist"},
+        dims={"front": {"width": 320, "height": 240}},
+    )
+
+    assert bound["front"]["width"] == 320
+    assert bound["front"]["height"] == 240
+    # Identity/transport are untouched — only the frame size is overridden.
+    assert bound["front"]["camera_index"] == 1
+    assert bound["front"]["unique_id"] == "0x1400000005ac8600"
+    assert bound["front"]["fps"] == 30
+
+
+def test_bind_robot_cameras_falls_back_to_record_dims_without_an_override(
+    tmp_lerobot_home: Path,
+) -> None:
+    """A checkpoint that doesn't expose image dims (or an older client that
+    sends none) must still start — the record's own size stands."""
+    cfg.save_robot_record("lab1", {"cameras": [_camera_entry("wrist")]}, allow_create=True)
+
+    assert cfg.bind_robot_cameras("lab1", {"front": "wrist"})["front"]["width"] == 640
+    assert cfg.bind_robot_cameras("lab1", {"front": "wrist"}, dims={})["front"]["width"] == 640
+    # An override for a DIFFERENT camera doesn't leak onto this one.
+    unrelated = cfg.bind_robot_cameras(
+        "lab1", {"front": "wrist"}, dims={"top": {"width": 320, "height": 240}}
+    )
+    assert unrelated["front"]["width"] == 640
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"width": 320},  # half an override
+        {"height": 240},
+        {"width": 0, "height": 240},  # nonsense sizes
+        {"width": -320, "height": -240},
+        {"width": True, "height": True},  # bool is an int subclass
+        {"width": "320", "height": "240"},
+        {},
+    ],
+)
+def test_bind_robot_cameras_ignores_unusable_dims(tmp_lerobot_home: Path, override: dict) -> None:
+    """Both dimensions or neither: a half-applied override would capture at a
+    mixed policy/record aspect, which is worse than either source alone."""
+    cfg.save_robot_record("lab1", {"cameras": [_camera_entry("wrist")]}, allow_create=True)
+
+    bound = cfg.bind_robot_cameras("lab1", {"front": "wrist"}, dims={"front": override})
+
+    assert bound["front"]["width"] == 640
+    assert bound["front"]["height"] == 480
+
+
+def test_bind_robot_cameras_copies_so_callers_cant_alias_the_record(
+    tmp_lerobot_home: Path,
+) -> None:
+    """Two policy names may bind the same physical camera; each must get its
+    own dict so a later mutation can't leak across roles."""
+    cfg.save_robot_record("lab1", {"cameras": [_camera_entry("wrist")]}, allow_create=True)
+
+    bound = cfg.bind_robot_cameras("lab1", {"left": "wrist", "right": "wrist"})
+
+    assert bound["left"] is not bound["right"]
+    assert bound["left"] == bound["right"]


### PR DESCRIPTION
## What

Recording and inference sessions now get their cameras from the saved robot record (`robots/*.json`) server-side, instead of trusting whatever camera configs the request payload carries. Cameras are edited in one place — Robot settings — and the session panels show them read-only with live previews.

## Why

Camera names are dataset schema (`observation.images.<name>`) and policy features, not session preferences. The old flow seeded a session-local editable copy of the record's cameras and never wrote edits back, so what a session actually recorded could silently drift from the record — the exact drift class the disjoint-camera fine-tune guard exists to catch. Making the backend resolve cameras from the record turns that drift from an accident into an impossibility.

## Contract

- **Recording**: `RecordingRequest` no longer accepts `cameras`; the full record set is resolved from `robot_name`. Blank name / camera-less record ⇒ camera-less recording (as before); a non-blank name with no matching record ⇒ 400. Existing hardening (per-platform cv2 backend pin, MJPG fourcc default) unchanged.
- **Inference**: `cameras` → `camera_bindings` (policy camera name → record camera name) + `camera_dims` (per-camera width/height the frontend forwards from `/policy-config`, same pattern as `checkpoint_state_dim`). Missing camera names, duplicate names in the record, or bindings without a valid robot all 400 pre-spawn with messages listing what's available.
- **Capture resolution comes from the checkpoint, not the record**: lerobot v0.6.0's standard rollout pipeline has no image resize (only the HIL processor path does), so capture size *is* policy input size and must match training. The record supplies device identity (index/unique_id, fps, fourcc, backend); checkpoint dims overlay width/height, both-or-neither, with record dims as fallback when a checkpoint exposes no image dims.
- `unique_id` stays in the resolved session config but is dropped at `--robot.cameras=` serialization — lerobot's `OpenCVCameraConfig` rejects unknown fields, and unique_id re-anchoring is separate work not yet on main (a test pins this).
- **Frontend**: session-local camera drafts are gone (`StudioContext.cameras`/`camerasSeededFor`); Collect shows the record's cameras via a read-only `SessionCameraList` (previews + "edit in Robot settings"); Deploy/InferenceModal bind by record camera name, keep the every-camera-bound-and-connected start gate, and show "Captures at W×H — the policy's resolution". `CameraConfiguration` now blocks duplicate camera names at edit time, matching the backend refusal.

## Testing

- New unit tests for the pure resolution helpers in `utils/config.py` (16 cases: whitelisting, duplicate/blank names, dims overlay + rejection of half/invalid overrides) and for the recording/inference 400 paths and arg construction (incl. `unique_id` never reaching the CLI arg).
- Full suite: 1135 passed; the only failures (7, `tests/test_models.py`) pre-exist on untouched main in this environment (real `~/.cache` state leaking into `tmp_lerobot_home` tests) and are identical before/after.
- Frontend: lint and `tsc -p tsconfig.app.json` baselines byte-identical before/after; build succeeds. `frontend/dist/` deliberately untouched (CI rebuilds it on merge).

Carved from the rig integration branch (`ea0b8e4`), adapted to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)