### PR TITLE
fix(cameras): hotplug/replug self-recovers via main-runloop pump; preview tile releases on remove

### DIFF
--- a/camera_runloop_experiment.py
+++ b/camera_runloop_experiment.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+"""Experiment: does a live NSRunLoop let this process's AVFoundation device
+snapshot refresh on USB camera hotplug/replug?
+
+Background: the makermodslab server's in-process AVFoundation device list is
+snapshotted at first touch and never refreshes (device-connection
+notifications need an active NSRunLoop, which uvicorn doesn't run). That's
+why a hot-plugged camera needs a server restart, and why a same-port replug
+yields a stale device whose cap.read() blocks forever (blank preview). This
+script tests whether keeping a runloop alive fixes both — if it does, the
+server fix is a tiny daemon thread and the restart requirement disappears.
+
+Run each mode from the same terminal you normally run `makermodslab` in (it
+has camera permission), with the server STOPPED (it holds the cameras):
+
+    .venv/bin/python camera_runloop_experiment.py --runloop none     # control
+    .venv/bin/python camera_runloop_experiment.py --runloop thread   # candidate fix
+    .venv/bin/python camera_runloop_experiment.py --runloop main     # fallback variant
+
+Protocol per run: start it, wait for two "read ok" lines, unplug the watched
+camera, wait ~10 s, plug it back into the SAME port, watch another ~20 s,
+Ctrl-C. Two signals to watch:
+
+  - "DEVICE LIST CHANGED" lines on unplug/replug -> the snapshot refreshes.
+  - the read probe returning to "ok" after the replug -> stale-device blank
+    preview is cured.
+
+Expected control result (--runloop none): no list change on unplug, probe
+stuck on open-failed/TIMEOUT after replug — today's bug, reproduced. If
+--runloop thread shows both signals recovering, the fix is proven. Restart
+the script between trials (a timed-out probe leaks its wedged capture).
+"""
+
+import argparse
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import cv2
+import objc
+from Foundation import NSDate, NSDefaultRunLoopMode, NSRunLoop
+
+from makermodslab.camera_identity import list_cameras_in_process
+
+# Generous: a USB camera's first frame after a replug can take several seconds
+# to arrive; only a read still stuck past this is the wedge signature.
+PROBE_TIMEOUT_S = 8.0
+CYCLE_S = 3.0
+
+
+def fmt(cams: list[dict]) -> str:
+    return ", ".join(f"[{c['index']}] {c['name']} {c['unique_id']}" for c in cams) or "(none)"
+
+
+def probe_read(index: int) -> str:
+    """Open cv2 `index` and read one frame under a watchdog thread."""
+    result: dict = {}
+
+    def work():
+        cap = cv2.VideoCapture(index, cv2.CAP_AVFOUNDATION)
+        if not cap.isOpened():
+            result["r"] = "open-failed"
+            return
+        ok, frame = cap.read()
+        result["r"] = "ok" if ok and frame is not None else "blank"
+        cap.release()
+
+    t = threading.Thread(target=work, daemon=True)
+    t.start()
+    t.join(PROBE_TIMEOUT_S)
+    if t.is_alive():
+        return "TIMEOUT (read wedged — capture leaked; restart script before the next trial)"
+    return result.get("r", "no-result")
+
+
+def start_runloop_thread() -> None:
+    """Dedicated thread: first AVFoundation touch, then keep its runloop alive."""
+    ready = threading.Event()
+
+    def run():
+        with objc.autorelease_pool():
+            list_cameras_in_process()
+        ready.set()
+        rl = NSRunLoop.currentRunLoop()
+        while True:
+            with objc.autorelease_pool():
+                busy = rl.runMode_beforeDate_(NSDefaultRunLoopMode, NSDate.dateWithTimeIntervalSinceNow_(1.0))
+            if not busy:  # no input sources attached yet — don't spin
+                time.sleep(0.1)
+
+    t = threading.Thread(target=run, daemon=True, name="avf-runloop")
+    t.start()
+    if not ready.wait(10):
+        raise SystemExit("runloop thread failed to initialize AVFoundation")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--runloop", choices=["none", "thread", "main"], default="none")
+    ap.add_argument(
+        "--watch",
+        default="USB Camera",
+        help="probe the first camera whose name contains this substring",
+    )
+    args = ap.parse_args()
+
+    # A running server (or an open browser preview tab) holds the cameras and
+    # makes every probe read blank, masking the experiment's result entirely.
+    try:
+        urllib.request.urlopen(  # noqa: S310  # nosec B310 — fixed localhost URL, no user input
+            "http://localhost:8000/available-cameras", timeout=1
+        )
+        print(
+            "WARNING: a makermodslab server is RUNNING on :8000. Stop it and close "
+            "any browser tabs with preview tiles before trusting these results — "
+            "its captures make every probe read blank.",
+            flush=True,
+        )
+    except (urllib.error.URLError, OSError):
+        pass
+
+    pump = None
+    if args.runloop == "thread":
+        start_runloop_thread()
+    elif args.runloop == "main":
+        with objc.autorelease_pool():
+            list_cameras_in_process()  # first AVFoundation touch on the main thread
+        rl = NSRunLoop.currentRunLoop()
+
+        def pump(seconds: float) -> None:
+            end = time.monotonic() + seconds
+            while time.monotonic() < end:
+                with objc.autorelease_pool():
+                    busy = rl.runMode_beforeDate_(
+                        NSDefaultRunLoopMode, NSDate.dateWithTimeIntervalSinceNow_(0.25)
+                    )
+                if not busy:
+                    time.sleep(0.1)
+
+    print(
+        f"runloop={args.runloop}; watching first camera matching {args.watch!r}; Ctrl-C to stop",
+        flush=True,
+    )
+    last_ids: list[str] | None = None
+    while True:
+        with objc.autorelease_pool():
+            cams = list_cameras_in_process() or []
+        ids = [c["unique_id"] for c in cams]
+        if ids != last_ids:
+            last_ids = ids
+            print(f"{time.strftime('%H:%M:%S')} DEVICE LIST CHANGED: {fmt(cams)}", flush=True)
+        # Probe EVERY match, not just the first: the two robot cameras are
+        # identically named, and unplugging the second twin while probing only
+        # the first would show a healthy "ok" forever.
+        targets = [c for c in cams if args.watch.lower() in c["name"].lower()]
+        if not targets:
+            print(
+                f"{time.strftime('%H:%M:%S')} probe: no camera matching "
+                f"{args.watch!r} in the in-process list",
+                flush=True,
+            )
+        for target in targets:
+            started = time.monotonic()
+            outcome = probe_read(target["index"])
+            print(
+                f"{time.strftime('%H:%M:%S')} probe [{target['index']}] "
+                f"{target['unique_id']}: read {outcome} "
+                f"({time.monotonic() - started:.1f}s)",
+                flush=True,
+            )
+        if pump is not None:
+            pump(CYCLE_S)
+        else:
+            time.sleep(CYCLE_S)
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/components/BackendCameraStream.tsx
+++ b/frontend/src/components/BackendCameraStream.tsx
@@ -33,8 +33,8 @@ const RETRY_MAX_MS = 12000;
  * endpoint WHY (the 409/503 detail — "recording is using the cameras" etc.),
  * shows that on the tile, and retries with capped backoff; clicking the tile
  * retries immediately. Parents should render it whenever a cameraIndex is
- * known and unmount it to pause/release (unmount cleanup clears the img src
- * so the browser drops the HTTP connection and the server releases the
+ * known and unmount it to pause/release (the img's detach handler clears its
+ * src so the browser drops the HTTP connection and the server releases the
  * shared capture).
  */
 const BackendCameraStream: React.FC<BackendCameraStreamProps> = ({
@@ -43,7 +43,7 @@ const BackendCameraStream: React.FC<BackendCameraStreamProps> = ({
   className,
 }) => {
   const { baseUrl, fetchWithHeaders } = useApi();
-  const imgRef = useRef<HTMLImageElement>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
   const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attemptRef = useRef(0);
   // Bumping remounts the <img> with a cache-busted URL — a clean retry.
@@ -64,13 +64,22 @@ const BackendCameraStream: React.FC<BackendCameraStreamProps> = ({
   }, [cameraIndex, uniqueId]);
 
   useEffect(() => {
-    const img = imgRef.current;
     return () => {
       if (retryTimer.current) clearTimeout(retryTimer.current);
-      // Detaching an <img> doesn't reliably abort its in-flight request;
-      // clearing src does, which is what lets the backend release the camera.
-      if (img) img.src = "";
     };
+  }, []);
+
+  // Detaching an <img> doesn't reliably abort its in-flight request; clearing
+  // src does, which is what lets the backend release the camera. A callback
+  // ref (not a mount-effect cleanup) because `key={attempt}` remounts the
+  // <img> on every retry: a cleanup captured at mount clears the first,
+  // long-dead element and leaves the live stream's connection open after the
+  // tile is removed.
+  const attachImg = useCallback((node: HTMLImageElement | null) => {
+    if (node === null && imgRef.current) {
+      imgRef.current.src = "";
+    }
+    imgRef.current = node;
   }, []);
 
   const scheduleRetry = useCallback(() => {
@@ -146,7 +155,7 @@ const BackendCameraStream: React.FC<BackendCameraStreamProps> = ({
   return (
     <img
       key={attempt}
-      ref={imgRef}
+      ref={attachImg}
       src={`${baseUrl}/camera-preview/${cameraIndex}?r=${attempt}${
         uniqueId ? `&unique_id=${encodeURIComponent(uniqueId)}` : ""
       }`}

--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -44,6 +44,13 @@ though it runs on the main thread — never pumps it. Pumping briefly on a
 timer keeps the in-process snapshot live (hardware-verified 2026-08-07 via
 camera_runloop_experiment.py: a background-thread runloop does NOT refresh
 the cache; pumping the main thread's does).
+
+A live device list means indices genuinely renumber *at runtime*, so any
+per-camera state a caller caches must be keyed by identity, not by index: a
+handle opened for the device that was index 0 stays bound to that device after
+another camera sorts ahead of it and becomes index 0. Callers that cache
+therefore use :func:`identify_cv2_index`, which returns the index to open
+*and* the key to file it under.
 """
 
 import asyncio
@@ -67,8 +74,29 @@ def list_cameras_in_process() -> list[dict] | None:
 
     Returns ``[{"index", "name", "unique_id"}, ...]`` reflecting the same
     (possibly stale) AVFoundation state cv2.VideoCapture resolves indices
-    against, or None when identity can't be established (non-macOS, PyObjC
-    unavailable, AVFoundation query failure).
+    against.
+
+    None and ``[]`` are **different answers**, and callers rely on that:
+
+    - None — the enumeration could not be performed at all (non-macOS, PyObjC
+      unavailable, the framework failing to load, no device-type constant
+      resolving, AVFoundation answering nothing). Nothing is known about the
+      device set, so callers fall back to trusting the index they were given.
+    - ``[]`` — the enumeration *was* performed and found zero cameras. A
+      requested device is then definitively absent, and callers must fail
+      loudly rather than open whatever sits at the index.
+
+    Keeping those apart takes deliberate care, because the natural failure of
+    almost every step here is "no devices found" rather than an exception: an
+    unloaded framework resolves no device-type constants, and a discovery
+    session handed an empty type list matches nothing by construction. Each
+    such step therefore returns None explicitly instead of falling through to
+    an empty result that would be indistinguishable from a real, empty
+    machine. (Camera permission is the one case not caught here: a process
+    denied macOS camera access enumerates only built-ins, so a Mac without a
+    built-in camera reports ``[]`` truthfully — it asked, and AVFoundation
+    showed it nothing. It cannot open those devices through cv2 either, so
+    failing loudly stays the right answer.)
     """
     if platform.system() != "Darwin":
         return None
@@ -77,7 +105,12 @@ def list_cameras_in_process() -> list[dict] | None:
         from Foundation import NSBundle
 
         bundle = NSBundle.bundleWithPath_("/System/Library/Frameworks/AVFoundation.framework")
-        bundle.load()
+        if not bundle.load():
+            # Without the framework loaded no device-type constant below can
+            # resolve, and the discovery session would report an empty device
+            # set. That is a failure to ask, not an empty machine.
+            logger.warning("AVFoundation framework did not load — camera identity unavailable")
+            return None
         types = []
         for name in _AVF_DEVICE_TYPE_NAMES:
             loaded = {}
@@ -87,11 +120,33 @@ def list_cameras_in_process() -> list[dict] | None:
                 continue
             if loaded.get(name) is not None:
                 types.append(loaded[name])
+        if not types:
+            # Never run a discovery session with an empty type list: it can
+            # only match nothing, and that nothing would be a lie. Individual
+            # names are expected to miss (they are version-gated); all of them
+            # missing means the lookup itself is broken.
+            logger.warning(
+                "No AVFoundation camera device-type constants resolved (renamed by macOS?) — "
+                "camera identity unavailable"
+            )
+            return None
         cls = objc.lookUpClass("AVCaptureDeviceDiscoverySession")
         devs = []
+        answered = False
         for media_type in ("vide", "muxx"):
             session = cls.discoverySessionWithDeviceTypes_mediaType_position_(types, media_type, 0)
-            devs.extend(session.devices() or [])
+            found = session.devices()
+            # nil (a query that did not answer) is tracked apart from an empty
+            # array (a query that answered "none"); flattening both with
+            # `or []` is what would let a failed query read as an empty
+            # machine. One query answering is enough to trust the result.
+            if found is None:
+                continue
+            answered = True
+            devs.extend(found)
+        if not answered:
+            logger.warning("AVFoundation discovery answered nothing — camera identity unavailable")
+            return None
         devs.sort(key=lambda d: d.uniqueID())
         return [
             {"index": i, "name": str(d.localizedName()), "unique_id": str(d.uniqueID())}
@@ -102,24 +157,36 @@ def list_cameras_in_process() -> list[dict] | None:
         return None
 
 
-def resolve_cv2_index(unique_id: str | None, fallback_index: int) -> int | None:
-    """The index THIS process's cv2 opens for ``unique_id``.
+def resolve_in_enumeration(
+    cameras: list[dict] | None, unique_id: str | None, fallback_index: int
+) -> int | None:
+    """Position of ``unique_id`` in an in-process enumeration, else None.
 
-    - No unique_id, or identity unavailable (non-macOS / query failure):
-      ``fallback_index`` — legacy trust-the-index behavior.
-    - unique_id found in the in-process list: its position there (which can
-      differ from the fresh-subprocess enumeration index the caller has).
-    - unique_id verifiably absent: None — the device attached after this
-      process started; only a restart makes it reachable. Callers must error
-      out instead of opening a different physical camera.
+    Shared by :func:`resolve_cv2_index` and :func:`identify_cv2_index` so both
+    report an index shift, and a verifiably-absent device, identically. Both
+    inputs are nullable so a caller may hand an enumeration straight through
+    without pre-checking it.
     """
-    if not unique_id:
-        return fallback_index
-    cameras = list_cameras_in_process()
-    if cameras is None:
+    # MERGE NOTE — the integration branch's variant of this function guards
+    # `if not unique_id or not cameras`, which sends an EMPTY list to
+    # fallback_index as well. This branch guards only `cameras is None`, and
+    # the difference is deliberate: list_cameras_in_process() guarantees that
+    # None and [] are different answers (see its docstring — every "could not
+    # ask" path returns None explicitly, precisely so that [] can be trusted).
+    #   None -> nothing is known about the device set; the caller's index is
+    #           the best answer available, so trust it.
+    #   []   -> the enumeration ran and found no cameras, so the requested
+    #           device is definitively absent. Return None and let the caller
+    #           fail loudly, which is this module's whole contract.
+    # Collapsing [] into fallback_index would open whatever unrelated device
+    # sits at that number and turn the preview endpoint's honest 503 into a
+    # wrong-camera stream. Whoever resolves this conflict: the two bodies are
+    # not interchangeable, and this branch's None/[] guarantee is what makes
+    # falling through on [] correct here.
+    if not unique_id or cameras is None:
         return fallback_index
     for cam in cameras:
-        if cam["unique_id"] == unique_id:
+        if cam.get("unique_id") == unique_id:
             if cam["index"] != fallback_index:
                 logger.info(
                     "Camera %s: in-process cv2 index %d differs from enumerated index %d "
@@ -135,6 +202,65 @@ def resolve_cv2_index(unique_id: str | None, fallback_index: int) -> int | None:
         unique_id,
     )
     return None
+
+
+def resolve_cv2_index(unique_id: str | None, fallback_index: int) -> int | None:
+    """The index THIS process's cv2 opens for ``unique_id``.
+
+    - No unique_id, or identity unavailable (non-macOS / query failure):
+      ``fallback_index`` — legacy trust-the-index behavior.
+    - unique_id found in the in-process list: its position there (which can
+      differ from the fresh-subprocess enumeration index the caller has).
+    - unique_id verifiably absent: None — the device attached after this
+      process started; only a restart makes it reachable. Callers must error
+      out instead of opening a different physical camera.
+
+    Callers that additionally *cache* something per camera want
+    :func:`identify_cv2_index`, which returns the same index plus the identity
+    to key that cache by — an index alone is not a stable cache key.
+    """
+    if not unique_id:
+        return fallback_index
+    cameras = list_cameras_in_process()
+    if cameras is None:
+        return fallback_index
+    return resolve_in_enumeration(cameras, unique_id, fallback_index)
+
+
+def identify_cv2_index(unique_id: str | None, fallback_index: int) -> tuple[int, str | None] | None:
+    """``(index to open, identity key)`` for a camera — :func:`resolve_cv2_index` plus identity.
+
+    Same contract as :func:`resolve_cv2_index` for the index, including the
+    None return for a verifiably-absent device (callers must fail loudly). The
+    second element is the camera's uniqueID, or None when this process cannot
+    establish identity at all (non-macOS / PyObjC missing / query failure) —
+    the caller then has nothing better than the index to key by.
+
+    A caller who supplies no ``unique_id`` gets one **backfilled** from the
+    in-process enumeration. That is load-bearing, not cosmetic: the identity is
+    optional on the wire (the frontend's ``BackendCameraStream`` takes
+    ``uniqueId?``), so without the backfill one client would key a device by
+    its uniqueID while another keyed the *same* device by an int, and a shared,
+    single-handle resource would be opened twice.
+    """
+    cameras = list_cameras_in_process()
+    if cameras is None:
+        # No identity to be had: legacy trust-the-index behavior, and the
+        # caller keys by the index — exactly what it did before identity
+        # existed. On these platforms the in-process device list is not
+        # live-refreshed either, so indices do not renumber underneath us.
+        return fallback_index, None
+    if not unique_id:
+        for cam in cameras:
+            if cam["index"] == fallback_index:
+                return fallback_index, cam["unique_id"]
+        # Nothing at that index in this process's view. Don't invent an
+        # identity; the open itself will fail loudly enough.
+        return fallback_index, None
+    resolved = resolve_in_enumeration(cameras, unique_id, fallback_index)
+    if resolved is None:
+        return None
+    return resolved, unique_id
 
 
 async def pump_avfoundation_runloop(interval_s: float = 0.5, pump_s: float = 0.05) -> None:

--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -29,13 +29,27 @@ The stable link between the two index spaces is AVFoundation's ``uniqueID``.
 actually open *in this process*, by walking the same in-process device list
 cv2 walks (video + muxed devices, uniqueID-sorted — mirrors OpenCV's
 cap_avfoundation_mac.mm). A device attached after startup is invisible to
-in-process AVFoundation entirely; for that case resolution returns None and
-callers must fail loudly (telling the user to restart MakerMods Lab) rather than
-open whatever now sits at the stale index.
+in-process AVFoundation entirely — and, worse, a camera replugged into the
+SAME port keeps its uniqueID, so it stays *present* in the stale list as a
+dead device object that opens "successfully" and then never produces a frame
+(silently blank previews, reads that can block forever). Resolution returns
+None only for the verifiably-absent case; callers must fail loudly (telling
+the user to restart MakerMods Lab) rather than open whatever now sits at the
+stale index.
+
+Both failure modes disappear while :func:`pump_avfoundation_runloop` runs:
+AVFoundation queues its device-cache updates on the main dispatch queue,
+which only the MAIN thread's runloop drains, and uvicorn's asyncio loop —
+though it runs on the main thread — never pumps it. Pumping briefly on a
+timer keeps the in-process snapshot live (hardware-verified 2026-08-07 via
+camera_runloop_experiment.py: a background-thread runloop does NOT refresh
+the cache; pumping the main thread's does).
 """
 
+import asyncio
 import logging
 import platform
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -121,3 +135,41 @@ def resolve_cv2_index(unique_id: str | None, fallback_index: int) -> int | None:
         unique_id,
     )
     return None
+
+
+async def pump_avfoundation_runloop(interval_s: float = 0.5, pump_s: float = 0.05) -> None:
+    """Keep this process's AVFoundation camera snapshot live (macOS).
+
+    Run as an asyncio background task from server startup. It must live in the
+    main thread's event loop — AVFoundation delivers device connect/disconnect
+    cache updates via the main dispatch queue, and only the main thread's
+    runloop drains that queue (a background thread's runloop verifiably does
+    not — see the module docstring). Each cycle blocks the loop for at most
+    ``pump_s`` (~50 ms) every ``interval_s``, then yields back to asyncio.
+
+    No-op on non-macOS or when PyObjC is unavailable; exits with a warning if
+    scheduled off the main thread; cancels cleanly on shutdown.
+    """
+    if platform.system() != "Darwin":
+        return
+    if threading.current_thread() is not threading.main_thread():
+        logger.warning(
+            "AVFoundation runloop pump scheduled off the main thread — "
+            "hotplug refresh disabled (cache updates only drain on the main runloop)"
+        )
+        return
+    try:
+        import objc
+        from Foundation import NSDate, NSDefaultRunLoopMode, NSRunLoop
+    except ImportError:
+        logger.warning("PyObjC unavailable — AVFoundation hotplug refresh disabled")
+        return
+    # First AVFoundation touch from the main thread, so the snapshot exists
+    # before the first pump and is anchored where the updates get drained.
+    list_cameras_in_process()
+    runloop = NSRunLoop.currentRunLoop()
+    logger.info("AVFoundation runloop pump running — camera hotplug/replug is live")
+    while True:
+        with objc.autorelease_pool():
+            runloop.runMode_beforeDate_(NSDefaultRunLoopMode, NSDate.dateWithTimeIntervalSinceNow_(pump_s))
+        await asyncio.sleep(interval_s)

--- a/makermodslab/camera_preview.py
+++ b/makermodslab/camera_preview.py
@@ -51,9 +51,15 @@ class CameraOpenError(RuntimeError):
 
 
 class _SharedCapture:
-    """One refcounted cv2.VideoCapture, shared by every client of an index."""
+    """One refcounted cv2.VideoCapture, shared by every client of a camera."""
 
-    def __init__(self, index: int) -> None:
+    def __init__(self, key: str | int, index: int) -> None:
+        # Registry key: the camera's AVFoundation uniqueID when identity is
+        # available, else the bare index (see CameraPreviewManager).
+        self.key = key
+        # The index cv2.VideoCapture() was called with. Kept for the open and
+        # for log lines about this handle — it is the honest description of
+        # what was opened, even after the device set renumbers underneath it.
         self.index = index
         self.cap: cv2.VideoCapture | None = None
         self.refcount = 0
@@ -69,28 +75,56 @@ class _SharedCapture:
 class CameraPreviewManager:
     """Refcounted, shared MJPEG streaming of the backend's cv2 cameras.
 
-    One cv2.VideoCapture per camera index, shared across all connected preview
+    One cv2.VideoCapture per camera, shared across all connected preview
     clients; the last client detaching releases the device. Recording and
     teleoperation always win: their start paths call :meth:`stop_all`, which
     tells every client generator to exit and force-releases any capture a
     stalled client would otherwise keep holding.
+
+    The registry is keyed by camera *identity* (AVFoundation uniqueID), not by
+    cv2 index, because an index is not a stable name for a device: the
+    in-process device list is live (camera_identity.pump_avfoundation_runloop),
+    so attaching a camera that sorts ahead of another renumbers it while a
+    capture bound to the old device is still open. Keyed by int, a client
+    asking for the newly-arrived camera at index 0 would be handed the handle
+    bound to the camera that *used* to be index 0 — the user would then
+    configure and name one camera while watching another's picture, and that
+    name lands in a robot record. Where identity is unavailable (non-macOS,
+    PyObjC missing, enumeration failure) the key falls back to the index,
+    preserving the original sharing behavior; on those platforms the device
+    list is not live-refreshed, so indices do not renumber underneath us.
+
+    What identity keying does NOT fix: a camera replugged into the SAME port
+    keeps its uniqueID, so a capture still registered across that replug is
+    handed back for the right device even though the handle behind it is dead
+    (``isOpened()`` stays True and its next read never returns). Identity
+    cannot see that — the uniqueID is present; only the device object behind
+    that particular handle has died — and this change does not address it. It
+    is a known, still-open gap. The key does one thing: it stops two
+    *different* physical cameras from colliding on one entry.
     """
 
     def __init__(self) -> None:
-        self._captures: dict[int, _SharedCapture] = {}
+        self._captures: dict[str | int, _SharedCapture] = {}
         # Guards the registry dict and the refcounts; never held during device
-        # I/O (open/read/release happen under the per-index lock instead).
+        # I/O (open/read/release happen under the per-camera lock instead).
         self._registry_lock = threading.Lock()
 
-    def open_stream(self, index: int):
-        """Open (or share) the capture for ``index`` and return a frame generator.
+    def open_stream(self, index: int, key: str | int | None = None):
+        """Open (or share) a camera's capture and return a frame generator.
+
+        ``index`` is what cv2 opens; ``key`` is the camera's identity, as
+        returned by :func:`camera_identity.identify_cv2_index` — the same
+        physical device shares one capture across every index it has been
+        known by. ``None`` means identity is unavailable, and the index itself
+        becomes the key.
 
         Raises :class:`CameraOpenError` when the device can't be opened. The
         generator yields ``multipart/x-mixed-replace`` JPEG parts (boundary
         ``frame``) at ~TARGET_FPS and drops its reference on exit — client
         disconnect, :meth:`stop_all`, or the device dying mid-stream.
         """
-        entry = self._acquire(index)
+        entry = self._acquire(index, index if key is None else key)
         return self._frames(entry)
 
     def stop_all(self, timeout: float = 1.0) -> None:
@@ -100,7 +134,7 @@ class CameraPreviewManager:
         frame, waits up to ``timeout`` seconds for them to detach, then
         force-releases anything still held — a client stalled mid-yield on a
         dead connection must not keep the device away from recording/teleop.
-        The force-release happens under the per-index lock, so it can never
+        The force-release happens under the per-camera lock, so it can never
         pull the capture out from under a thread inside cap.read().
         """
         with self._registry_lock:
@@ -113,7 +147,7 @@ class CameraPreviewManager:
         for entry in entries:
             while time.monotonic() < deadline:
                 with self._registry_lock:
-                    detached = self._captures.get(entry.index) is not entry
+                    detached = self._captures.get(entry.key) is not entry
                 if detached:
                     break
                 time.sleep(0.02)
@@ -128,15 +162,15 @@ class CameraPreviewManager:
             # Deregister so a lagging client's _release becomes a no-op and a
             # future preview starts from a fresh entry (fresh stop event).
             with self._registry_lock:
-                if self._captures.get(entry.index) is entry:
-                    del self._captures[entry.index]
+                if self._captures.get(entry.key) is entry:
+                    del self._captures[entry.key]
 
-    def _acquire(self, index: int) -> _SharedCapture:
+    def _acquire(self, index: int, key: str | int) -> _SharedCapture:
         with self._registry_lock:
-            entry = self._captures.get(index)
+            entry = self._captures.get(key)
             if entry is None:
-                entry = _SharedCapture(index)
-                self._captures[index] = entry
+                entry = _SharedCapture(key, index)
+                self._captures[key] = entry
             entry.refcount += 1
         try:
             with entry.lock:
@@ -149,6 +183,10 @@ class CameraPreviewManager:
                             "by another application."
                         )
                     entry.cap = cap
+                    # Keep entry.index describing the handle that actually
+                    # exists: this open may be a re-open of an entry created
+                    # when the device answered to a different index.
+                    entry.index = index
         except Exception:
             self._release(entry)
             raise
@@ -161,8 +199,8 @@ class CameraPreviewManager:
                 return
             # Last client: deregister before the (slow) device release so a new
             # client never latches onto a capture that is being torn down.
-            if self._captures.get(entry.index) is entry:
-                del self._captures[entry.index]
+            if self._captures.get(entry.key) is entry:
+                del self._captures[entry.key]
         with entry.lock:
             if entry.cap is not None:
                 entry.cap.release()

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -62,7 +62,7 @@ from .auto_calibrate import (
     auto_calibration_manager,
 )
 from .calibrate import CalibrationRequest, calibration_manager
-from .camera_identity import pump_avfoundation_runloop, resolve_cv2_index
+from .camera_identity import identify_cv2_index, pump_avfoundation_runloop
 from .camera_preview import CameraOpenError, camera_preview_manager
 from .identify import identify_arm_by_motion
 from .jobs import (
@@ -2470,9 +2470,13 @@ def camera_preview_stream(index: int, unique_id: str | None = None):
 
     ``unique_id`` (AVFoundation uniqueID, from /available-cameras) re-anchors
     the index to the physical device before opening: cv2 resolves indices
-    against this process's startup device snapshot, which diverges from the
+    against this process's device snapshot, which diverges from the
     fresh-subprocess enumeration after a replug — without the re-anchor the
     stream can silently show a different camera (see makermodslab/camera_identity.py).
+    The identity is also what the preview registry shares captures by, so the
+    resolver hands back both: the index to open and the key to file it under.
+    Keying by the bare index aliased two different cameras onto one handle
+    whenever the device set renumbered mid-session.
 
     Returns 409 while recording or inference is active (they own the cv2
     devices) and 503 when the camera can't be opened. Teleoperation drives the
@@ -2489,15 +2493,25 @@ def camera_preview_stream(index: int, unique_id: str | None = None):
             status_code=409,
             detail="Inference is active — the cameras are in use. Stop the run to preview them.",
         )
-    resolved = resolve_cv2_index(unique_id, index)
-    if resolved is None:
+    identified = identify_cv2_index(unique_id, index)
+    if identified is None:
         raise HTTPException(
             status_code=503,
-            detail="Camera not visible to the server — it was plugged in after MakerMods Lab "
-            "started. Restart MakerMods Lab to use it.",
+            # Two causes reach here and the server cannot tell them apart
+            # without plumbing that would not change the remedy: the camera
+            # was attached after startup and this process never saw it, or
+            # macOS is denying MakerMods Lab camera access, in which case the
+            # enumeration truthfully reports nothing and cv2 could not open
+            # the device either. Naming both beats asserting the first and
+            # sending the user to a restart that cannot help.
+            detail="Camera not visible to the server — either it was plugged in after "
+            "MakerMods Lab started, or macOS is not granting MakerMods Lab camera access "
+            "(System Settings → Privacy & Security → Camera). Grant access if it is missing, "
+            "then restart MakerMods Lab.",
         )
+    resolved, key = identified
     try:
-        stream = camera_preview_manager.open_stream(resolved)
+        stream = camera_preview_manager.open_stream(resolved, key)
     except CameraOpenError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     return StreamingResponse(stream, media_type="multipart/x-mixed-replace; boundary=frame")

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -62,7 +62,7 @@ from .auto_calibrate import (
     auto_calibration_manager,
 )
 from .calibrate import CalibrationRequest, calibration_manager
-from .camera_identity import resolve_cv2_index
+from .camera_identity import pump_avfoundation_runloop, resolve_cv2_index
 from .camera_preview import CameraOpenError, camera_preview_manager
 from .identify import identify_arm_by_motion
 from .jobs import (
@@ -2699,10 +2699,33 @@ def startup_event():
     warn_if_cuda_mismatch()
 
 
+# Strong reference so the loop's task set can't drop the pump mid-flight.
+_avf_pump_task: asyncio.Task | None = None
+
+
+@app.on_event("startup")
+async def start_avfoundation_pump():
+    """Keep the in-process camera list live on macOS (hotplug/replug).
+
+    Async handler on purpose: it runs inside the event loop (main thread),
+    which is where the pump must live — AVFoundation's device-cache updates
+    only drain on the main thread's runloop (see camera_identity). A sync
+    startup handler would run in the threadpool and couldn't schedule it.
+    No-op off macOS.
+    """
+    global _avf_pump_task
+    _avf_pump_task = asyncio.create_task(pump_avfoundation_runloop())
+
+
 @app.on_event("shutdown")
 async def shutdown_event():
     """Clean up resources when FastAPI shuts down"""
     logger.info("🔄 FastAPI shutting down, cleaning up...")
+
+    # Stop the AVFoundation pump first so its next tick can't interleave with
+    # shutdown (and so --reload restarts don't log a destroyed-pending-task).
+    if _avf_pump_task is not None:
+        _avf_pump_task.cancel()
 
     # Teleoperation and recording drive the follower(s) as background threads
     # INSIDE this process (teleoperation_thread / recording_thread); auto-

--- a/tests/test_camera_identity.py
+++ b/tests/test_camera_identity.py
@@ -1,0 +1,335 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for makermodslab.camera_identity — uniqueID → cv2 index resolution.
+
+The in-process AVFoundation enumeration is always patched: the host's real
+camera list would make these machine-dependent, and on macOS enumerating
+external cameras needs camera permission.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import makermodslab.camera_identity as camera_identity
+from makermodslab.camera_identity import (
+    identify_cv2_index,
+    list_cameras_in_process,
+    resolve_cv2_index,
+)
+
+# A two-camera in-process view: "uid-A" sorted ahead of "uid-B", which is what
+# a camera attached mid-session does to the device already streaming.
+TWO_CAMERAS = [
+    {"index": 0, "name": "Robot Cam", "unique_id": "uid-A"},
+    {"index": 1, "name": "Robot Cam", "unique_id": "uid-B"},
+]
+
+
+@pytest.fixture
+def enumeration(monkeypatch: pytest.MonkeyPatch):
+    """Patch the in-process device list; returns a setter taking the list (or
+    None for "identity unavailable" — non-macOS, PyObjC missing, query error)."""
+
+    def _set(cameras: list[dict] | None) -> None:
+        monkeypatch.setattr(camera_identity, "list_cameras_in_process", lambda: cameras)
+
+    return _set
+
+
+# ---------------------------------------------------------------------------
+# resolve_cv2_index — index only (unchanged contract)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_the_in_process_index_not_the_callers(enumeration) -> None:
+    """The caller's index comes from a fresh-subprocess enumeration; this
+    process may open the same device at a different number."""
+    enumeration(TWO_CAMERAS)
+    assert resolve_cv2_index("uid-B", 0) == 1
+
+
+def test_resolve_returns_none_for_a_device_this_process_cannot_see(enumeration) -> None:
+    enumeration(TWO_CAMERAS)
+    assert resolve_cv2_index("uid-missing", 0) is None
+
+
+def test_resolve_without_a_unique_id_trusts_the_index_without_enumerating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom() -> list[dict] | None:
+        raise AssertionError("enumeration must not be needed to trust an index")
+
+    monkeypatch.setattr(camera_identity, "list_cameras_in_process", _boom)
+    assert resolve_cv2_index(None, 2) == 2
+    assert resolve_cv2_index("", 2) == 2
+
+
+def test_resolve_falls_back_to_the_index_when_identity_is_unavailable(enumeration) -> None:
+    enumeration(None)
+    assert resolve_cv2_index("uid-B", 3) == 3
+
+
+# ---------------------------------------------------------------------------
+# identify_cv2_index — index + the key a caller can cache the device under
+# ---------------------------------------------------------------------------
+
+
+def test_identify_returns_the_resolved_index_and_the_identity(enumeration) -> None:
+    enumeration(TWO_CAMERAS)
+    assert identify_cv2_index("uid-B", 0) == (1, "uid-B")
+
+
+def test_identify_backfills_the_identity_when_the_caller_supplied_none(enumeration) -> None:
+    """The uniqueID is optional on the wire (the frontend's BackendCameraStream
+    takes `uniqueId?`). Without the backfill, one client would key a device by
+    its uniqueID and another the SAME device by an int, and a shared,
+    single-handle resource would be opened twice."""
+    enumeration(TWO_CAMERAS)
+    assert identify_cv2_index(None, 0) == (0, "uid-A")
+    assert identify_cv2_index("", 1) == (1, "uid-B")
+
+
+def test_identify_invents_no_identity_for_an_index_that_is_not_there(enumeration) -> None:
+    enumeration(TWO_CAMERAS)
+    assert identify_cv2_index(None, 7) == (7, None)
+
+
+def test_identify_returns_no_identity_when_enumeration_is_unavailable(enumeration) -> None:
+    """Nothing to key by: the caller falls back to the index, exactly as it
+    behaved before identity existed. (These platforms have no live device
+    list either, so indices do not renumber underneath the caller.)"""
+    enumeration(None)
+    assert identify_cv2_index("uid-B", 3) == (3, None)
+    assert identify_cv2_index(None, 3) == (3, None)
+
+
+def test_identify_returns_none_for_a_device_this_process_cannot_see(enumeration) -> None:
+    """Same fail-loudly contract as resolve_cv2_index: never silently hand back
+    whatever else now sits at the caller's index."""
+    enumeration(TWO_CAMERAS)
+    assert identify_cv2_index("uid-missing", 0) is None
+
+
+# ---------------------------------------------------------------------------
+# None vs [] — a deliberate fork, pinned here so it stays a decision
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_enumeration_is_not_the_same_answer_as_no_enumeration() -> None:
+    """The distinction the whole module rests on, asserted side by side.
+
+    ``[]`` means the enumeration ran and this machine has no cameras, so a
+    requested device is definitively absent and the resolvers must fail loudly
+    (None) rather than open whatever sits at the caller's index. ``None`` means
+    the enumeration could not run at all, where the caller's index is the best
+    answer available and is trusted. The integration branch's variant of
+    resolve_in_enumeration collapses both into the index; if these two
+    assertions ever have to change together, that collapse has been merged in
+    by accident. See the MERGE NOTE in camera_identity.resolve_in_enumeration.
+    """
+    assert camera_identity.resolve_in_enumeration([], "uid-A", 3) is None
+    assert camera_identity.resolve_in_enumeration(None, "uid-A", 3) == 3
+
+
+def test_resolve_fails_loudly_when_the_machine_has_no_cameras(enumeration) -> None:
+    enumeration([])
+    assert resolve_cv2_index("uid-A", 0) is None
+    assert resolve_cv2_index("uid-A", 7) is None
+
+
+def test_resolve_trusts_the_index_when_the_enumeration_could_not_run(enumeration) -> None:
+    enumeration(None)
+    assert resolve_cv2_index("uid-A", 0) == 0
+    assert resolve_cv2_index("uid-A", 7) == 7
+
+
+def test_identify_carries_the_same_fork(enumeration) -> None:
+    """identify_cv2_index inherits both sides: absent-on-an-empty-machine is a
+    hard failure, un-enumerable is index-with-no-identity."""
+    enumeration([])
+    assert identify_cv2_index("uid-A", 0) is None
+    assert identify_cv2_index(None, 0) == (0, None)  # nothing to backfill from
+    enumeration(None)
+    assert identify_cv2_index("uid-A", 0) == (0, None)
+
+
+# ---------------------------------------------------------------------------
+# list_cameras_in_process — the guarantee the fork above depends on: every
+# "could not ask" path returns None, never an empty list.
+#
+# These drive the real function with a stand-in for the slice of PyObjC it
+# uses, so no real AVFoundation call is ever made. That is unavoidably
+# mock-shaped: it pins the CONTROL FLOW (which failures short-circuit, and
+# that a discovery session is never run with an empty type list), not
+# AVFoundation's real behavior.
+# ---------------------------------------------------------------------------
+
+ALL_TYPE_NAMES = {name: object() for name in camera_identity._AVF_DEVICE_TYPE_NAMES}
+
+
+class FakeObjCError(Exception):
+    """Stand-in for ``objc.error``."""
+
+
+class FakeAVDevice:
+    def __init__(self, unique_id: str, name: str) -> None:
+        self._unique_id = unique_id
+        self._name = name
+
+    def uniqueID(self) -> str:  # noqa: N802 — Cocoa's camelCase API
+        return self._unique_id
+
+    def localizedName(self) -> str:  # noqa: N802 — Cocoa's camelCase API
+        return self._name
+
+
+class FakeAVFoundation:
+    """The slice of PyObjC/AVFoundation that list_cameras_in_process() touches."""
+
+    def __init__(self, bundle_loads: bool, constants: dict, devices_by_media: dict) -> None:
+        self._bundle_loads = bundle_loads
+        self._constants = constants
+        self._devices_by_media = devices_by_media
+        self.discovery_calls: list[tuple[list, str]] = []
+
+    # --- Foundation.NSBundle -------------------------------------------------
+    def bundleWithPath_(self, path: str):  # noqa: N802 — Cocoa's camelCase API
+        return self
+
+    def load(self) -> bool:
+        return self._bundle_loads
+
+    # --- objc ----------------------------------------------------------------
+    def loadBundleVariables(self, bundle, out: dict, spec: list) -> None:  # noqa: N802
+        ((name, _encoding),) = spec
+        if name not in self._constants:
+            raise FakeObjCError(name)
+        out[name] = self._constants[name]
+
+    def lookUpClass(self, name: str):  # noqa: N802 — Cocoa's camelCase API
+        outer = self
+
+        class _DiscoverySession:
+            @staticmethod
+            def discoverySessionWithDeviceTypes_mediaType_position_(  # noqa: N802
+                device_types, media_type: str, position: int
+            ):
+                outer.discovery_calls.append((list(device_types), media_type))
+                return types.SimpleNamespace(devices=lambda: outer._devices_by_media.get(media_type))
+
+        return _DiscoverySession
+
+
+@pytest.fixture
+def fake_avfoundation(monkeypatch: pytest.MonkeyPatch):
+    """Install the stand-in and pretend we're on macOS; returns the installer."""
+
+    def _install(
+        *,
+        bundle_loads: bool = True,
+        constants: dict | None = None,
+        devices_by_media: dict | None = None,
+    ) -> FakeAVFoundation:
+        fake = FakeAVFoundation(
+            bundle_loads,
+            ALL_TYPE_NAMES if constants is None else constants,
+            {"vide": [], "muxx": []} if devices_by_media is None else devices_by_media,
+        )
+        objc_module = types.ModuleType("objc")
+        objc_module.error = FakeObjCError
+        objc_module.loadBundleVariables = fake.loadBundleVariables
+        objc_module.lookUpClass = fake.lookUpClass
+        foundation_module = types.ModuleType("Foundation")
+        foundation_module.NSBundle = fake
+        monkeypatch.setitem(sys.modules, "objc", objc_module)
+        monkeypatch.setitem(sys.modules, "Foundation", foundation_module)
+        monkeypatch.setattr(camera_identity.platform, "system", lambda: "Darwin")
+        return fake
+
+    return _install
+
+
+def test_enumeration_unavailable_when_the_framework_does_not_load(fake_avfoundation) -> None:
+    """An unloaded framework resolves no device-type constants, so the natural
+    outcome is "no devices" — which must not be reported as an empty machine."""
+    fake = fake_avfoundation(bundle_loads=False)
+    assert list_cameras_in_process() is None
+    assert fake.discovery_calls == []
+
+
+def test_enumeration_unavailable_when_no_device_type_constant_resolves(fake_avfoundation) -> None:
+    """Every constant lookup failing means the lookup itself is broken (macOS
+    renamed them?). A discovery session must never run with an empty type
+    list: it can only match nothing, and that nothing would be a lie."""
+    fake = fake_avfoundation(constants={})
+    assert list_cameras_in_process() is None
+    assert fake.discovery_calls == []
+
+
+def test_enumeration_unavailable_when_discovery_answers_nothing(fake_avfoundation) -> None:
+    """nil from every query is a failure to answer, not an answer of "none"."""
+    fake_avfoundation(devices_by_media={"vide": None, "muxx": None})
+    assert list_cameras_in_process() is None
+
+
+def test_one_answering_query_is_enough_to_trust_an_empty_result(fake_avfoundation) -> None:
+    """A single query answering (with an empty array) is a real enumeration."""
+    fake_avfoundation(devices_by_media={"vide": [], "muxx": None})
+    assert list_cameras_in_process() == []
+
+
+def test_a_machine_with_no_cameras_reports_an_empty_list_not_none(fake_avfoundation) -> None:
+    """The other half of the guarantee: a genuine empty machine must be
+    distinguishable from a failed enumeration, or the fork above is moot."""
+    fake_avfoundation()
+    result = list_cameras_in_process()
+    assert result is not None
+    assert result == []
+
+
+def test_devices_are_indexed_in_unique_id_order(fake_avfoundation) -> None:
+    """cv2 assigns macOS camera indices by sorting on uniqueID; the returned
+    index is that position, not discovery order."""
+    fake_avfoundation(
+        devices_by_media={
+            "vide": [FakeAVDevice("uid-B", "Cam B"), FakeAVDevice("uid-A", "Cam A")],
+            "muxx": [],
+        }
+    )
+    assert list_cameras_in_process() == [
+        {"index": 0, "name": "Cam A", "unique_id": "uid-A"},
+        {"index": 1, "name": "Cam B", "unique_id": "uid-B"},
+    ]
+
+
+def test_a_missing_version_gated_constant_is_not_a_failure(fake_avfoundation) -> None:
+    """Individual names are expected to miss — they are version-gated (macOS
+    <14 has no AVCaptureDeviceTypeExternal). Only ALL of them missing is a
+    broken lookup."""
+    survivor = "AVCaptureDeviceTypeBuiltInWideAngleCamera"
+    fake = fake_avfoundation(
+        constants={survivor: ALL_TYPE_NAMES[survivor]},
+        devices_by_media={"vide": [FakeAVDevice("uid-A", "Cam A")], "muxx": []},
+    )
+    assert list_cameras_in_process() == [{"index": 0, "name": "Cam A", "unique_id": "uid-A"}]
+    assert fake.discovery_calls[0][0] == [ALL_TYPE_NAMES[survivor]]
+
+
+def test_non_macos_has_no_in_process_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(camera_identity.platform, "system", lambda: "Linux")
+    assert list_cameras_in_process() is None

--- a/tests/test_camera_preview.py
+++ b/tests/test_camera_preview.py
@@ -23,6 +23,7 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
+import makermodslab.camera_identity as camera_identity
 import makermodslab.camera_preview as camera_preview
 import makermodslab.record as record
 import makermodslab.rollout as rollout
@@ -59,6 +60,30 @@ class FailingVideoCapture(FakeVideoCapture):
     def __init__(self, index: int, backend: int | None = None) -> None:
         super().__init__(index, backend)
         self.opened = False
+
+
+class OneFrameVideoCapture(FakeVideoCapture):
+    """A capture that serves exactly one frame, then reports failure — so the
+    endpoint's (endless by design) generator terminates and a TestClient
+    request can complete against the REAL manager rather than a stub."""
+
+    def read(self):
+        if not self.opened:
+            return False, None
+        self.opened = False
+        return True, np.zeros((8, 8, 3), dtype=np.uint8)
+
+
+@pytest.fixture(autouse=True)
+def no_host_camera_enumeration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never let identity resolution touch the host's real AVFoundation list.
+
+    The default ("identity unavailable") is what non-macOS hosts see, and it
+    keys previews by index exactly as they were keyed before identity existed,
+    so the pre-existing tests below are unaffected. Tests that exercise
+    identity patch this with a device list of their own.
+    """
+    monkeypatch.setattr(camera_identity, "list_cameras_in_process", lambda: None)
 
 
 @pytest.fixture
@@ -190,6 +215,120 @@ def test_stream_after_stop_all_reopens_the_camera(fake_captures: list[FakeVideoC
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Identity keying — the registry is keyed by the camera's uniqueID, not by its
+# cv2 index, because the in-process device list is live and indices renumber
+# mid-session (camera_identity.pump_avfoundation_runloop).
+# ---------------------------------------------------------------------------
+
+
+def test_same_index_different_identity_get_distinct_captures(
+    fake_captures: list[FakeVideoCapture],
+) -> None:
+    """The bug this keying fixes: camera A is attached, sorts ahead of the
+    camera already streaming, and resolves to the index that camera is open on.
+    Keyed by that int, the second client was handed the FIRST camera's handle —
+    it would then be configured and named while showing the other's picture."""
+    manager = CameraPreviewManager()
+    gen_b = manager.open_stream(0, "uid-B")  # streaming B, opened at index 0
+    gen_a = manager.open_stream(0, "uid-A")  # A now resolves to index 0 too
+    next(gen_b)
+    next(gen_a)
+
+    assert len(fake_captures) == 2
+    assert set(manager._captures) == {"uid-A", "uid-B"}
+    assert manager._captures["uid-A"].cap is not manager._captures["uid-B"].cap
+    gen_a.close()
+    gen_b.close()
+
+
+def test_same_identity_different_index_shares_one_capture(
+    fake_captures: list[FakeVideoCapture],
+) -> None:
+    """The mirror case, which must NOT regress into a second open: B renumbers
+    from 0 to 1 while a client still streams it, and the new client for B
+    shares the existing device-bound handle instead of opening the device
+    twice (a busy camera would refuse the second open)."""
+    manager = CameraPreviewManager()
+    gen_first = manager.open_stream(0, "uid-B")
+    gen_second = manager.open_stream(1, "uid-B")
+    next(gen_first)
+    next(gen_second)
+
+    assert len(fake_captures) == 1
+    assert fake_captures[0].index == 0  # the index the handle was opened at
+    assert list(manager._captures) == ["uid-B"]
+    assert manager._captures["uid-B"].refcount == 2
+
+    gen_first.close()
+    assert not fake_captures[0].released
+    gen_second.close()
+    assert fake_captures[0].released
+    assert manager._captures == {}
+
+
+def test_identity_unavailable_falls_back_to_index_keying(
+    fake_captures: list[FakeVideoCapture],
+) -> None:
+    """Where the platform can't establish identity (non-macOS, PyObjC missing),
+    the index is the key and sharing behaves exactly as it did before."""
+    manager = CameraPreviewManager()
+    gen_a = manager.open_stream(0, None)
+    gen_b = manager.open_stream(0, None)
+    next(gen_a)
+    next(gen_b)
+
+    assert len(fake_captures) == 1
+    assert list(manager._captures) == [0]
+    gen_a.close()
+    gen_b.close()
+    assert fake_captures[0].released
+
+
+def test_camera_preview_endpoint_keys_by_identity(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end through the endpoint: a client already streaming camera B on
+    index 0, then a request for camera A that resolves to index 0 as well, must
+    open a SECOND capture — not inherit B's handle."""
+    instances: list[OneFrameVideoCapture] = []
+
+    def factory(index: int, backend: int | None = None) -> OneFrameVideoCapture:
+        cap = OneFrameVideoCapture(index, backend)
+        instances.append(cap)
+        return cap
+
+    monkeypatch.setattr(camera_preview.cv2, "VideoCapture", factory)
+    manager = CameraPreviewManager()
+    monkeypatch.setattr(server_mod, "camera_preview_manager", manager)
+
+    # Browser 1: B is the only camera, so it is index 0.
+    monkeypatch.setattr(
+        camera_identity,
+        "list_cameras_in_process",
+        lambda: [{"index": 0, "name": "cam", "unique_id": "uid-B"}],
+    )
+    gen_b = manager.open_stream(*camera_identity.identify_cv2_index("uid-B", 0))
+    next(gen_b)  # attached and holding the capture
+
+    # A is plugged in and sorts ahead of B, taking index 0.
+    monkeypatch.setattr(
+        camera_identity,
+        "list_cameras_in_process",
+        lambda: [
+            {"index": 0, "name": "cam", "unique_id": "uid-A"},
+            {"index": 1, "name": "cam", "unique_id": "uid-B"},
+        ],
+    )
+    response = client.get("/camera-preview/0", params={"unique_id": "uid-A"})
+
+    assert response.status_code == 200
+    assert b"--frame" in response.content
+    assert len(instances) == 2  # a fresh, A-bound capture, not B's handle
+    assert set(manager._captures) == {"uid-B"}  # A's stream finished and freed
+    gen_b.close()
+
+
 def test_camera_preview_409_while_recording(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(record, "recording_active", True)
     response = client.get("/camera-preview/0")
@@ -204,7 +343,7 @@ def test_camera_preview_allowed_while_teleoperating(
     teleop does not contend — it must NOT 409. (The manager is patched to a
     finite stream so the TestClient request completes.)"""
 
-    def finite_stream(index: int):
+    def finite_stream(index: int, key: str | int | None = None):
         yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\nfake-jpeg\r\n"
 
     monkeypatch.setattr(teleoperate, "teleoperation_active", True)
@@ -228,7 +367,7 @@ def test_camera_preview_streams_multipart_mjpeg(client: TestClient, monkeypatch:
     a FINITE stream so the TestClient request completes (the real generator is
     endless by design; its behavior is covered by the manager tests above)."""
 
-    def finite_stream(index: int):
+    def finite_stream(index: int, key: str | int | None = None):
         yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\nfake-jpeg\r\n"
 
     monkeypatch.setattr(server_mod.camera_preview_manager, "open_stream", finite_stream)


### PR DESCRIPTION
Three camera fixes. The first two are hardware-verified on a real SO-101 rig (macOS, twin USB cameras) on 2026-08-07; the third closes an aliasing bug that the first one makes reachable, and is covered by unit tests.

**1. Camera hotplug/replug now self-recovers — the "restart MakerMods Lab" paths become unreachable on macOS.**

AVFoundation's in-process device list freezes at first touch because its device-cache updates are queued on the main dispatch queue, which only the MAIN thread's runloop drains — and uvicorn never pumps it. Consequences: cameras plugged in after startup stayed invisible until a server restart, and a camera replugged into the same USB port kept its uniqueID but became a stale device object that opens "successfully" and never delivers a frame (silently blank preview; the blocked read can also wedge locks and graceful shutdown).

A three-arm experiment on real hardware (`camera_runloop_experiment.py`, committed for reproducibility; protocol in its docstring) established: with no runloop the list freezes (control); a background-thread NSRunLoop changes nothing; pumping the main thread's runloop refreshes the list on unplug/replug AND makes a same-port-replugged camera readable again.

Fix: `camera_identity.pump_avfoundation_runloop()` — an asyncio task on the main-thread event loop pumping the runloop ~50 ms every 0.5 s — started from an async startup handler (async so it runs on the event loop, not the sync-handler threadpool) and cancelled at shutdown. No-op off macOS. End-to-end verified: unplug → tile dies; same-port replug → tile recovers by itself in seconds, no restart.

Out of scope by design: changing which port a camera occupies while the server runs. uniqueID is the port path, so identical cameras swapped pairwise are undetectable in principle — that stays a fixed-topology bench rule.

**2. Removing a camera tile now always releases the camera.**

`BackendCameraStream`'s unmount cleanup captured the `<img>` element once at mount, but `key={attempt}` remounts the element on every retry — so after any transient stream error, deleting the tile cleared a long-dead element's `src` and left the live MJPEG connection open, keeping the server's shared capture (and the physical camera) held indefinitely. Replaced with a callback ref that clears `src` on every element detach (retry remounts and final unmount alike). Introduced by direct-push 8a748ea; reproduced and verified released via server logs.

**3. The preview capture registry is keyed by camera identity, not by cv2 index — closing an aliasing bug that fix 1 makes reachable.**

A live device list means indices genuinely renumber *at runtime*, and `CameraPreviewManager._captures` was keyed by the bare index. `/camera-preview/{index}` re-anchors the caller's index to the physical device via uniqueID and then discards that identity one call later, looking the entry up by the int:

> Browser 1 streams camera B, which resolved to index 0, so `_captures[0]` holds a handle bound to B. The user attaches camera A, which sorts ahead of B by uniqueID and takes index 0. Browser 2 selects A; identity resolution correctly returns 0 — and the registry hands back the capture still bound to **B**. The user configures and names A while watching B's picture, and that name is written into a robot record that labels every dataset recorded afterwards.

Before the pump this was unreachable: a frozen device list makes uniqueID→index constant for the process lifetime, so the index was a sound stand-in for identity. It stops being one here, which is why this ships in the same PR rather than behind it — otherwise `main` carries a live wrong-camera bug for as long as a follow-up waits for review.

- `camera_identity.identify_cv2_index()` returns `(index to open, identity key)`. It **backfills** the uniqueID when the caller supplied none, which is load-bearing rather than cosmetic: `uniqueId` is optional on `BackendCameraStream`, so without the backfill one client would key a device by its uniqueID while another keyed the *same* device by an int, and a single-handle shared resource would be opened twice.
- `CameraPreviewManager` keys the registry by that identity, falling back to the index only where identity is unavailable (non-macOS, PyObjC missing, query failure) — exactly the platforms whose device list is not live-refreshed anyway, so the original sharing behaviour is preserved there.

**A guarantee the above depends on, which the code did not actually deliver.** Falling through on an empty enumeration is only safe if `[]` really means "asked, found nothing." Three paths in `list_cameras_in_process()` returned `[]` when the enumeration had *not* worked: `bundle.load()`'s return value was discarded; each device-type constant was looked up individually with `objc.error` swallowed by `continue`, and a discovery session handed an empty type list matches nothing *by construction*; and `session.devices() or []` flattened a nil query result into an empty array. Each now returns `None` explicitly, which is what the function's own docstring already promised. The contract is now stated there: `None` = could not ask, trust the caller's index; `[]` = asked and found nothing, so the device is verifiably absent and callers must fail loudly.

Camera-permission denial is deliberately *not* folded into that: a process denied macOS camera access enumerates only built-ins, so on a Mac without one it truthfully reports `[]`, and it could not open those devices through cv2 either. Failing loudly stays correct — but the message was wrong, so the preview's 503 now names permission denial alongside attached-after-startup and points at System Settings, instead of asserting the latter and prescribing a restart that cannot help.

Still not addressed, and stated as such in the code: a camera replugged into the **same** port keeps its uniqueID, so a dead handle is still returned for the right device (that is the wedge containment in the follow-up PR, not this key), and two identical cameras **swapped between ports** exchange uniqueIDs — the same in-principle limit already noted under fix 1. Identity keying does one thing: it stops two *different* physical cameras from colliding on one entry.

**Checks**

- `pytest tests/test_camera_preview.py tests/test_camera_identity.py` → **39 passed** (18 preview, of which 4 are new; 21 in the new `tests/test_camera_identity.py`).
- `ruff check` / `ruff format --check` on the five touched files → clean.
- Mutation-verified: reverting the registry key to the bare index and disabling the three enumeration guards fails exactly six tests — the three keying tests and the three guard tests — and nothing else, so each is independently load-bearing.
- Fix 3 is unit-tested only. Its hardware repro needs a second camera that sorts ahead of a streaming one by uniqueID (i.e. by USB port path), which is a port-topology-dependent setup rather than a plug/unplug; the failure it prevents is a *wrong picture*, which is invisible unless the two cameras are pointed at distinguishable scenes.
- The `list_cameras_in_process()` tests pin control flow — which failure short-circuits, and that a discovery session never runs with an empty type list — not AVFoundation's real behaviour. Their header says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
