### PR TITLE
feat(jobs): resume chains — one row per chain, one-click Continue, job numbers

### DIFF
--- a/frontend/src/components/jobs/CheckpointDropdown.tsx
+++ b/frontend/src/components/jobs/CheckpointDropdown.tsx
@@ -25,6 +25,20 @@ interface Props {
   /** Trigger id, so a <Label htmlFor> can be attached when the dropdown is
    * rendered as a labelled form field (the Run panel). */
   id?: string;
+  /** Which run each checkpoint came from, keyed by `ref`, for the callers that
+   * merge a whole resume lineage into one list (JobCard, ModelCard).
+   *
+   * Optional because most callers show a single run's checkpoints, where the
+   * attribution would be the same word on every row. Even when supplied it is
+   * only RENDERED if the list actually spans more than one run — see below.
+   *
+   * Each value carries the run NUMBER as the visible distinguisher — runs on
+   * one chain share a name by design — plus a `detail` string surfaced on
+   * hover for matching a row against a log line or an API message. */
+  owners?: Record<
+    string,
+    { name: string; number: number; detail: string }
+  >;
 }
 
 export const CheckpointDropdown: React.FC<Props> = ({
@@ -35,6 +49,7 @@ export const CheckpointDropdown: React.FC<Props> = ({
   placeholder = "Select checkpoint",
   className,
   id,
+  owners,
 }) => {
   // step 0 is the sentinel for an imported single-model checkpoint (lerobot
   // never saves at step 0), so it has no meaningful step number — show
@@ -51,6 +66,24 @@ export const CheckpointDropdown: React.FC<Props> = ({
   const sortKey = (c: JobCheckpoint) =>
     c.step === 0 ? Number.MAX_SAFE_INTEGER : c.step;
   const ordered = [...checkpoints].sort((a, b) => sortKey(b) - sortKey(a));
+  // Attribution earns its space only when the list MERGES runs. A single run's
+  // checkpoints all carry the same owner, so printing it on every row would be
+  // noise on the common case — and on a lineage it is the opposite of noise,
+  // because "step 2000" appears once per run that saved one and the step alone
+  // cannot say which is which (the `selectedRef` note above is the same fact
+  // from the selection side).
+  const attributed =
+    owners !== undefined &&
+    new Set(ordered.map((c) => owners[c.ref]?.detail).filter(Boolean)).size > 1;
+  // Resolved, not assumed: a `selectedRef` naming a checkpoint that is no
+  // longer in the list (a refresh dropped it) must fall back to the
+  // placeholder, never to a step number invented from a missing entry — step 0
+  // is the "latest" sentinel, so a `?? 0` would have quietly labelled a stale
+  // selection "latest".
+  const selected =
+    selectedRef === null
+      ? undefined
+      : checkpoints.find((c) => c.ref === selectedRef);
   return (
     <Select
       value={selectedRef ?? undefined}
@@ -68,18 +101,53 @@ export const CheckpointDropdown: React.FC<Props> = ({
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        <SelectValue placeholder={placeholder} />
+        {/* The TRIGGER stays the step alone even when the list is attributed.
+            Radix would otherwise mirror the whole selected row into it, and the
+            trigger is the tightest space on the card (ModelCard pins it to
+            w-36, JobCard shares a single action line with the Resume button) —
+            an owner + timestamp there would push the step out of view, losing
+            the one fact the collapsed control exists to show. The disambiguator
+            belongs where the ambiguity is visible: the open list. */}
+        {attributed && selected !== undefined ? (
+          <SelectValue placeholder={placeholder}>
+            {labelFor(selected.step)}
+          </SelectValue>
+        ) : (
+          <SelectValue placeholder={placeholder} />
+        )}
       </SelectTrigger>
       <SelectContent className="bg-popover border-border">
-        {ordered.map((c) => (
-          <SelectItem
-            key={c.ref}
-            value={c.ref}
-            onClick={(e) => e.stopPropagation()}
-          >
-            {labelFor(c.step)}
-          </SelectItem>
-        ))}
+        {ordered.map((c) => {
+          const owner = owners?.[c.ref];
+          return (
+            <SelectItem
+              key={c.ref}
+              value={c.ref}
+              onClick={(e) => e.stopPropagation()}
+            >
+              {attributed && owner ? (
+                // Two lines rather than one: the step is what the user picks
+                // by, so it keeps the readable weight, and the run it belongs
+                // to sits under it. The RUN NUMBER leads that second line — it
+                // is short enough for a dense row and is the same handle the
+                // backend's refusals lead with, so a 409 naming #46 points at
+                // a row the user can find. The timestamp and full id stay one
+                // hover away rather than spending width here.
+                <span className="flex flex-col gap-0.5" title={owner.detail}>
+                  <span>{labelFor(c.step)}</span>
+                  <span className="whitespace-nowrap text-[10px] leading-none text-muted-foreground">
+                    {owner.number > 0 ? (
+                      <span className="font-mono">#{owner.number} </span>
+                    ) : null}
+                    {owner.name}
+                  </span>
+                </span>
+              ) : (
+                labelFor(c.step)
+              )}
+            </SelectItem>
+          );
+        })}
       </SelectContent>
     </Select>
   );

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -368,21 +368,28 @@ const JobCard: React.FC<Props> = ({
   // reached its target — the way to build on it is Fine-tune, which starts a
   // fresh LR schedule instead of restoring a spent one.
   //
-  // Sticks (user decision 2026-08-07), the second and larger narrowing: an
-  // INHERITED checkpoint is no longer a resume source at all. Its owner has a
-  // child by construction — the run below it on this card's own path — and
-  // jobs.py refuses a second continuation of a run that already has one, so
-  // the button would only buy a 409. The dropdown still lists the whole
-  // lineage, and an inherited checkpoint remains selectable for inference; it
-  // is Resume alone that dims, via the existing `selectedIsResumable` gate.
-  // The empty-handed case (this tip saved nothing, so no selection lights the
-  // button) is recoverable by deleting this run and resuming its parent —
-  // which the library row's toast spells out.
+  // Continue is deliberately NOT step-selectable (user decision 2026-08-10):
+  // it always takes the newest resumable checkpoint, `resumableCheckpoints`
+  // being newest-first. That is the one-click behaviour the jobs library row
+  // has always had, so the two entry points now differ in nothing at all.
+  //
+  // The dropdown beside it still drives Run / Fine-tune / Download, where
+  // picking an older checkpoint is a real choice. Resuming from one is not:
+  // it re-trains steps the chain already covered, and it blocks the intended
+  // end state, where a continuation ABSORBS its parent (inheriting its
+  // checkpoints outright, so there is no ancestor left to reach back to). A
+  // rewound child re-writes steps its parent still holds, so absorbing it
+  // would have to either collide or silently discard the superseded ones;
+  // continuing from the newest checkpoint is a pure append and does neither.
+  //
+  // What stays is the REACH, invisibly: the newest resumable checkpoint may
+  // be owned by an ANCESTOR, since a tip that died before saving anything has
+  // none of its own. The user presses one button and never learns which run
+  // held the bytes — but that reach is what keeps every row in the library
+  // done-or-resumable, and buildResumeSeed still records the owner separately
+  // from the lineage edge so the chain stays linear.
   const resumable = resumableCheckpoints(job, lineageCheckpoints);
-  const selectedIsResumable =
-    !isRunning &&
-    selected != null &&
-    resumable.some((c) => c.ckpt.ref === selected.ckpt.ref);
+  const resumeSource = isRunning ? null : (resumable[0] ?? null);
 
   // ONE verb. This used to fork into "Continue" (a local-owned checkpoint) and
   // "Resume" (a cloud-owned one) — two buttons that differed only in wording,
@@ -394,18 +401,21 @@ const JobCard: React.FC<Props> = ({
   // form's default, which the form itself already shows and lets you change.
   // Asking a novice to tell two verbs apart for one action is the cost; there
   // is no benefit left to pay it with.
-  const canResume = selectedIsResumable;
+  const canResume = resumeSource != null;
 
-  // Step 0 is the whole-repo/single-model sentinel (see CheckpointDropdown),
-  // which has no meaningful number to name — matching its "latest" label.
+  // Names the step it WILL use, not one the user chose — the button is now the
+  // whole decision. Step 0 is the whole-repo/single-model sentinel (see
+  // CheckpointDropdown), which has no meaningful number to name, matching its
+  // "latest" label.
+  const resumeStep = resumeSource?.ckpt.step ?? null;
   const resumeLabel =
-    selectedStep == null || selectedStep === 0
+    resumeStep == null || resumeStep === 0
       ? "Resume from latest"
-      : `Resume from step ${selectedStep.toLocaleString()}`;
+      : `Resume from step ${resumeStep.toLocaleString()}`;
 
   // No dialog and no route jump: continuing opens the Train panel's
   // "Start a new training" form in resume mode, seeded from this run and the
-  // dropdown's checkpoint — the same in-place flow Fine-tune already uses,
+  // newest resumable checkpoint — the same in-place flow Fine-tune already uses,
   // rather than navigating away to /training and losing the studio.
   //
   // The configurator PREFILLS from this seed, then renders read-only the
@@ -416,15 +426,18 @@ const JobCard: React.FC<Props> = ({
   // resume).
   //
   // The payload itself comes from the ONE shared builder (buildResumeSeed), so
-  // this and the library's row-level quick-resume can no longer drift. It is
-  // handed THIS card's run (the leaf being continued — the lineage edge) plus
-  // the selected entry, which carries its own owner; the builder keeps those
-  // two apart. Passing the owner as the run is precisely the fork bug chain
-  // rewind fixes. The runner still follows the owner there, since it says where
-  // the bytes live and therefore whether they must move first (F7).
+  // this and the library's row-level quick-resume can no longer drift — they
+  // now pass the same entry, the top of the same rule's list. It is handed
+  // THIS card's run (the leaf being continued — the lineage edge) plus that
+  // entry, which carries its own owner; the builder keeps those two apart.
+  // Passing the owner as the run is precisely the fork bug chain rewind fixes.
+  // The runner still follows the owner there, since it says where the bytes
+  // live and therefore whether they must move first (F7).
   const goToResume = () => {
-    if (selected == null) return;
-    openStudio("train", { train: { resume: buildResumeSeed(job, selected) } });
+    if (resumeSource == null) return;
+    openStudio("train", {
+      train: { resume: buildResumeSeed(job, resumeSource) },
+    });
   };
 
   const handleResume = (e: React.MouseEvent) => {

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -521,8 +521,8 @@ const JobCard: React.FC<Props> = ({
   const showInferenceRow =
     lineageCheckpoints.length > 0 && selectedStep != null;
   // The previous commit's delete-first hint is gone with the rule that needed
-  // it: under chain rewind an empty-handed tip is simply resumable — it
-  // continues ITSELF from whatever its ancestors saved — so there is no longer
+  // it: an empty-handed tip is simply resumable — it continues ITSELF from
+  // the newest thing its ancestors saved — so there is no longer
   // a state where visible inherited checkpoints are unusable for a reason the
   // card never says. What is left is a genuinely dead chain (nothing saved
   // anywhere, or everything owned by finished runs), and the library row's

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -41,6 +41,7 @@ import { useStudio } from "@/contexts/StudioContext";
 import { useToast } from "@/hooks/use-toast";
 import {
   LineageCheckpoint,
+  blockedByContinuedOwner,
   buildResumeSeed,
   loadLineageCheckpoints,
   resumableCheckpoints,
@@ -366,6 +367,17 @@ const JobCard: React.FC<Props> = ({
   // a checkpoint inherited from an ancestor that stopped short. That chain
   // reached its target — the way to build on it is Fine-tune, which starts a
   // fresh LR schedule instead of restoring a spent one.
+  //
+  // Sticks (user decision 2026-08-07), the second and larger narrowing: an
+  // INHERITED checkpoint is no longer a resume source at all. Its owner has a
+  // child by construction — the run below it on this card's own path — and
+  // jobs.py refuses a second continuation of a run that already has one, so
+  // the button would only buy a 409. The dropdown still lists the whole
+  // lineage, and an inherited checkpoint remains selectable for inference; it
+  // is Resume alone that dims, via the existing `selectedIsResumable` gate.
+  // The empty-handed case (this tip saved nothing, so no selection lights the
+  // button) is recoverable by deleting this run and resuming its parent —
+  // which the library row's toast spells out.
   const resumable = resumableCheckpoints(job, lineageCheckpoints);
   const selectedIsResumable =
     !isRunning &&
@@ -496,6 +508,28 @@ const JobCard: React.FC<Props> = ({
   // when ModelsLibrary is rewired to render ModelCard — see the header note.)
   const showInferenceRow =
     lineageCheckpoints.length > 0 && selectedStep != null;
+  // The empty-handed tip: this run saved nothing of its own, and everything it
+  // inherited belongs to a run that has already been continued — so under the
+  // sticks rule nothing here is resumable, and the recovery is to delete THIS
+  // run and resume the one behind it. Without this the card just dropped its
+  // whole action row and said nothing, which is the one case where silence is
+  // worst: the checkpoints are visibly there, and the reason they can't be
+  // used is a rule the card never mentions.
+  //
+  // Keyed on `resumable.length === 0`, not on `canResume`: when this run does
+  // have resumable checkpoints of its own, a selection that lands on an
+  // inherited one is a choice the user just made (the default is the newest
+  // resumable), and the answer there is to pick another step, not to delete
+  // the run.
+  const continuedOwnerHint =
+    resumable.length === 0
+      ? blockedByContinuedOwner(job, lineageCheckpoints)
+      : null;
+
+  // (Upstream the row is gated on `resumable.length > 0 || continuedOwnerHint`,
+  // because there it carries Resume alone. Here it also carries Run /
+  // Fine-tune / Download, so `showInferenceRow` above — "there is a checkpoint
+  // at all" — is already the wider gate and covers the empty-handed tip.)
 
   // Unified metadata rows (same format as the dataset/model cards). Imported
   // models keep their source path in the subtitle; trainings surface what they
@@ -708,6 +742,19 @@ const JobCard: React.FC<Props> = ({
                 <FastForward className="w-3.5 h-3.5 shrink-0" />
                 <span className="truncate">{resumeLabel}</span>
               </Button>
+            ) : continuedOwnerHint ? (
+              // Where the button would be, the two-step way to get it back.
+              // Names the run and the step so it can be acted on without
+              // opening anything else — same guidance, same numbers, as the
+              // library row's toast (both read the rule, not a re-derivation).
+              <div className="min-w-0 flex-1 text-[11px] leading-tight text-muted-foreground">
+                Saved no checkpoints of its own, and its parent was already
+                continued. Delete this run, then resume{" "}
+                <span className="text-foreground font-medium">
+                  {jobDisplayName(continuedOwnerHint.job)}
+                </span>{" "}
+                from step {continuedOwnerHint.ckpt.step.toLocaleString()}.
+              </div>
             ) : null}
             {canFinetune ? (
               <Button

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -16,7 +16,7 @@ import {
   jobDisplayName,
   renameJob,
 } from "@/lib/jobsApi";
-import { runTaskTitle } from "@/lib/modelNames";
+import { jobRunStamp, runTaskTitle } from "@/lib/modelNames";
 import {
   Square,
   Trash2,
@@ -41,8 +41,8 @@ import { useStudio } from "@/contexts/StudioContext";
 import { useToast } from "@/hooks/use-toast";
 import {
   LineageCheckpoint,
-  blockedByContinuedOwner,
   buildResumeSeed,
+  checkpointOwners,
   loadLineageCheckpoints,
   resumableCheckpoints,
 } from "./resumeSeed";
@@ -416,16 +416,15 @@ const JobCard: React.FC<Props> = ({
   // resume).
   //
   // The payload itself comes from the ONE shared builder (buildResumeSeed), so
-  // this and the library's row-level quick-resume can no longer drift. The
-  // runner is derived there from the OWNING run — the seed's record of where
-  // the parent actually ran, which the form reads both as its default Compute
-  // and as the fact that decides whether continuing elsewhere has to move the
-  // checkpoint first (F7).
+  // this and the library's row-level quick-resume can no longer drift. It is
+  // handed THIS card's run (the leaf being continued — the lineage edge) plus
+  // the selected entry, which carries its own owner; the builder keeps those
+  // two apart. Passing the owner as the run is precisely the fork bug chain
+  // rewind fixes. The runner still follows the owner there, since it says where
+  // the bytes live and therefore whether they must move first (F7).
   const goToResume = () => {
-    if (selectedStep == null) return;
-    openStudio("train", {
-      train: { resume: buildResumeSeed(selectedJob, selectedStep) },
-    });
+    if (selected == null) return;
+    openStudio("train", { train: { resume: buildResumeSeed(job, selected) } });
   };
 
   const handleResume = (e: React.MouseEvent) => {
@@ -508,28 +507,18 @@ const JobCard: React.FC<Props> = ({
   // when ModelsLibrary is rewired to render ModelCard — see the header note.)
   const showInferenceRow =
     lineageCheckpoints.length > 0 && selectedStep != null;
-  // The empty-handed tip: this run saved nothing of its own, and everything it
-  // inherited belongs to a run that has already been continued — so under the
-  // sticks rule nothing here is resumable, and the recovery is to delete THIS
-  // run and resume the one behind it. Without this the card just dropped its
-  // whole action row and said nothing, which is the one case where silence is
-  // worst: the checkpoints are visibly there, and the reason they can't be
-  // used is a rule the card never mentions.
+  // The previous commit's delete-first hint is gone with the rule that needed
+  // it: under chain rewind an empty-handed tip is simply resumable — it
+  // continues ITSELF from whatever its ancestors saved — so there is no longer
+  // a state where visible inherited checkpoints are unusable for a reason the
+  // card never says. What is left is a genuinely dead chain (nothing saved
+  // anywhere, or everything owned by finished runs), and the library row's
+  // toast explains that on click.
   //
-  // Keyed on `resumable.length === 0`, not on `canResume`: when this run does
-  // have resumable checkpoints of its own, a selection that lands on an
-  // inherited one is a choice the user just made (the default is the newest
-  // resumable), and the answer there is to pick another step, not to delete
-  // the run.
-  const continuedOwnerHint =
-    resumable.length === 0
-      ? blockedByContinuedOwner(job, lineageCheckpoints)
-      : null;
-
-  // (Upstream the row is gated on `resumable.length > 0 || continuedOwnerHint`,
-  // because there it carries Resume alone. Here it also carries Run /
-  // Fine-tune / Download, so `showInferenceRow` above — "there is a checkpoint
-  // at all" — is already the wider gate and covers the empty-handed tip.)
+  // (Upstream the row is gated on `resumable.length > 0`, because there it
+  // carries Resume alone. Here it also carries Run / Fine-tune / Download, so
+  // `showInferenceRow` above — "there is a checkpoint at all" — is the wider
+  // gate and stays.)
 
   // Unified metadata rows (same format as the dataset/model cards). Imported
   // models keep their source path in the subtitle; trainings surface what they
@@ -650,11 +639,27 @@ const JobCard: React.FC<Props> = ({
           </div>
         </div>
         <div>
-          <DisplayName
-            name={taskTitle}
-            full={displayName}
-            className="text-foreground font-semibold"
-          />
+          {/* The run NUMBER rides OUTSIDE the truncating title, so a long name
+              can never eat the one token that identifies the run — every run on
+              a resume chain shares this title, and the number is the same
+              handle the backend's refusals lead with (a 409 naming #46 points
+              at a row the user can find). Its hover carries the run stamp and
+              the full id. */}
+          <div className="flex min-w-0 items-baseline gap-1.5">
+            {job.job_number > 0 ? (
+              <span
+                className="shrink-0 font-mono text-muted-foreground"
+                title={`${jobRunStamp(job.id)} · ${job.id}`}
+              >
+                #{job.job_number}
+              </span>
+            ) : null}
+            <DisplayName
+              name={taskTitle}
+              full={displayName}
+              className="min-w-0 text-foreground font-semibold"
+            />
+          </div>
           {/* When aliased, keep the true identity visible: the run id for
               trainings (imported models already show their repo id / path in
               the subtitle below). */}
@@ -719,6 +724,12 @@ const JobCard: React.FC<Props> = ({
                   selectedRef={selectedRef}
                   onChange={(c) => setSelectedRef(c.ref)}
                   className="w-full min-w-0"
+                  // This list is a whole lineage, so two entries can both read
+                  // "step 2000" and belong to different runs — and the runs
+                  // share a display name, because a continuation continues the
+                  // same model. The dropdown renders this only when the list
+                  // really does span runs.
+                  owners={checkpointOwners(lineageCheckpoints)}
                 />
               </div>
             ) : null}
@@ -742,19 +753,6 @@ const JobCard: React.FC<Props> = ({
                 <FastForward className="w-3.5 h-3.5 shrink-0" />
                 <span className="truncate">{resumeLabel}</span>
               </Button>
-            ) : continuedOwnerHint ? (
-              // Where the button would be, the two-step way to get it back.
-              // Names the run and the step so it can be acted on without
-              // opening anything else — same guidance, same numbers, as the
-              // library row's toast (both read the rule, not a re-derivation).
-              <div className="min-w-0 flex-1 text-[11px] leading-tight text-muted-foreground">
-                Saved no checkpoints of its own, and its parent was already
-                continued. Delete this run, then resume{" "}
-                <span className="text-foreground font-medium">
-                  {jobDisplayName(continuedOwnerHint.job)}
-                </span>{" "}
-                from step {continuedOwnerHint.ckpt.step.toLocaleString()}.
-              </div>
             ) : null}
             {canFinetune ? (
               <Button

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -40,11 +40,11 @@ import { useApi } from "@/contexts/ApiContext";
 import { useStudio } from "@/contexts/StudioContext";
 import { useToast } from "@/hooks/use-toast";
 import {
-  JobCheckpoint,
-  dedupeCheckpointEntries,
-  listJobCheckpoints,
-} from "@/lib/checkpointsApi";
-import { buildResumeSeed } from "./resumeSeed";
+  LineageCheckpoint,
+  buildResumeSeed,
+  loadLineageCheckpoints,
+  resumableCheckpoints,
+} from "./resumeSeed";
 import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
 import PolicyExtraDialog from "@/components/training/PolicyExtraDialog";
 
@@ -94,6 +94,23 @@ const statePresentation: Record<
   },
 };
 
+/**
+ * Card for the jobs history: what a training is doing (state, progress, logs)
+ * and the run-shaped actions — stop, Resume, rename, delete.
+ *
+ * Resume is the one this change owns, and it is now a SINGLE verb decided by
+ * the shared rule in resumeSeed (`resumableCheckpoints`), so this card and the
+ * library row's one-click resume cannot disagree.
+ *
+ * The model-shaped actions (Run, Fine-tune, Download) are still rendered here.
+ * They act on the WEIGHTS a run produced rather than on the run, and upstream
+ * they move to ModelCard in the model library — but that rewiring (ModelsLibrary
+ * collapsing runs to one card per Hub repo, ModelCard actually being rendered)
+ * is deliberately not on this stack yet, and ModelsLibrary still mounts THIS
+ * card with `onPlay` for imported and uploaded models. Removing them here would
+ * make Run/Fine-tune/Download unreachable, so they stay until the card swap
+ * lands.
+ */
 const JobCard: React.FC<Props> = ({
   job,
   onStop,
@@ -148,7 +165,7 @@ const JobCard: React.FC<Props> = ({
   // right run. Sorted newest-step-first so the current run sits above inherited
   // source checkpoints in the dropdown.
   const [lineageCheckpoints, setLineageCheckpoints] = useState<
-    { job: JobRecord; ckpt: JobCheckpoint }[]
+    LineageCheckpoint[]
   >([]);
   // Selection is keyed on the checkpoint `ref` (its unique identity), not the
   // step — a lineage can hold two distinct checkpoints with the same step.
@@ -212,37 +229,31 @@ const JobCard: React.FC<Props> = ({
     .join("|");
 
   useEffect(() => {
-    const lineage = [job, ...ancestors].filter((j) => j.checkpoint_count > 0);
-    if (lineage.length === 0) {
-      setLineageCheckpoints([]);
-      setSelectedRef(null);
-      return;
-    }
     let cancelled = false;
-    Promise.all(
-      lineage.map((j) =>
-        listJobCheckpoints(baseUrl, fetchWithHeaders, j.id)
-          .then((cks) => cks.map((ckpt) => ({ job: j, ckpt })))
-          .catch(() => [] as { job: JobRecord; ckpt: JobCheckpoint }[]),
-      ),
-    ).then((results) => {
-      if (cancelled) return;
-      // Flat-merge, then collapse duplicates: a cloud resume reuses its
-      // parent's output repo, so parent and child both enumerate the same Hub
-      // checkpoint tree and every inherited step would otherwise appear
-      // twice. Lineage order puts this run's list before its ancestors' and
-      // the sort is stable for equal steps, so the surviving entry of a
-      // duplicate pair is tagged with the nearest (child) run.
-      const combined = dedupeCheckpointEntries(
-        results.flat().sort((a, b) => b.ckpt.step - a.ckpt.step),
-      );
-      setLineageCheckpoints(combined);
-      setSelectedRef((prev) =>
-        prev != null && combined.some((c) => c.ckpt.ref === prev)
-          ? prev
-          : (combined[0]?.ckpt.ref ?? null),
-      );
-    });
+    // The shared loader — this card and the library row's one-click resume
+    // read the SAME ancestor-path list, so they can't offer different
+    // checkpoints for the same run.
+    loadLineageCheckpoints(baseUrl, fetchWithHeaders, job, ancestors).then(
+      (combined) => {
+        if (cancelled) return;
+        setLineageCheckpoints(combined);
+        // Default to the newest RESUMABLE checkpoint, not the newest one in
+        // the lineage. They differ exactly when the newest is excluded by the
+        // rule — most often an ancestor checkpoint saved past this run's step
+        // target — and defaulting to it opened the card with the Resume button
+        // hidden and no hint that picking an older step would bring it back.
+        // The dropdown still lists the whole lineage; only the starting
+        // selection is narrowed. Falls back to the newest checkpoint when
+        // nothing is resumable, so the row still reads as a checkpoint list.
+        setSelectedRef((prev) =>
+          prev != null && combined.some((c) => c.ckpt.ref === prev)
+            ? prev
+            : (resumableCheckpoints(job, combined)[0]?.ckpt.ref ??
+              combined[0]?.ckpt.ref ??
+              null),
+        );
+      },
+    );
     return () => {
       cancelled = true;
     };
@@ -340,42 +351,45 @@ const JobCard: React.FC<Props> = ({
     onPlay(selectedJob, selectedStep);
   };
 
-  // Resume — local Continue and cloud Resume alike — is for a run that stopped
-  // SHORT of what it was configured to do: failed, interrupted or cancelled,
-  // with a saved checkpoint below the step target.
+  // Resume — one verb, whichever runner owns the checkpoint — is decided by
+  // the ONE shared rule (resumableCheckpoints), so this card and the library
+  // row's one-click resume can't disagree about whether a run can continue.
   //
-  // A `done` run is deliberately excluded. Resuming restores the optimizer AND
-  // the LR schedule's position, and a completed run's schedule is spent: the
-  // SmolVLA preset cosine-decays to a 2.5e-6 floor over a fixed 30k-step
-  // horizon, so continuing past a reached target trains at floor LR — the loss
-  // curve flattens and reads as convergence while the run is barely learning.
-  // Fine-tuning from the final checkpoint is the intended way to build on a
-  // completed run: it starts a FRESH schedule from those weights. Blanket rule,
-  // no per-policy exceptions.
-  const endedBeforeTarget =
-    (selectedJob.state === "failed" || selectedJob.state === "interrupted") &&
-    (selectedJob.config.steps === 0 ||
-      selectedStep == null ||
-      selectedStep < selectedJob.config.steps);
-
-  // Continue (local resume) additionally needs the optimizer/step state to be
-  // on THIS machine — i.e. a local run's own checkpoint dir.
-  const canContinue =
-    selectedJob.runner === "local" &&
+  // The question is asked of the LEAF, not of each lineage entry: this card
+  // always renders the tip of a chain (the libraries give a row to leaves
+  // only), and it is the tip's state and step target that say whether the
+  // TRAINING is unfinished. The rule then picks which checkpoints along the
+  // leaf's ancestor path may serve as the source, and each one carries its
+  // owning run so the seed resumes from the run that actually holds it.
+  //
+  // Behaviour change worth naming: a `done` leaf no longer offers Resume for
+  // a checkpoint inherited from an ancestor that stopped short. That chain
+  // reached its target — the way to build on it is Fine-tune, which starts a
+  // fresh LR schedule instead of restoring a spent one.
+  const resumable = resumableCheckpoints(job, lineageCheckpoints);
+  const selectedIsResumable =
     !isRunning &&
-    lineageCheckpoints.length > 0 &&
-    selectedStep != null &&
-    endedBeforeTarget;
+    selected != null &&
+    resumable.some((c) => c.ckpt.ref === selected.ckpt.ref);
 
-  // Resume (cloud): an HF Job is immutable once ended, so this launches a NEW
-  // cloud job that continues from the parent's Hub checkpoint (restoring
-  // optimizer + step, unlike Fine-tune).
-  const canResumeCloud =
-    selectedJob.runner === "hf_cloud" &&
-    !isRunning &&
-    lineageCheckpoints.length > 0 &&
-    selectedStep != null &&
-    endedBeforeTarget;
+  // ONE verb. This used to fork into "Continue" (a local-owned checkpoint) and
+  // "Resume" (a cloud-owned one) — two buttons that differed only in wording,
+  // because pre-F7 the owner's runner really was a constraint on where the
+  // continuation could run. It no longer is: jobs.py continues on EITHER
+  // runner, moving the checkpoint as needed, and the Train form merely opens
+  // with Compute DEFAULTED to where the owner ran, toggle live. So the
+  // distinction had become dead information at the button level — it named the
+  // form's default, which the form itself already shows and lets you change.
+  // Asking a novice to tell two verbs apart for one action is the cost; there
+  // is no benefit left to pay it with.
+  const canResume = selectedIsResumable;
+
+  // Step 0 is the whole-repo/single-model sentinel (see CheckpointDropdown),
+  // which has no meaningful number to name — matching its "latest" label.
+  const resumeLabel =
+    selectedStep == null || selectedStep === 0
+      ? "Resume from latest"
+      : `Resume from step ${selectedStep.toLocaleString()}`;
 
   // No dialog and no route jump: continuing opens the Train panel's
   // "Start a new training" form in resume mode, seeded from this run and the
@@ -391,11 +405,10 @@ const JobCard: React.FC<Props> = ({
   //
   // The payload itself comes from the ONE shared builder (buildResumeSeed), so
   // this and the library's row-level quick-resume can no longer drift. The
-  // parent's runner is derived there from the job rather than passed in: local
-  // Continue is gated on canContinue and cloud Resume on canResumeCloud, both
-  // of which already require selectedJob.runner to match, so a caller-supplied
-  // runner could only ever disagree by mistake. Where the continuation RUNS is
-  // then the form's choice, not this call site's.
+  // runner is derived there from the OWNING run — the seed's record of where
+  // the parent actually ran, which the form reads both as its default Compute
+  // and as the fact that decides whether continuing elsewhere has to move the
+  // checkpoint first (F7).
   const goToResume = () => {
     if (selectedStep == null) return;
     openStudio("train", {
@@ -403,12 +416,7 @@ const JobCard: React.FC<Props> = ({
     });
   };
 
-  const handleContinue = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    goToResume();
-  };
-
-  const handleResumeCloud = (e: React.MouseEvent) => {
+  const handleResume = (e: React.MouseEvent) => {
     e.stopPropagation();
     goToResume();
   };
@@ -481,6 +489,11 @@ const JobCard: React.FC<Props> = ({
   };
 
   const showProgressBar = isRunning;
+  // The action row carries Run / Resume / Fine-tune / Download, so it is gated
+  // on having a checkpoint at all rather than on Resume's own rule. (Upstream
+  // of this branch the row exists to serve Resume alone and narrows to
+  // `resumable.length > 0`; the model-shaped actions only move off this card
+  // when ModelsLibrary is rewired to render ModelCard — see the header note.)
   const showInferenceRow =
     lineageCheckpoints.length > 0 && selectedStep != null;
 
@@ -656,8 +669,11 @@ const JobCard: React.FC<Props> = ({
         ) : null}
         {showInferenceRow ? (
           // Single-line action row: the checkpoint dropdown flexes and the
-          // buttons never wrap. Secondary actions (Continue / Resume /
-          // Download) are icon-only so the row fits a narrow grid card.
+          // buttons never wrap. Resume now carries its step in the label — one
+          // verb, so the row says what it will do without a hover — and takes
+          // the width it needs; the dropdown yields, which fits now that there
+          // is one resume button here instead of two. Download stays icon-only
+          // so the row still fits a narrow grid card.
           <div className="mt-auto flex items-center gap-1.5 pt-1">
             {/* A single checkpoint offers no choice — skip the dropdown and
                 free the row for the buttons (imported models are the common
@@ -680,28 +696,17 @@ const JobCard: React.FC<Props> = ({
             >
               <Play className="w-3.5 h-3.5" /> Run
             </Button>
-            {canContinue ? (
+            {canResume ? (
               <Button
                 size="sm"
                 variant="outline"
-                onClick={handleContinue}
-                className="h-8 w-8 shrink-0 p-0 border-info/50 text-info hover:bg-info/10"
-                aria-label="Continue training from this checkpoint"
-                title="Continue training from this checkpoint"
+                onClick={handleResume}
+                className="h-8 shrink-0 gap-1.5 px-2.5 border-info/50 text-info hover:bg-info/10"
+                aria-label={resumeLabel}
+                title="Opens the training form to continue from this checkpoint. Compute defaults to where this checkpoint's run executed, and can be retargeted before you start."
               >
-                <FastForward className="w-3.5 h-3.5" />
-              </Button>
-            ) : null}
-            {canResumeCloud ? (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleResumeCloud}
-                className="h-8 w-8 shrink-0 p-0 border-info/50 text-info hover:bg-info/10"
-                aria-label="Resume this cloud run from its last checkpoint"
-                title="Resume: launch a new cloud job continuing from this checkpoint"
-              >
-                <FastForward className="w-3.5 h-3.5" />
+                <FastForward className="w-3.5 h-3.5 shrink-0" />
+                <span className="truncate">{resumeLabel}</span>
               </Button>
             ) : null}
             {canFinetune ? (

--- a/frontend/src/components/jobs/JobsDataContext.tsx
+++ b/frontend/src/components/jobs/JobsDataContext.tsx
@@ -39,15 +39,17 @@ interface JobsDataValue {
   supersededIds: Set<string>;
   /** Resume lineage of a job, nearest parent first. */
   ancestorsOf: (job: JobRecord) => JobRecord[];
-  /** Running, or with a checkpoint anywhere in its chain — i.e. worth showing
-   * outside the libraries' UNTRACKED fold. Lives on the context rather than
-   * being a pure helper because the answer depends on the ancestor records
-   * only the provider holds.
+  /** Checkpoints reachable from a job: its own plus its loaded ancestors'.
    *
-   * (The chain-wide checkpoint count this reads used to be exported too, as
-   * the libraries' Resume gate. Under the sticks rule that gate is the leaf's
-   * own `checkpoint_count` — a plain field, no provider needed — so the count
-   * is now an implementation detail of this one answer.) */
+   * The libraries' Resume gate, because under CHAIN REWIND a run continues
+   * from anything on its lineage — so a tip that died before saving anything
+   * is resumable on its ancestors' checkpoints, and its own `checkpoint_count`
+   * of 0 would hide the button on the commonest resumable shape there is.
+   * Lives on the context because only the provider holds the ancestor records. */
+  chainCheckpointCount: (job: JobRecord) => number;
+  /** Running, or with a checkpoint anywhere in its chain — i.e. worth showing
+   * outside the libraries' UNTRACKED fold. Same chain-wide reading as the gate
+   * above, and now for the same reason. */
   isJobActive: (job: JobRecord) => boolean;
   hubAuthenticated: boolean;
   hubJobsPermission: boolean;
@@ -367,13 +369,11 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Checkpoints reachable from a run: its own plus every LOADED ancestor's.
   //
-  // NOT the resume gate any more — under sticks only a leaf's own checkpoints
-  // can be continued from (see `resumableCheckpoints`), and the row gates on
-  // `job.checkpoint_count` directly. What this still answers is whether a row
-  // has anything BEHIND it at all, which is what `isJobActive` needs: a tip
-  // that saved nothing but inherited a chain is exactly the row a user has to
-  // reach in order to delete it and free its parent for a new continuation, so
-  // it must not be filed away as a leftover.
+  // THE resume gate, and the fold gate, on the same reading: chain rewind lets
+  // a run continue from anything on its lineage, so what decides both is what
+  // the CHAIN holds, not what this tip happened to save. The commonest
+  // resumable shape — a tip that died before its first checkpoint — has zero of
+  // its own and a full chain behind it.
   const chainCheckpointCount = useCallback(
     (job: JobRecord): number =>
       [job, ...ancestorsOf(job)].reduce((n, j) => n + j.checkpoint_count, 0),
@@ -424,6 +424,7 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
       untrackedHubModels,
       supersededIds,
       ancestorsOf,
+      chainCheckpointCount,
       isJobActive,
       hubAuthenticated,
       hubJobsPermission,
@@ -443,6 +444,7 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
       untrackedHubModels,
       supersededIds,
       ancestorsOf,
+      chainCheckpointCount,
       isJobActive,
       hubAuthenticated,
       hubJobsPermission,

--- a/frontend/src/components/jobs/JobsDataContext.tsx
+++ b/frontend/src/components/jobs/JobsDataContext.tsx
@@ -39,14 +39,15 @@ interface JobsDataValue {
   supersededIds: Set<string>;
   /** Resume lineage of a job, nearest parent first. */
   ancestorsOf: (job: JobRecord) => JobRecord[];
-  /** Checkpoints reachable from a job: its own plus its loaded ancestors'.
-   * The number to gate a chain's Resume affordance on — a leaf that died
-   * before its first save still has its ancestors' to continue from. */
-  chainCheckpointCount: (job: JobRecord) => number;
-  /** Running, or with a checkpoint anywhere in its chain to resume from —
-   * i.e. worth showing outside the libraries' UNTRACKED fold. Lives on the
-   * context rather than being a pure helper because the answer depends on the
-   * ancestor records only the provider holds. */
+  /** Running, or with a checkpoint anywhere in its chain — i.e. worth showing
+   * outside the libraries' UNTRACKED fold. Lives on the context rather than
+   * being a pure helper because the answer depends on the ancestor records
+   * only the provider holds.
+   *
+   * (The chain-wide checkpoint count this reads used to be exported too, as
+   * the libraries' Resume gate. Under the sticks rule that gate is the leaf's
+   * own `checkpoint_count` — a plain field, no provider needed — so the count
+   * is now an implementation detail of this one answer.) */
   isJobActive: (job: JobRecord) => boolean;
   hubAuthenticated: boolean;
   hubJobsPermission: boolean;
@@ -329,9 +330,12 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
   // resumed, so it is hidden from the top level and reached through the
   // descendant that continued it — one row per LEAF, one row per chain.
   //
-  // Each job names one parent, but a parent can have SEVERAL children (nothing
-  // stops two resumes off one run), so the lineage is a forest of trees rather
-  // than a set of chains — hence `child_ids` rather than a single successor.
+  // New lineages are CHAINS: jobs.py refuses a resume whose source already has
+  // a child (sticks only, user decision 2026-08-07), so a run created from here
+  // on can gain at most one. `child_ids` stays a LIST and everything below
+  // stays fork-tolerant anyway, because registries written before that rule
+  // hold real forks and must keep rendering exactly as they did — several
+  // leaves off one trunk, each with its own row, no migration.
   const byId = useMemo(() => {
     const m = new Map(jobs.map((j) => [j.id, j]));
     // Cached ancestors fill in parents paged out of the list (never overriding
@@ -362,11 +366,14 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 
   // Checkpoints reachable from a run: its own plus every LOADED ancestor's.
-  // A row stands for a whole CHAIN (the libraries render one row per leaf), so
-  // this — not the tip's own `checkpoint_count` — is what says whether there is
-  // anything to continue from: the commonest resumable shape after the leaf
-  // collapse is a tip that died before saving anything, whose only checkpoints
-  // are inherited.
+  //
+  // NOT the resume gate any more — under sticks only a leaf's own checkpoints
+  // can be continued from (see `resumableCheckpoints`), and the row gates on
+  // `job.checkpoint_count` directly. What this still answers is whether a row
+  // has anything BEHIND it at all, which is what `isJobActive` needs: a tip
+  // that saved nothing but inherited a chain is exactly the row a user has to
+  // reach in order to delete it and free its parent for a new continuation, so
+  // it must not be filed away as a leftover.
   const chainCheckpointCount = useCallback(
     (job: JobRecord): number =>
       [job, ...ancestorsOf(job)].reduce((n, j) => n + j.checkpoint_count, 0),
@@ -384,15 +391,16 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
     [byId],
   );
 
-  // Active = still running, or resumable — i.e. the CHAIN has a checkpoint to
-  // continue from. Everything else folds under UNTRACKED in the libraries, so
-  // this decides whether a run is reachable without opening the fold, and a
-  // resumable chain must not be filed away as leftovers.
+  // Active = still running, or the CHAIN has a checkpoint. Everything else
+  // folds under UNTRACKED in the libraries, so this decides whether a run is
+  // reachable without opening the fold.
   //
-  // Chain-aware for the same reason the resume gate is: after the leaf
-  // collapse a row's own `checkpoint_count` is the wrong number — a tip that
-  // died before its first save is exactly the run the user wants to resume,
-  // and it has zero of its own.
+  // Deliberately still chain-aware, where the resume gate no longer is: this
+  // asks "is there anything here worth looking at", not "can this be
+  // continued". A tip that died before its first save inherits a whole chain's
+  // history and checkpoints — it charts, it can serve inference from an
+  // inherited checkpoint, and deleting it is the move that frees its parent to
+  // be resumed. Folding it away would hide the only handle on that.
   //
   // While the ancestor backfill is in flight the answer is INDETERMINATE, and
   // indeterminate resolves to active: a chain that flickered into the fold on
@@ -416,7 +424,6 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
       untrackedHubModels,
       supersededIds,
       ancestorsOf,
-      chainCheckpointCount,
       isJobActive,
       hubAuthenticated,
       hubJobsPermission,
@@ -436,7 +443,6 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
       untrackedHubModels,
       supersededIds,
       ancestorsOf,
-      chainCheckpointCount,
       isJobActive,
       hubAuthenticated,
       hubJobsPermission,

--- a/frontend/src/components/jobs/JobsDataContext.tsx
+++ b/frontend/src/components/jobs/JobsDataContext.tsx
@@ -41,9 +41,9 @@ interface JobsDataValue {
   ancestorsOf: (job: JobRecord) => JobRecord[];
   /** Checkpoints reachable from a job: its own plus its loaded ancestors'.
    *
-   * The libraries' Resume gate, because under CHAIN REWIND a run continues
-   * from anything on its lineage — so a tip that died before saving anything
-   * is resumable on its ancestors' checkpoints, and its own `checkpoint_count`
+   * The libraries' Resume gate, because a run continues from the newest
+   * checkpoint on its LINEAGE — so a tip that died before saving anything is
+   * resumable on its ancestors' checkpoints, and its own `checkpoint_count`
    * of 0 would hide the button on the commonest resumable shape there is.
    * Lives on the context because only the provider holds the ancestor records. */
   chainCheckpointCount: (job: JobRecord) => number;
@@ -369,9 +369,10 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Checkpoints reachable from a run: its own plus every LOADED ancestor's.
   //
-  // THE resume gate, and the fold gate, on the same reading: chain rewind lets
-  // a run continue from anything on its lineage, so what decides both is what
-  // the CHAIN holds, not what this tip happened to save. The commonest
+  // THE resume gate, and the fold gate, on the same reading: a run continues
+  // from the newest checkpoint on its lineage, its own or an ancestor's, so
+  // what decides both is what the CHAIN holds, not what this tip happened to
+  // save. The commonest
   // resumable shape — a tip that died before its first checkpoint — has zero of
   // its own and a full chain behind it.
   const chainCheckpointCount = useCallback(

--- a/frontend/src/components/jobs/JobsDataContext.tsx
+++ b/frontend/src/components/jobs/JobsDataContext.tsx
@@ -25,9 +25,6 @@ import {
 
 const LIMIT = 10;
 
-export const isJobActive = (j: JobRecord) =>
-  j.state === "running" || j.checkpoint_count > 0;
-
 interface JobsDataValue {
   /** Local job registry page (trainings, cloud mirrors, imports). */
   jobs: JobRecord[];
@@ -42,6 +39,15 @@ interface JobsDataValue {
   supersededIds: Set<string>;
   /** Resume lineage of a job, nearest parent first. */
   ancestorsOf: (job: JobRecord) => JobRecord[];
+  /** Checkpoints reachable from a job: its own plus its loaded ancestors'.
+   * The number to gate a chain's Resume affordance on — a leaf that died
+   * before its first save still has its ancestors' to continue from. */
+  chainCheckpointCount: (job: JobRecord) => number;
+  /** Running, or with a checkpoint anywhere in its chain to resume from —
+   * i.e. worth showing outside the libraries' UNTRACKED fold. Lives on the
+   * context rather than being a pure helper because the answer depends on the
+   * ancestor records only the provider holds. */
+  isJobActive: (job: JobRecord) => boolean;
   hubAuthenticated: boolean;
   hubJobsPermission: boolean;
   error: string | null;
@@ -181,43 +187,36 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useJobsChangedSignal(refresh, applyProgress);
 
-  // Fetch the transitive closure of resume ancestors that aren't in the loaded
-  // page (or already cached), so nesting works regardless of how old the source
-  // run is. Idempotent: only unseen ids are fetched, so the frequent list
-  // refreshes during a run don't re-fetch. Missing/deleted ancestors are
-  // skipped, ending the chain.
+  // Backfill the resume ancestors that aren't in the loaded page (or already
+  // cached), so a chain nests regardless of how old its source runs are.
+  //
+  // The server hands each record its whole `ancestor_ids` closure, so this is
+  // one parallel fan-out over known-missing ids — not the old hop-by-hop walk,
+  // which had to fetch a parent before it could learn about a grandparent and
+  // so paid one serial round-trip per generation. Idempotent: only unseen ids
+  // are fetched, so the frequent list refreshes during a run don't re-fetch.
+  // A fetch that fails (the run was deleted between the list and this call) is
+  // dropped, and that chain simply stops there.
   useEffect(() => {
     let cancelled = false;
     const loaded = new Set(jobs.map((j) => j.id));
-    const queue = jobs
-      .map((j) => j.config?.resume_from_job_id)
-      .filter(
-        (id): id is string => !!id && !loaded.has(id) && !ancestorCache[id],
-      );
-    if (queue.length === 0) return;
+    const missing = [
+      ...new Set(jobs.flatMap((j) => j.ancestor_ids ?? [])),
+    ].filter((id) => !loaded.has(id) && !ancestorCache[id]);
+    if (missing.length === 0) return;
     (async () => {
-      const fetched: Record<string, JobRecord> = {};
-      const seen = new Set(queue);
-      while (queue.length > 0) {
-        const id = queue.shift() as string;
-        try {
-          const rec = await getJob(baseUrl, fetchWithHeaders, id);
-          fetched[id] = rec;
-          const parent = rec.config?.resume_from_job_id;
-          if (
-            parent &&
-            !loaded.has(parent) &&
-            !ancestorCache[parent] &&
-            !seen.has(parent)
-          ) {
-            seen.add(parent);
-            queue.push(parent);
-          }
-        } catch {
-          // Ancestor deleted or unreachable — skip; the chain just stops here.
-        }
-      }
-      if (!cancelled && Object.keys(fetched).length > 0) {
+      const settled = await Promise.all(
+        missing.map((id) =>
+          getJob(baseUrl, fetchWithHeaders, id)
+            .then((rec) => [id, rec] as const)
+            .catch(() => null),
+        ),
+      );
+      if (cancelled) return;
+      const fetched = Object.fromEntries(
+        settled.filter((e): e is [string, JobRecord] => e !== null),
+      );
+      if (Object.keys(fetched).length > 0) {
         setAncestorCache((prev) => ({ ...prev, ...fetched }));
       }
     })();
@@ -326,9 +325,13 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
     [hubModels, trackedRepoIds],
   );
 
-  // Resume lineage: job B stores config.resume_from_job_id = A. Hide A (the
-  // superseded run) from the top level and nest it under B, so a resumed chain
-  // reads as one entry. Lineage is linear — each job resumes from one parent.
+  // Resume lineage, as the server computed it: a run with children has been
+  // resumed, so it is hidden from the top level and reached through the
+  // descendant that continued it — one row per LEAF, one row per chain.
+  //
+  // Each job names one parent, but a parent can have SEVERAL children (nothing
+  // stops two resumes off one run), so the lineage is a forest of trees rather
+  // than a set of chains — hence `child_ids` rather than a single successor.
   const byId = useMemo(() => {
     const m = new Map(jobs.map((j) => [j.id, j]));
     // Cached ancestors fill in parents paged out of the list (never overriding
@@ -338,30 +341,69 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
     }
     return m;
   }, [jobs, ancestorCache]);
-  const supersededIds = useMemo(() => {
-    const s = new Set<string>();
-    for (const j of jobs) {
-      const parent = j.config?.resume_from_job_id;
-      // Only a real successor (running or with its own checkpoints) supersedes
-      // its parent — a failed continuation shouldn't hide the source run.
-      const legit = j.state === "running" || j.checkpoint_count > 0;
-      if (parent && byId.has(parent) && legit) s.add(parent);
-    }
-    return s;
-  }, [jobs, byId]);
+  // Superseded is now a plain reading of the record: the server knows every
+  // child, this page might not. That closes two holes in the client-side
+  // approximation this replaces — a child sitting past the page limit failed
+  // to hide its parent, and a child that died before its first checkpoint was
+  // ruled "not legit" and left the chain rendering as two rows. A dead tip
+  // still represents its chain; the row says so by being dead.
+  const supersededIds = useMemo(
+    () => new Set(jobs.filter((j) => j.child_ids.length > 0).map((j) => j.id)),
+    [jobs],
+  );
+  // Nearest parent first, straight from the server's walk; ids it lists but
+  // this client hasn't loaded yet are skipped until the backfill above lands.
   const ancestorsOf = useCallback(
-    (job: JobRecord): JobRecord[] => {
-      const chain: JobRecord[] = [];
-      const seen = new Set<string>([job.id]);
-      let cur = byId.get(job.config?.resume_from_job_id ?? "");
-      while (cur && !seen.has(cur.id)) {
-        chain.push(cur);
-        seen.add(cur.id);
-        cur = byId.get(cur.config?.resume_from_job_id ?? "");
-      }
-      return chain;
-    },
+    (job: JobRecord): JobRecord[] =>
+      (job.ancestor_ids ?? [])
+        .map((id) => byId.get(id))
+        .filter((rec): rec is JobRecord => rec !== undefined),
     [byId],
+  );
+
+  // Checkpoints reachable from a run: its own plus every LOADED ancestor's.
+  // A row stands for a whole CHAIN (the libraries render one row per leaf), so
+  // this — not the tip's own `checkpoint_count` — is what says whether there is
+  // anything to continue from: the commonest resumable shape after the leaf
+  // collapse is a tip that died before saving anything, whose only checkpoints
+  // are inherited.
+  const chainCheckpointCount = useCallback(
+    (job: JobRecord): number =>
+      [job, ...ancestorsOf(job)].reduce((n, j) => n + j.checkpoint_count, 0),
+    [ancestorsOf],
+  );
+
+  // True while the server named an ancestor this client hasn't fetched yet, so
+  // the count above is a known UNDERCOUNT rather than an answer. The backfill
+  // effect above resolves these one render later; until it does, a chain whose
+  // checkpoints all live in an unloaded ancestor would otherwise read as
+  // having none.
+  const ancestorsPending = useCallback(
+    (job: JobRecord): boolean =>
+      (job.ancestor_ids ?? []).some((id) => !byId.has(id)),
+    [byId],
+  );
+
+  // Active = still running, or resumable — i.e. the CHAIN has a checkpoint to
+  // continue from. Everything else folds under UNTRACKED in the libraries, so
+  // this decides whether a run is reachable without opening the fold, and a
+  // resumable chain must not be filed away as leftovers.
+  //
+  // Chain-aware for the same reason the resume gate is: after the leaf
+  // collapse a row's own `checkpoint_count` is the wrong number — a tip that
+  // died before its first save is exactly the run the user wants to resume,
+  // and it has zero of its own.
+  //
+  // While the ancestor backfill is in flight the answer is INDETERMINATE, and
+  // indeterminate resolves to active: a chain that flickered into the fold on
+  // mount and back out a moment later would move rows under the user's cursor
+  // for the sake of a value the client simply hasn't received yet.
+  const isJobActive = useCallback(
+    (job: JobRecord): boolean =>
+      job.state === "running" ||
+      chainCheckpointCount(job) > 0 ||
+      ancestorsPending(job),
+    [chainCheckpointCount, ancestorsPending],
   );
 
   const value = useMemo(
@@ -374,6 +416,8 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
       untrackedHubModels,
       supersededIds,
       ancestorsOf,
+      chainCheckpointCount,
+      isJobActive,
       hubAuthenticated,
       hubJobsPermission,
       error,
@@ -392,6 +436,8 @@ export const JobsDataProvider: React.FC<{ children: React.ReactNode }> = ({
       untrackedHubModels,
       supersededIds,
       ancestorsOf,
+      chainCheckpointCount,
+      isJobActive,
       hubAuthenticated,
       hubJobsPermission,
       error,

--- a/frontend/src/components/jobs/JobsDropdown.tsx
+++ b/frontend/src/components/jobs/JobsDropdown.tsx
@@ -45,22 +45,17 @@ export type JobsEntry =
       key: string;
       time: number;
       job: JobRecord;
-      /** Checkpoints this row's run saved ITSELF — the number the Resume gate
-       * wants under the sticks rule, where only a leaf's own checkpoints can
-       * be continued from and a row is always a leaf (the list shows one row
-       * per leaf). Inherited ones are still listed on the card and still
-       * usable for inference; they are simply not resume sources, because the
-       * run that owns them has already been continued and jobs.py refuses a
-       * second continuation (`JobAlreadyContinuedError`).
-       *
-       * This used to be a CHAIN-wide count, for the opposite reason: inherited
-       * checkpoints were resumable, so a tip that died before saving anything
-       * still had something to continue from and its own count under-reported.
-       * Under sticks that same tip has nothing to resume — the recovery is to
-       * delete it and resume its parent — so the chain-wide count would light
-       * a button the exact rule then refuses. Straight off the record now, so
-       * it also needs no ancestor backfill to be correct. */
-      ownCheckpointCount: number;
+      /** Checkpoints reachable from this row's run — its own plus those of the
+       * runs it continues. A row is a whole CHAIN (the list shows one row per
+       * leaf), and under CHAIN REWIND a run may continue from any checkpoint on
+       * its lineage, so the run's own `checkpoint_count` is the wrong number to
+       * gate Resume on: the commonest resumable shape is a tip that died before
+       * saving anything, whose checkpoints are all inherited. Counted by
+       * JobsDataContext, which holds the ancestor records — and which files a
+       * chain whose ancestors are still being backfilled as active, so a row is
+       * never hidden away in the UNTRACKED fold on the strength of a count that
+       * hasn't settled. */
+      chainCheckpointCount: number;
     }
   | { kind: "hub"; key: string; time: number; job: HubJob };
 
@@ -108,6 +103,11 @@ interface Described {
   /** What the title line MEANS: the untouched name, for the hover title. Equal
    * to `name` whenever nothing was peeled. */
   fullName: string;
+  /** The run's number, rendered beside the name. Neither `name` nor `fullName`
+   * identifies a run on a resume chain — every run on one shares them, because
+   * a continuation continues the same model. 0 ⇒ not assigned (a record the
+   * backend hasn't backfilled yet); render nothing rather than "#0". */
+  number: number;
   /** The run's policy, as a chip label — read off the record's own
    * `config.policy_type`, never inferred from the name. Null only when the
    * record states no policy (a Hub-only job). */
@@ -144,6 +144,9 @@ function describeEntry(entry: JobsEntry): Described {
     return {
       name: hubName,
       fullName: hubName,
+      // A Hub-only job has no local record, so it has no run number — the
+      // sequence numbers this registry's own runs. 0 renders nothing.
+      number: 0,
       policyLabel: null,
       policyTitle: "",
       present,
@@ -181,6 +184,10 @@ function describeEntry(entry: JobsEntry): Described {
   return {
     name,
     fullName,
+    // The run number, rendered beside the name because the name does not
+    // identify a run on its own: every run on a resume chain carries the same
+    // one. 0 ⇒ a record the backend hasn't backfilled; render nothing.
+    number: job.job_number,
     policyLabel: policyType ? policyTypeShortLabel(policyType) : null,
     policyTitle: policyType ? policyTypeDisplayName(policyType) : "",
     present,
@@ -204,18 +211,13 @@ function describeEntry(entry: JobsEntry): Described {
   };
 }
 
-/** Resume is offered on a run that ended before its target with a checkpoint
- * OF ITS OWN to continue from. The state half is the ONE shared leaf rule
- * (`isResumableLeaf`), so this row's button and the detail card's Resume can't
- * disagree; the checkpoint half is the run's own count, which under the sticks
- * rule is the same set the exact rule works over — it just can't see the step
- * target or the owner's state without a fetch, so the click still resolves the
- * real list and says so if it comes back empty.
- *
- * A run with NO checkpoints of its own gets no button here at all, which is
- * correct but silent — the explanation for that case (delete this run, resume
- * its parent) lives on the run's card, where the inherited checkpoints it
- * can't use are visible and the silence would otherwise be loudest.
+/** Resume is offered on a chain whose tip ended before its target with
+ * something, anywhere in the chain, to continue from — chain rewind lets the
+ * tip continue from any checkpoint on its lineage. The state half is the ONE
+ * shared leaf rule (`isResumableLeaf`), so this row's button and the detail
+ * card's Resume can't disagree; the checkpoint half is deliberately the cheap
+ * chain-wide count, because the exact per-step answer needs a fetch. The click
+ * resolves the real list and says so if it comes back empty.
  *
  * ONE verb across both levels of control: this row is the shortcut — same
  * action, same default (the newest resumable checkpoint) — and the detail
@@ -223,7 +225,7 @@ function describeEntry(entry: JobsEntry): Described {
 const canResumeEntry = (entry: JobsEntry): boolean =>
   entry.kind === "job" &&
   isResumableLeaf(entry.job) &&
-  entry.ownCheckpointCount > 0;
+  entry.chainCheckpointCount > 0;
 
 const COL_STATE = "w-[4.75rem] shrink-0";
 // The run's policy. Always occupies its column — a row whose record names no
@@ -309,7 +311,14 @@ const JobsRow: React.FC<RowProps> = ({
           <span className="truncate">{d.present.label}</span>
         </span>
         {/* The hover title is the FULL name — the peel is a display shortening,
-            so the exact identity stays one hover away. */}
+            so the exact identity stays one hover away. The number sits outside
+            that span so truncation can never eat it: it is the shortest thing
+            in the row and the only one that identifies the run. */}
+        {d.number > 0 ? (
+          <span className="shrink-0 font-mono text-muted-foreground">
+            #{d.number}
+          </span>
+        ) : null}
         <span
           className="min-w-0 flex-1 truncate text-foreground"
           title={d.fullName}
@@ -532,6 +541,11 @@ const JobsDropdown: React.FC<JobsDropdownProps> = ({
                   />
                   {d.present.label}
                 </span>
+                {d.number > 0 ? (
+                  <span className="shrink-0 font-mono text-sm text-muted-foreground">
+                    #{d.number}
+                  </span>
+                ) : null}
                 <span
                   className="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
                   title={d.fullName}

--- a/frontend/src/components/jobs/JobsDropdown.tsx
+++ b/frontend/src/components/jobs/JobsDropdown.tsx
@@ -45,16 +45,22 @@ export type JobsEntry =
       key: string;
       time: number;
       job: JobRecord;
-      /** Checkpoints reachable from this row's run — its own plus those of the
-       * runs it resumed from. A row is a whole CHAIN (the list shows one row
-       * per leaf), so the run's own `checkpoint_count` is the wrong number to
-       * gate the Resume button on: the most common resumable shape after the
-       * leaf collapse is a tip that died before saving anything, whose only
-       * checkpoints are inherited. Counted by JobsDataContext, which holds the
-       * ancestor records — and which files a chain whose ancestors are still
-       * being backfilled as active, so a row is never hidden away in the
-       * UNTRACKED fold on the strength of a count that hasn't settled. */
-      chainCheckpointCount: number;
+      /** Checkpoints this row's run saved ITSELF — the number the Resume gate
+       * wants under the sticks rule, where only a leaf's own checkpoints can
+       * be continued from and a row is always a leaf (the list shows one row
+       * per leaf). Inherited ones are still listed on the card and still
+       * usable for inference; they are simply not resume sources, because the
+       * run that owns them has already been continued and jobs.py refuses a
+       * second continuation (`JobAlreadyContinuedError`).
+       *
+       * This used to be a CHAIN-wide count, for the opposite reason: inherited
+       * checkpoints were resumable, so a tip that died before saving anything
+       * still had something to continue from and its own count under-reported.
+       * Under sticks that same tip has nothing to resume — the recovery is to
+       * delete it and resume its parent — so the chain-wide count would light
+       * a button the exact rule then refuses. Straight off the record now, so
+       * it also needs no ancestor backfill to be correct. */
+      ownCheckpointCount: number;
     }
   | { kind: "hub"; key: string; time: number; job: HubJob };
 
@@ -198,12 +204,18 @@ function describeEntry(entry: JobsEntry): Described {
   };
 }
 
-/** Resume is offered on a chain whose tip ended before its target with
- * something, anywhere in the chain, to resume from. The state half is the ONE
- * shared leaf rule (`isResumableLeaf`), so this row's button and the detail
- * card's Resume can't disagree; the checkpoint half is deliberately the
- * cheap chain-wide count, because the exact per-step answer needs a fetch. The
- * click resolves the real list and says so if it comes back empty.
+/** Resume is offered on a run that ended before its target with a checkpoint
+ * OF ITS OWN to continue from. The state half is the ONE shared leaf rule
+ * (`isResumableLeaf`), so this row's button and the detail card's Resume can't
+ * disagree; the checkpoint half is the run's own count, which under the sticks
+ * rule is the same set the exact rule works over — it just can't see the step
+ * target or the owner's state without a fetch, so the click still resolves the
+ * real list and says so if it comes back empty.
+ *
+ * A run with NO checkpoints of its own gets no button here at all, which is
+ * correct but silent — the explanation for that case (delete this run, resume
+ * its parent) lives on the run's card, where the inherited checkpoints it
+ * can't use are visible and the silence would otherwise be loudest.
  *
  * ONE verb across both levels of control: this row is the shortcut — same
  * action, same default (the newest resumable checkpoint) — and the detail
@@ -211,7 +223,7 @@ function describeEntry(entry: JobsEntry): Described {
 const canResumeEntry = (entry: JobsEntry): boolean =>
   entry.kind === "job" &&
   isResumableLeaf(entry.job) &&
-  entry.chainCheckpointCount > 0;
+  entry.ownCheckpointCount > 0;
 
 const COL_STATE = "w-[4.75rem] shrink-0";
 // The run's policy. Always occupies its column — a row whose record names no

--- a/frontend/src/components/jobs/JobsDropdown.tsx
+++ b/frontend/src/components/jobs/JobsDropdown.tsx
@@ -31,6 +31,7 @@ import {
   isHubJobActive,
   jobDisplayName,
 } from "@/lib/jobsApi";
+import { isResumableLeaf } from "./resumeSeed";
 
 /**
  * One selectable run in the jobs dropdown. Local/cloud runs (`job`) and
@@ -39,7 +40,22 @@ import {
  * into a row of em dashes.
  */
 export type JobsEntry =
-  | { kind: "job"; key: string; time: number; job: JobRecord }
+  | {
+      kind: "job";
+      key: string;
+      time: number;
+      job: JobRecord;
+      /** Checkpoints reachable from this row's run — its own plus those of the
+       * runs it resumed from. A row is a whole CHAIN (the list shows one row
+       * per leaf), so the run's own `checkpoint_count` is the wrong number to
+       * gate the Resume button on: the most common resumable shape after the
+       * leaf collapse is a tip that died before saving anything, whose only
+       * checkpoints are inherited. Counted by JobsDataContext, which holds the
+       * ancestor records — and which files a chain whose ancestors are still
+       * being backfilled as active, so a row is never hidden away in the
+       * UNTRACKED fold on the strength of a count that hasn't settled. */
+      chainCheckpointCount: number;
+    }
   | { kind: "hub"; key: string; time: number; job: HubJob };
 
 function relativeTime(ms: number): string {
@@ -182,13 +198,20 @@ function describeEntry(entry: JobsEntry): Described {
   };
 }
 
-/** Resume is offered on a run that ended before its target with something to
- * resume from. The row's button takes the newest checkpoint; picking a
- * specific step stays in the selected run's detail card below the dropdown. */
+/** Resume is offered on a chain whose tip ended before its target with
+ * something, anywhere in the chain, to resume from. The state half is the ONE
+ * shared leaf rule (`isResumableLeaf`), so this row's button and the detail
+ * card's Resume can't disagree; the checkpoint half is deliberately the
+ * cheap chain-wide count, because the exact per-step answer needs a fetch. The
+ * click resolves the real list and says so if it comes back empty.
+ *
+ * ONE verb across both levels of control: this row is the shortcut — same
+ * action, same default (the newest resumable checkpoint) — and the detail
+ * card below is that action plus the choice of which step to start from. */
 const canResumeEntry = (entry: JobsEntry): boolean =>
   entry.kind === "job" &&
-  (entry.job.state === "failed" || entry.job.state === "interrupted") &&
-  entry.job.checkpoint_count > 0;
+  isResumableLeaf(entry.job) &&
+  entry.chainCheckpointCount > 0;
 
 const COL_STATE = "w-[4.75rem] shrink-0";
 // The run's policy. Always occupies its column — a row whose record names no
@@ -222,7 +245,7 @@ interface RowProps {
  * chip, the dataset namespace is dropped) so rows of one policy+namespace stop
  * reading identically once the column truncates.
  * Everything else about the run (rename, monitor, checkpoint picker, Run,
- * Continue/Resume-from-step, Download, delete) lives in the detail card the
+ * Resume-from-step, Download, delete) lives in the detail card the
  * selection drives.
  */
 const JobsRow: React.FC<RowProps> = ({
@@ -321,8 +344,8 @@ const JobsRow: React.FC<RowProps> = ({
                 e.stopPropagation();
                 onResume(record);
               }}
-              aria-label="Resume this run from its last checkpoint"
-              title="Resume from the last checkpoint (pick a specific step below)"
+              aria-label="Resume from the newest usable checkpoint"
+              title="Resume from the newest usable checkpoint (pick a specific step in the card below)"
               className="flex h-5 w-5 items-center justify-center rounded text-info transition-colors hover:bg-info/10 disabled:opacity-50"
             >
               {resuming ? (

--- a/frontend/src/components/jobs/JobsDropdown.tsx
+++ b/frontend/src/components/jobs/JobsDropdown.tsx
@@ -47,10 +47,11 @@ export type JobsEntry =
       job: JobRecord;
       /** Checkpoints reachable from this row's run — its own plus those of the
        * runs it continues. A row is a whole CHAIN (the list shows one row per
-       * leaf), and under CHAIN REWIND a run may continue from any checkpoint on
-       * its lineage, so the run's own `checkpoint_count` is the wrong number to
-       * gate Resume on: the commonest resumable shape is a tip that died before
-       * saving anything, whose checkpoints are all inherited. Counted by
+       * leaf), and a resume takes the newest checkpoint on that LINEAGE, which
+       * may be an ancestor's, so the run's own `checkpoint_count` is the wrong
+       * number to gate Resume on: the commonest resumable shape is a tip that
+       * died before saving anything, whose checkpoints are all inherited.
+       * Counted by
        * JobsDataContext, which holds the ancestor records — and which files a
        * chain whose ancestors are still being backfilled as active, so a row is
        * never hidden away in the UNTRACKED fold on the strength of a count that
@@ -212,16 +213,20 @@ function describeEntry(entry: JobsEntry): Described {
 }
 
 /** Resume is offered on a chain whose tip ended before its target with
- * something, anywhere in the chain, to continue from — chain rewind lets the
- * tip continue from any checkpoint on its lineage. The state half is the ONE
+ * something, anywhere in the chain, to continue from — the tip continues from
+ * the newest checkpoint on its lineage, its own or an ancestor's. The state
+ * half is the ONE
  * shared leaf rule (`isResumableLeaf`), so this row's button and the detail
  * card's Resume can't disagree; the checkpoint half is deliberately the cheap
  * chain-wide count, because the exact per-step answer needs a fetch. The click
  * resolves the real list and says so if it comes back empty.
  *
- * ONE verb across both levels of control: this row is the shortcut — same
- * action, same default (the newest resumable checkpoint) — and the detail
- * card below is that action plus the choice of which step to start from. */
+ * ONE verb across both levels of control, and by now the same action with
+ * nothing added: Continue is not step-selectable on either (user decision
+ * 2026-08-10), so this row and the detail card below both take the newest
+ * resumable checkpoint. The card keeps a checkpoint dropdown, but it drives
+ * only Run / Fine-tune / Download — picking an older checkpoint is a real
+ * choice for those and not for a continuation. */
 const canResumeEntry = (entry: JobsEntry): boolean =>
   entry.kind === "job" &&
   isResumableLeaf(entry.job) &&
@@ -366,7 +371,7 @@ const JobsRow: React.FC<RowProps> = ({
                 onResume(record);
               }}
               aria-label="Resume from the newest usable checkpoint"
-              title="Resume from the newest usable checkpoint (pick a specific step in the card below)"
+              title="Resume from the newest usable checkpoint"
               className="flex h-5 w-5 items-center justify-center rounded text-info transition-colors hover:bg-info/10 disabled:opacity-50"
             >
               {resuming ? (

--- a/frontend/src/components/jobs/JobsLibrary.tsx
+++ b/frontend/src/components/jobs/JobsLibrary.tsx
@@ -10,6 +10,7 @@ import { useStudio } from "@/contexts/StudioContext";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import {
+  blockedByContinuedOwner,
   buildResumeSeed,
   loadLineageCheckpoints,
   noResumeReason,
@@ -20,7 +21,12 @@ import JobCard from "./JobCard";
 import HubJobCard from "./HubJobCard";
 import JobsDropdown, { JobsEntry } from "./JobsDropdown";
 import { useJobsData } from "./JobsDataContext";
-import { HubJob, JobRecord, isHubJobActive } from "@/lib/jobsApi";
+import {
+  HubJob,
+  JobRecord,
+  isHubJobActive,
+  jobDisplayName,
+} from "@/lib/jobsApi";
 
 /** Recency keys (ms) for the mixed local/cloud/hub list — every library is
  * ordered newest-first regardless of where a run lives. */
@@ -70,7 +76,6 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
     untrackedHubJobs,
     supersededIds,
     ancestorsOf,
-    chainCheckpointCount,
     isJobActive,
     hubAuthenticated,
     hubJobsPermission,
@@ -140,8 +145,10 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
     [untrackedHubJobs, matchesQuery, showOnline],
   );
 
-  // Active = running, or the CHAIN has a checkpoint to resume from (see
-  // isJobActive). Everything else folds under UNTRACKED inside the dropdown so
+  // Active = running, or the CHAIN has a checkpoint (see isJobActive; it stays
+  // chain-wide on purpose, because a tip whose only checkpoints are inherited
+  // is precisely the row the user must reach in order to delete it and free
+  // its parent). Everything else folds under UNTRACKED inside the dropdown so
   // the trigger lands on what's still relevant. Superseded runs are dropped
   // from both — they surface nested under their successor's card instead.
   const toEntries = useCallback(
@@ -153,12 +160,17 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
             key: jobEntryKey(job),
             time: jobTime(job),
             job,
-            // The row stands for the whole chain, so its Resume gate counts
-            // the chain's checkpoints, not just the tip's. Counted by the
-            // provider, which owns the ancestor records — and which files a
-            // chain whose ancestors haven't landed yet as active regardless,
-            // so a row can't sit in the fold while its count reads low.
-            chainCheckpointCount: chainCheckpointCount(job),
+            // The row's Resume gate is the tip's OWN checkpoint count, which
+            // under the sticks rule is not an approximation of the real answer
+            // but exactly it: only a leaf's own checkpoints are resumable, and
+            // this row is a leaf. (It used to count the whole chain, because
+            // inherited checkpoints were resumable too and the tip's own count
+            // therefore under-reported. That is no longer the rule — see
+            // `resumableCheckpoints` — so the chain-wide count would now light
+            // the button on rows the exact rule refuses.) No ancestor records
+            // are needed for it, so it also can't read low while a backfill is
+            // still in flight.
+            ownCheckpointCount: job.checkpoint_count,
           }),
         ),
         ...hubs.map(
@@ -170,7 +182,7 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
           }),
         ),
       ].sort((a, b) => b.time - a.time),
-    [chainCheckpointCount],
+    [],
   );
 
   const trackedRuns = useMemo(
@@ -243,14 +255,30 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
         // chain is often an ancestor rather than this row's own run.
         const best = resumableCheckpoints(job, lineage)[0];
         if (!best) {
-          // The row's button gates on the CHEAP chain-wide count, so landing
-          // here is normal — this is where the exact rule gets to explain
-          // itself. The cause comes from the rule itself (`noResumeReason`)
-          // rather than being re-guessed from the lineage here: guessing is
-          // what produced the "already at its step target" message for a run
-          // whose checkpoints were below its target and had been dropped by a
+          // The row's button gates on the run's own checkpoint COUNT, which
+          // can't see the step target or the owner's state, so landing here is
+          // normal — this is where the exact rule gets to explain itself. The
+          // cause comes from the rule itself (`noResumeReason`) rather than
+          // being re-guessed from the lineage here: guessing is what produced
+          // the "already at its step target" message for a run whose
+          // checkpoints were below its target and had been dropped by a
           // different filter entirely.
           const reason = noResumeReason(job, lineage);
+          // Sticks: every checkpoint in reach belongs to a run something has
+          // already continued, which the backend refuses as a resume source.
+          // A two-step recovery, not a dead end, so the message spells both
+          // steps out and NAMES the run and step waiting at the end of them
+          // (from the rule, so it can't name one the resume would then refuse).
+          //
+          // Reached from HERE only when this run's own checkpoints exist but
+          // couldn't be listed (a per-job fetch failure — the loader degrades
+          // to fewer entries rather than rejecting), because the row's gate
+          // already hides the button when the count is zero. The ordinary
+          // empty-handed tip meets this same guidance on its card instead.
+          // Kept complete regardless: `noResumeReason` is total, and a caller
+          // that reaches a branch with no answer is how the toast came to
+          // blame the wrong filter in the first place.
+          const blocked = blockedByContinuedOwner(job, lineage);
           const description: Record<NoResumeReason, string> = {
             "not-resumable":
               "This run isn't in a state that can be continued.",
@@ -260,6 +288,13 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
               "Every checkpoint this run can continue from belongs to a run that already " +
               "reached its target, so its learning-rate schedule is spent. Fine-tune from " +
               "the final checkpoint instead.",
+            "parent-continued": blocked
+              ? `This attempt saved no checkpoints and its parent was already continued. ` +
+                `Delete this attempt, then resume ${jobDisplayName(blocked.job)} from step ` +
+                `${blocked.ckpt.step.toLocaleString()}.`
+              : "This attempt saved no checkpoints, and the runs it continues from have " +
+                "already been continued. Delete this attempt to free its parent for a " +
+                "new continuation.",
             "at-target":
               "Every checkpoint this run can continue from is already at its step target. " +
               "Raise the target to continue, or fine-tune from the final checkpoint.",

--- a/frontend/src/components/jobs/JobsLibrary.tsx
+++ b/frontend/src/components/jobs/JobsLibrary.tsx
@@ -10,7 +10,6 @@ import { useStudio } from "@/contexts/StudioContext";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import {
-  blockedByContinuedOwner,
   buildResumeSeed,
   loadLineageCheckpoints,
   noResumeReason,
@@ -21,12 +20,7 @@ import JobCard from "./JobCard";
 import HubJobCard from "./HubJobCard";
 import JobsDropdown, { JobsEntry } from "./JobsDropdown";
 import { useJobsData } from "./JobsDataContext";
-import {
-  HubJob,
-  JobRecord,
-  isHubJobActive,
-  jobDisplayName,
-} from "@/lib/jobsApi";
+import { HubJob, JobRecord, isHubJobActive } from "@/lib/jobsApi";
 
 /** Recency keys (ms) for the mixed local/cloud/hub list — every library is
  * ordered newest-first regardless of where a run lives. */
@@ -76,6 +70,7 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
     untrackedHubJobs,
     supersededIds,
     ancestorsOf,
+    chainCheckpointCount,
     isJobActive,
     hubAuthenticated,
     hubJobsPermission,
@@ -145,11 +140,10 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
     [untrackedHubJobs, matchesQuery, showOnline],
   );
 
-  // Active = running, or the CHAIN has a checkpoint (see isJobActive; it stays
-  // chain-wide on purpose, because a tip whose only checkpoints are inherited
-  // is precisely the row the user must reach in order to delete it and free
-  // its parent). Everything else folds under UNTRACKED inside the dropdown so
-  // the trigger lands on what's still relevant. Superseded runs are dropped
+  // Active = running, or the CHAIN has a checkpoint (see isJobActive) — which
+  // under chain rewind is the same thing as "resumable", since a run continues
+  // from anything on its lineage. Everything else folds under UNTRACKED inside
+  // the dropdown so the trigger lands on what's still relevant. Superseded runs are dropped
   // from both — they surface nested under their successor's card instead.
   const toEntries = useCallback(
     (jobs: JobRecord[], hubs: HubJob[]): JobsEntry[] =>
@@ -160,17 +154,16 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
             key: jobEntryKey(job),
             time: jobTime(job),
             job,
-            // The row's Resume gate is the tip's OWN checkpoint count, which
-            // under the sticks rule is not an approximation of the real answer
-            // but exactly it: only a leaf's own checkpoints are resumable, and
-            // this row is a leaf. (It used to count the whole chain, because
-            // inherited checkpoints were resumable too and the tip's own count
-            // therefore under-reported. That is no longer the rule — see
-            // `resumableCheckpoints` — so the chain-wide count would now light
-            // the button on rows the exact rule refuses.) No ancestor records
-            // are needed for it, so it also can't read low while a backfill is
-            // still in flight.
-            ownCheckpointCount: job.checkpoint_count,
+            // The row stands for a whole CHAIN, and chain rewind lets it
+            // continue from any checkpoint on that chain — so the gate counts
+            // the chain, not just this tip. The tip's own count is the wrong
+            // number for the commonest resumable shape there is: a run that
+            // died before its first save, whose checkpoints are all inherited.
+            // Counted by the provider, which holds the ancestor records — and
+            // which files a chain whose ancestors haven't landed yet as active
+            // regardless, so a row can't sit in the fold while its count reads
+            // low.
+            chainCheckpointCount: chainCheckpointCount(job),
           }),
         ),
         ...hubs.map(
@@ -182,7 +175,7 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
           }),
         ),
       ].sort((a, b) => b.time - a.time),
-    [],
+    [chainCheckpointCount],
   );
 
   const trackedRuns = useMemo(
@@ -250,12 +243,12 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
           job,
           ancestorsOf(job),
         );
-        // Newest first, and each entry knows which run owns it — so the seed
-        // resumes from the run that actually holds the checkpoint, which on a
-        // chain is often an ancestor rather than this row's own run.
+        // Newest first, and each entry knows which run owns it — which on a
+        // chain is often an ancestor. The seed continues THIS row's run either
+        // way (chain rewind); the owner only says where the bytes come from.
         const best = resumableCheckpoints(job, lineage)[0];
         if (!best) {
-          // The row's button gates on the run's own checkpoint COUNT, which
+          // The row's button gates on the chain's checkpoint COUNT, which
           // can't see the step target or the owner's state, so landing here is
           // normal — this is where the exact rule gets to explain itself. The
           // cause comes from the rule itself (`noResumeReason`) rather than
@@ -264,21 +257,11 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
           // checkpoints were below its target and had been dropped by a
           // different filter entirely.
           const reason = noResumeReason(job, lineage);
-          // Sticks: every checkpoint in reach belongs to a run something has
-          // already continued, which the backend refuses as a resume source.
-          // A two-step recovery, not a dead end, so the message spells both
-          // steps out and NAMES the run and step waiting at the end of them
-          // (from the rule, so it can't name one the resume would then refuse).
-          //
-          // Reached from HERE only when this run's own checkpoints exist but
-          // couldn't be listed (a per-job fetch failure — the loader degrades
-          // to fewer entries rather than rejecting), because the row's gate
-          // already hides the button when the count is zero. The ordinary
-          // empty-handed tip meets this same guidance on its card instead.
-          // Kept complete regardless: `noResumeReason` is total, and a caller
-          // that reaches a branch with no answer is how the toast came to
-          // blame the wrong filter in the first place.
-          const blocked = blockedByContinuedOwner(job, lineage);
+          // Under chain rewind these are the genuinely stranded cases only: a
+          // chain that saved nothing anywhere, or one whose every checkpoint
+          // belongs to a finished run. The delete-first wording that used to
+          // live here is gone with the rule that made it necessary — an
+          // empty-handed tip now simply resumes from what it inherited.
           const description: Record<NoResumeReason, string> = {
             "not-resumable":
               "This run isn't in a state that can be continued.",
@@ -288,13 +271,6 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
               "Every checkpoint this run can continue from belongs to a run that already " +
               "reached its target, so its learning-rate schedule is spent. Fine-tune from " +
               "the final checkpoint instead.",
-            "parent-continued": blocked
-              ? `This attempt saved no checkpoints and its parent was already continued. ` +
-                `Delete this attempt, then resume ${jobDisplayName(blocked.job)} from step ` +
-                `${blocked.ckpt.step.toLocaleString()}.`
-              : "This attempt saved no checkpoints, and the runs it continues from have " +
-                "already been continued. Delete this attempt to free its parent for a " +
-                "new continuation.",
             "at-target":
               "Every checkpoint this run can continue from is already at its step target. " +
               "Raise the target to continue, or fine-tune from the final checkpoint.",
@@ -322,7 +298,7 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
         // runner: post-F7 a local run continuing a cloud parent lists that
         // parent's Hub repo too — see `cloudSiblingStepCap`.
         openStudio("train", {
-          train: { resume: buildResumeSeed(best.job, best.ckpt.step) },
+          train: { resume: buildResumeSeed(job, best) },
         });
       } catch (e) {
         toast({

--- a/frontend/src/components/jobs/JobsLibrary.tsx
+++ b/frontend/src/components/jobs/JobsLibrary.tsx
@@ -141,8 +141,8 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
   );
 
   // Active = running, or the CHAIN has a checkpoint (see isJobActive) — which
-  // under chain rewind is the same thing as "resumable", since a run continues
-  // from anything on its lineage. Everything else folds under UNTRACKED inside
+  // is the same thing as "resumable", since a run continues from the newest
+  // checkpoint on its lineage. Everything else folds under UNTRACKED inside
   // the dropdown so the trigger lands on what's still relevant. Superseded runs are dropped
   // from both — they surface nested under their successor's card instead.
   const toEntries = useCallback(
@@ -154,9 +154,10 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
             key: jobEntryKey(job),
             time: jobTime(job),
             job,
-            // The row stands for a whole CHAIN, and chain rewind lets it
-            // continue from any checkpoint on that chain — so the gate counts
-            // the chain, not just this tip. The tip's own count is the wrong
+            // The row stands for a whole CHAIN, and it continues from the
+            // newest checkpoint on that chain, its own or an ancestor's — so
+            // the gate counts the chain, not just this tip. The tip's own
+            // count is the wrong
             // number for the commonest resumable shape there is: a run that
             // died before its first save, whose checkpoints are all inherited.
             // Counted by the provider, which holds the ancestor records — and
@@ -232,7 +233,9 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
   // card's Resume produces. Same shared loader AND same shared rule,
   // so the two entry points can offer neither a different checkpoint nor a
   // different verdict (this path used to walk its own, thinner logic).
-  // Choosing a *specific* step stays on the selected run's card below.
+  // There is no longer a second, step-selectable way in: the card's Resume
+  // takes the same newest entry this does, so the row and the card are one
+  // affordance in two places rather than a quick path and a precise one.
   const handleResume = useCallback(
     async (job: JobRecord) => {
       setResumingId(job.id);

--- a/frontend/src/components/jobs/JobsLibrary.tsx
+++ b/frontend/src/components/jobs/JobsLibrary.tsx
@@ -9,12 +9,17 @@ import { useApi } from "@/contexts/ApiContext";
 import { useStudio } from "@/contexts/StudioContext";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
-import { listJobCheckpoints } from "@/lib/checkpointsApi";
-import { buildResumeSeed, latestResumableStep } from "./resumeSeed";
+import {
+  buildResumeSeed,
+  loadLineageCheckpoints,
+  noResumeReason,
+  resumableCheckpoints,
+} from "./resumeSeed";
+import type { NoResumeReason } from "./resumeSeed";
 import JobCard from "./JobCard";
 import HubJobCard from "./HubJobCard";
 import JobsDropdown, { JobsEntry } from "./JobsDropdown";
-import { isJobActive, useJobsData } from "./JobsDataContext";
+import { useJobsData } from "./JobsDataContext";
 import { HubJob, JobRecord, isHubJobActive } from "@/lib/jobsApi";
 
 /** Recency keys (ms) for the mixed local/cloud/hub list — every library is
@@ -51,7 +56,9 @@ interface JobsLibraryProps {
  * list gives one row per run with its state, where it ran, when, and the
  * row-level primary actions; and the selected run's card below the dropdown
  * keeps every other affordance — monitor, rename, checkpoint picker,
- * Run / Continue / Resume-from-step / Download / delete.
+ * Run / Resume-from-step / Download / delete. (Run and Download are
+ * model-shaped actions and move to ModelCard once ModelsLibrary is rewired to
+ * render it; they still live on JobCard on this stack.)
  *
  * The models column that used to sit beside this lives in the Deploy panel
  * (ModelsLibrary) — a model artifact is deployed, not trained.
@@ -63,6 +70,8 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
     untrackedHubJobs,
     supersededIds,
     ancestorsOf,
+    chainCheckpointCount,
+    isJobActive,
     hubAuthenticated,
     hubJobsPermission,
     error,
@@ -131,27 +140,37 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
     [untrackedHubJobs, matchesQuery, showOnline],
   );
 
-  // Active = running or has runnable checkpoints. Everything else folds under
-  // UNTRACKED inside the dropdown so the trigger lands on what's still
-  // relevant. Superseded runs are dropped from both — they surface nested under
-  // their successor's card instead.
+  // Active = running, or the CHAIN has a checkpoint to resume from (see
+  // isJobActive). Everything else folds under UNTRACKED inside the dropdown so
+  // the trigger lands on what's still relevant. Superseded runs are dropped
+  // from both — they surface nested under their successor's card instead.
   const toEntries = useCallback(
     (jobs: JobRecord[], hubs: HubJob[]): JobsEntry[] =>
       [
-        ...jobs.map((job): JobsEntry => ({
-          kind: "job",
-          key: jobEntryKey(job),
-          time: jobTime(job),
-          job,
-        })),
-        ...hubs.map((job): JobsEntry => ({
-          kind: "hub",
-          key: hubEntryKey(job),
-          time: hubTime(job),
-          job,
-        })),
+        ...jobs.map(
+          (job): JobsEntry => ({
+            kind: "job",
+            key: jobEntryKey(job),
+            time: jobTime(job),
+            job,
+            // The row stands for the whole chain, so its Resume gate counts
+            // the chain's checkpoints, not just the tip's. Counted by the
+            // provider, which owns the ancestor records — and which files a
+            // chain whose ancestors haven't landed yet as active regardless,
+            // so a row can't sit in the fold while its count reads low.
+            chainCheckpointCount: chainCheckpointCount(job),
+          }),
+        ),
+        ...hubs.map(
+          (job): JobsEntry => ({
+            kind: "hub",
+            key: hubEntryKey(job),
+            time: hubTime(job),
+            job,
+          }),
+        ),
       ].sort((a, b) => b.time - a.time),
-    [],
+    [chainCheckpointCount],
   );
 
   const trackedRuns = useMemo(
@@ -164,10 +183,10 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
   const activeEntries = useMemo(
     () =>
       toEntries(
-        trackedRuns.filter(isJobActive),
+        trackedRuns.filter((j) => isJobActive(j)),
         filteredHub.filter(isHubJobActive),
       ),
-    [toEntries, trackedRuns, filteredHub],
+    [toEntries, trackedRuns, filteredHub, isJobActive],
   );
   const untrackedEntries = useMemo(
     () =>
@@ -175,7 +194,7 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
         trackedRuns.filter((j) => !isJobActive(j)),
         filteredHub.filter((h) => !isHubJobActive(h)),
       ),
-    [toEntries, trackedRuns, filteredHub],
+    [toEntries, trackedRuns, filteredHub, isJobActive],
   );
 
   const activeCount = activeEntries.length;
@@ -203,53 +222,73 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
       : autoKey;
   const selected = allEntries.find((e) => e.key === selectedKey) ?? null;
 
-  // Resume from the row: resolve the run's newest checkpoint and open the
-  // Train panel's form in resume mode with exactly the seed the card's
-  // Continue/Resume produces — same shared builder, so the two can't drift
-  // (this path used to assemble its own, thinner payload). Choosing a
-  // *specific* step stays on the selected run's card below.
+  // Resume from the row: resolve the chain's newest resumable checkpoint and
+  // open the Train panel's form in resume mode with exactly the seed the
+  // card's Resume produces. Same shared loader AND same shared rule,
+  // so the two entry points can offer neither a different checkpoint nor a
+  // different verdict (this path used to walk its own, thinner logic).
+  // Choosing a *specific* step stays on the selected run's card below.
   const handleResume = useCallback(
     async (job: JobRecord) => {
       setResumingId(job.id);
       try {
-        const cks = await listJobCheckpoints(baseUrl, fetchWithHeaders, job.id);
-        const step = latestResumableStep(cks);
-        if (step == null) {
+        const lineage = await loadLineageCheckpoints(
+          baseUrl,
+          fetchWithHeaders,
+          job,
+          ancestorsOf(job),
+        );
+        // Newest first, and each entry knows which run owns it — so the seed
+        // resumes from the run that actually holds the checkpoint, which on a
+        // chain is often an ancestor rather than this row's own run.
+        const best = resumableCheckpoints(job, lineage)[0];
+        if (!best) {
+          // The row's button gates on the CHEAP chain-wide count, so landing
+          // here is normal — this is where the exact rule gets to explain
+          // itself. The cause comes from the rule itself (`noResumeReason`)
+          // rather than being re-guessed from the lineage here: guessing is
+          // what produced the "already at its step target" message for a run
+          // whose checkpoints were below its target and had been dropped by a
+          // different filter entirely.
+          const reason = noResumeReason(job, lineage);
+          const description: Record<NoResumeReason, string> = {
+            "not-resumable":
+              "This run isn't in a state that can be continued.",
+            "no-checkpoints":
+              "This run and the runs it continues from saved no checkpoint.",
+            "owner-done":
+              "Every checkpoint this run can continue from belongs to a run that already " +
+              "reached its target, so its learning-rate schedule is spent. Fine-tune from " +
+              "the final checkpoint instead.",
+            "at-target":
+              "Every checkpoint this run can continue from is already at its step target. " +
+              "Raise the target to continue, or fine-tune from the final checkpoint.",
+            "sibling-cap":
+              "Every checkpoint left in this run's lineage was saved past the step this run " +
+              "reached, so it belongs to another continuation sharing the same cloud output.",
+            other: "No checkpoint in this run's lineage can be resumed from.",
+          };
           toast({
             title: "Nothing to resume from",
-            description: "This run saved no checkpoint.",
-            variant: "destructive",
+            description: description[reason],
+            variant: reason === "no-checkpoints" ? "destructive" : "default",
           });
           return;
         }
-        // KNOWN APPROXIMATION — the step above may not be this run's own.
-        // A resumed CLOUD run reuses its parent's Hub output repo, so
-        // listJobCheckpoints(job.id) returns the whole lineage's checkpoints,
-        // including ones written by sibling runs: two children forked off one
-        // parent, and the sibling that ran to completion left checkpoints at
-        // the shared target in the same repo — so "the newest checkpoint" here
-        // can belong to that sibling.
-        //
-        // True per-run checkpoint attribution is an identity-redesign item,
-        // not a fix that belongs at this call site: with FORKS in the lineage
-        // even a "newest checkpoint below our own target" pick would still
-        // land on the done sibling's interleaved checkpoints, which is
-        // semantically wrong rather than merely approximate. JobCard's lineage
-        // merge defends the CARD path (and lets the user pick a step by hand);
-        // the row's one-click resume knowingly accepts the approximation and
-        // is honest about it in the message below.
-        const target = job.config?.steps ?? 0;
-        if (target > 0 && step >= target) {
-          toast({
-            title: "Nothing to resume",
-            description:
-              "The newest checkpoint in this run's repo is already at the step target. " +
-              "Raise the step target to continue, or fine-tune from the final checkpoint. " +
-              "A resumed run shares its repo with its lineage, so this checkpoint may belong to a sibling run.",
-          });
-          return;
-        }
-        openStudio("train", { train: { resume: buildResumeSeed(job, step) } });
+        // KNOWN LIMIT, CLOUD-OWNED checkpoints only and now narrowed: the runs
+        // of a cloud chain all publish to the parent's Hub repo, so a FORKED
+        // SIBLING's checkpoints are in that listing too and nothing in them
+        // says who wrote them. resumableCheckpoints drops every step above this
+        // run's OWN furthest step — those provably belong to a sibling — so
+        // what can still slip through is a sibling that forked early, inside
+        // this run's range. Per-run attribution of Hub checkpoints is a backend
+        // change. Locally-owned checkpoints are exact (each run owns its output
+        // dir). Note the limit follows the checkpoint's OWNER, not this run's
+        // runner: post-F7 a local run continuing a cloud parent lists that
+        // parent's Hub repo too — see `cloudSiblingStepCap`.
+        openStudio("train", {
+          train: { resume: buildResumeSeed(best.job, best.ckpt.step) },
+        });
       } catch (e) {
         toast({
           title: "Couldn't load checkpoints",
@@ -260,7 +299,7 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
         setResumingId(null);
       }
     },
-    [baseUrl, fetchWithHeaders, openStudio, toast],
+    [ancestorsOf, baseUrl, fetchWithHeaders, openStudio, toast],
   );
 
   const emptyMessage = query
@@ -406,8 +445,9 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
                           // checkpoint ref) that its fetch effect only replaces
                           // once the new run's fetch resolves. Without a key the
                           // instance is reused and, in that window, Run /
-                          // Continue / Resume / Download would act on the PREVIOUS
-                          // run while the header already shows the new one.
+                          // Resume / Fine-tune / Download would act on the
+                          // PREVIOUS run while the header already shows the
+                          // new one.
                           key={selected.key}
                           job={selected.job}
                           onStop={stop}

--- a/frontend/src/components/jobs/ModelCard.tsx
+++ b/frontend/src/components/jobs/ModelCard.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/lib/checkpointsApi";
 import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
 import { displayDedupeSuffix, splitDedupeSuffix } from "@/lib/modelNames";
+import { checkpointOwners } from "./resumeSeed";
 
 interface Props {
   /** The model, represented by its backing job record: an import, or a
@@ -687,6 +688,13 @@ const ModelCard: React.FC<Props> = ({
                 disabled={!selectorEnabled}
                 placeholder="No checkpoints"
                 className="w-36"
+                // Same ambiguity as JobCard's resume row, same fix: this list
+                // merges a lineage, so "step 2000" can appear once per run and
+                // the runs share a display name. It matters more here — the
+                // selection routes Run / Fine-tune / Download to the OWNING
+                // record, so picking the wrong one silently acts on a
+                // different model's weights.
+                owners={checkpointOwners(lineageCheckpoints)}
               />,
               "shrink-0",
             )}

--- a/frontend/src/components/jobs/resumeSeed.ts
+++ b/frontend/src/components/jobs/resumeSeed.ts
@@ -55,9 +55,10 @@ export function checkpointOwners(
 /** Load the checkpoints reachable from `leaf`, walking its OWN ancestor path:
  * the leaf's own list first, then each ancestor's, nearest first.
  *
- * Both resume entry points (the library row's one-click and the card's
- * step-picker) read this one list, so they can't offer different checkpoints
- * for the same run. Sorted newest-step-first, then deduped by `ref` — with
+ * Both resume entry points read this one list — and, since Continue stopped
+ * being step-selectable, both take the same entry out of it — so they can
+ * neither offer nor use a different checkpoint for the same run. Sorted
+ * newest-step-first, then deduped by `ref` — with
  * lineage order preserved for equal refs, the surviving entry of a duplicate
  * pair is attributed to the NEAREST run in the chain.
  *
@@ -65,11 +66,11 @@ export function checkpointOwners(
  * repo, so every run in a cloud chain enumerates the same shared tree and each
  * inherited step would otherwise appear once per run.
  *
- * The whole ancestor path is loaded even though only the leaf's OWN entries
- * are resumable (see `resumableCheckpoints`): the card LISTS this list, and
- * being able to look at what a chain saved — and to run inference on an
- * inherited checkpoint — is not the same affordance as continuing training
- * from it. Narrowing happens at the resume rule, not here.
+ * The whole ancestor path is loaded even though a resume only ever uses the
+ * newest resumable entry: the card's dropdown LISTS this list, and picking an
+ * inherited checkpoint to run inference on, fine-tune from or download is a
+ * real choice — it is continuing TRAINING from an older one that is not (see
+ * `resumableCheckpoints`). Narrowing happens at the resume rule, not here.
  *
  * KNOWN LIMIT, cloud only: because that Hub repo is shared by the WHOLE tree,
  * a checkpoint written by a FORKED SIBLING is in the listing too, and there is
@@ -182,22 +183,29 @@ function cloudSiblingStepCap(leaf: JobRecord): number | null {
  *    furthest step — above that it provably belongs to a sibling sharing the
  *    Hub repo (see `cloudSiblingStepCap`).
  *
- * CHAIN REWIND (user decision 2026-08-08). The lineage is offered WHOLE: any
- * checkpoint on the leaf's ancestor path can start a continuation, including
- * one an ancestor saved. What makes that safe — and what the earlier
- * sticks-only narrowing got wrong — is where the lineage EDGE points. A resume
- * always continues the LEAF (`buildResumeSeed` seeds the leaf as the source
- * run) and merely reads its bytes from whichever run owns the chosen
- * checkpoint. So the chain grows parent -> leaf -> new run and stays linear no
- * matter how far back the user reaches.
+ * THE REACH ACROSS THE LINEAGE, and why it survives a latest-only Continue.
+ * The list this returns spans the leaf's whole ancestor path, including
+ * checkpoints an ancestor saved. Both callers then take `[0]` and nothing
+ * else — Continue is not step-selectable (user decision 2026-08-10) — so the
+ * reach is never a choice the user makes. It exists for one case: a tip that
+ * died before saving anything has no checkpoints of its own, and without the
+ * reach it would have nothing to continue from at all. That is the invariant
+ * this rule holds up — every row in the jobs library is either done or
+ * directly resumable — and it is why the rule returns a LIST rather than the
+ * one entry its callers use: the list is what `noResumeReason` reads to
+ * explain an empty result, and returning it whole keeps that explanation in
+ * one place.
+ *
+ * What makes the reach safe is where the lineage EDGE points. A resume always
+ * continues the LEAF (`buildResumeSeed` seeds the leaf as the source run) and
+ * merely reads its bytes from whichever run owns the newest entry. So the
+ * chain grows parent -> leaf -> new run and stays linear however far back the
+ * bytes came from.
  *
  * The old fork bug was the edge pointing at the checkpoint's OWNER, which made
  * an ancestor grow a second child. Excluding continued owners was a fix aimed
  * at the symptom: it kept the chain linear by removing the offering, at the
- * cost of stranding the commonest case — a tip that died before saving
- * anything, whose only checkpoints are inherited. That tip is now simply
- * resumable, which is the invariant this rule exists to hold up: every row in
- * the jobs library is either done or directly resumable.
+ * cost of stranding exactly the empty-handed tip described above.
  *
  * What is deliberately NOT a rule: the owner sharing the leaf's runner. A
  * continuation may cross runners in EITHER direction (F7) — jobs.py
@@ -270,20 +278,23 @@ export function noResumeReason(
  * Build the seed that puts the Train panel's configurator into resume mode:
  * `leaf` continues, from the checkpoint `entry` names.
  *
- * CHAIN REWIND (user decision 2026-08-08), and the whole point of taking an
- * ENTRY rather than a bare (job, step) pair: the two records in a rewind answer
- * different questions, and collapsing them is what produced the fork bug.
+ * The whole point of taking an ENTRY rather than a bare (job, step) pair: the
+ * two records answer different questions, and collapsing them is what produced
+ * the fork bug. They are the same record on the common case — a tip resuming
+ * its own newest checkpoint — and differ only when the reach fired, i.e. when
+ * the tip had nothing of its own to offer.
  *
  *   `leaf` is the run being continued — the row the user clicked. It becomes
  *   `resume_from_job_id`, the lineage edge, so the chain grows
- *   parent -> leaf -> new run and stays linear however far back the user
- *   reached. Its config is what prefills the form, because the new run is the
- *   next attempt at THIS run, not at its ancestor.
+ *   parent -> leaf -> new run and stays linear however far back the bytes
+ *   came from. Its config is what prefills the form, because the new run is
+ *   the next attempt at THIS run, not at its ancestor.
  *
- *   `entry.job` is the run that OWNS the chosen checkpoint, which on a rewind
- *   is an ancestor. It travels as `checkpointJobId` — provenance only — so the
- *   backend knows whose storage to read the bytes from. jobs.py refuses an
- *   owner that is not on the leaf's ancestor path or does not hold the step.
+ *   `entry.job` is the run that OWNS the newest resumable checkpoint, which is
+ *   an ancestor when the leaf saved none of its own. It travels as
+ *   `checkpointJobId` — provenance only — so the backend knows whose storage
+ *   to read the bytes from. jobs.py refuses an owner that is not on the leaf's
+ *   ancestor path or does not hold the step.
  *
  * This used to be called with the OWNER as `job`, which made an ancestor's
  * checkpoint start a continuation OF THE ANCESTOR — a second child, i.e. a
@@ -294,9 +305,10 @@ export function noResumeReason(
  * read them (F7) and what the form defaults Compute to.
  *
  * THE one place a resume seed is assembled. Both entry points call it — the
- * job card's step-selectable Resume and the jobs library's row-level
- * quick-resume — because they previously built the same payload
- * independently, which is exactly the shape of duplication that drifts.
+ * job card's Resume and the jobs library's row-level quick-resume — because
+ * they previously built the same payload independently, which is exactly the
+ * shape of duplication that drifts. They now also pass the same entry, the
+ * top of the same rule's list, so there is nothing left for them to differ on.
  *
  * Carries the parent run's configured shape forward. The registry already
  * holds it as `job.config` (the persisted TrainingRequest), so this needs no
@@ -346,9 +358,9 @@ export function buildResumeSeed(
   return {
     jobId: leaf.id,
     step,
-    // Provenance, omitted on a plain tip-resume so the request stays exactly
-    // the shape it was before rewind existed (the backend reads absent as
-    // "the leaf owns it").
+    // Provenance, omitted when the leaf owns the checkpoint — the common case
+    // — so that request stays exactly the shape it was before the owner field
+    // existed (the backend reads absent as "the leaf owns it").
     checkpointJobId: owner.id === leaf.id ? undefined : owner.id,
     name: jobDisplayName(leaf),
     datasetRepoId: parent.dataset_repo_id,

--- a/frontend/src/components/jobs/resumeSeed.ts
+++ b/frontend/src/components/jobs/resumeSeed.ts
@@ -31,6 +31,12 @@ export interface LineageCheckpoint {
  * repo, so every run in a cloud chain enumerates the same shared tree and each
  * inherited step would otherwise appear once per run.
  *
+ * The whole ancestor path is loaded even though only the leaf's OWN entries
+ * are resumable (see `resumableCheckpoints`): the card LISTS this list, and
+ * being able to look at what a chain saved — and to run inference on an
+ * inherited checkpoint — is not the same affordance as continuing training
+ * from it. Narrowing happens at the resume rule, not here.
+ *
  * KNOWN LIMIT, cloud only: because that Hub repo is shared by the WHOLE tree,
  * a checkpoint written by a FORKED SIBLING is in the listing too, and there is
  * nothing in it to attribute a step to the run that wrote it — so an ancestor
@@ -133,14 +139,36 @@ function cloudSiblingStepCap(leaf: JobRecord): number | null {
  * and the card's can no longer disagree about whether a run is resumable:
  *
  *  - the leaf must be in a resumable state (above);
+ *  - the checkpoint's OWNER must not be `done` — the backend refuses a
+ *    finished run as a resume source, so offering one only buys a 400;
+ *  - the checkpoint's OWNER must have no children — STICKS ONLY (user
+ *    decision 2026-08-07), see below;
  *  - the checkpoint must sit strictly below the leaf's step target, or the
  *    continuation would start at (or past) the finish line. A target of 0
  *    means "unset", so nothing is excluded;
  *  - on a CLOUD leaf, the checkpoint must also sit at or below the leaf's own
  *    furthest step — above that it provably belongs to a sibling sharing the
- *    Hub repo (see `cloudSiblingStepCap`);
- *  - the checkpoint's OWNER must not be `done` — the backend refuses a
- *    finished run as a resume source, so offering one only buys a 400.
+ *    Hub repo (see `cloudSiblingStepCap`).
+ *
+ * STICKS ONLY, and what it costs. A resume lineage is now a CHAIN: jobs.py
+ * refuses a resume whose source already has a child (`JobAlreadyContinuedError`
+ * -> 409), so continuing an ANCESTOR — which by construction already has a
+ * child, the run below it on the path — is a click that could only end in that
+ * refusal. Excluding an owner with children therefore leaves exactly the LEAF's
+ * own checkpoints resumable, and the UI stops offering what the backend would
+ * reject. It is the same rule stated at both ends, not a second policy.
+ *
+ * The list still SHOWS the whole lineage (`loadLineageCheckpoints` is
+ * unchanged, and the card's dropdown renders all of it) — inspection and
+ * inference on an inherited checkpoint are untouched. Only the Resume button
+ * narrows, which is the affordance the 409 governs.
+ *
+ * The cost, stated plainly because it is the thing a user will hit: a tip that
+ * died before saving anything now has NOTHING to resume, where it used to
+ * inherit its parent's checkpoints. That case is not a dead end — deleting the
+ * empty tip frees the parent to be resumed again — and `noResumeReason`
+ * returns "parent-continued" so the toast can say exactly that. Branching is
+ * deferred, not abolished; legacy forks keep rendering as they always did.
  *
  * What is deliberately NOT a rule: the owner sharing the leaf's runner. A
  * continuation may cross runners in EITHER direction (F7) — jobs.py
@@ -164,10 +192,45 @@ export function resumableCheckpoints(
     .filter(
       (entry) =>
         entry.job.state !== "done" &&
+        entry.job.child_ids.length === 0 &&
         (target === 0 || entry.ckpt.step < target) &&
         (cap === null || entry.ckpt.step <= cap),
     )
     .sort((a, b) => b.ckpt.step - a.ckpt.step);
+}
+
+/** The newest lineage checkpoint that only the sticks rule excludes — i.e. the
+ * one the user would be resuming if they first deleted the run in front of it.
+ *
+ * Exists so the empty-result toast can NAME the parent and the step instead of
+ * saying "delete something". Lives here rather than in the toast because it is
+ * the sticks rule read backwards, and a caller re-deriving it would be free to
+ * disagree with `resumableCheckpoints` about which entry that is — the exact
+ * drift the one-rule consolidation was for.
+ *
+ * Every other filter still applies: an entry a `done` owner or the step target
+ * would have dropped anyway is not "blocked by a continuation", and offering
+ * it as the delete-first payoff would be a lie. Returns null when there is no
+ * such entry, which is every case except the empty-handed tip.
+ */
+export function blockedByContinuedOwner(
+  leaf: JobRecord,
+  lineage: LineageCheckpoint[],
+): LineageCheckpoint | null {
+  if (!isResumableLeaf(leaf)) return null;
+  const target = leaf.config?.steps ?? 0;
+  const cap = cloudSiblingStepCap(leaf);
+  return (
+    lineage
+      .filter(
+        (entry) =>
+          entry.job.state !== "done" &&
+          entry.job.child_ids.length > 0 &&
+          (target === 0 || entry.ckpt.step < target) &&
+          (cap === null || entry.ckpt.step <= cap),
+      )
+      .sort((a, b) => b.ckpt.step - a.ckpt.step)[0] ?? null
+  );
 }
 
 /** Which rule above emptied the list — for the one caller that has to explain
@@ -183,6 +246,7 @@ export type NoResumeReason =
   | "not-resumable" // the leaf's own state — no run to continue
   | "no-checkpoints" // nothing saved anywhere in the lineage
   | "owner-done" // every candidate belongs to a finished run
+  | "parent-continued" // sticks: every candidate is owned by an already-continued run
   | "at-target" // every candidate is at or past the leaf's step target
   | "sibling-cap" // cloud: every candidate is above the leaf's own furthest step
   | "other";
@@ -195,8 +259,16 @@ export function noResumeReason(
   if (lineage.length === 0) return "no-checkpoints";
   const live = lineage.filter((entry) => entry.job.state !== "done");
   if (live.length === 0) return "owner-done";
+  // Sticks, and deliberately AFTER `owner-done`: both can be true of a legacy
+  // chain, and only one of them has a way out. Telling the user to delete this
+  // attempt so they can resume a parent that has itself finished would send
+  // them to a refusal ("its schedule is spent — fine-tune instead"), so the
+  // finished-owner answer wins where they overlap. jobs.py orders its two
+  // refusals the same way, for the same reason.
+  const ownedByLeaf = live.filter((entry) => entry.job.child_ids.length === 0);
+  if (ownedByLeaf.length === 0) return "parent-continued";
   const target = leaf.config?.steps ?? 0;
-  const belowTarget = live.filter(
+  const belowTarget = ownedByLeaf.filter(
     (entry) => target === 0 || entry.ckpt.step < target,
   );
   if (belowTarget.length === 0) return "at-target";

--- a/frontend/src/components/jobs/resumeSeed.ts
+++ b/frontend/src/components/jobs/resumeSeed.ts
@@ -1,4 +1,5 @@
 import { JobRecord, jobDisplayName } from "@/lib/jobsApi";
+import { jobRunStamp, middleEllipsis } from "@/lib/modelNames";
 import type { Fetcher } from "@/lib/apiClient";
 import {
   JobCheckpoint,
@@ -16,6 +17,39 @@ import type { ResumeSeed } from "@/components/training/TrainingConfigurator";
 export interface LineageCheckpoint {
   job: JobRecord;
   ckpt: JobCheckpoint;
+}
+
+/** Owner attribution for `CheckpointDropdown`, keyed by checkpoint `ref`.
+ *
+ * Shared by both cards that merge a lineage into one list (JobCard's resume
+ * row, ModelCard's history selector) so the two can't describe the same
+ * checkpoint differently. The name alone cannot do this job: a continuation
+ * continues the same model, so every run on a chain displays the same name.
+ *
+ * `number` is the visible distinguisher — short enough to sit in a dense row,
+ * and the same thing the backend's refusals now lead with. `detail` is the
+ * hover layer: the id's timestamp tail plus the full id, for when the user
+ * needs to match a row against a log line or an API message rather than just
+ * tell two rows apart.
+ *
+ * The name is middle-ellipsized because it shares a line inside a popover that
+ * sizes itself to its widest row. Middle rather than end for the usual reason —
+ * a name's tail is the half that identifies it. */
+export function checkpointOwners(
+  lineage: LineageCheckpoint[],
+): Record<string, { name: string; number: number; detail: string }> {
+  const owners: Record<
+    string,
+    { name: string; number: number; detail: string }
+  > = {};
+  for (const { job, ckpt } of lineage) {
+    owners[ckpt.ref] = {
+      name: middleEllipsis(jobDisplayName(job), 28),
+      number: job.job_number,
+      detail: `${jobRunStamp(job.id)} · ${job.id}`,
+    };
+  }
+  return owners;
 }
 
 /** Load the checkpoints reachable from `leaf`, walking its OWN ancestor path:
@@ -141,8 +175,6 @@ function cloudSiblingStepCap(leaf: JobRecord): number | null {
  *  - the leaf must be in a resumable state (above);
  *  - the checkpoint's OWNER must not be `done` — the backend refuses a
  *    finished run as a resume source, so offering one only buys a 400;
- *  - the checkpoint's OWNER must have no children — STICKS ONLY (user
- *    decision 2026-08-07), see below;
  *  - the checkpoint must sit strictly below the leaf's step target, or the
  *    continuation would start at (or past) the finish line. A target of 0
  *    means "unset", so nothing is excluded;
@@ -150,25 +182,22 @@ function cloudSiblingStepCap(leaf: JobRecord): number | null {
  *    furthest step — above that it provably belongs to a sibling sharing the
  *    Hub repo (see `cloudSiblingStepCap`).
  *
- * STICKS ONLY, and what it costs. A resume lineage is now a CHAIN: jobs.py
- * refuses a resume whose source already has a child (`JobAlreadyContinuedError`
- * -> 409), so continuing an ANCESTOR — which by construction already has a
- * child, the run below it on the path — is a click that could only end in that
- * refusal. Excluding an owner with children therefore leaves exactly the LEAF's
- * own checkpoints resumable, and the UI stops offering what the backend would
- * reject. It is the same rule stated at both ends, not a second policy.
+ * CHAIN REWIND (user decision 2026-08-08). The lineage is offered WHOLE: any
+ * checkpoint on the leaf's ancestor path can start a continuation, including
+ * one an ancestor saved. What makes that safe — and what the earlier
+ * sticks-only narrowing got wrong — is where the lineage EDGE points. A resume
+ * always continues the LEAF (`buildResumeSeed` seeds the leaf as the source
+ * run) and merely reads its bytes from whichever run owns the chosen
+ * checkpoint. So the chain grows parent -> leaf -> new run and stays linear no
+ * matter how far back the user reaches.
  *
- * The list still SHOWS the whole lineage (`loadLineageCheckpoints` is
- * unchanged, and the card's dropdown renders all of it) — inspection and
- * inference on an inherited checkpoint are untouched. Only the Resume button
- * narrows, which is the affordance the 409 governs.
- *
- * The cost, stated plainly because it is the thing a user will hit: a tip that
- * died before saving anything now has NOTHING to resume, where it used to
- * inherit its parent's checkpoints. That case is not a dead end — deleting the
- * empty tip frees the parent to be resumed again — and `noResumeReason`
- * returns "parent-continued" so the toast can say exactly that. Branching is
- * deferred, not abolished; legacy forks keep rendering as they always did.
+ * The old fork bug was the edge pointing at the checkpoint's OWNER, which made
+ * an ancestor grow a second child. Excluding continued owners was a fix aimed
+ * at the symptom: it kept the chain linear by removing the offering, at the
+ * cost of stranding the commonest case — a tip that died before saving
+ * anything, whose only checkpoints are inherited. That tip is now simply
+ * resumable, which is the invariant this rule exists to hold up: every row in
+ * the jobs library is either done or directly resumable.
  *
  * What is deliberately NOT a rule: the owner sharing the leaf's runner. A
  * continuation may cross runners in EITHER direction (F7) — jobs.py
@@ -192,45 +221,10 @@ export function resumableCheckpoints(
     .filter(
       (entry) =>
         entry.job.state !== "done" &&
-        entry.job.child_ids.length === 0 &&
         (target === 0 || entry.ckpt.step < target) &&
         (cap === null || entry.ckpt.step <= cap),
     )
     .sort((a, b) => b.ckpt.step - a.ckpt.step);
-}
-
-/** The newest lineage checkpoint that only the sticks rule excludes — i.e. the
- * one the user would be resuming if they first deleted the run in front of it.
- *
- * Exists so the empty-result toast can NAME the parent and the step instead of
- * saying "delete something". Lives here rather than in the toast because it is
- * the sticks rule read backwards, and a caller re-deriving it would be free to
- * disagree with `resumableCheckpoints` about which entry that is — the exact
- * drift the one-rule consolidation was for.
- *
- * Every other filter still applies: an entry a `done` owner or the step target
- * would have dropped anyway is not "blocked by a continuation", and offering
- * it as the delete-first payoff would be a lie. Returns null when there is no
- * such entry, which is every case except the empty-handed tip.
- */
-export function blockedByContinuedOwner(
-  leaf: JobRecord,
-  lineage: LineageCheckpoint[],
-): LineageCheckpoint | null {
-  if (!isResumableLeaf(leaf)) return null;
-  const target = leaf.config?.steps ?? 0;
-  const cap = cloudSiblingStepCap(leaf);
-  return (
-    lineage
-      .filter(
-        (entry) =>
-          entry.job.state !== "done" &&
-          entry.job.child_ids.length > 0 &&
-          (target === 0 || entry.ckpt.step < target) &&
-          (cap === null || entry.ckpt.step <= cap),
-      )
-      .sort((a, b) => b.ckpt.step - a.ckpt.step)[0] ?? null
-  );
 }
 
 /** Which rule above emptied the list — for the one caller that has to explain
@@ -246,7 +240,6 @@ export type NoResumeReason =
   | "not-resumable" // the leaf's own state — no run to continue
   | "no-checkpoints" // nothing saved anywhere in the lineage
   | "owner-done" // every candidate belongs to a finished run
-  | "parent-continued" // sticks: every candidate is owned by an already-continued run
   | "at-target" // every candidate is at or past the leaf's step target
   | "sibling-cap" // cloud: every candidate is above the leaf's own furthest step
   | "other";
@@ -259,16 +252,8 @@ export function noResumeReason(
   if (lineage.length === 0) return "no-checkpoints";
   const live = lineage.filter((entry) => entry.job.state !== "done");
   if (live.length === 0) return "owner-done";
-  // Sticks, and deliberately AFTER `owner-done`: both can be true of a legacy
-  // chain, and only one of them has a way out. Telling the user to delete this
-  // attempt so they can resume a parent that has itself finished would send
-  // them to a refusal ("its schedule is spent — fine-tune instead"), so the
-  // finished-owner answer wins where they overlap. jobs.py orders its two
-  // refusals the same way, for the same reason.
-  const ownedByLeaf = live.filter((entry) => entry.job.child_ids.length === 0);
-  if (ownedByLeaf.length === 0) return "parent-continued";
   const target = leaf.config?.steps ?? 0;
-  const belowTarget = ownedByLeaf.filter(
+  const belowTarget = live.filter(
     (entry) => target === 0 || entry.ckpt.step < target,
   );
   if (belowTarget.length === 0) return "at-target";
@@ -282,8 +267,31 @@ export function noResumeReason(
 }
 
 /**
- * Build the seed that puts the Train panel's configurator into resume mode for
- * `job` continuing from `step`.
+ * Build the seed that puts the Train panel's configurator into resume mode:
+ * `leaf` continues, from the checkpoint `entry` names.
+ *
+ * CHAIN REWIND (user decision 2026-08-08), and the whole point of taking an
+ * ENTRY rather than a bare (job, step) pair: the two records in a rewind answer
+ * different questions, and collapsing them is what produced the fork bug.
+ *
+ *   `leaf` is the run being continued — the row the user clicked. It becomes
+ *   `resume_from_job_id`, the lineage edge, so the chain grows
+ *   parent -> leaf -> new run and stays linear however far back the user
+ *   reached. Its config is what prefills the form, because the new run is the
+ *   next attempt at THIS run, not at its ancestor.
+ *
+ *   `entry.job` is the run that OWNS the chosen checkpoint, which on a rewind
+ *   is an ancestor. It travels as `checkpointJobId` — provenance only — so the
+ *   backend knows whose storage to read the bytes from. jobs.py refuses an
+ *   owner that is not on the leaf's ancestor path or does not hold the step.
+ *
+ * This used to be called with the OWNER as `job`, which made an ancestor's
+ * checkpoint start a continuation OF THE ANCESTOR — a second child, i.e. a
+ * fork. The list of offered checkpoints was never the problem; the edge was.
+ *
+ * The runner still follows the OWNER, not the leaf: it says where the bytes
+ * live, which is what decides whether they must be moved before a trainer can
+ * read them (F7) and what the form defaults Compute to.
  *
  * THE one place a resume seed is assembled. Both entry points call it — the
  * job card's step-selectable Resume and the jobs library's row-level
@@ -294,46 +302,66 @@ export function noResumeReason(
  * holds it as `job.config` (the persisted TrainingRequest), so this needs no
  * extra fetch and no reading of the checkpoint's train_config.json.
  *
- * The runner is derived from the job, not passed in. `ResumeSeed.runner` is
- * the runner the PARENT ran on — F7 lets the continuation cross to the other
- * one, and the form needs the parent's side to know whether continuing on the
- * cloud has to upload a local checkpoint first. That fact lives on the record,
- * and both call sites already gate their buttons on `job.runner`, so a caller
- * supplying it could only ever disagree by mistake; which runner the
- * continuation actually launches on stays the form's choice. `imported`
- * records are not resumable and never reach here; they map to "local" for
- * exhaustiveness.
+ * `imported` records are not resumable and never reach here; they map to
+ * "local" for exhaustiveness.
  *
- * Scope note: this fills exactly the fields `ResumeSeed` declares today. That
- * used to stop at identity, dataset, policy, the step budget, the log/save
- * cadence and the runner/flavor — the timeout and hyperparameters were left out
- * because the seed type had nowhere to put them. `main` has since widened the
- * type (NEW-12), so they are carried here now; leaving them out would have
- * quietly regressed a shipped fix the moment the two branches met. Two of them
- * matter for different reasons: `hfJobTimeout` changes what the continuation
- * gets (omitted, the form renders blank and the runner resolves its own
- * default, capping a run already known to need longer), while the
- * hyperparameters do not change what trains — lerobot rebuilds those from the
- * checkpoint's train_config.json — but keep the form from displaying fresh-run
- * defaults for a continuation, and keep the new record's persisted config
- * truthful about the run's shape.
+ * Scope note — which of the two records each field is read from, since the
+ * seed draws on both. Everything describing THE RUN BEING CONTINUED comes from
+ * the leaf: identity, dataset, policy, the step budget, the log/save cadence,
+ * the hyperparameters. Everything describing THE COMPUTE IT WILL BE RENTED
+ * comes from the checkpoint's OWNER, following the runner above — `flavor` and
+ * `hfJobTimeout`, both gated on that owner-derived runner. Provenance
+ * (`checkpointJobId`) is the owner by definition.
+ *
+ * Sourcing the timeout from the leaf instead would blank it in precisely the
+ * cross-runner case the reach exists for. TrainingConfigurator submits
+ * `hf_job_timeout` only when the target runner is `hf_cloud`, so a leaf that
+ * trained LOCALLY structurally has none to give — while the gate here, keyed
+ * on the OWNER's runner, passes anyway because the ancestor holding the bytes
+ * is a cloud run. The form would render the field empty and the continuation
+ * would silently take `resolve_job_timeout`'s 24h fallback instead of the
+ * ancestor's configured timeout, which is the regression NEW-12 was written to
+ * prevent. `flavor` has been owner-sourced all along, under identical gating.
+ *
+ * The seed used to stop short of the timeout and hyperparameters, because the
+ * seed type had nowhere to put them. `main` has since widened the type
+ * (NEW-12), so they are carried here now; leaving them out would have quietly
+ * regressed a shipped fix the moment the two branches met. Two of them matter
+ * for different reasons: `hfJobTimeout` changes what the continuation gets
+ * (omitted, the form renders blank and the runner resolves its own default,
+ * capping a run already known to need longer), while the hyperparameters do
+ * not change what trains — lerobot rebuilds those from the checkpoint's
+ * train_config.json — but keep the form from displaying fresh-run defaults for
+ * a continuation, and keep the new record's persisted config truthful about
+ * the run's shape.
  */
-export function buildResumeSeed(job: JobRecord, step: number): ResumeSeed {
-  const parent = job.config;
-  const runner = job.runner === "hf_cloud" ? "hf_cloud" : "local";
+export function buildResumeSeed(
+  leaf: JobRecord,
+  entry: LineageCheckpoint,
+): ResumeSeed {
+  const owner = entry.job;
+  const step = entry.ckpt.step;
+  const parent = leaf.config;
+  const runner = owner.runner === "hf_cloud" ? "hf_cloud" : "local";
   return {
-    jobId: job.id,
+    jobId: leaf.id,
     step,
-    name: jobDisplayName(job),
+    // Provenance, omitted on a plain tip-resume so the request stays exactly
+    // the shape it was before rewind existed (the backend reads absent as
+    // "the leaf owns it").
+    checkpointJobId: owner.id === leaf.id ? undefined : owner.id,
+    name: jobDisplayName(leaf),
     datasetRepoId: parent.dataset_repo_id,
     policyType: parent.policy_type,
     sourceSteps: parent.steps,
     logFreq: parent.log_freq,
     saveFreq: parent.save_freq,
     runner,
-    flavor: runner === "hf_cloud" ? (job.hf_flavor ?? undefined) : undefined,
+    flavor: runner === "hf_cloud" ? (owner.hf_flavor ?? undefined) : undefined,
     hfJobTimeout:
-      runner === "hf_cloud" ? (parent.hf_job_timeout ?? undefined) : undefined,
+      runner === "hf_cloud"
+        ? (owner.config.hf_job_timeout ?? undefined)
+        : undefined,
     batchSize: parent.batch_size,
     seed: parent.seed,
     numWorkers: parent.num_workers,

--- a/frontend/src/components/jobs/resumeSeed.ts
+++ b/frontend/src/components/jobs/resumeSeed.ts
@@ -1,29 +1,212 @@
 import { JobRecord, jobDisplayName } from "@/lib/jobsApi";
-import type { JobCheckpoint } from "@/lib/checkpointsApi";
+import type { Fetcher } from "@/lib/apiClient";
+import {
+  JobCheckpoint,
+  dedupeCheckpointEntries,
+  listJobCheckpoints,
+} from "@/lib/checkpointsApi";
+// The panel rework's seeds.ts is not part of this branch; ResumeSeed keeps its
+// original home on TrainingConfigurator.
 import type { ResumeSeed } from "@/components/training/TrainingConfigurator";
 
-/** The step a "resume from the newest checkpoint" entry point should use, or
- * null when the run saved nothing.
+/** One checkpoint together with the run that owns it. Ownership is what a
+ * resume needs: the seed's `resume_from_job_id` must name the run the backend
+ * should resolve the checkpoint out of, which on a lineage is often an
+ * ANCESTOR of the run whose row was clicked. */
+export interface LineageCheckpoint {
+  job: JobRecord;
+  ckpt: JobCheckpoint;
+}
+
+/** Load the checkpoints reachable from `leaf`, walking its OWN ancestor path:
+ * the leaf's own list first, then each ancestor's, nearest first.
  *
- * Explicitly a MAX over the steps rather than `cks[cks.length - 1]`: the
- * backend happens to list ascending, but two callers relying on that unstated
- * order is how the row-level quick-resume and the card's Continue drifted
- * apart in the first place. Reading the max is order-independent and identical
- * to the old tail-read on an ascending list, so this is a hardening, not a
- * behaviour change.
+ * Both resume entry points (the library row's one-click and the card's
+ * step-picker) read this one list, so they can't offer different checkpoints
+ * for the same run. Sorted newest-step-first, then deduped by `ref` — with
+ * lineage order preserved for equal refs, the surviving entry of a duplicate
+ * pair is attributed to the NEAREST run in the chain.
  *
- * Note this deliberately does NOT honour CheckpointDropdown's step-0-means-
- * "latest" sentinel (an imported single-model checkpoint, which lerobot never
- * writes at step 0). That sentinel exists for *display and inference*; there is
- * no optimizer state to resume from at step 0, so a mixed list must resume from
- * its highest real step, not from the sentinel. A list holding only the
- * sentinel still yields 0, which the callers' own "already reached its
- * target" / resume gates handle. */
-export function latestResumableStep(
-  checkpoints: JobCheckpoint[],
-): number | null {
-  if (checkpoints.length === 0) return null;
-  return checkpoints.reduce((best, c) => (c.step > best ? c.step : best), -1);
+ * The dedupe is not cosmetic: a cloud resume reuses its parent's Hub output
+ * repo, so every run in a cloud chain enumerates the same shared tree and each
+ * inherited step would otherwise appear once per run.
+ *
+ * KNOWN LIMIT, cloud only: because that Hub repo is shared by the WHOLE tree,
+ * a checkpoint written by a FORKED SIBLING is in the listing too, and there is
+ * nothing in it to attribute a step to the run that wrote it — so an ancestor
+ * walk can't exclude a sibling's checkpoint the way it excludes an unrelated
+ * run's. Local runs have no such ambiguity (each owns its output dir).
+ * `resumableCheckpoints` narrows this for the resume path with a step cap
+ * (see `cloudSiblingStepCap`); what remains after it is a sibling that forked
+ * EARLY, whose checkpoints fall inside the leaf's own step range. True per-run
+ * attribution of Hub checkpoints is a backend/identity change.
+ *
+ * A per-job failure yields no entries rather than rejecting: one unreachable
+ * ancestor must not blank the checkpoints the rest of the chain does have. */
+export async function loadLineageCheckpoints(
+  baseUrl: string,
+  fetcher: Fetcher,
+  leaf: JobRecord,
+  ancestors: JobRecord[],
+): Promise<LineageCheckpoint[]> {
+  const chain = [leaf, ...ancestors].filter((j) => j.checkpoint_count > 0);
+  if (chain.length === 0) return [];
+  const results = await Promise.all(
+    chain.map((job) =>
+      listJobCheckpoints(baseUrl, fetcher, job.id)
+        .then((cks) => cks.map((ckpt) => ({ job, ckpt })))
+        .catch(() => [] as LineageCheckpoint[]),
+    ),
+  );
+  return dedupeCheckpointEntries(
+    results.flat().sort((a, b) => b.ckpt.step - a.ckpt.step),
+  );
+}
+
+/** Whether a run is in a state a resume can continue from.
+ *
+ * Asked of the LEAF — the tip of a resume chain, which is the only thing the
+ * jobs list renders a row for. A leaf that is `running` has nothing to
+ * continue yet; a `done` one reached its target, and resuming it would restore
+ * an LR schedule that is already spent (SmolVLA's preset cosine-decays to a
+ * 2.5e-6 floor over a fixed horizon, so the continuation trains at floor LR
+ * while its loss curve flattens and reads as convergence). Fine-tune is the
+ * intended way to build on a finished run. `imported` records have no run to
+ * continue at all. The backend enforces the same refusals — this is the UI
+ * half, so the button is absent rather than erroring on click. */
+export function isResumableLeaf(job: JobRecord): boolean {
+  return (
+    (job.runner === "local" || job.runner === "hf_cloud") &&
+    (job.state === "failed" || job.state === "interrupted")
+  );
+}
+
+/** The highest checkpoint step a CLOUD leaf can prove lies on its own path, or
+ * null when no cap applies (a local leaf, or one that never reported a step).
+ *
+ * A cloud chain publishes to ONE shared Hub repo, so its listing also holds
+ * whatever a forked SIBLING wrote, and a checkpoint carries nothing that names
+ * the run that wrote it. One thing is still provable without that attribution:
+ * the leaf never trained past its own furthest step, so a checkpoint STRICTLY
+ * ABOVE that step cannot lie on the leaf's path and must belong to a sibling
+ * (or a sibling's descendant). Capping there excludes exactly the
+ * provably-foreign steps. The live example is exactly this shape: two children
+ * forked off one parent, the sibling ran to the shared 30k target, and its
+ * checkpoints were being offered as "the newest checkpoint" to a leaf that
+ * died at 6k.
+ *
+ * It narrows the known limit rather than closing it — a sibling that forked
+ * EARLY wrote its checkpoints inside the leaf's own step range, where nothing
+ * here can tell them apart. Per-run attribution of Hub checkpoints is a
+ * backend/identity change, not something this call site can fix.
+ *
+ * POST-F7 GAP, deliberately left as-is here: the contaminating listing belongs
+ * to the checkpoint's OWNER, not to the leaf, and a LOCAL leaf resumed from a
+ * cloud parent now enumerates that parent's shared Hub repo too — so it can be
+ * offered a forked sibling's checkpoint with no cap applied. Re-keying this on
+ * the owner (`entry.job.runner === "hf_cloud"`) rather than on the leaf would
+ * close that, and would change nothing for a pure-local or pure-cloud chain;
+ * it is left for review rather than changed in passing, because it also
+ * decides whether an ancestor's checkpoints ABOVE the leaf's inherited step
+ * stay offered. On the live cross-runner example both keyings agree.
+ * REVIEWED and deliberately kept leaf-keyed: owner-keying would hide a
+ * superseded ancestor's above-step checkpoints, which have no other access
+ * point in the UI — a real loss, traded against a sibling case that is both
+ * rarer and recoverable, and the simpler rule is the one a novice can predict.
+ *
+ * `metrics.current_step` is the right reading, and not merely "how far it got
+ * before dying": a resumed run's metrics are SEEDED at the checkpoint step it
+ * resumed from (jobs.py `_initial_metrics`), so even a leaf that died before
+ * its first tqdm frame reports a step at or above its inherited floor — which
+ * is what keeps this cap from excluding the ANCESTOR checkpoints the leaf is
+ * most often resumed from. A 0 means nothing was ever reported (no resume
+ * floor, no log line), i.e. unknown rather than "step zero", so no cap. */
+function cloudSiblingStepCap(leaf: JobRecord): number | null {
+  if (leaf.runner !== "hf_cloud") return null;
+  const furthest = leaf.metrics?.current_step ?? 0;
+  return furthest > 0 ? furthest : null;
+}
+
+/** The checkpoints `leaf` may actually be resumed from, newest-step-first.
+ *
+ * THE one resume rule. Both entry points call it, so the row's Resume button
+ * and the card's can no longer disagree about whether a run is resumable:
+ *
+ *  - the leaf must be in a resumable state (above);
+ *  - the checkpoint must sit strictly below the leaf's step target, or the
+ *    continuation would start at (or past) the finish line. A target of 0
+ *    means "unset", so nothing is excluded;
+ *  - on a CLOUD leaf, the checkpoint must also sit at or below the leaf's own
+ *    furthest step — above that it provably belongs to a sibling sharing the
+ *    Hub repo (see `cloudSiblingStepCap`);
+ *  - the checkpoint's OWNER must not be `done` — the backend refuses a
+ *    finished run as a resume source, so offering one only buys a 400.
+ *
+ * What is deliberately NOT a rule: the owner sharing the leaf's runner. A
+ * continuation may cross runners in EITHER direction (F7) — jobs.py
+ * materializes a cloud parent's Hub checkpoint onto this disk for a
+ * cloud→local one, and uploads a local parent's to the Hub, with consent, for
+ * a local→cloud one. So the owner's runner decides only where the checkpoint
+ * has to be MOVED before the trainer can read it, and becomes the Train form's
+ * DEFAULT Compute (which stays editable — see ComputePane). Filtering on it
+ * hid every checkpoint from a local leaf whose parent ran on the cloud,
+ * leaving that card with no resume row at all while the library row still
+ * offered a resume it then refused.
+ */
+export function resumableCheckpoints(
+  leaf: JobRecord,
+  lineage: LineageCheckpoint[],
+): LineageCheckpoint[] {
+  if (!isResumableLeaf(leaf)) return [];
+  const target = leaf.config?.steps ?? 0;
+  const cap = cloudSiblingStepCap(leaf);
+  return lineage
+    .filter(
+      (entry) =>
+        entry.job.state !== "done" &&
+        (target === 0 || entry.ckpt.step < target) &&
+        (cap === null || entry.ckpt.step <= cap),
+    )
+    .sort((a, b) => b.ckpt.step - a.ckpt.step);
+}
+
+/** Which rule above emptied the list — for the one caller that has to explain
+ * an empty result to the user instead of just hiding a button.
+ *
+ * Lives here, beside the rule, because the alternative is a caller
+ * re-implementing the filters to guess at the cause, which is how the toast
+ * came to blame the step target for an exclusion the runner filter had made:
+ * the run's checkpoints sat BELOW its target, and the message said the
+ * opposite. The filters are applied in the same order as above, and the first
+ * one to empty a non-empty set is the answer. */
+export type NoResumeReason =
+  | "not-resumable" // the leaf's own state — no run to continue
+  | "no-checkpoints" // nothing saved anywhere in the lineage
+  | "owner-done" // every candidate belongs to a finished run
+  | "at-target" // every candidate is at or past the leaf's step target
+  | "sibling-cap" // cloud: every candidate is above the leaf's own furthest step
+  | "other";
+
+export function noResumeReason(
+  leaf: JobRecord,
+  lineage: LineageCheckpoint[],
+): NoResumeReason {
+  if (!isResumableLeaf(leaf)) return "not-resumable";
+  if (lineage.length === 0) return "no-checkpoints";
+  const live = lineage.filter((entry) => entry.job.state !== "done");
+  if (live.length === 0) return "owner-done";
+  const target = leaf.config?.steps ?? 0;
+  const belowTarget = live.filter(
+    (entry) => target === 0 || entry.ckpt.step < target,
+  );
+  if (belowTarget.length === 0) return "at-target";
+  const cap = cloudSiblingStepCap(leaf);
+  if (cap !== null && belowTarget.every((entry) => entry.ckpt.step > cap))
+    return "sibling-cap";
+  // Unreachable while this mirrors `resumableCheckpoints` — a non-empty set
+  // surviving every filter means the caller had a checkpoint to offer. Kept as
+  // a total answer rather than a throw: a wrong-but-vague toast beats a crash.
+  return "other";
 }
 
 /**
@@ -31,8 +214,8 @@ export function latestResumableStep(
  * `job` continuing from `step`.
  *
  * THE one place a resume seed is assembled. Both entry points call it — the
- * job card's step-selectable Continue / Resume-cloud and the jobs library's
- * row-level quick-resume — because they previously built the same payload
+ * job card's step-selectable Resume and the jobs library's row-level
+ * quick-resume — because they previously built the same payload
  * independently, which is exactly the shape of duplication that drifts.
  *
  * Carries the parent run's configured shape forward. The registry already

--- a/frontend/src/components/studio/TrainPanel.tsx
+++ b/frontend/src/components/studio/TrainPanel.tsx
@@ -263,11 +263,16 @@ const TrainPanel: React.FC = () => {
           setFinetuneSeed(null);
           return;
         }
+        // Carry the chosen checkpoint's own storage side along with its step:
+        // a "local" one exists only on this machine, so fine-tuning it on the
+        // cloud has to upload it first and the form has to say so.
+        const chosen = cks.find((c) => c.step === latest);
         setFinetuneSeed({
           jobId,
           step: latest,
           name: name ?? jobId,
           policyType: policy ?? "act",
+          checkpointSource: chosen?.source,
         });
         if (policy) setPolicyType(policy);
       } catch (e) {

--- a/frontend/src/components/studio/TrainPanel.tsx
+++ b/frontend/src/components/studio/TrainPanel.tsx
@@ -606,9 +606,25 @@ const TrainPanel: React.FC = () => {
                 Keyed on both seeds (same composite the /training route uses):
                 switching between runs — or between resuming and fine-tuning —
                 must rebuild the form, since the seeds are read once as initial
-                state. Both null ⇒ a stable fresh key. */}
+                state. Both null ⇒ a stable fresh key.
+
+                The key carries the whole seed identity — run, step and (for a
+                resume) the checkpoint's owner — not just the run id. The jobs
+                library stays expandable while the form is open, so a second
+                Continue / Fine-tune on the same run is reachable, and only the
+                banner and the step validation read the seed live: everything
+                derived at mount (resume_from_step, the checkpoint owner, steps,
+                the optimizer/W&B prefills, the compute default) would stay
+                frozen at the first press. That shipped a request continuing
+                from the first checkpoint under a banner naming the second —
+                which the backend cannot catch, both being internally valid.
+                Resume no longer offers a step choice, so the resume half is
+                belt-and-braces; the fine-tune half is live, since ModelCard's
+                history selector really can re-fire at a different step. */}
             <TrainingConfigurator
-              key={`${resumeSeed?.jobId ?? ""}::${finetuneSeed?.jobId ?? "fresh"}`}
+              key={`${resumeSeed?.jobId ?? ""}@${resumeSeed?.step ?? ""}@${
+                resumeSeed?.checkpointJobId ?? ""
+              }::${finetuneSeed?.jobId ?? "fresh"}@${finetuneSeed?.step ?? ""}`}
               policyType={policyType}
               onPolicyTypeChange={setPolicyType}
               datasetRepoId={trainingDatasetRepoId}

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -36,8 +36,15 @@ import { getDatasetInfo } from "@/lib/replayApi";
 // Passed by the "Continue" button on a completed local job, or the "Resume"
 // button on a cloud run that ended before its step target.
 export type ResumeSeed = {
+  // The run being CONTINUED — the lineage edge. Always the leaf the user
+  // clicked, never the checkpoint's owner, so chains stay linear (see
+  // buildResumeSeed).
   jobId: string;
   step: number | null; // null ⇒ resume from the latest checkpoint
+  // CHAIN REWIND provenance: the ancestor whose storage holds the chosen
+  // checkpoint, when it isn't the leaf's own. Undefined ⇒ the leaf owns it.
+  // Never the edge — only where the bytes are read from.
+  checkpointJobId?: string;
   name: string;
   datasetRepoId: string;
   policyType: string;
@@ -83,7 +90,21 @@ export type FinetuneSeed = {
   step: number | null; // null ⇒ latest checkpoint of the source
   name: string;
   policyType: string;
+  // Where the CHOSEN checkpoint's bytes live — the checkpoint's own `source`
+  // field, straight from the job's checkpoint listing. It is exactly the fact
+  // the backend keys on: a "local" checkpoint resolves to an absolute path on
+  // this machine, which a pod cannot read, so fine-tuning it on the cloud has
+  // to stage its weights to the Hub first (and asks for that consent).
+  // Undefined ⇒ unknown (a stale deep-link seed built before this field), which
+  // shows no notice and leaves the backend's 400 as the backstop.
+  checkpointSource?: "local" | "hub";
 };
+
+/** Which local→cloud transfer a launch needs, if any. "resume" moves the whole
+ * checkpoint of the run being continued (weights AND optimizer state);
+ * "finetune" moves only the base checkpoint's weights, since a fine-tune starts
+ * a fresh optimizer and never reads the rest. */
+export type CheckpointUploadKind = "resume" | "finetune" | null;
 
 interface TrainingConfiguratorProps {
   /** Controlled policy type (chosen upstream — the panel policy grid or the
@@ -119,7 +140,7 @@ const defaultUseAmp = (policyType: string): boolean =>
 
 function configToRequest(
   c: TrainingConfig,
-  needsCheckpointUpload: boolean,
+  checkpointUploadKind: CheckpointUploadKind,
 ): TrainingRequest {
   // The backend's TrainingRequest has more optional fields; the form covers
   // the user-meaningful subset.
@@ -138,11 +159,18 @@ function configToRequest(
     resume: c.resume,
     resume_from_job_id: c.resume_from_job_id,
     resume_from_step: c.resume_from_step,
-    // Consent, not a mode: sent only for the one combination that has to push
-    // bytes to the Hub (a local parent continued on cloud compute), and the
-    // backend refuses that combination without it. Left undefined otherwise so
-    // no other launch carries an upload permission it has no use for.
-    upload_resume_checkpoint: needsCheckpointUpload ? true : undefined,
+    resume_from_checkpoint_job_id: c.resume_from_checkpoint_job_id,
+    // Consent, not a mode: sent only for the combinations that have to push
+    // bytes to the Hub (a checkpoint only this machine has, needed by a run on
+    // cloud compute), and the backend refuses those without it. Left undefined
+    // otherwise so no other launch carries an upload permission it has no use
+    // for. One field per MODE rather than one shared flag, because they consent
+    // to different disclosures: the whole checkpoint of the run being continued,
+    // versus the base model's weights.
+    upload_resume_checkpoint:
+      checkpointUploadKind === "resume" ? true : undefined,
+    upload_finetune_checkpoint:
+      checkpointUploadKind === "finetune" ? true : undefined,
     finetune_from_job_id: c.finetune_from_job_id,
     finetune_from_step: c.finetune_from_step,
     wandb_enable: c.wandb_enable,
@@ -246,6 +274,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     resume: !!resumeSeed,
     resume_from_job_id: resumeSeed?.jobId,
     resume_from_step: resumeSeed?.step ?? undefined,
+    resume_from_checkpoint_job_id: resumeSeed?.checkpointJobId,
     finetune_from_job_id: finetuneSeed?.jobId,
     finetune_from_step: finetuneSeed?.step ?? undefined,
     wandb_enable: false,
@@ -396,14 +425,26 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
   const datasetLocalOnly = selectedDatasetItem?.source === "local";
   const needsUpload = isCloud && datasetLocalOnly;
 
-  // A resume whose parent ran locally, retargeted at cloud compute: the pod
-  // can't read this machine's disk, so the parent's checkpoint has to be
-  // uploaded to a private Hub repo before the job is submitted (F7). Derived
-  // from the seed's runner rather than from the config, because the config's
-  // `target` is now the user's live choice — the seed is the only record of
-  // where the parent actually ran.
-  const needsCheckpointUpload =
-    resumeSeed != null && resumeSeed.runner !== "hf_cloud" && isCloud;
+  // A checkpoint this machine alone holds, needed by a run that will happen on
+  // a pod that can't read this disk — so it has to be uploaded to a private Hub
+  // repo before the job is submitted (F7). Two ways in, and which one it is
+  // decides what moves and which consent field carries it:
+  //
+  //   * "resume" — the parent ran locally and the continuation was retargeted
+  //     at the cloud. Derived from the SEED's runner rather than the config,
+  //     because the config's `target` is the user's live choice while the seed
+  //     is the only record of where the parent actually ran.
+  //   * "finetune" — the chosen base checkpoint is a local one. Read off the
+  //     seed's `checkpointSource`, which is the checkpoint's own `source` field
+  //     — exactly what the backend keys on. Undefined (a stale deep-link seed)
+  //     is treated as no-notice; the backend's 400 is the backstop.
+  const checkpointUploadKind: CheckpointUploadKind =
+    resumeSeed != null && resumeSeed.runner !== "hf_cloud" && isCloud
+      ? "resume"
+      : finetuneSeed?.checkpointSource === "local" && isCloud
+        ? "finetune"
+        : null;
+  const needsCheckpointUpload = checkpointUploadKind != null;
 
   // Approximate on-disk size for the notice (cheap detail endpoint; local only).
   const [datasetSizeBytes, setDatasetSizeBytes] = useState<number | null>(null);
@@ -435,7 +476,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
       const job = await startTrainingJob(
         baseUrl,
         fetchWithHeaders,
-        configToRequest(config, needsCheckpointUpload),
+        configToRequest(config, checkpointUploadKind),
       );
       toast({ title: "Training Started", description: job.name });
       onStarted?.(job.id);
@@ -462,7 +503,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     baseUrl,
     fetchWithHeaders,
     config,
-    needsCheckpointUpload,
+    checkpointUploadKind,
     toast,
     navigate,
     location.pathname,
@@ -689,11 +730,21 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
           local run's continuation at the cloud. That direction moves the
           parent's checkpoint to the Hub first, which is a disclosure — hence a
           notice before the click, and a Start button that says "Upload". */}
-      {needsCheckpointUpload && resumeSeed ? (
+      {checkpointUploadKind === "resume" && resumeSeed ? (
         <div className="mt-6">
           <LocalCheckpointCloudNotice
+            mode="resume"
             runName={resumeSeed.name}
             step={resumeSeed.step}
+            offline={offline}
+          />
+        </div>
+      ) : checkpointUploadKind === "finetune" && finetuneSeed ? (
+        <div className="mt-6">
+          <LocalCheckpointCloudNotice
+            mode="finetune"
+            runName={finetuneSeed.name}
+            step={finetuneSeed.step}
             offline={offline}
           />
         </div>
@@ -741,7 +792,13 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
                       ? "Upload & continue training"
                       : "Continue training"
                     : finetuneSeed
-                      ? "Start fine-tuning"
+                      ? // A local base fine-tuned on the cloud has to push its
+                        // weights first, so the button says what the click
+                        // actually does — the same promise the resume branch
+                        // above makes.
+                        needsCheckpointUpload
+                        ? "Upload & start training"
+                        : "Start fine-tuning"
                       : needsUpload
                         ? "Upload & start training"
                         : "Start training"}

--- a/frontend/src/components/training/config/EssentialsCard.tsx
+++ b/frontend/src/components/training/config/EssentialsCard.tsx
@@ -67,6 +67,24 @@ const EssentialsCard: React.FC<ConfigComponentProps> = ({
     }
   };
 
+  // The step this continuation starts FROM, beside the name it continues.
+  // Requested here specifically: the name is what the user recognises the run
+  // by, and the starting step is the one number that says which attempt this
+  // is — the two belong together.
+  //
+  // Training steps (above) is the TARGET; this is the floor. A resume turns on
+  // the gap between them, so neither number means much alone.
+  //
+  // Step 0 is the whole-repo/single-model sentinel, not a real training step
+  // (see CheckpointDropdown) — it and a missing step both read as "latest",
+  // the same word the checkpoint picker uses for it.
+  const resumeStep = config.resume_from_step;
+  const resumedFrom = !resumeLocked
+    ? null
+    : resumeStep
+      ? `from step ${resumeStep.toLocaleString()}`
+      : "from latest checkpoint";
+
   return (
     <section className="space-y-4">
       <div className="grid grid-cols-2 gap-4">
@@ -100,7 +118,14 @@ const EssentialsCard: React.FC<ConfigComponentProps> = ({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="job_name">Run name</Label>
+        <div className="flex items-baseline gap-2">
+          <Label htmlFor="job_name">Run name</Label>
+          {resumedFrom ? (
+            <span className="truncate text-xs font-normal text-muted-foreground">
+              {resumedFrom}
+            </span>
+          ) : null}
+        </div>
         <Input
           id="job_name"
           value={config.job_name || ""}

--- a/frontend/src/components/training/config/LocalCheckpointCloudNotice.tsx
+++ b/frontend/src/components/training/config/LocalCheckpointCloudNotice.tsx
@@ -2,37 +2,45 @@ import React from "react";
 import { AlertTriangle, Lock, UploadCloud, WifiOff } from "lucide-react";
 
 interface LocalCheckpointCloudNoticeProps {
-  /** The run being continued, for a notice that names what moves. */
+  /** Which crossing this is: a local run being CONTINUED on the cloud (the
+   * whole checkpoint moves, weights and optimizer state), or a local base being
+   * FINE-TUNED there (only its weights move — a fine-tune starts a fresh
+   * optimizer and never reads the rest). */
+  mode: "resume" | "finetune";
+  /** The run being continued / the base being fine-tuned, for a notice that
+   * names what moves. */
   runName: string;
-  /** The checkpoint step the continuation resumes from; null ⇒ the latest. */
+  /** The checkpoint step involved; null ⇒ the latest. */
   step: number | null;
   /** Backend is in HF_HUB_OFFLINE mode: nothing can be uploaded, so this
-   * continuation can't run on the cloud at all. */
+   * launch can't run on the cloud at all. */
   offline: boolean;
 }
 
 /**
- * Amber notice shown when a run that trained LOCALLY is being continued on
- * Hugging Face Cloud. The pod resumes from the Hub, so the parent's checkpoint
- * — weights AND optimizer state — has to be uploaded first (F7's local→cloud
- * direction).
+ * Amber notice shown when a run targeting Hugging Face Cloud depends on a
+ * checkpoint that exists only on this machine. The pod reads its checkpoints
+ * from the Hub, so those bytes have to be uploaded first — F7's local→cloud
+ * direction, in both of its modes (see `mode`).
  *
  * The twin of LocalDatasetCloudNotice, and deliberately louder about privacy
  * than its dataset sibling: a dataset upload is public by default because a
- * dataset is a thing people share, while this is an intermediate artifact of
- * someone's own run that the user never asked to publish. It goes to a private
- * repo, and the notice says so before the click rather than after — an upload
- * is a disclosure, so it is never a silent side effect of Continue. The backend
- * enforces the same rule: it refuses this launch unless the request carries the
+ * dataset is a thing people share, while this is an artifact of someone's own
+ * run that the user never asked to publish. It goes to a private repo, and the
+ * notice says so before the click rather than after — an upload is a
+ * disclosure, so it is never a silent side effect of launching. The backend
+ * enforces the same rule: it refuses the launch unless the request carries the
  * consent this notice is asking for.
  */
 const LocalCheckpointCloudNotice: React.FC<LocalCheckpointCloudNoticeProps> = ({
+  mode,
   runName,
   step,
   offline,
 }) => {
   const stepLabel =
     step != null ? `step ${step.toLocaleString()}` : "its latest checkpoint";
+  const isFinetune = mode === "finetune";
 
   if (offline) {
     return (
@@ -44,14 +52,20 @@ const LocalCheckpointCloudNotice: React.FC<LocalCheckpointCloudNoticeProps> = ({
               This checkpoint is only on this machine
             </div>
             <p className="mt-1 text-amber-700/80 dark:text-amber-200/80">
-              Hugging Face Cloud continues from the Hub, but the server is in
-              offline mode (
+              {isFinetune
+                ? "Hugging Face Cloud loads base weights from the Hub"
+                : "Hugging Face Cloud continues from the Hub"}
+              , but the server is in offline mode (
               <code className="text-amber-700 dark:text-amber-100">
                 HF_HUB_OFFLINE
               </code>
               ), so {stepLabel} of{" "}
               <span className="font-medium">{runName}</span> can't be uploaded.
-              Switch off offline mode, or continue this run locally.
+              Switch off offline mode, or{" "}
+              {isFinetune
+                ? "run this fine-tune locally"
+                : "continue this run locally"}
+              .
             </p>
           </div>
         </div>
@@ -67,21 +81,34 @@ const LocalCheckpointCloudNotice: React.FC<LocalCheckpointCloudNoticeProps> = ({
           <div className="font-semibold">
             This checkpoint is only on this machine
           </div>
-          <p className="mt-1 text-amber-700/80 dark:text-amber-200/80">
-            Hugging Face Cloud continues from the Hub, so {stepLabel} of{" "}
-            <span className="font-medium">{runName}</span> — its weights and
-            optimizer state — will be uploaded to a{" "}
-            <span className="font-medium">private</span> repo in your account
-            before the job starts. Continuing the same checkpoint again reuses
-            that upload.
-          </p>
+          {isFinetune ? (
+            <p className="mt-1 text-amber-700/80 dark:text-amber-200/80">
+              Hugging Face Cloud loads base weights from the Hub, so {stepLabel}{" "}
+              of <span className="font-medium">{runName}</span> — its weights,
+              not its optimizer state — will be uploaded to a{" "}
+              <span className="font-medium">private</span> repo in your account
+              before the job starts. Fine-tuning the same checkpoint again
+              reuses that upload.
+            </p>
+          ) : (
+            <p className="mt-1 text-amber-700/80 dark:text-amber-200/80">
+              Hugging Face Cloud continues from the Hub, so {stepLabel} of{" "}
+              <span className="font-medium">{runName}</span> — its weights and
+              optimizer state — will be uploaded to a{" "}
+              <span className="font-medium">private</span> repo in your account
+              before the job starts. Continuing the same checkpoint again reuses
+              that upload.
+            </p>
+          )}
           <p className="mt-2 flex items-center gap-2 text-amber-700/70 dark:text-amber-200/70">
             <Lock className="w-4 h-4" />
             Private to your account — nothing is published.
           </p>
           <p className="mt-1 flex items-center gap-2 text-amber-700/70 dark:text-amber-200/70">
             <UploadCloud className="w-4 h-4" />
-            Use “Upload &amp; continue training” below to upload, then launch.
+            Use “
+            {isFinetune ? "Upload & start training" : "Upload & continue training"}
+            ” below to upload, then launch.
           </p>
         </div>
       </div>

--- a/frontend/src/components/training/types.ts
+++ b/frontend/src/components/training/types.ts
@@ -24,8 +24,12 @@ export interface TrainingConfig {
   // Output configuration
   resume: boolean;
   // Set by the "Continue training" flow (source run + checkpoint step).
+  // `resume_from_job_id` is the LEAF being continued — the lineage edge.
   resume_from_job_id?: string;
   resume_from_step?: number;
+  // Chain rewind: the ancestor whose storage holds that checkpoint, when it is
+  // not the leaf's own. Provenance, not the edge.
+  resume_from_checkpoint_job_id?: string;
   // Set by the "Fine-tune" flow: fresh run initialized from a source
   // checkpoint's weights (resume stays false).
   finetune_from_job_id?: string;

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -96,6 +96,17 @@ export interface JobRecord {
   hf_job_url: string | null;
   wandb_run_url: string | null;
   checkpoint_count: number;
+  // Resume lineage, derived server-side over the WHOLE registry (not just the
+  // page this request returned) — see JobRecord in makermodslab/jobs.py.
+  //
+  // `child_ids`: the runs that resumed this one, newest-first. Empty ⇒ this
+  // record is a LEAF, the live tip of its chain, and the one the libraries
+  // give a row to; anything with children is superseded and reached through
+  // its descendant instead. A fine-tune is NOT a child — it is a new model.
+  // `ancestor_ids`: transitive resume ancestors, nearest parent first, holding
+  // only ids the server still has (so each is fetchable by id).
+  child_ids: string[];
+  ancestor_ids: string[];
 }
 
 // Per-running-job snapshot pushed by the watchdog over WS at ~1Hz. Subset

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -205,7 +205,22 @@ export async function startTrainingJob(
       action: "Start training",
     });
   } catch (e) {
-    if (e instanceof ApiError && e.status === 409) {
+    // The local-run mutex is the 409 this rewrite exists for: the backend's
+    // own text there is "Job already running: <repr>", which is not a sentence
+    // to show a user. It is NOT the only 409 this endpoint can return, and
+    // blanket-rewriting every one of them swallowed messages that were the
+    // whole point of the refusal — a cloud run on a local-only dataset
+    // (upload it first), and a second continuation of an already-continued run
+    // (delete the existing one first, naming it). Both of those tell the user
+    // what to do next; "another training is already running" tells them
+    // something that isn't true. So substitute only for the mutex, and pass
+    // every other refusal's `detail` through verbatim (apiRequest already puts
+    // it in the message).
+    if (
+      e instanceof ApiError &&
+      e.status === 409 &&
+      (e.detail ?? "").startsWith("Job already running")
+    ) {
       throw new Error("Another training is already running. Stop it first.");
     }
     throw e;

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -42,12 +42,21 @@ export interface TrainingRequest {
   // resume from. The backend resolves these into the checkpoint's config_path.
   resume_from_job_id?: string;
   resume_from_step?: number;
+  // CHAIN REWIND: which run's storage holds the chosen checkpoint, when the
+  // user rewound to an ancestor's rather than the leaf's own. `resume_from_job_id`
+  // stays the lineage edge (always the leaf); this is provenance only. Absent ⇒
+  // the leaf owns the checkpoint. See makermodslab/train.py for why it can't be
+  // derived from the step.
+  resume_from_checkpoint_job_id?: string;
   // Consent for the one resume shape that has to publish something: continuing
   // a LOCAL run on cloud compute uploads its checkpoint to a private Hub repo
   // first, because the pod can't read this machine's disk (F7). The backend
   // refuses that combination unless this is true, so it can never be a silent
   // side effect of Continue.
   upload_resume_checkpoint?: boolean;
+  // The fine-tune twin of the consent above: a base checkpoint that lives only
+  // on this machine, fine-tuned on cloud compute. Only its WEIGHTS are staged.
+  upload_finetune_checkpoint?: boolean;
   // Set by the "Fine-tune" flow: start a fresh run whose weights are init'd
   // from an imported/existing checkpoint. The backend resolves these into
   // policy_pretrained_path (which it also accepts directly).
@@ -77,6 +86,15 @@ export interface TrainingRequest {
 
 export interface JobRecord {
   id: string;
+  // Short, stable, human-facing run number ("#46"), assigned once at creation
+  // from a persisted registry counter and never reused — see JobRecord in
+  // makermodslab/jobs.py. THE distinguisher between runs in the UI: the id is
+  // unique but unspeakable, and a display name is shared by every run on a
+  // resume chain (a continuation continues the same model).
+  //
+  // 0 ⇒ unassigned, only possible for a record read before the backend
+  // backfilled it. Render nothing rather than "#0".
+  job_number: number;
   name: string;
   // User-set display alias (rename is metadata-only; the id / output dir /
   // hub repo id never change). Null/absent ⇒ show `name`.

--- a/frontend/src/lib/mockHub.ts
+++ b/frontend/src/lib/mockHub.ts
@@ -114,6 +114,8 @@ const job = (j: Partial<JobRecord> & Pick<JobRecord, "id" | "name">): JobRecord 
   hf_job_url: null,
   wandb_run_url: null,
   checkpoint_count: 0,
+  child_ids: [],
+  ancestor_ids: [],
   ...j,
 });
 

--- a/frontend/src/lib/mockHub.ts
+++ b/frontend/src/lib/mockHub.ts
@@ -97,7 +97,13 @@ const metrics = (current: number, total: number, loss = 0.042) => ({
   eta_seconds: total > current ? (total - current) * 0.4 : null,
 });
 
+// Mirrors the backend's persisted counter closely enough for the mock to look
+// real: every job gets its own number, in declaration order, and none repeats.
+// Overridable per entry via the spread below.
+let mockJobNumber = 0;
+
 const job = (j: Partial<JobRecord> & Pick<JobRecord, "id" | "name">): JobRecord => ({
+  job_number: ++mockJobNumber,
   display_name: null,
   state: "done",
   config: cfg(`${USER}/sock_2_only_merged`, "act", 10_000),

--- a/frontend/src/lib/modelNames.ts
+++ b/frontend/src/lib/modelNames.ts
@@ -31,6 +31,46 @@ export function middleEllipsis(text: string, max = 32): string {
 }
 
 /**
+ * The part of a job id that tells two runs apart: its run timestamp.
+ *
+ * Needed because a display NAME does not tell two runs apart within a resume
+ * chain, and cannot: a continuation continues the same model, so every run on
+ * the chain carries the same name by design. Anywhere the UI attributes
+ * something to its owning run inside a lineage — the checkpoint dropdown, the
+ * card hints — the name alone renders identical text for different runs.
+ *
+ * The id is where the difference lives. `_named_job_id` / `_generate_job_id`
+ * (makermodslab/jobs.py) both end in `_%Y-%m-%d_%H-%M-%S`, optionally followed
+ * by the `-2`, `-3`, … guard against two runs created in the same second. That
+ * tail is returned VERBATIM rather than reformatted into something prettier:
+ * it has to stay a literal substring of the id, so what the user reads here
+ * matches what the backend's refusals print (`'alias' (id)`) and what they can
+ * search the list for. Prettifying it would break that correspondence for a
+ * few saved characters.
+ *
+ * Returns null when the id has no such tail — an imported record, or an id
+ * some other tool wrote — so callers can fall back rather than render a
+ * confident-looking lie.
+ */
+const JOB_ID_STAMP_RE = /_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}(?:-\d+)?)$/;
+
+export function jobIdStamp(jobId: string): string | null {
+  return JOB_ID_STAMP_RE.exec(jobId)?.[1] ?? null;
+}
+
+/**
+ * How a run is named when it has to be told apart from its own chain: the
+ * display name plus the id's distinguishing tail.
+ *
+ * Falls back to a middle-ellipsized id when there is no timestamp tail to
+ * quote — middle, not end, for the usual reason (see `middleEllipsis`): an
+ * id's tail is the half that identifies it.
+ */
+export function jobRunStamp(jobId: string): string {
+  return jobIdStamp(jobId) ?? middleEllipsis(jobId, 24);
+}
+
+/**
  * A trailing " (…)" the backend appended to break a name collision.
  *
  * `dedupe_display_names` (makermodslab/utils/naming.py) resolves two rows that

--- a/frontend/src/pages/Training.tsx
+++ b/frontend/src/pages/Training.tsx
@@ -70,7 +70,14 @@ const ConfigurationMode: React.FC = () => {
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto max-w-3xl px-4 py-6">
         <TrainingConfigurator
-          key={`${resumeSource?.jobId ?? ""}::${finetuneSource?.jobId ?? ""}`}
+          // Same composite the studio's Train panel keys on: the seeds are read
+          // once as initial state, so the step (and a resume's checkpoint
+          // owner) has to be in the key too — a second seed for the same run
+          // would otherwise update the banner and the step validation while the
+          // payload kept the first pick.
+          key={`${resumeSource?.jobId ?? ""}@${resumeSource?.step ?? ""}@${
+            resumeSource?.checkpointJobId ?? ""
+          }::${finetuneSource?.jobId ?? ""}@${finetuneSource?.step ?? ""}`}
           policyType={policyType}
           onPolicyTypeChange={setPolicyType}
           datasetRepoId={datasetRepoId}

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -124,9 +124,18 @@ class JobRecord(BaseModel):
     #
     # `child_ids`: the runs that resumed THIS one, newest-first. Empty ⇒ this
     # record is a LEAF, i.e. the live tip of its chain; the UI shows one row per
-    # leaf and reaches the rest of the chain through `ancestor_ids`. A job can
-    # have several children (nothing stops two resumes off one parent), so the
-    # lineage is a forest of trees, not a set of chains.
+    # leaf and reaches the rest of the chain through `ancestor_ids`.
+    #
+    # STICKS ONLY (user decision 2026-08-07). New lineages are CHAINS: `start`
+    # refuses a resume whose source already has a child
+    # (`JobAlreadyContinuedError`), so a run created from here on can gain at
+    # most one child and every fresh lineage is linear. The field stays a LIST,
+    # and every reader below stays forest-capable, because branching is deferred
+    # rather than abolished: registries written before this rule really do hold
+    # forks (the live example is two children off one parent), and they must
+    # keep loading, listing and rendering exactly as they did — one row per
+    # leaf, no migration, no refusal at read time. Treat "several children" as
+    # legacy-only data, not as an impossible state.
     #
     # `ancestor_ids`: the transitive resume ancestors, nearest parent first.
     #
@@ -2380,7 +2389,10 @@ def _oom_failure_reason(log_path: Path, rc: int | None) -> str | None:
 def build_child_index(records: Iterable[JobRecord]) -> dict[str, list[str]]:
     """Map job id -> the ids of the runs that resumed it, newest-first.
 
-    The one place the resume forest's edges are defined. An edge is
+    The one place a resume edge is defined, for every reader: the leaf/
+    superseded split, the mid-chain delete guard (`JobHasChildrenError`) and
+    the second-resume guard (`JobAlreadyContinuedError`) all ask this same
+    question, so "is this run continued?" cannot mean two things. An edge is
     `config.resume_from_job_id` and nothing else — a fine-tune
     (`finetune_from_job_id`) starts a fresh schedule from a checkpoint's
     weights, so it is a new model whose source keeps its own identity, not a
@@ -2457,6 +2469,34 @@ class JobHasChildrenError(Exception):
     the descendants so the user can delete from the tip inwards.
 
     Carries the direct child ids; the HTTP layer turns them into the message.
+    """
+
+    def __init__(self, job_id: str, child_ids: builtins.list[str]) -> None:
+        super().__init__(job_id)
+        self.job_id = job_id
+        self.child_ids = child_ids
+
+
+class JobAlreadyContinuedError(Exception):
+    """Raised when start() is asked to resume a run that already has a child.
+
+    STICKS ONLY (user decision 2026-08-07): a resume lineage is a chain, so a
+    run may be continued ONCE. A second continuation would fork it, and a fork
+    is the shape every other part of this feature has to pay for — two rows
+    claiming the same history, a shared cloud output repo whose checkpoints
+    can't be attributed to the sibling that wrote them (see the frontend's
+    `cloudSiblingStepCap`), and a delete guard that can only say "not this one"
+    without saying which tip to start from. Refusing at CREATION time is the
+    cheap end of that trade: no new fork can appear, while the forks already on
+    disk keep working untouched (this is not a load-time or list-time check).
+
+    The intended path is in the message the HTTP layer builds from these ids:
+    delete the existing continuation, which frees its parent to be resumed
+    again. Branching is deferred, not ruled out for good.
+
+    Carries the source run's id and its direct child ids, same shape as
+    `JobHasChildrenError`, because the two are the same fact seen from the two
+    ends — one refuses removing the parent, the other refuses re-continuing it.
     """
 
     def __init__(self, job_id: str, child_ids: builtins.list[str]) -> None:
@@ -2839,6 +2879,26 @@ class JobRegistry:
                             "continuation would train at the schedule's floor. Fine-tune from "
                             "its final checkpoint instead."
                         )
+                    # STICKS ONLY (user decision 2026-08-07): one continuation
+                    # per run. A source that already has a child would FORK
+                    # here, so refuse and let the message name the delete-first
+                    # path (see JobAlreadyContinuedError for the why).
+                    #
+                    # Derived from the registry at start time, under the same
+                    # lock that inserts the record, so two concurrent resumes of
+                    # one parent can't both pass — and derived by
+                    # `build_child_index`, the same edge definition the delete
+                    # guard and the leaf/superseded split use, so the run the UI
+                    # calls "already continued" is exactly the run refused here.
+                    #
+                    # Deliberately AFTER the `done` refusal above: a finished
+                    # source is unresumable whether or not anything continued
+                    # it, and telling the user to delete a child to unlock a
+                    # resume that would then be refused for a different reason
+                    # is worse guidance than "fine-tune instead".
+                    already_continued = build_child_index(self._records.values()).get(source.id, [])
+                    if already_continued:
+                        raise JobAlreadyContinuedError(source.id, already_continued)
                     # A resume may continue on EITHER runner (F7). What changes
                     # across the four combinations is only where the parent's
                     # checkpoint has to end up before the trainer can read it —
@@ -2907,6 +2967,42 @@ class JobRegistry:
                         "Resume is on but no source checkpoint was selected. Use "
                         '"Continue" on a local run that stopped short of its step '
                         "target rather than toggling resume manually."
+                    )
+
+                # A continuation has to have somewhere to go: the target must be
+                # strictly ABOVE the step being resumed from. At or below it,
+                # lerobot's training range is empty (lerobot_train.py's
+                # `range(step, cfg.steps)`), so the run does no work, exits
+                # cleanly, and lands in the registry as a `done` phantom that
+                # claims a target it never trained toward — the worst shape
+                # available, because it also poisons the source: `done` is
+                # exactly what the refusal above reads to say "nothing to
+                # resume".
+                #
+                # Deliberately HERE, at the bottom of the resume block, not
+                # beside its siblings at the top: the step is only known once
+                # the branches above have RESOLVED it. The equivalent
+                # pre-flight in server.py's endpoint reads the request's
+                # `resume_from_step`, which is None whenever the user picked
+                # "latest" — so every latest-checkpoint resume walked past it.
+                # `_resume_start_step` is the same reading `_initial_metrics`
+                # seeds progress from, so the number refused here is the number
+                # the record would have started at.
+                #
+                # No "unset" escape for `steps == 0`, even though a stored
+                # `steps` of 0 does mean "unknown" elsewhere (the frontend's
+                # resumableCheckpoints reads a PARENT record's target that way).
+                # This is the incoming request's own target — a required field
+                # with a default — so 0 here is a request to train nothing, the
+                # very case this refuses, and the endpoint's pre-flight has
+                # always refused it too.
+                resumed_from = _resume_start_step(config)
+                if resumed_from is not None and config.steps <= resumed_from:
+                    raise ValueError(
+                        f"Resume target of {config.steps} steps is not beyond checkpoint "
+                        f"step {resumed_from} — the continuation would train nothing. "
+                        "Raise the step target above the checkpoint, or pick an earlier "
+                        "checkpoint."
                     )
 
             job_id = self._unique_job_id(config.policy_type, config.dataset_repo_id)

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -30,7 +30,7 @@ import subprocess
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
 from pathlib import Path
 from queue import Empty, Queue
@@ -119,6 +119,23 @@ class JobRecord(BaseModel):
     wandb_run_url: str | None = None
     # Step dirs known to be present under checkpoints/ in that repo.
     checkpoints_hub_steps: list[str] = []
+    # Resume lineage, derived at list/get time from the whole registry — same
+    # deal as checkpoint_count above (computed on read, meaningless on disk).
+    #
+    # `child_ids`: the runs that resumed THIS one, newest-first. Empty ⇒ this
+    # record is a LEAF, i.e. the live tip of its chain; the UI shows one row per
+    # leaf and reaches the rest of the chain through `ancestor_ids`. A job can
+    # have several children (nothing stops two resumes off one parent), so the
+    # lineage is a forest of trees, not a set of chains.
+    #
+    # `ancestor_ids`: the transitive resume ancestors, nearest parent first.
+    #
+    # Only `resume_from_job_id` is an edge here. A FINE-TUNE
+    # (`finetune_from_job_id`) is deliberately not: it starts a fresh optimizer
+    # and LR schedule from a checkpoint's weights, so it is a new model rather
+    # than a continuation, and its source must keep its own row.
+    child_ids: list[str] = []
+    ancestor_ids: list[str] = []
 
 
 class JobCheckpoint(BaseModel):
@@ -2360,6 +2377,62 @@ def _oom_failure_reason(log_path: Path, rc: int | None) -> str | None:
     return None
 
 
+def build_child_index(records: Iterable[JobRecord]) -> dict[str, list[str]]:
+    """Map job id -> the ids of the runs that resumed it, newest-first.
+
+    The one place the resume forest's edges are defined. An edge is
+    `config.resume_from_job_id` and nothing else — a fine-tune
+    (`finetune_from_job_id`) starts a fresh schedule from a checkpoint's
+    weights, so it is a new model whose source keeps its own identity, not a
+    continuation that supersedes it.
+
+    Built over EVERY record, never over a page: "does this run have a
+    successor?" must not change answer because the successor fell off the end
+    of a capped listing (which is exactly how the frontend's old client-side
+    approximation lost parents whose child sat past the 50-record page).
+
+    A record naming itself as its own source is skipped rather than indexed —
+    a one-node cycle is corrupt data, and dropping the edge keeps every walk
+    below terminating without a special case. Parent ids with no record are
+    still keyed here; nothing reads them, since lookups start from a record.
+    """
+    children: dict[str, list[str]] = {}
+    for record in sorted(records, key=lambda r: r.started_at, reverse=True):
+        parent_id = record.config.resume_from_job_id
+        if not parent_id or parent_id == record.id:
+            continue
+        children.setdefault(parent_id, []).append(record.id)
+    return children
+
+
+def ancestor_ids_of(records: Mapping[str, JobRecord], job_id: str) -> list[str]:
+    """The transitive resume ancestors of `job_id`, nearest parent first.
+
+    Same walk as `read_metrics_history`, and the same two terminations: a
+    MISSING ancestor (the source run was deleted) truncates the chain rather
+    than raising — the lineage just starts later — and an id already seen ends
+    it, so corrupt data that points a chain back at itself can't spin here.
+
+    Returns only ids the registry actually holds, which is what lets the
+    frontend fetch each one by id: an ancestor is absent from the client's
+    capped page, never from the server.
+    """
+    out: list[str] = []
+    seen = {job_id}
+    current = records.get(job_id)
+    while current is not None:
+        parent_id = current.config.resume_from_job_id
+        if not parent_id or parent_id in seen:
+            break
+        parent = records.get(parent_id)
+        if parent is None:
+            break
+        out.append(parent_id)
+        seen.add(parent_id)
+        current = parent
+    return out
+
+
 class JobAlreadyRunningError(Exception):
     """Raised when start() is called while another local job is running."""
 
@@ -2370,6 +2443,26 @@ class JobNotFoundError(Exception):
 
 class JobNotRunningError(Exception):
     """Raised when stop() is called on a non-running job."""
+
+
+class JobHasChildrenError(Exception):
+    """Raised when delete() is called on a run something else resumed from.
+
+    Deleting a node mid-chain used to silently orphan its whole subtree: the
+    children survive with a `resume_from_job_id` pointing at nothing, so their
+    lineage walk truncates and the run history they inherited (the loss curve
+    before the resume step, the checkpoints they can fall back to) is simply
+    gone — and for a LOCAL parent the deletion also wipes the on-disk
+    checkpoint directory the children resumed out of. Refuse instead, and name
+    the descendants so the user can delete from the tip inwards.
+
+    Carries the direct child ids; the HTTP layer turns them into the message.
+    """
+
+    def __init__(self, job_id: str, child_ids: builtins.list[str]) -> None:
+        super().__init__(job_id)
+        self.job_id = job_id
+        self.child_ids = child_ids
 
 
 class DatasetNotOnHubError(Exception):
@@ -2556,21 +2649,42 @@ class JobRegistry:
             if r.state == "running" and r.runner == "local":
                 raise JobAlreadyRunningError(r.id)
 
+    def _annotate_lineage(
+        self,
+        record: JobRecord,
+        snapshot: Mapping[str, JobRecord],
+        children: Mapping[str, builtins.list[str]],
+    ) -> None:
+        """Stamp the derived resume-tree fields onto `record`, in place.
+
+        Derived on read for the same reason checkpoint_count is: the answer
+        depends on OTHER records (a run becomes a non-leaf the moment something
+        resumes it), so a value frozen into this record's job.json would be
+        wrong by the time anyone read it.
+        """
+        record.child_ids = list(children.get(record.id, ()))
+        record.ancestor_ids = ancestor_ids_of(snapshot, record.id)
+
     def list(self, limit: int = 10) -> builtins.list[JobRecord]:
         with self._lock:
-            records = list(self._records.values())
-        records.sort(key=lambda r: r.started_at, reverse=True)
-        records = records[:limit]
+            snapshot = dict(self._records)
+        records = sorted(snapshot.values(), key=lambda r: r.started_at, reverse=True)[:limit]
+        # Indexed over the whole snapshot, then applied to the page: a run's
+        # leaf-ness is a fact about the registry, not about what fits on a page.
+        children = build_child_index(snapshot.values())
         for r in records:
             r.checkpoint_count = self._count_checkpoints(r)
+            self._annotate_lineage(r, snapshot, children)
         return records
 
     def get(self, job_id: str) -> JobRecord:
         with self._lock:
-            record = self._records.get(job_id)
+            snapshot = dict(self._records)
+        record = snapshot.get(job_id)
         if record is None:
             raise JobNotFoundError(job_id)
         record.checkpoint_count = self._count_checkpoints(record)
+        self._annotate_lineage(record, snapshot, build_child_index(snapshot.values()))
         return record
 
     def start(self, config: TrainingRequest, target: JobTarget | None = None) -> JobRecord:
@@ -3601,6 +3715,14 @@ class JobRegistry:
                 raise JobNotFoundError(job_id)
             if record.state == "running":
                 raise JobNotRunningError(job_id)
+            # Deleting a node with descendants is refused, not cascaded: a
+            # cascade would take runs the user never named (and, for local
+            # runs, their output dirs) on the strength of one click. Leaf
+            # deletes — every delete the UI actually offers, since the list is
+            # one row per leaf — are unaffected.
+            children = build_child_index(self._records.values()).get(job_id, [])
+            if children:
+                raise JobHasChildrenError(job_id, children)
             self._records.pop(job_id, None)
             self._runners.pop(job_id, None)
             self._last_persist_at.pop(job_id, None)

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -3708,8 +3708,8 @@ class JobRegistry:
            Anything else is not a rewind: a sibling, an unrelated run, or a
            descendant would put bytes from off this chain into a run whose
            history claims to be continuous. `ancestor_ids_of` is the same walk
-           the UI offers checkpoints along, so the API accepts exactly what the
-           dropdown can produce and nothing more.
+           the UI loads checkpoints along, so the API accepts nothing the UI
+           could not have reached.
         2. The owner actually holds the named step. Without this a caller could
            name any ancestor with any step and get whatever
            `_resolve_resume_config_path` happened to find — including its
@@ -3720,6 +3720,12 @@ class JobRegistry:
         rewound chain one step number can name several different checkpoints
         (see TrainingRequest.resume_from_checkpoint_job_id), so "latest" has no
         meaning once an owner is named.
+
+        The app itself only ever names an owner for a latest-only Continue — an
+        ancestor exactly when the leaf saved nothing of its own (user decision
+        2026-08-10) — so an arbitrary rewind arrives only from a direct API
+        call. That makes these two checks the whole validation for that shape,
+        not a second line behind a UI that already narrowed it.
         """
         owner_id = config.resume_from_checkpoint_job_id
         if owner_id == leaf.id:

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -81,6 +81,22 @@ class LogLine(BaseModel):
 
 class JobRecord(BaseModel):
     id: str
+    # Short, stable, human-facing run number ("#46"). The id is unique but not
+    # speakable, and a display NAME is shared by every run on a resume chain by
+    # design — so this is the thing a person can point at across the UI, the
+    # API's refusal messages, and a conversation about their own runs.
+    #
+    # Assigned once at creation from a PERSISTED registry counter (see
+    # `_take_job_number`), never derived from the records present. Deriving
+    # max(existing)+1 would hand a deleted run's number to the next one, so two
+    # runs a week apart could both have been "#46" — which is exactly the
+    # ambiguity this field exists to remove. The counter only moves forward.
+    #
+    # 0 means "not assigned yet": a record written before this field existed.
+    # `_assign_job_numbers` backfills those once at load, in started_at order,
+    # so 0 is not observable after a registry has been opened. Readers should
+    # still treat it as "no number" rather than printing "#0".
+    job_number: int = 0
     name: str
     # User-editable display alias set via JobRegistry.rename. Display-only:
     # the immutable identity (id / output_dir / hf_repo_id) never changes on
@@ -1115,6 +1131,45 @@ def hub_checkpoint_missing_files(api, repo_id: str, step_dir: str) -> list[str]:
     return missing_checkpoint_files({f[len(prefix) :] for f in files if f.startswith(prefix)})
 
 
+def missing_pretrained_files(names):
+    """Which required WEIGHTS artifacts are absent from `names` (relative posix
+    paths inside one checkpoints/<step>/).
+
+    The fine-tune rule, as opposed to the resume one: a fine-tune reads
+    pretrained_model/ only, so training_state/ is not required — and neither is
+    train_config.json, which a Hub-imported base (a flat model repo laid out by
+    push_to_hub, not by a checkpoint save) legitimately lacks. config.json is
+    what the HF Jobs wrapper itself gates the pod-side download on; the weights
+    are matched by suffix rather than by name because PEFT adapters rename them.
+    """
+    missing = []
+    if "pretrained_model/config.json" not in names:
+        missing.append("pretrained_model/config.json")
+    if not any(n.startswith("pretrained_model/") and n.endswith(".safetensors") for n in names):
+        missing.append("pretrained_model/*.safetensors")
+    return missing
+
+
+def hub_pretrained_missing_files(api, repo_id: str, step_dir: str) -> list[str]:
+    """Which required WEIGHTS files of `repo_id`'s checkpoints/<step_dir>/ are
+    absent — hub_checkpoint_missing_files with the fine-tune rule
+    (missing_pretrained_files) instead of the resume one. Used by the staged
+    fine-tune-base reuse check, which must not demand the training_state/ that a
+    weights-only staging upload never pushed.
+
+    Raises ValueError when the listing itself can't be read, for the same
+    reason as its resume twin: an unverifiable base is refused, not assumed.
+    """
+    try:
+        files = set(api.list_repo_files(repo_id, repo_type="model"))
+    except Exception as exc:
+        raise ValueError(
+            f"Could not read {repo_id!r} to verify its checkpoint at step {step_dir}: {exc}"
+        ) from exc
+    prefix = f"checkpoints/{step_dir}/"
+    return missing_pretrained_files({f[len(prefix) :] for f in files if f.startswith(prefix)})
+
+
 def _resolve_cloud_resume(source: JobRecord, step: int | None) -> tuple[str, str]:
     """Return (repo_id, step_dir) identifying the Hub checkpoint a run continuing
     a CLOUD parent resumes from (`step` = None ⇒ the latest available on the Hub).
@@ -1769,6 +1824,40 @@ def upload_local_checkpoint(checkpoint_dir: Path, repo_id: str, step_dir: str, *
     )
 
 
+def upload_local_pretrained(pretrained_dir: Path, repo_id: str, step_dir: str, *, api=None) -> None:
+    """Push one local pretrained_model/ tree to `repo_id` as that repo's
+    checkpoints/<step_dir>/pretrained_model.
+
+    The WEIGHTS-ONLY sibling of upload_local_checkpoint, for F7's local→cloud
+    FINE-TUNE direction: the pod cannot see this machine's disk, so a base
+    checkpoint that lives only here has to exist on the Hub before the job is
+    submitted. A fine-tune never reads training_state/ — it starts a fresh
+    optimizer at step 0 — so the optimizer half (the bigger one) is deliberately
+    not staged. That is also why this is a separate function rather than a call
+    into its resume twin: that twin's contract is "the whole tree goes up", and
+    weakening it there would make a resume's guarantee unreadable.
+
+    PRIVATE at creation, for the same reason as the twin: a staging upload is a
+    by-product of launching a fine-tune, not a model the user chose to publish,
+    and `exist_ok` never downgrades an existing repo's visibility. The caller is
+    responsible for having asked first (see JobRegistry's consent gate) — this
+    function only moves the bytes.
+
+    The layout matches what the HF Jobs wrapper materializes for a
+    'repo@checkpoints/<step>' fine-tune ref (it downloads pretrained_model/*
+    only), so the staged step is usable by the pod exactly as uploaded.
+    """
+    api = api or shared_hf_api()
+    api.create_repo(repo_id=repo_id, repo_type="model", private=True, exist_ok=True)
+    api.upload_folder(
+        repo_id=repo_id,
+        repo_type="model",
+        folder_path=str(pretrained_dir),
+        path_in_repo=f"checkpoints/{step_dir}/pretrained_model",
+        commit_message=f"checkpoint {step_dir} weights (uploaded as a cloud fine-tune base)",
+    )
+
+
 def checkpoints_staging_repo_id(username: str, job_id: str) -> str:
     """The Hub repo a LOCAL run's checkpoints are staged in for a cloud resume.
 
@@ -2386,6 +2475,18 @@ def _oom_failure_reason(log_path: Path, rc: int | None) -> str | None:
     return None
 
 
+# Registry-wide state, so it sits at the ROOT rather than in any job dir — a
+# counter living inside one run's directory would die with that run, which is
+# the one thing it must not do. A plain file is invisible to `_load_from_disk`,
+# which globs directories only, and no job id can collide with it (every
+# generated id carries a timestamp suffix).
+_JOB_COUNTER_FILE = "job_counter.json"
+
+
+def _job_counter_path(output_root: Path) -> Path:
+    return output_root / _JOB_COUNTER_FILE
+
+
 def build_child_index(records: Iterable[JobRecord]) -> dict[str, list[str]]:
     """Map job id -> the ids of the runs that resumed it, newest-first.
 
@@ -2443,6 +2544,21 @@ def ancestor_ids_of(records: Mapping[str, JobRecord], job_id: str) -> list[str]:
         seen.add(parent_id)
         current = parent
     return out
+
+
+def _owner_holds_step(owner: JobRecord, step: int) -> bool:
+    """Whether `owner` has a checkpoint at `step`, for the rewind guard.
+
+    LOCAL owners are checked here, off the filesystem, because it is free and
+    synchronous. A CLOUD owner reads as True: its checkpoints are a Hub listing,
+    and `_resolve_cloud_resume` — which runs moments later on the same owner and
+    step — already refuses an absent or incomplete one with a better message.
+    Re-checking here would just buy a second Hub round-trip to reach the same
+    verdict.
+    """
+    if owner.runner != "local":
+        return True
+    return any(c.step == step for c in _list_local_checkpoints(owner.output_dir))
 
 
 class JobAlreadyRunningError(Exception):
@@ -2548,6 +2664,10 @@ class JobRegistry:
         # 'running' after a restart is reconciled by _load_from_disk instead.
         self._stop_requested: set[str] = set()
 
+        # Next value `_take_job_number` will hand out. Loaded from disk below
+        # and only ever written forward; guarded by _lock, like _records.
+        self._next_job_number: int = 1
+
         # job_id -> the thread materializing that job's base checkpoint before
         # its trainer can start (see _materialize_then_start). Entries are left
         # behind once the thread finishes — a finished Thread object is inert
@@ -2573,6 +2693,10 @@ class JobRegistry:
         self._migrate_legacy_cwd_jobs()
         self._load_from_disk()
         self._dedupe_imported_records()
+        # After the dedupe, so a duplicate that is about to be collapsed never
+        # consumes a run number (it would leave a permanent gap naming a record
+        # the user never saw).
+        self._assign_job_numbers()
         # After the dedupe, so a collapsed duplicate can't be counted as a
         # colliding title and drag a suffix onto the card that survived it.
         self._resolve_imported_names()
@@ -2761,6 +2885,48 @@ class JobRegistry:
                 "from a checkpoint's weights."
             )
 
+        # The mirror of the refusal above, and of "Resume is on but no source
+        # checkpoint was selected" further down: a resume SOURCE without the
+        # resume FLAG. `resume` is what every guard downstream branches on — the
+        # sticks refusal, the completed-source refusal, the step-target guard,
+        # the checkpoint-completeness checks all live under `if config.resume`.
+        # So this combination was accepted as an ordinary fresh run that skipped
+        # every one of them, while still persisting `resume_from_job_id` into
+        # its record — which `build_child_index` reads as a lineage edge. The
+        # result was a run that trains from scratch but counts as a
+        # continuation: it supersedes the parent it never continued, hides that
+        # parent's row, and blocks the parent from being resumed for real. It
+        # cost the user a spurious third child of a two-child fork.
+        #
+        # REFUSED, not repaired-by-implying-`resume=true`: the two readings of
+        # the request contradict each other and the caller is the only one who
+        # knows which was meant. Silently upgrading a fresh run into a
+        # continuation would subject it to guards it never opted into and start
+        # it from a checkpoint nobody asked for; silently dropping the id would
+        # throw away the only clue the caller wanted a continuation. The UI
+        # cannot produce either combination — useTrainingConfig derives `resume`
+        # and `resume_from_job_id` from the same ResumeSeed, so they always move
+        # together — which is exactly why this is stated as a contract rather
+        # than accommodated.
+        if not config.resume and (config.resume_from_job_id or config.resume_from_step is not None):
+            named = "resume_from_job_id" if config.resume_from_job_id else "resume_from_step"
+            raise ValueError(
+                f"{named} was given but 'resume' is false, so this would launch a fresh "
+                "run that still records itself as a continuation. Set 'resume': true to "
+                f"continue that run, or drop {named} to train from scratch."
+            )
+
+        # Same shape on the fine-tune side, where the id IS the mode flag (there
+        # is no `finetune` boolean): a step with nothing to take it from was
+        # silently ignored, so a request naming a checkpoint step trained from
+        # scratch and said nothing about it.
+        if config.finetune_from_step is not None and not config.finetune_from_job_id:
+            raise ValueError(
+                "finetune_from_step was given without finetune_from_job_id, so there is "
+                "no source checkpoint to take those weights from. Name the source run, "
+                "or drop finetune_from_step to train from scratch."
+            )
+
         # Fail fast on the local-run mutex before any of the (possibly slow)
         # pretrained-path work below. Re-checked under the lock at record
         # creation — THAT is the authoritative check; this one only spares a
@@ -2783,6 +2949,10 @@ class JobRegistry:
         # materialization itself is deferred to a background thread that starts
         # after the record exists — see the `deferred_hub_ref` branch below.
         # ------------------------------------------------------------------
+        # Kept for the local-base → cloud staging decision further down, which
+        # needs the SOURCE record (its staging repo, its already-staged steps)
+        # long after this block has moved on. None on every other path.
+        finetune_source: JobRecord | None = None
         if config.finetune_from_job_id:
             # Fine-tune: turn the selected source run + step into the
             # pretrained_path lerobot loads weights from. A fresh run (resume
@@ -2797,6 +2967,7 @@ class JobRegistry:
             # like a fine-tune. Checked before the pretrained path resolves
             # (cheap, no Hub call) so a contradicting request never starts.
             _check_finetune_policy_type(source, config.policy_type)
+            finetune_source = source
             config.policy_pretrained_path = _resolve_finetune_pretrained_path(
                 source, config.finetune_from_step
             )
@@ -2842,6 +3013,29 @@ class JobRegistry:
                 # ref pod-side (see the HF Jobs wrapper), because a host path is
                 # meaningless there.
                 deferred_hub_ref = config.policy_pretrained_path
+
+        # F7's fourth quadrant: a fine-tune whose BASE lives only on this
+        # machine, launched on cloud compute. The pod cannot read this disk, so
+        # the base's weights are staged to a private Hub repo and the request is
+        # rewritten to point at the ref the pod can materialize.
+        #
+        # Declared HERE, after the guard block above rather than beside its
+        # siblings inside it, deliberately: the guard reads the checkpoint's
+        # config.json off this disk from the LOCAL ABSOLUTE PATH, so the rewrite
+        # can only happen once it has. The rewrite lands on `config` itself,
+        # which is what gets persisted on the record and what the runner reads —
+        # so the history shows the ref that actually ran, not a host path that
+        # never could (and the runner's own host-path refusal becomes
+        # belt-and-braces, for requests that bypass the registry entirely).
+        deferred_finetune_upload: tuple[Path, str, str] | None = None
+        if (
+            target.runner == "hf_cloud"
+            and config.finetune_from_job_id
+            and config.policy_pretrained_path
+            and Path(config.policy_pretrained_path).is_absolute()
+        ):
+            deferred_finetune_upload, hub_ref = self._resolve_upload_finetune(finetune_source, config)
+            config.policy_pretrained_path = hub_ref
 
         with self._lock:
             # Authoritative local-run mutex: re-checked here, under the lock
@@ -2899,6 +3093,31 @@ class JobRegistry:
                     already_continued = build_child_index(self._records.values()).get(source.id, [])
                     if already_continued:
                         raise JobAlreadyContinuedError(source.id, already_continued)
+
+                    # CHAIN REWIND: from here on, TWO records matter and they
+                    # answer different questions.
+                    #
+                    #   `source` is the LEAF — the run the user clicked and the
+                    #   one this continuation attaches to. Every check above is
+                    #   its business: its state, its lineage, its step target.
+                    #   The edge stays leaf -> new run, so chains stay linear no
+                    #   matter which checkpoint was picked.
+                    #
+                    #   `owner` is where the BYTES live. On a plain tip-resume
+                    #   they are the same record. On a rewind the user reached
+                    #   back to an ancestor's checkpoint, and only the byte
+                    #   resolution below follows it there — which runner's
+                    #   storage to read, and whether the bytes have to move
+                    #   first (F7). Nothing is copied: the trainer is pointed at
+                    #   the ancestor's checkpoint while writing into this run's
+                    #   own output dir, exactly as a tip-resume already does.
+                    #
+                    # This split is what made the old behaviour a fork bug: the
+                    # edge used to point at the checkpoint's owner, so rewinding
+                    # to an ancestor made the ANCESTOR grow a second child.
+                    owner = source
+                    if config.resume_from_checkpoint_job_id:
+                        owner = self._resolve_checkpoint_owner(source, config)
                     # A resume may continue on EITHER runner (F7). What changes
                     # across the four combinations is only where the parent's
                     # checkpoint has to end up before the trainer can read it —
@@ -2911,17 +3130,25 @@ class JobRegistry:
                     # quietly starts at step 0 while the record calls itself a
                     # continuation is MT42, the worst outcome available here.
                     #
-                    # Only local/hf_cloud parents reach here: an imported record
-                    # is created with state="done", so the refusal above already
-                    # took it (imported models are fine-tune sources, never
-                    # resume sources).
-                    if source.runner == "hf_cloud":
-                        # The parent's checkpoints are on the Hub. Naming the
+                    # Keyed on the OWNER throughout, not the leaf: which storage
+                    # holds the chosen bytes is a fact about the run that wrote
+                    # them. A rewind can therefore cross runners twice over — a
+                    # local leaf whose cloud grandparent owns the checkpoint
+                    # takes the cloud→local branch — and the F7 machinery needs
+                    # no extension for it, because it was always keyed on "where
+                    # do these bytes live" rather than on the lineage.
+                    #
+                    # Only local/hf_cloud owners reach here: an imported record
+                    # is created with state="done", so it can never be a leaf
+                    # (refused above) and `_resolve_checkpoint_owner` only ever
+                    # returns a run on that leaf's ancestor path.
+                    if owner.runner == "hf_cloud":
+                        # The owner's checkpoints are on the Hub. Naming the
                         # chosen one is the same job for both targets, and
                         # _resolve_cloud_resume refuses an incomplete or absent
                         # one here — synchronously, as a 400, before any record
                         # or GPU exists.
-                        repo_id, step_dir = _resolve_cloud_resume(source, config.resume_from_step)
+                        repo_id, step_dir = _resolve_cloud_resume(owner, config.resume_from_step)
                         if target.runner == "hf_cloud":
                             # An HF Job is immutable once ended: resuming a cloud
                             # run launches a NEW cloud job that continues from the
@@ -2945,9 +3172,15 @@ class JobRegistry:
                             deferred_resume_ref = f"{repo_id}@checkpoints/{step_dir}"
                             config.resume_from_step = int(step_dir)
                     elif target.runner == "local":
-                        config.config_path = _resolve_resume_config_path(source, config.resume_from_step)
+                        # local → local, including a rewind: the trainer is
+                        # pointed at the OWNER's checkpoint directory and writes
+                        # into this run's own output dir (build_training_command
+                        # passes --config_path and --output_dir separately). So
+                        # a rewind copies nothing and needs no staging — only
+                        # the path being resolved changes.
+                        config.config_path = _resolve_resume_config_path(owner, config.resume_from_step)
                     else:
-                        # local → Cloud: the parent's checkpoint exists only on
+                        # local → Cloud: the owner's checkpoint exists only on
                         # this machine, so it must reach the Hub before the pod
                         # starts. Resolve + validate it here (the same gate a
                         # local→local resume passes), then either reuse an
@@ -2957,7 +3190,7 @@ class JobRegistry:
                             deferred_resume_upload,
                             hub_repo,
                             hub_step,
-                        ) = self._resolve_upload_resume(source, config)
+                        ) = self._resolve_upload_resume(owner, config)
                         config.resume_from_hub_repo = hub_repo
                         config.resume_from_hub_step = hub_step
                         config.resume_from_uploaded_checkpoint = True
@@ -3015,6 +3248,9 @@ class JobRegistry:
             )
             record = JobRecord(
                 id=job_id,
+                # Allocated here, inside the same lock that inserts the record,
+                # so two concurrent starts can't be handed the same number.
+                job_number=self._take_job_number(),
                 name=name,
                 state="running",
                 config=config,
@@ -3038,6 +3274,7 @@ class JobRegistry:
                 deferred_hub_ref is not None
                 or deferred_resume_ref is not None
                 or deferred_resume_upload is not None
+                or deferred_finetune_upload is not None
             )
             if deferred:
                 # Something still has to move (GBs, minutes). Hand the caller its
@@ -3071,7 +3308,7 @@ class JobRegistry:
                     )
                     thread_target = self._download_resume_then_start
                     thread_args = (job_id, deferred_resume_ref, lerobot_output_dir, prep)
-                else:
+                elif deferred_resume_upload is not None:
                     ckpt_dir, upload_repo, upload_step = deferred_resume_upload
                     prep.emit(
                         f"Preparing continuation: uploading checkpoint {upload_step} "
@@ -3079,6 +3316,14 @@ class JobRegistry:
                     )
                     thread_target = self._upload_resume_then_start
                     thread_args = (job_id, ckpt_dir, upload_repo, upload_step, target, prep)
+                else:
+                    pretrained_dir, upload_repo, upload_step = deferred_finetune_upload
+                    prep.emit(
+                        f"Preparing fine-tune: uploading checkpoint {upload_step} "
+                        f"to the private repo {upload_repo} so the cloud job can read it…"
+                    )
+                    thread_target = self._upload_finetune_then_start
+                    thread_args = (job_id, pretrained_dir, upload_repo, upload_step, target, prep)
                 thread = threading.Thread(
                     target=thread_target,
                     args=thread_args,
@@ -3276,16 +3521,85 @@ class JobRegistry:
             f"Checkpoint {step_dir} is on the Hub — submitting the cloud job.",
         )
 
-    def _remember_uploaded_checkpoint(self, job_id: str, repo_id: str, step_dir: str) -> None:
-        """Record on the PARENT run where its checkpoint was uploaded.
+    def _upload_finetune_then_start(
+        self,
+        job_id: str,
+        pretrained_dir: Path,
+        repo_id: str,
+        step_dir: str,
+        target: JobTarget,
+        prep: PreparingJobRunner,
+    ) -> None:
+        """Push a LOCAL base checkpoint's WEIGHTS to the Hub, then fine-tune on
+        the cloud.
 
-        Keyed off the child's `resume_from_job_id` rather than passed in, so the
-        note always lands on the record whose bytes were actually pushed. A
-        missing parent (deleted mid-upload) is not an error: the upload still
-        happened and the child still runs; only the re-use shortcut is lost."""
+        F7's remaining quadrant, and the weights-only twin of
+        _upload_resume_then_start. The pod materializes its base from the Hub,
+        so these bytes have to be there before the job is submitted — and the
+        request already carries the user's explicit consent for the upload (see
+        _resolve_upload_finetune). training_state/ is deliberately left behind:
+        a fine-tune starts a fresh optimizer at step 0 and never reads it, and
+        it is the bigger half of the checkpoint.
+
+        The upload is re-verified from the Hub's own file listing — under the
+        fine-tune completeness rule — before anything is submitted, and the job
+        is finalised `failed` if it can't be confirmed. A run recorded as a
+        fine-tune of a checkpoint either trains from that checkpoint or does not
+        start at all; it never becomes a from-scratch run on rented hardware
+        (the fine-tune reading of MT42).
+
+        On success the staging is recorded on the SOURCE's record, so fine-tuning
+        the same step again reuses it instead of pushing the same GBs twice.
+        """
+        try:
+            prep.emit(f"Uploading {step_dir} weights from {pretrained_dir}…")
+            upload_local_pretrained(pretrained_dir, repo_id, step_dir)
+            missing = hub_pretrained_missing_files(shared_hf_api(), repo_id, step_dir)
+            if missing:
+                raise ValueError(f"the upload finished but {repo_id} is still missing {', '.join(missing)}")
+        except Exception as exc:
+            logger.exception("Fine-tune base upload failed for job %s", job_id)
+            self._fail_prepare(
+                job_id,
+                prep,
+                f"Could not upload the base checkpoint at step {step_dir} to {repo_id}, "
+                f"so this fine-tune cannot run on the cloud: {exc}",
+            )
+            return
+
+        self._remember_uploaded_checkpoint(job_id, repo_id, step_dir)
+        self._start_after_prepare(
+            job_id,
+            # A cloud runner ignores the host output dir (its pod writes to a
+            # container path); pass it anyway so the callers stay identical.
+            str(_job_dir(self._output_root, job_id) / "run"),
+            prep,
+            target,
+            None,
+            f"Checkpoint {step_dir} is on the Hub — submitting the cloud job.",
+        )
+
+    def _remember_uploaded_checkpoint(self, job_id: str, repo_id: str, step_dir: str) -> None:
+        """Record on the SOURCE run where its checkpoint was staged.
+
+        Keyed off the child's `resume_from_job_id` / `finetune_from_job_id`
+        rather than passed in, so the note always lands on the record whose bytes
+        were actually pushed. A missing source (deleted mid-upload) is not an
+        error: the upload still happened and the child still runs; only the
+        re-use shortcut is lost.
+
+        One list for both directions even though a fine-tune stages WEIGHTS ONLY
+        while a resume stages the whole tree. That is safe because neither reuse
+        path trusts this list on its own: each re-reads the Hub listing and
+        applies its OWN completeness rule first. So a later RESUME of a step
+        that only a fine-tune staged finds training_state/ missing, falls
+        through to the consent gate, and uploads the full tree — upload_folder
+        then simply adds the half that wasn't there."""
         with self._lock:
             child = self._records.get(job_id)
-            parent_id = child.config.resume_from_job_id if child else None
+            parent_id = (
+                (child.config.resume_from_job_id or child.config.finetune_from_job_id) if child else None
+            )
             parent = self._records.get(parent_id) if parent_id else None
             if parent is None:
                 return
@@ -3383,6 +3697,55 @@ class JobRegistry:
             if notify:
                 self._notify_change()
 
+    def _resolve_checkpoint_owner(self, leaf: JobRecord, config: TrainingRequest) -> JobRecord:
+        """The run whose storage holds the checkpoint a REWIND picked.
+
+        Caller holds _lock. Two things are verified, and both exist to stop the
+        same failure — a continuation that quietly trains from weights the user
+        did not choose:
+
+        1. The named owner is the leaf itself or one of its own ANCESTORS.
+           Anything else is not a rewind: a sibling, an unrelated run, or a
+           descendant would put bytes from off this chain into a run whose
+           history claims to be continuous. `ancestor_ids_of` is the same walk
+           the UI offers checkpoints along, so the API accepts exactly what the
+           dropdown can produce and nothing more.
+        2. The owner actually holds the named step. Without this a caller could
+           name any ancestor with any step and get whatever
+           `_resolve_resume_config_path` happened to find — including its
+           "latest" fallback, which is the silent-wrong-weights case in its
+           purest form.
+
+        Step is required for a rewind for the same reason the owner is: on a
+        rewound chain one step number can name several different checkpoints
+        (see TrainingRequest.resume_from_checkpoint_job_id), so "latest" has no
+        meaning once an owner is named.
+        """
+        owner_id = config.resume_from_checkpoint_job_id
+        if owner_id == leaf.id:
+            return leaf
+        owner = self._records.get(owner_id or "")
+        if owner is None:
+            raise ValueError(f"Resume checkpoint owner {owner_id!r} not found.")
+        if owner_id not in ancestor_ids_of(self._records, leaf.id):
+            raise ValueError(
+                f"Run {owner_id!r} is not on {leaf.id!r}'s lineage, so its checkpoints "
+                f"cannot be resumed into {leaf.id!r}. A continuation may only rewind to a "
+                "checkpoint saved by the run itself or by one of the runs it continues."
+            )
+        if config.resume_from_step is None:
+            raise ValueError(
+                "resume_from_step is required when resume_from_checkpoint_job_id names "
+                "another run: one step number can refer to several checkpoints across a "
+                "rewound lineage, so there is no unambiguous 'latest' to pick."
+            )
+        if not _owner_holds_step(owner, config.resume_from_step):
+            raise ValueError(
+                f"Run {owner_id!r} has no checkpoint at step {config.resume_from_step}, so "
+                "there is nothing there to continue from."
+            )
+        return owner
+
     def _resolve_upload_resume(
         self, source: JobRecord, config: TrainingRequest
     ) -> tuple[tuple[Path, str, str] | None, str, str]:
@@ -3447,6 +3810,86 @@ class JobRegistry:
             )
         repo_id = checkpoints_staging_repo_id(username, source.id)
         return (checkpoint_dir, repo_id, step_dir), repo_id, step_dir
+
+    def _resolve_upload_finetune(
+        self, source: JobRecord, config: TrainingRequest
+    ) -> tuple[tuple[Path, str, str] | None, str]:
+        """Plan the Hub side of a LOCAL base → CLOUD fine-tune.
+
+        Returns (pending_upload, hub_ref): `pending_upload` is (pretrained_model
+        dir, repo id, step dir) when weights still have to be pushed, or None
+        when an earlier launch already staged this exact step and the Hub still
+        has it — fine-tuning the same base twice must not push the same GBs
+        twice. `hub_ref` is the 'repo@checkpoints/<step_dir>' the run actually
+        trains from, and replaces the host path on the request: the pod
+        materializes that ref itself (the HF Jobs wrapper), and a host path is
+        meaningless there.
+
+        The resume twin beside it stages the WHOLE checkpoint; this one stages
+        pretrained_model/ only, because a fine-tune starts a fresh optimizer at
+        step 0 and never reads training_state/ (see upload_local_pretrained).
+        Same private staging repo per source run, so the two directions share
+        one place per parent rather than inventing a second convention.
+
+        Called from `start` OUTSIDE the registry lock (the fine-tune resolution
+        is), before any record exists, so every refusal below is a ValueError
+        (→ HTTP 400) that leaves nothing behind — each describes something the
+        user has to change:
+          * the upload wasn't consented to — an upload is a disclosure, so it is
+            never a silent side effect of picking a base model;
+          * there is no Hub identity to upload as, or the server is offline.
+        """
+        # The caller only reaches here for an ABSOLUTE pretrained path, which is
+        # what a `local` checkpoint ref resolves to (see
+        # _resolve_finetune_pretrained_path) — the dir lerobot would have loaded
+        # from disk, and therefore the dir whose bytes have to go up.
+        pretrained_dir = Path(config.policy_pretrained_path)
+        if pretrained_dir.name == "pretrained_model" and pretrained_dir.parent.name.isdigit():
+            # The ordinary checkpoints/<step>/pretrained_model layout: the step
+            # is on the path, exactly as _resolve_upload_resume reads it.
+            step_dir = pretrained_dir.parent.name
+        else:
+            # A flat imported directory that IS the pretrained_model. Its
+            # listing (_list_imported_local) offers exactly one checkpoint, at
+            # step 0, so "latest" (finetune_from_step None) and an explicit 0
+            # name the same thing — which is why the step can be recovered from
+            # the request here without re-running the resolver.
+            step_dir = f"{int(config.finetune_from_step or 0):06d}"
+
+        # Already staged by an earlier fine-tune? Trust the record only as far
+        # as the Hub confirms it — a deleted repo (or a half-finished push) must
+        # produce a fresh upload, not a pod that dies looking for weights. The
+        # completeness rule is the weights-only one: a staging upload never
+        # pushed the training_state/ its resume twin would demand.
+        if source.checkpoints_hub_repo_id and step_dir in source.checkpoints_hub_steps:
+            with contextlib.suppress(Exception):
+                if not hub_pretrained_missing_files(
+                    shared_hf_api(), source.checkpoints_hub_repo_id, step_dir
+                ):
+                    return None, f"{source.checkpoints_hub_repo_id}@checkpoints/{step_dir}"
+
+        if not config.upload_finetune_checkpoint:
+            raise ValueError(
+                f"Fine-tuning this model on {_RUNNER_LABELS['hf_cloud']} needs its "
+                f"checkpoint at step {int(step_dir)} on the Hub, and it is only on "
+                "this machine. Confirm the upload in the training form (it goes to "
+                "a private repo), or run the fine-tune locally instead."
+            )
+        if hf_hub_offline():
+            raise ValueError(
+                "Offline mode is on, so this base checkpoint can't be uploaded to "
+                "the Hub — fine-tune it locally, or switch offline mode off."
+            )
+        whoami = cached_whoami()
+        username = (whoami or {}).get("name")
+        if not username:
+            raise ValueError(
+                "Fine-tuning a local model on the cloud uploads its weights to your "
+                f"Hugging Face account, so you have to be signed in. Run '{LOGIN_COMMAND}' "
+                "or paste a token in the app, then try again."
+            )
+        repo_id = checkpoints_staging_repo_id(username, source.id)
+        return (pretrained_dir, repo_id, step_dir), f"{repo_id}@checkpoints/{step_dir}"
 
     def _finalize_prepare(self, job_id: str, state: JobState, error_message: str) -> None:
         """Lock-taking wrapper around _finalize_prepare_locked."""
@@ -3563,6 +4006,10 @@ class JobRegistry:
             job_id = self._unique_job_id(policy_type, "imported")
             record = JobRecord(
                 id=job_id,
+                # An import is a record in the same list as the runs, so it
+                # carries a number from the same sequence — the alternative is
+                # a library where some rows have one and some don't.
+                job_number=self._take_job_number(),
                 # Identity only — no "Imported ·" prefix (the card's own
                 # provenance chip says that) and no namespace or policy token
                 # (the policy row says that). See derive_imported_title.
@@ -4163,6 +4610,92 @@ class JobRegistry:
         tmp = path.with_suffix(path.suffix + ".tmp")
         tmp.write_text(record.model_dump_json(indent=2))
         os.replace(tmp, path)
+
+    # ------------------------------------------------------------------
+    # Run numbers. The counter is the authority; the records are not.
+    # ------------------------------------------------------------------
+
+    def _read_job_counter(self) -> int:
+        """The persisted next-number, or 0 when there isn't a usable one.
+
+        Every failure reads as 0 — absent file (a registry predating this),
+        unparsable JSON, wrong type, a value below 1. 0 means "no opinion", and
+        the caller floors it against the numbers actually in use, so a lost or
+        corrupt counter costs a gap at worst and never a duplicate.
+        """
+        path = _job_counter_path(self._output_root)
+        try:
+            value = json.loads(path.read_text()).get("next_job_number")
+        except (OSError, ValueError, AttributeError):
+            return 0
+        return value if isinstance(value, int) and not isinstance(value, bool) and value >= 1 else 0
+
+    def _write_job_counter(self) -> None:
+        """Persist `_next_job_number`. Caller holds _lock.
+
+        Same tmp + os.replace as _write_meta, for the same reason and one more:
+        a half-written counter that failed to parse would read as 0 and hand out
+        numbers already on records.
+        """
+        path = _job_counter_path(self._output_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps({"next_job_number": self._next_job_number}, indent=2))
+        os.replace(tmp, path)
+
+    def _take_job_number(self) -> int:
+        """Allocate the next run number. CALLER MUST HOLD _lock.
+
+        Persisted before it is returned, so a crash between allocating and
+        writing the job.json burns the number rather than re-issuing it. A gap
+        in the sequence is a non-event; a repeat is the bug this field exists to
+        prevent.
+        """
+        number = self._next_job_number
+        self._next_job_number = number + 1
+        self._write_job_counter()
+        return number
+
+    def _assign_job_numbers(self) -> None:
+        """Give every loaded record a run number, once, at boot.
+
+        Runs single-threaded from __init__ (no lock needed, same as the dedupe
+        pass above). Two jobs:
+
+        1. Seed the counter. It is the MAX of the persisted value and one past
+           the highest number already on a record — so a counter that was lost
+           can't reissue a live number, and a counter that is ahead (because the
+           runs holding those numbers were deleted) keeps its lead.
+        2. Backfill records written before the field existed, oldest first, so
+           the numbers agree with the order the user saw them happen. `id` is
+           the tie-break: `started_at` has second granularity for legacy records
+           and ties are real, so without it two boots could order the same pair
+           differently and silently renumber history.
+
+        Idempotent: a second boot finds every record numbered, writes nothing,
+        and re-seeds the counter to the same value.
+        """
+        highest = max((r.job_number for r in self._records.values()), default=0)
+        persisted = self._read_job_counter()
+        self._next_job_number = max(persisted, highest + 1)
+        unnumbered = sorted(
+            (r for r in self._records.values() if r.job_number < 1),
+            key=lambda r: (r.started_at, r.id),
+        )
+        for record in unnumbered:
+            record.job_number = self._next_job_number
+            self._next_job_number += 1
+            self._write_meta(record)
+        # Written when we numbered something, and also when the counter file is
+        # missing or behind while numbered records exist — that is the degraded
+        # case where deleting the highest-numbered runs and restarting would
+        # otherwise recompute a floor that reissues their numbers. An EMPTY
+        # registry writes nothing: there is no history to protect, and a fresh
+        # root should stay untouched until it actually holds a run.
+        if unnumbered or (highest > 0 and persisted < self._next_job_number):
+            self._write_job_counter()
+        if unnumbered:
+            logger.info("Assigned run numbers to %d pre-existing job(s).", len(unnumbered))
 
 
 # Module-level singleton. Anchored to ~/.cache so history survives launches

--- a/makermodslab/models.py
+++ b/makermodslab/models.py
@@ -53,6 +53,7 @@ from .datasets import (
     _lerobot_cache_root,
 )
 from .jobs import (
+    JobHasChildrenError,
     JobRecord,
     _list_local_checkpoints,
     _read_checkpoint_config,
@@ -1387,6 +1388,18 @@ def delete_local_model(model_id: str) -> dict[str, Any]:
         raise ModelError(
             409,
             f"Model {model_id!r} is still training — stop the run before deleting it.",
+        ) from exc
+    except JobHasChildrenError as exc:
+        # Mid-chain delete, reached from the MODEL library rather than the jobs
+        # one: another run resumed out of this run's checkpoint dir, which the
+        # delete would take with it. Same refusal and same shape the /jobs
+        # route returns (409, naming the continuations) — without this it fell
+        # into the catch-all below and surfaced as a 502 "Failed to delete".
+        continued_by = ", ".join(repr(cid) for cid in exc.child_ids)
+        raise ModelError(
+            409,
+            f"Model {model_id!r} was continued by {continued_by}, which would be left "
+            "pointing at a deleted run. Delete the continuation(s) first.",
         ) from exc
     except JobNotFoundError as exc:
         raise ModelError(404, f"Model {model_id!r} not found.") from exc

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -224,10 +224,19 @@ def localize_config_for_cloud(config: TrainingRequest, flavor: str) -> None:
     # form, which the wrapper materializes pod-side before launching the trainer
     # (the twin of the resume download above). What cannot work is a host path:
     # the container has no view of this machine's disk.
+    #
+    # Belt-and-braces since F7's fine-tune quadrant landed: a local base picked
+    # in the UI never arrives here as a path any more — JobRegistry.start stages
+    # its weights to a private Hub repo (with the user's consent) and rewrites
+    # the request to the resulting ref before the runner is reached. Only a
+    # request that bypasses the registry can still trip this, so the message
+    # names both ways out rather than claiming the case is unsupported.
     if config.policy_pretrained_path and Path(config.policy_pretrained_path).is_absolute():
         raise ValueError(
-            "Fine-tuning a cloud job from a local checkpoint isn't supported — "
-            "push the source model to the Hub and fine-tune from the Hub copy."
+            "A cloud job can't fine-tune from a checkpoint on this machine — the "
+            "container has no view of this disk. Launch it from the training form, "
+            "which offers to upload the base checkpoint to a private Hub repo first, "
+            "or push the source model to the Hub and fine-tune from the Hub copy."
         )
     # The container resolves the dataset from the Hub by repo_id; a host-local
     # dataset root doesn't exist there.

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -1184,18 +1184,39 @@ def models_import(request: ModelImportRequest):
 
 
 def _job_label(job_id: str) -> str:
-    """A run named the way its row names it: alias (id), or the bare id.
+    """A run named the way its row names it: `#46 'alias' (id)`.
 
     For refusal messages that have to point at a *different* run than the one
     the user acted on — "delete X first" is only actionable if X is findable in
-    the list, and the list shows the display alias, not the id.
+    the list. All three parts earn their place: the NUMBER is what the UI shows
+    and what a person can repeat back; the NAME is shared by every run on a
+    resume chain, so it locates the lineage but not the run; the ID is the
+    unambiguous one and the only one that survives a rename.
+
+    Degrades a part at a time — an unnumbered record (pre-backfill) or an
+    unnamed one just drops that piece, and an id the registry no longer holds
+    falls back to the bare id.
     """
     try:
         record = job_registry.get(job_id)
     except JobNotFoundError:
         return repr(job_id)
     name = (record.display_name or record.name or "").strip()
-    return f"{name!r} ({job_id})" if name else repr(job_id)
+    label = f"{name!r} ({job_id})" if name else repr(job_id)
+    return f"#{record.job_number} {label}" if record.job_number > 0 else label
+
+
+def _is_finished_run(job_id: str) -> bool:
+    """True when the run reached its target — i.e. holds finished training.
+
+    Used to keep refusal messages from casually recommending its deletion. An
+    unresolvable id reads as False: the message degrades to the plainer advice
+    rather than inventing a reason to keep something that may not exist.
+    """
+    try:
+        return job_registry.get(job_id).state == "done"
+    except JobNotFoundError:
+        return False
 
 
 @app.post("/jobs/training", status_code=201)
@@ -1291,16 +1312,39 @@ async def create_training_job(req: Request):
         # this layer rather than baked into the exception.
         #
         # The message has to TEACH the way out, because the way out is not
-        # obvious from the refusal: the fork is unblocked by deleting the
-        # existing continuation, which is itself a leaf and therefore deletable.
+        # obvious from the refusal — but which way out is honest depends on what
+        # is standing in the way, and getting that wrong is worse than saying
+        # nothing. Two shapes:
+        #
+        #  - ONE unfinished continuation (every lineage the sticks rule can
+        #    create): deleting it is cheap and correct, so say so.
+        #  - a LEGACY FORK, or a continuation that ran to completion: "delete
+        #    the continuation(s) first" is advice to throw away work. On the
+        #    user's own registry this fired for a parent whose two children
+        #    included a finished 30k run — the single run in that lineage
+        #    nobody should delete. Recommend fine-tune instead: it starts a
+        #    fresh schedule from the same weights, is not restricted to one per
+        #    run, and needs nothing deleted.
         continued_by = ", ".join(_job_label(cid) for cid in exc.child_ids)
         source = _job_label(exc.job_id)
+        finished = [_job_label(cid) for cid in exc.child_ids if _is_finished_run(cid)]
+        if len(exc.child_ids) == 1 and not finished:
+            remedy = f"A run can be continued once, so delete {continued_by} first, then resume {source}."
+        else:
+            cost = (
+                f", including the finished {'runs' if len(finished) > 1 else 'run'} {', '.join(finished)}"
+                if finished
+                else ""
+            )
+            remedy = (
+                f"A run can be continued once, so resuming {source} would mean first "
+                f"deleting {continued_by}{cost}. Fine-tune from {source}'s checkpoint "
+                "instead — that starts a fresh schedule from the same weights, needs "
+                "nothing deleted, and is not limited to one per run."
+            )
         raise HTTPException(
             status_code=409,
-            detail=(
-                f"{source} was already continued by {continued_by}. A run can be "
-                f"continued once, so delete {continued_by} first, then resume {source}."
-            ),
+            detail=f"{source} was already continued by {continued_by}. {remedy}",
         ) from exc
     except ValueError as exc:
         # e.g. "flavor is required when runner is hf_cloud"

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -67,6 +67,7 @@ from .camera_preview import CameraOpenError, camera_preview_manager
 from .identify import identify_arm_by_motion
 from .jobs import (
     DatasetNotOnHubError,
+    JobAlreadyContinuedError,
     JobAlreadyRunningError,
     JobHasChildrenError,
     JobNotFoundError,
@@ -1182,6 +1183,21 @@ def models_import(request: ModelImportRequest):
 # ============================================================================
 
 
+def _job_label(job_id: str) -> str:
+    """A run named the way its row names it: alias (id), or the bare id.
+
+    For refusal messages that have to point at a *different* run than the one
+    the user acted on — "delete X first" is only actionable if X is findable in
+    the list, and the list shows the display alias, not the id.
+    """
+    try:
+        record = job_registry.get(job_id)
+    except JobNotFoundError:
+        return repr(job_id)
+    name = (record.display_name or record.name or "").strip()
+    return f"{name!r} ({job_id})" if name else repr(job_id)
+
+
 @app.post("/jobs/training", status_code=201)
 async def create_training_job(req: Request):
     raw = await req.json()
@@ -1207,6 +1223,13 @@ async def create_training_job(req: Request):
     # Hard block (not a warning): when resuming, the total step count must be
     # strictly above the checkpoint's step — lerobot requires --steps be raised
     # above the resumed checkpoint, and steps == checkpoint would train nothing.
+    #
+    # This is the FAST half only, and cannot be the whole guard: it reads the
+    # request's `resume_from_step`, which is None whenever the caller picked
+    # "latest checkpoint" and left the step for the registry to resolve. Those
+    # requests walk straight past this. JobRegistry.start re-asks the same
+    # question at the bottom of its resume block, once the step is a number;
+    # that one is the authority, and it raises ValueError -> the 400 below.
     if cfg.resume_from_step is not None and cfg.steps <= cfg.resume_from_step:
         logger.warning(
             "Rejecting resume: steps (%d) <= checkpoint step (%d).",
@@ -1260,6 +1283,25 @@ async def create_training_job(req: Request):
         # dataset first (the browser flow does this automatically before
         # submitting, so this fires for non-UI callers).
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except JobAlreadyContinuedError as exc:
+        # Sticks only: the source already has a continuation, so a second one
+        # would fork it. 409 for the same reason the mid-chain delete refusal
+        # is a 409 — a conflict with existing state, not a malformed request —
+        # and routed here the same way, with the ids turned into a message at
+        # this layer rather than baked into the exception.
+        #
+        # The message has to TEACH the way out, because the way out is not
+        # obvious from the refusal: the fork is unblocked by deleting the
+        # existing continuation, which is itself a leaf and therefore deletable.
+        continued_by = ", ".join(_job_label(cid) for cid in exc.child_ids)
+        source = _job_label(exc.job_id)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"{source} was already continued by {continued_by}. A run can be "
+                f"continued once, so delete {continued_by} first, then resume {source}."
+            ),
+        ) from exc
     except ValueError as exc:
         # e.g. "flavor is required when runner is hf_cloud"
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -68,6 +68,7 @@ from .identify import identify_arm_by_motion
 from .jobs import (
     DatasetNotOnHubError,
     JobAlreadyRunningError,
+    JobHasChildrenError,
     JobNotFoundError,
     JobNotRunningError,
     JobTarget,
@@ -1777,6 +1778,17 @@ def delete_job(job_id: str):
         raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found") from exc
     except JobNotRunningError as exc:
         raise HTTPException(status_code=409, detail=f"Job {job_id!r} is running; stop it first") from exc
+    except JobHasChildrenError as exc:
+        # Mid-chain delete: name the runs that continue from this one so the
+        # user can work inwards from the tip instead of guessing.
+        continued_by = ", ".join(repr(cid) for cid in exc.child_ids)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Job {job_id!r} was continued by {continued_by}, which would be left "
+                "pointing at a deleted run. Delete the continuation(s) first."
+            ),
+        ) from exc
     # Deleting a tracked cloud run removes the local record, but its Hub job
     # would resurface in /jobs/hub as an untracked card on the next poll (the
     # HF Jobs API has no delete). Mark it dismissed so the removal sticks.

--- a/makermodslab/train.py
+++ b/makermodslab/train.py
@@ -182,6 +182,23 @@ class TrainingRequest(BaseModel):
     # needs the checkpoint's train_config.json to reconstruct the run).
     resume_from_job_id: str | None = None
     resume_from_step: int | None = None
+    # CHAIN REWIND. `resume_from_job_id` is the LINEAGE EDGE — always the leaf
+    # the user clicked, so chains stay linear (parent -> leaf -> this run). This
+    # field is the PROVENANCE: which run's storage the chosen checkpoint bytes
+    # actually come from, when the user rewound to an ancestor's checkpoint
+    # rather than the leaf's own. None ⇒ the leaf owns it (every plain
+    # tip-resume, and every record written before rewind existed — so no
+    # migration).
+    #
+    # It cannot be derived from the step, which is why it is carried
+    # explicitly: rewind itself produces same-step-different-owner checkpoints
+    # on ONE linear path. Rewind a leaf to its trunk's step 2000, and the new
+    # run saves its own 4000 and 6000 alongside the trunk's 4000 and the old
+    # leaf's 6000 — all four on the new run's single ancestor path. Guessing
+    # the owner from the step would silently train from different weights than
+    # the user picked. JobRegistry.start refuses an owner that is not on the
+    # leaf's ancestor path or does not hold the named step.
+    resume_from_checkpoint_job_id: str | None = None
     # Set by the "Fine-tune" flow: start a FRESH run (fresh optimizer, step 0)
     # whose weights are initialized from an imported/existing checkpoint. Unlike
     # resume, this needs no optimizer/step state — weights-only is exactly the
@@ -212,6 +229,14 @@ class TrainingRequest(BaseModel):
     # other path — nothing is uploaded when the checkpoint is already on the Hub,
     # including a re-resume of a step a previous continuation already pushed.
     upload_resume_checkpoint: bool = False
+    # The fine-tune twin of the consent above: a fine-tune whose BASE checkpoint
+    # lives only on this machine, launched on cloud compute. The base's weights
+    # (pretrained_model/ only — a fine-tune never reads training_state/) are
+    # staged to the same private per-source Hub repo a cloud resume uses, and
+    # the registry refuses the launch without this consent. Ignored whenever the
+    # base is already on the Hub, including a re-fine-tune of a step an earlier
+    # launch already staged.
+    upload_finetune_checkpoint: bool = False
     # Set by the registry (never by a client) when `resume_from_hub_repo` is the
     # staging repo above rather than a cloud parent's own output repo. It tells
     # the cloud runner not to adopt the source repo as this run's OUTPUT repo:

--- a/makermodslab/train.py
+++ b/makermodslab/train.py
@@ -198,6 +198,14 @@ class TrainingRequest(BaseModel):
     # the owner from the step would silently train from different weights than
     # the user picked. JobRegistry.start refuses an owner that is not on the
     # leaf's ancestor path or does not hold the named step.
+    #
+    # WIDER THAN THE UI, deliberately (user decision 2026-08-10). The app's
+    # Continue is latest-only: it always resumes the newest checkpoint on the
+    # lineage, so the only owner it ever names is the one that happens to hold
+    # that checkpoint — an ancestor exactly when the leaf saved nothing of its
+    # own. An arbitrary rewind is reachable only by calling the API directly.
+    # The guards below are therefore not dead code protecting a UI path; they
+    # are the whole validation for a surface the UI no longer narrows first.
     resume_from_checkpoint_job_id: str | None = None
     # Set by the "Fine-tune" flow: start a FRESH run (fresh optimizer, step 0)
     # whose weights are initialized from an imported/existing checkpoint. Unlike

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4501,3 +4501,240 @@ def test_read_log_tail_messages_skips_malformed_lines(tmp_path) -> None:
     path = tmp_path / "log.jsonl"
     path.write_text('{"timestamp": 1.0, "message": "ok"}\nnot json at all\n{"timestamp": 2.0}\n')
     assert _read_log_tail_messages(path) == ["ok"]
+# ---------------------------------------------------------------------------
+# Resume lineage: the child index, the ancestor walk, and the delete guard that
+# reads them. All pure registry state — no runner is started here.
+
+
+def _lineage_record(
+    job_id: str,
+    *,
+    parent: str | None = None,
+    started_at: float = 0.0,
+    finetune_parent: str | None = None,
+    state: str = "failed",
+):
+    """A bare record whose only interesting property is who it continues from."""
+    from makermodslab.jobs import JobRecord
+    from makermodslab.train import TrainingRequest
+
+    return JobRecord(
+        id=job_id,
+        name=job_id,
+        state=state,
+        config=TrainingRequest(
+            dataset_repo_id="user/ds",
+            resume=parent is not None,
+            resume_from_job_id=parent,
+            finetune_from_job_id=finetune_parent,
+        ),
+        output_dir=f"/nonexistent/{job_id}",
+        started_at=started_at,
+    )
+
+
+def test_build_child_index_maps_parents_to_children_newest_first() -> None:
+    from makermodslab.jobs import build_child_index
+
+    index = build_child_index(
+        [
+            _lineage_record("A"),
+            _lineage_record("B", parent="A", started_at=10.0),
+            _lineage_record("C", parent="B", started_at=20.0),
+        ]
+    )
+
+    assert index == {"A": ["B"], "B": ["C"]}
+
+
+def test_build_child_index_keeps_every_child_of_a_fork_newest_first() -> None:
+    """Nothing stops two runs resuming one parent, so the lineage is a forest,
+    not a set of chains — both forks must be indexed, newest first."""
+    from makermodslab.jobs import build_child_index
+
+    index = build_child_index(
+        [
+            _lineage_record("A"),
+            _lineage_record("older", parent="A", started_at=10.0),
+            _lineage_record("newer", parent="A", started_at=20.0),
+        ]
+    )
+
+    assert index["A"] == ["newer", "older"]
+
+
+def test_build_child_index_ignores_finetune_edges() -> None:
+    """A fine-tune starts a fresh schedule from a checkpoint's weights: a new
+    model, not a continuation, so it must NOT supersede (hide) its source."""
+    from makermodslab.jobs import build_child_index
+
+    index = build_child_index(
+        [
+            _lineage_record("A"),
+            _lineage_record("F", finetune_parent="A", started_at=10.0),
+        ]
+    )
+
+    assert index == {}
+
+
+def test_build_child_index_drops_a_self_edge() -> None:
+    from makermodslab.jobs import build_child_index
+
+    assert build_child_index([_lineage_record("A", parent="A")]) == {}
+
+
+def test_ancestor_ids_walk_nearest_parent_first() -> None:
+    from makermodslab.jobs import ancestor_ids_of
+
+    records = {
+        r.id: r
+        for r in [
+            _lineage_record("A"),
+            _lineage_record("B", parent="A"),
+            _lineage_record("C", parent="B"),
+        ]
+    }
+
+    assert ancestor_ids_of(records, "C") == ["B", "A"]
+    assert ancestor_ids_of(records, "A") == []
+
+
+def test_ancestor_ids_of_forked_siblings_share_the_trunk() -> None:
+    from makermodslab.jobs import ancestor_ids_of
+
+    records = {
+        r.id: r
+        for r in [
+            _lineage_record("A"),
+            _lineage_record("B", parent="A"),
+            _lineage_record("fork1", parent="B"),
+            _lineage_record("fork2", parent="B"),
+        ]
+    }
+
+    assert ancestor_ids_of(records, "fork1") == ["B", "A"]
+    assert ancestor_ids_of(records, "fork2") == ["B", "A"]
+
+
+def test_ancestor_ids_truncate_at_a_deleted_ancestor() -> None:
+    """A source run that no longer exists ends the walk — the lineage just
+    starts later, exactly as read_metrics_history's curve does."""
+    from makermodslab.jobs import ancestor_ids_of
+
+    records = {
+        r.id: r
+        for r in [
+            _lineage_record("B", parent="gone"),
+            _lineage_record("C", parent="B"),
+        ]
+    }
+
+    assert ancestor_ids_of(records, "C") == ["B"]
+
+
+def test_ancestor_ids_survive_a_cycle() -> None:
+    """Corrupt data that points a chain back at itself must terminate, not spin."""
+    from makermodslab.jobs import ancestor_ids_of
+
+    records = {
+        r.id: r
+        for r in [
+            _lineage_record("A", parent="B"),
+            _lineage_record("B", parent="A"),
+        ]
+    }
+
+    assert ancestor_ids_of(records, "A") == ["B"]
+
+
+def test_list_annotates_lineage_and_marks_leaves(tmp_path) -> None:
+    from makermodslab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path)
+    for rec in [
+        _lineage_record("A", started_at=1.0),
+        _lineage_record("B", parent="A", started_at=2.0),
+        _lineage_record("C", parent="B", started_at=3.0),
+    ]:
+        reg._records[rec.id] = rec
+
+    by_id = {r.id: r for r in reg.list(limit=10)}
+
+    assert by_id["A"].child_ids == ["B"] and by_id["A"].ancestor_ids == []
+    assert by_id["B"].child_ids == ["C"] and by_id["B"].ancestor_ids == ["A"]
+    # The tip of the chain is the leaf: no children, whole trunk behind it.
+    assert by_id["C"].child_ids == [] and by_id["C"].ancestor_ids == ["B", "A"]
+
+
+def test_list_sees_a_child_that_fell_off_the_page(tmp_path) -> None:
+    """The child index is built over the whole registry, so a parent is still
+    known to be superseded when its successor is past the listing's limit —
+    the hole in the old client-side approximation."""
+    from makermodslab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path)
+    reg._records["A"] = _lineage_record("A", started_at=1.0)
+    reg._records["B"] = _lineage_record("B", parent="A", started_at=2.0)
+
+    # limit=1 returns only the newest (B); A is off the page entirely.
+    page = reg.list(limit=1)
+    assert [r.id for r in page] == ["B"]
+    # ...and asking for A alone still reports its successor.
+    assert reg.get("A").child_ids == ["B"]
+
+
+def test_get_annotates_lineage(tmp_path) -> None:
+    from makermodslab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path)
+    reg._records["A"] = _lineage_record("A", started_at=1.0)
+    reg._records["B"] = _lineage_record("B", parent="A", started_at=2.0)
+
+    record = reg.get("B")
+    assert record.child_ids == []
+    assert record.ancestor_ids == ["A"]
+
+
+def test_delete_refuses_a_run_that_was_continued(tmp_path) -> None:
+    """Deleting mid-chain would orphan the subtree (and wipe the local
+    checkpoint dir its children resumed out of), so it is refused."""
+    from makermodslab.jobs import JobHasChildrenError, JobRegistry
+
+    reg = JobRegistry(tmp_path)
+    reg._records["A"] = _lineage_record("A", started_at=1.0)
+    reg._records["B"] = _lineage_record("B", parent="A", started_at=2.0)
+
+    with pytest.raises(JobHasChildrenError) as excinfo:
+        reg.delete("A")
+    assert excinfo.value.child_ids == ["B"]
+    # Nothing was removed.
+    assert set(reg._records) == {"A", "B"}
+
+
+def test_delete_allows_a_leaf_then_its_freed_parent(tmp_path) -> None:
+    """Deleting from the tip inwards works: once the child is gone the parent
+    is itself a leaf."""
+    from makermodslab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path)
+    reg._records["A"] = _lineage_record("A", started_at=1.0)
+    reg._records["B"] = _lineage_record("B", parent="A", started_at=2.0)
+
+    reg.delete("B")
+    reg.delete("A")
+
+    assert reg._records == {}
+
+
+def test_delete_is_unaffected_by_a_finetune_child(tmp_path) -> None:
+    """A fine-tune is not a lineage edge, so its source stays deletable."""
+    from makermodslab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path)
+    reg._records["A"] = _lineage_record("A", started_at=1.0)
+    reg._records["F"] = _lineage_record("F", finetune_parent="A", started_at=2.0)
+
+    reg.delete("A")
+
+    assert set(reg._records) == {"F"}

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -170,6 +170,15 @@ def _hub_checkpoint_files(step_dir: str, *, with_optimizer: bool = True) -> list
     return files
 
 
+def _hub_pretrained_files(step_dir: str) -> list[str]:
+    """The repo paths a WEIGHTS-ONLY staging upload publishes — the fine-tune
+    base half of the tree above, with no training_state/ at all."""
+    return [
+        f"checkpoints/{step_dir}/pretrained_model/config.json",
+        f"checkpoints/{step_dir}/pretrained_model/model.safetensors",
+    ]
+
+
 def test_resolve_cloud_resume_returns_repo_and_step_dir(monkeypatch) -> None:
     from makermodslab.jobs import _resolve_cloud_resume
 
@@ -269,6 +278,7 @@ def test_resolve_cloud_resume_rejects_missing_repo() -> None:
 
 
 def _complete_names() -> set[str]:
+    """Every file a COMPLETE, resumable checkpoint tree holds."""
     return {
         "pretrained_model/config.json",
         "pretrained_model/model.safetensors",
@@ -349,6 +359,56 @@ def test_scan_checkpoint_dir_reports_relative_names_and_a_change_sensitive_finge
 
     (ck / "training_state" / "optimizer_state.safetensors").write_bytes(b"grown-larger")
     assert scan_checkpoint_dir(ck)[1] != fingerprint  # a byte written moves it
+
+
+# ── the weights-only completeness rule, for a fine-tune base (F7's fourth
+# quadrant) ─────────────────────────────────────────────────────────────────
+# A fine-tune reads pretrained_model/ and nothing else, so the staged copy of a
+# local base is weights-only and needs its own completeness rule. Judging it by
+# the resume rule would declare every staging upload broken.
+
+
+def test_missing_pretrained_files_accepts_the_weights_half_alone() -> None:
+    from makermodslab.jobs import missing_pretrained_files
+
+    names = {n for n in _complete_names() if n.startswith("pretrained_model/")}
+    assert missing_pretrained_files(names) == []
+
+
+def test_missing_pretrained_files_does_not_require_train_config() -> None:
+    """A flat Hub-imported base (laid out by push_to_hub, not by a checkpoint
+    save) legitimately has no train_config.json — requiring it would refuse the
+    canonical SmolVLA-style base."""
+    from makermodslab.jobs import missing_pretrained_files
+
+    assert (
+        missing_pretrained_files({"pretrained_model/config.json", "pretrained_model/model.safetensors"}) == []
+    )
+
+
+def test_missing_pretrained_files_flags_a_missing_config() -> None:
+    """config.json is what the in-container wrapper gates its download on."""
+    from makermodslab.jobs import missing_pretrained_files
+
+    assert missing_pretrained_files({"pretrained_model/model.safetensors"}) == [
+        "pretrained_model/config.json"
+    ]
+
+
+def test_missing_pretrained_files_flags_missing_weights() -> None:
+    from makermodslab.jobs import missing_pretrained_files
+
+    assert missing_pretrained_files({"pretrained_model/config.json"}) == ["pretrained_model/*.safetensors"]
+
+
+def test_missing_pretrained_files_ignores_a_missing_training_state() -> None:
+    """The whole point: the optimizer half is deliberately never staged, so its
+    absence must not read as an incomplete upload."""
+    from makermodslab.jobs import missing_pretrained_files
+
+    names = {n for n in _complete_names() if n.startswith("pretrained_model/")}
+    assert not any(n.startswith("training_state/") for n in names)
+    assert missing_pretrained_files(names) == []
 
 
 def test_parse_duration_handles_mm_ss_and_hh_mm_ss() -> None:
@@ -2263,6 +2323,112 @@ def _child_of(reg, parent_id: str, *, job_id: str = "child", state: str = "inter
     return reg._records[job_id]
 
 
+# ── …and only when the request actually ASKS to resume ──────────────────────
+# A resume source with `resume` left false used to launch as an ordinary fresh
+# run: it skipped every guard below (they all sit under `if config.resume`) yet
+# still persisted resume_from_job_id, which build_child_index reads as a
+# lineage edge. That produced a run that trained from scratch while counting as
+# a continuation — superseding a parent it never continued, and blocking that
+# parent from being resumed for real.
+
+
+def test_start_refuses_a_resume_source_without_the_resume_flag(tmp_path) -> None:
+    """The combination the live repro produced: a spurious extra child of an
+    existing lineage, created by a request that never said 'resume'."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    request = TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=False,  # the hole
+        resume_from_job_id="src",
+    )
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="resume_from_job_id was given but 'resume' is false"),
+    ):
+        reg.start(request, JobTarget(runner="local"))
+
+    # No record, so no phantom lineage edge either.
+    assert [r.id for r in reg.list(limit=10)] == ["src"]
+    assert reg.get("src").child_ids == []
+    _assert_nothing_was_created(reg)
+
+
+def test_start_refuses_a_resume_step_without_the_resume_flag(tmp_path) -> None:
+    """Same contract, named by the field actually supplied."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="resume_from_step was given but 'resume' is false"),
+    ):
+        reg.start(
+            TrainingRequest(
+                dataset_repo_id="user/ds",
+                policy_type="act",
+                resume=False,
+                resume_from_step=100,
+            ),
+            JobTarget(runner="local"),
+        )
+
+
+def test_start_still_allows_a_plain_fresh_run(tmp_path) -> None:
+    """The other direction: neither field set, so nothing is refused. Without
+    this the guard could pass by rejecting every fresh run ever launched."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+            JobTarget(runner="local"),
+        )
+
+    assert record.config.resume is False
+    assert record.config.resume_from_job_id is None
+    # ...and it is not anybody's child.
+    assert reg.get("src").child_ids == []
+
+
+def test_start_refuses_a_finetune_step_without_a_finetune_source(tmp_path) -> None:
+    """The analogous fine-tune inconsistency. There is no `finetune` boolean —
+    the id IS the mode — so the mismatch is a step with nothing to take it
+    from, which used to be dropped silently and trained from scratch."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="finetune_from_step was given without"),
+    ):
+        reg.start(
+            TrainingRequest(
+                dataset_repo_id="user/ds",
+                policy_type="act",
+                finetune_from_step=100,
+            ),
+            JobTarget(runner="local"),
+        )
+
+
 def test_start_refuses_to_resume_an_already_continued_run(tmp_path) -> None:
     """The sticks rule: one continuation per run. A second would fork the
     lineage, so it is refused — naming the child, which is what lets the HTTP
@@ -2696,6 +2862,303 @@ def test_cross_runner_resume_still_refuses_a_completed_parent(tmp_path, monkeypa
     ):
         reg.start(_local_to_cloud_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
     _assert_nothing_was_created(reg)
+
+
+# ── local base → Cloud FINE-TUNE (F7's fourth quadrant) ──────────────────────
+# The same crossing as the resume above, for the other mode: a base checkpoint
+# that exists only on this machine, fine-tuned on rented hardware. What moves is
+# the WEIGHTS ONLY — a fine-tune starts a fresh optimizer at step 0 and never
+# reads training_state/, which is the bigger half — into the same private
+# per-source staging repo a cloud resume uses. The request is then rewritten to
+# the 'repo@checkpoints/<step>' ref the pod already knows how to materialize, so
+# the record describes the run that actually happens rather than a host path the
+# container could never resolve.
+
+
+def _local_finetune_request(*, consent: bool = True, job_id: str = "src", step: int | None = None):
+    from makermodslab.train import TrainingRequest
+
+    return TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        finetune_from_job_id=job_id,
+        finetune_from_step=step,
+        upload_finetune_checkpoint=consent,
+    )
+
+
+def test_local_base_finetuned_on_the_cloud_uploads_weights_then_submits(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """The base's weights go up first — pretrained_model/ only, PRIVATE repo —
+    and only then is the cloud job submitted, pointed at what was just staged."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")  # a finished local run IS a base
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    fake_runner.hf_job_id.return_value = "hfjob-1"
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_local_finetune_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
+
+    assert api.created == [
+        {"repo_id": "alice/src_checkpoints", "repo_type": "model", "private": True, "exist_ok": True}
+    ]
+    # ONE upload, and it is the weights subtree — never the whole checkpoint.
+    assert [u["path_in_repo"] for u in api.uploaded] == ["checkpoints/100/pretrained_model"]
+    assert api.uploaded[0]["folder_path"].endswith("checkpoints/100/pretrained_model")
+    record = reg._records[record.id]
+    assert record.config.policy_pretrained_path == "alice/src_checkpoints@checkpoints/100"
+    # A fine-tune stays a FRESH run: nothing about it is a continuation.
+    assert record.config.resume is False and record.config.resume_from_hub_repo is None
+    assert fake_runner.start.called
+
+
+def test_local_base_finetuned_on_the_cloud_records_the_ref_before_the_upload(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """The rewrite happens at record creation, not after the bytes land: the
+    record handed back from `start` — while the upload is still deferred —
+    already names the Hub ref the pod will read, so no persisted config ever
+    claims the run trains from a path only this machine has."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    fake_runner.hf_job_id.return_value = "hfjob-1"
+    fake_runner.hf_job_url.return_value = "https://hf.co/jobs/hfjob-1"
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_local_finetune_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        assert record.config.policy_pretrained_path == "alice/src_checkpoints@checkpoints/100"
+        _join_prepare(reg, record.id)
+
+    reloaded = JobRegistry(reg._output_root)._records[record.id]
+    assert reloaded.config.policy_pretrained_path == "alice/src_checkpoints@checkpoints/100"
+
+
+def test_local_base_finetuned_on_the_cloud_records_the_upload_on_the_source(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """Where the weights went is remembered on the SOURCE — keyed off the
+    child's finetune_from_job_id, since a fine-tune has no resume edge — and
+    survives a reload, so the next fine-tune of the same step reuses it."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()):
+        record = reg.start(_local_finetune_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
+
+    source = reg._records["src"]
+    assert source.checkpoints_hub_repo_id == "alice/src_checkpoints"
+    assert source.checkpoints_hub_steps == ["100"]
+    reloaded = JobRegistry(reg._output_root)._records["src"]
+    assert reloaded.checkpoints_hub_repo_id == "alice/src_checkpoints"
+    assert reloaded.checkpoints_hub_steps == ["100"]
+
+
+def test_local_base_finetuned_on_the_cloud_reuses_an_earlier_staging(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """Second fine-tune of the same base: the weights are already staged and
+    confirmed there, so nothing is uploaded — and no consent is asked for,
+    because nothing new is disclosed. The confirmation uses the WEIGHTS-ONLY
+    rule, so the training_state/ a staging upload never pushed doesn't read as
+    a broken repo."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    reg._records["src"].checkpoints_hub_repo_id = "alice/src_checkpoints"
+    reg._records["src"].checkpoints_hub_steps = ["100"]
+    api = _FakeUploadApi(_hub_pretrained_files("100"))
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(
+            _local_finetune_request(consent=False),
+            JobTarget(runner="hf_cloud", flavor="t4-small"),
+        )
+
+    assert api.uploaded == []
+    assert record.config.policy_pretrained_path == "alice/src_checkpoints@checkpoints/100"
+    # Nothing had to move, so the job went straight to the runner.
+    assert record.id not in reg._prepare_threads
+    assert fake_runner.start.called
+
+
+def test_local_base_finetuned_on_the_cloud_refuses_without_consent(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """An upload is a disclosure, so it never happens as a side effect of
+    picking a base model: without the form's explicit consent the launch is
+    refused, nothing is uploaded, and no record is left behind."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    with (
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="Confirm the upload in the training form"),
+    ):
+        reg.start(
+            _local_finetune_request(consent=False),
+            JobTarget(runner="hf_cloud", flavor="t4-small"),
+        )
+
+    assert api.created == [] and api.uploaded == []
+    assert list(reg._records) == ["src"]
+    _assert_nothing_was_created(reg)
+
+
+def test_local_base_finetuned_on_the_cloud_refuses_when_offline(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """Offline mode disables every Hub write, so the staging this fine-tune
+    depends on is impossible — say so instead of trying."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: _FakeUploadApi())
+    monkeypatch.setattr("makermodslab.jobs.hf_hub_offline", lambda: True)
+    with (
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="Offline mode"),
+    ):
+        reg.start(_local_finetune_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    _assert_nothing_was_created(reg)
+
+
+def test_local_base_finetuned_on_the_cloud_refuses_without_hf_auth(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """No Hub identity ⇒ no namespace to stage into. Refused with the login
+    instruction rather than failing later inside the runner."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: None)
+    with (
+        patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="signed in"),
+    ):
+        reg.start(_local_finetune_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+
+    assert api.uploaded == []
+    _assert_nothing_was_created(reg)
+
+
+def test_local_base_finetuned_on_the_cloud_stages_a_flat_import_at_step_zero(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """The other local base shape: a flat imported directory that IS the
+    pretrained_model, with no checkpoints/<step>/ around it to read the step
+    from. Its listing offers exactly one checkpoint, at step 0, so the staged
+    step dir is the zero-padded 0 — and the ref names it, rather than the repo
+    root, so the pod materializes the weights that were actually uploaded."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+
+    src = tmp_path / "flat_base"
+    src.mkdir()
+    (src / "config.json").write_text(_json.dumps({"type": "act"}))
+    (src / "model.safetensors").write_bytes(b"weights")
+
+    reg = JobRegistry(tmp_path / "root")
+    source = reg.register_imported(str(src))
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: MagicMock()):
+        record = reg.start(
+            _local_finetune_request(job_id=source.id),
+            JobTarget(runner="hf_cloud", flavor="t4-small"),
+        )
+        _join_prepare(reg, record.id)
+
+    assert [u["path_in_repo"] for u in api.uploaded] == ["checkpoints/000000/pretrained_model"]
+    assert api.uploaded[0]["folder_path"] == str(src.resolve())
+    assert (
+        reg._records[record.id].config.policy_pretrained_path
+        == f"alice/{source.id}_checkpoints@checkpoints/000000"
+    )
+
+
+def test_local_base_finetuned_on_the_cloud_never_starts_from_scratch(
+    tmp_path, monkeypatch, cloud_preflight
+) -> None:
+    """The fine-tune reading of MT42: when the weights can't be put where the
+    pod will look for them, the job FAILS — it does not quietly become a
+    from-scratch run on rented hardware while the record calls itself a
+    fine-tune of somebody's checkpoint."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    api = _FakeUploadApi()
+    api.upload_error = RuntimeError("413 payload too large")
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    monkeypatch.setattr("makermodslab.jobs.cached_whoami", lambda: {"name": "alice"})
+    fake_runner = MagicMock()
+    with patch("makermodslab.runners.hf_cloud.HfCloudJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_local_finetune_request(), JobTarget(runner="hf_cloud", flavor="t4-small"))
+        _join_prepare(reg, record.id)
+
+    failed = reg._records[record.id]
+    assert failed.state == "failed"
+    assert "413 payload too large" in failed.error_message
+    assert not fake_runner.start.called
+
+
+def test_local_base_finetuned_locally_stages_nothing(tmp_path, monkeypatch) -> None:
+    """The staging is a property of the CROSSING, not of the base: the same
+    local base fine-tuned on this machine keeps the host path and touches the
+    Hub not at all."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    api = _FakeUploadApi()
+    monkeypatch.setattr("makermodslab.jobs.shared_hf_api", lambda: api)
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_local_finetune_request(consent=False), JobTarget(runner="local"))
+
+    assert api.created == [] and api.uploaded == []
+    assert record.config.policy_pretrained_path.endswith("checkpoints/100/pretrained_model")
+    assert fake_runner.start.called
 
 
 # ---------------------------------------------------------------------------
@@ -4418,7 +4881,10 @@ class _FakeUploadApi:
 
     `list_repo_files` answers from whatever has been "uploaded" so far, so the
     post-upload verification in _upload_resume_then_start exercises the real
-    completeness rule instead of a stub that always says yes."""
+    completeness rule instead of a stub that always says yes. A weights-only
+    push (the fine-tune staging path, whose path_in_repo ends in
+    /pretrained_model) publishes only that half, so its verification meets the
+    same tree the real one would — not a full checkpoint it never uploaded."""
 
     def __init__(self, files: list[str] | None = None) -> None:
         self._files = list(files or [])
@@ -4433,8 +4899,11 @@ class _FakeUploadApi:
         if self.upload_error is not None:
             raise self.upload_error
         self.uploaded.append(kwargs)
-        step_dir = kwargs["path_in_repo"].rsplit("/", 1)[-1]
-        self._files.extend(_hub_checkpoint_files(step_dir))
+        parts = kwargs["path_in_repo"].split("/")
+        if parts[-1] == "pretrained_model":
+            self._files.extend(_hub_pretrained_files(parts[-2]))
+        else:
+            self._files.extend(_hub_checkpoint_files(parts[-1]))
 
     def list_repo_files(self, repo_id, repo_type):
         return self._files
@@ -4753,6 +5222,8 @@ def test_read_log_tail_messages_skips_malformed_lines(tmp_path) -> None:
     path = tmp_path / "log.jsonl"
     path.write_text('{"timestamp": 1.0, "message": "ok"}\nnot json at all\n{"timestamp": 2.0}\n')
     assert _read_log_tail_messages(path) == ["ok"]
+
+
 # ---------------------------------------------------------------------------
 # Resume lineage: the child index, the ancestor walk, and the delete guard that
 # reads them. All pure registry state — no runner is started here.
@@ -5121,3 +5592,664 @@ def test_endpoint_409_falls_back_to_the_id_when_a_run_is_gone(
 
     assert resp.status_code == 409
     assert "src" in resp.json()["detail"]
+
+
+# The 409's REMEDY is child-aware: "delete the continuation" is sound advice
+# only for the single-unfinished-child lineage the sticks rule creates. On a
+# legacy fork, or against a continuation that ran to completion, the same
+# sentence tells the user to throw away finished training.
+
+
+def _stub_children(monkeypatch, source_id: str, children: dict[str, str]):
+    """Raise JobAlreadyContinuedError(source_id, children) from start, and make
+    the registry resolve each child id to a record in the given state."""
+    import makermodslab.server as server_mod
+    from makermodslab.jobs import JobAlreadyContinuedError, JobNotFoundError, JobRecord
+    from makermodslab.train import TrainingRequest
+
+    states = {source_id: "interrupted", **children}
+
+    def _fake_get(job_id: str):
+        if job_id not in states:
+            raise JobNotFoundError(job_id)
+        return JobRecord(
+            id=job_id,
+            name=job_id,
+            state=states[job_id],
+            config=TrainingRequest(dataset_repo_id="user/ds"),
+            output_dir=f"/nonexistent/{job_id}",
+            started_at=0.0,
+        )
+
+    def _raise(config, target):
+        raise JobAlreadyContinuedError(source_id, list(children))
+
+    monkeypatch.setattr(server_mod.job_registry, "start", _raise)
+    monkeypatch.setattr(server_mod.job_registry, "get", _fake_get)
+
+
+def test_endpoint_409_keeps_delete_first_for_one_unfinished_child(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The linear case — the only shape sticks can produce — still gets the
+    cheap, correct two-step remedy."""
+    _stub_children(monkeypatch, "src", {"kid": "interrupted"})
+
+    detail = _post_resume(client).json()["detail"]
+
+    assert "delete" in detail.lower()
+    assert "fine-tune" not in detail.lower()
+
+
+def test_endpoint_409_recommends_finetune_on_a_legacy_fork(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two children: freeing the parent means deleting BOTH, so deletion stops
+    being reasonable advice and fine-tune (unrestricted by sticks) takes over."""
+    _stub_children(monkeypatch, "src", {"kid": "interrupted", "other": "failed"})
+
+    detail = _post_resume(client).json()["detail"]
+
+    assert "fine-tune" in detail.lower()
+    assert "kid" in detail and "other" in detail
+
+
+def test_endpoint_409_will_not_advise_deleting_a_finished_run(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The user's actual case: a lone continuation that ran to completion. The
+    advice must not be "delete it" — that is the run holding the finished
+    training — and the message says which run it is protecting."""
+    _stub_children(monkeypatch, "src", {"kid": "done"})
+
+    detail = _post_resume(client).json()["detail"]
+
+    assert "fine-tune" in detail.lower()
+    assert "finished run" in detail
+    assert "kid" in detail
+
+
+def test_endpoint_409_survives_an_unresolvable_child(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The state lookup must not turn the refusal into a 500 when a child id no
+    longer resolves; it just can't claim the run is finished."""
+    import makermodslab.server as server_mod
+    from makermodslab.jobs import JobAlreadyContinuedError, JobNotFoundError
+
+    def _raise(config, target):
+        raise JobAlreadyContinuedError("src", ["kid"])
+
+    def _fake_get(job_id: str):
+        raise JobNotFoundError(job_id)
+
+    monkeypatch.setattr(server_mod.job_registry, "start", _raise)
+    monkeypatch.setattr(server_mod.job_registry, "get", _fake_get)
+
+    resp = _post_resume(client)
+
+    assert resp.status_code == 409
+    assert "finished run" not in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Run numbers. A persisted, monotonic counter — the point is that a number is
+# never handed out twice, which is exactly what deriving max(existing)+1 at
+# render time cannot promise.
+
+
+def _numbered_registry(tmp_path):
+    from makermodslab.jobs import JobRegistry
+
+    return JobRegistry(tmp_path / "root")
+
+
+def test_start_numbers_runs_from_one_upward(tmp_path) -> None:
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _numbered_registry(tmp_path)
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    numbers = []
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        for _ in range(3):
+            rec = reg.start(
+                TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+                JobTarget(runner="local"),
+            )
+            reg._records[rec.id].state = "done"  # free the one-local-run mutex
+            numbers.append(rec.job_number)
+
+    assert numbers == [1, 2, 3]
+
+
+def test_job_numbers_survive_a_registry_reload(tmp_path) -> None:
+    """The counter is on disk, so a restart continues the sequence instead of
+    starting over and colliding with the runs already numbered."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _numbered_registry(tmp_path)
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        first = reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+            JobTarget(runner="local"),
+        )
+        reg._records[first.id].state = "done"
+        reg._persist(reg._records[first.id], force=True)
+
+    reopened = JobRegistry(tmp_path / "root")
+    assert reopened.get(first.id).job_number == first.job_number
+
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        second = reopened.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+            JobTarget(runner="local"),
+        )
+
+    assert second.job_number == first.job_number + 1
+
+
+def test_deleting_the_highest_numbered_run_does_not_free_its_number(tmp_path) -> None:
+    """THE reason the counter is persisted rather than derived. max(existing)+1
+    would reissue #1 here, so two different runs would have worn the same
+    number — across a restart too, since the counter file outlives the record."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _numbered_registry(tmp_path)
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        first = reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+            JobTarget(runner="local"),
+        )
+    reg._records[first.id].state = "done"
+    reg._persist(reg._records[first.id], force=True)
+    assert first.job_number == 1
+
+    reg.delete(first.id)
+    # ...and the registry is empty, so a derived number would restart at 1.
+    assert reg._records == {}
+
+    reopened = JobRegistry(tmp_path / "root")
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        second = reopened.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+            JobTarget(runner="local"),
+        )
+
+    assert second.job_number == 2
+
+
+def test_backfill_numbers_legacy_records_oldest_first(tmp_path) -> None:
+    """Records written before the field existed get numbers in the order they
+    happened, so the sequence agrees with the history the user remembers."""
+    from makermodslab.jobs import JobRegistry
+
+    root = tmp_path / "root"
+    for job_id, started in (("late", 300.0), ("early", 100.0), ("middle", 200.0)):
+        rec = _lineage_record(job_id, started_at=started)
+        d = root / job_id
+        d.mkdir(parents=True)
+        # Written WITHOUT job_number, the shape a pre-existing registry holds.
+        data = rec.model_dump(mode="json")
+        data.pop("job_number")
+        (d / "job.json").write_text(_json.dumps(data))
+
+    reg = JobRegistry(root)
+
+    assert reg.get("early").job_number == 1
+    assert reg.get("middle").job_number == 2
+    assert reg.get("late").job_number == 3
+
+
+def test_backfill_breaks_started_at_ties_deterministically(tmp_path) -> None:
+    """Legacy timestamps are second-granular, so ties are real. Without a
+    tie-break two boots could order the same pair differently and silently
+    renumber history."""
+    from makermodslab.jobs import JobRegistry
+
+    root = tmp_path / "root"
+    for job_id in ("bbb", "aaa"):
+        rec = _lineage_record(job_id, started_at=100.0)
+        d = root / job_id
+        d.mkdir(parents=True)
+        data = rec.model_dump(mode="json")
+        data.pop("job_number")
+        (d / "job.json").write_text(_json.dumps(data))
+
+    reg = JobRegistry(root)
+
+    assert reg.get("aaa").job_number == 1
+    assert reg.get("bbb").job_number == 2
+
+
+def test_backfill_is_idempotent_across_restarts(tmp_path) -> None:
+    """A second boot must find everything numbered and change nothing — the
+    numbers are persisted back to each job.json, not recomputed per process."""
+    from makermodslab.jobs import JobRegistry
+
+    root = tmp_path / "root"
+    for job_id, started in (("a", 100.0), ("b", 200.0)):
+        rec = _lineage_record(job_id, started_at=started)
+        d = root / job_id
+        d.mkdir(parents=True)
+        data = rec.model_dump(mode="json")
+        data.pop("job_number")
+        (d / "job.json").write_text(_json.dumps(data))
+
+    first = {r.id: r.job_number for r in JobRegistry(root).list(limit=10)}
+    second = {r.id: r.job_number for r in JobRegistry(root).list(limit=10)}
+
+    assert first == {"a": 1, "b": 2}
+    assert first == second
+
+
+def test_a_lost_counter_file_still_will_not_reissue_a_live_number(tmp_path) -> None:
+    """Degraded case: the counter is gone but the records are not. The floor is
+    recomputed from the records, and persisted, so the next boot keeps it even
+    after the highest-numbered run is deleted."""
+    from makermodslab.jobs import JobRegistry, _job_counter_path
+
+    root = tmp_path / "root"
+    for job_id, number in (("a", 1), ("b", 7)):
+        rec = _lineage_record(job_id, started_at=float(number))
+        rec.job_number = number
+        d = root / job_id
+        d.mkdir(parents=True)
+        (d / "job.json").write_text(rec.model_dump_json())
+
+    reg = JobRegistry(root)
+    assert _job_counter_path(root).exists()
+    assert reg._next_job_number == 8
+
+    reg.delete("b")
+    assert JobRegistry(root)._next_job_number == 8
+
+
+def test_a_corrupt_counter_file_is_ignored_not_fatal(tmp_path) -> None:
+    """A half-written or hand-edited counter must not take the registry down,
+    and must not read as a number below the records in use."""
+    from makermodslab.jobs import JobRegistry, _job_counter_path
+
+    root = tmp_path / "root"
+    rec = _lineage_record("a", started_at=1.0)
+    rec.job_number = 4
+    (root / "a").mkdir(parents=True)
+    (root / "a" / "job.json").write_text(rec.model_dump_json())
+    _job_counter_path(root).write_text("{not json")
+
+    assert JobRegistry(root)._next_job_number == 5
+
+
+def test_the_counter_file_is_not_mistaken_for_a_job(tmp_path) -> None:
+    """It lives in the registry root beside the job dirs, so the loader has to
+    keep ignoring it (it globs directories only)."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _numbered_registry(tmp_path)
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        rec = reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+            JobTarget(runner="local"),
+        )
+    reg._records[rec.id].state = "done"
+    reg._persist(reg._records[rec.id], force=True)
+
+    assert [r.id for r in JobRegistry(tmp_path / "root").list(limit=10)] == [rec.id]
+
+
+def test_imported_records_take_a_number_from_the_same_sequence(tmp_path) -> None:
+    """Imports share the libraries with runs, so a library where some rows have
+    a number and some don't is the thing to avoid."""
+    from makermodslab.jobs import JobRegistry
+
+    model = tmp_path / "model"
+    _make_pretrained(model)
+    reg = JobRegistry(tmp_path / "root")
+
+    assert reg.register_imported(str(model)).job_number == 1
+
+
+def test_endpoint_409_label_leads_with_the_run_number(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The number is what the UI shows, so the API's refusals have to speak it
+    too — while keeping the id, which is what survives a rename."""
+    import makermodslab.server as server_mod
+    from makermodslab.jobs import JobAlreadyContinuedError, JobNotFoundError, JobRecord
+    from makermodslab.train import TrainingRequest
+
+    numbers = {"src": 46, "kid": 47}
+
+    def _fake_get(job_id: str):
+        if job_id not in numbers:
+            raise JobNotFoundError(job_id)
+        return JobRecord(
+            id=job_id,
+            job_number=numbers[job_id],
+            name="overnight act",
+            state="interrupted",
+            config=TrainingRequest(dataset_repo_id="user/ds"),
+            output_dir=f"/nonexistent/{job_id}",
+            started_at=0.0,
+        )
+
+    def _raise(config, target):
+        raise JobAlreadyContinuedError("src", ["kid"])
+
+    monkeypatch.setattr(server_mod.job_registry, "start", _raise)
+    monkeypatch.setattr(server_mod.job_registry, "get", _fake_get)
+
+    detail = _post_resume(client).json()["detail"]
+
+    assert "#46" in detail and "#47" in detail
+    assert "src" in detail and "kid" in detail  # ids still present
+
+
+def test_endpoint_409_label_omits_the_number_when_unassigned(client, monkeypatch) -> None:
+    """A record that predates the field must not be labelled "#0"."""
+    import makermodslab.server as server_mod
+    from makermodslab.jobs import JobAlreadyContinuedError, JobRecord
+    from makermodslab.train import TrainingRequest
+
+    def _fake_get(job_id: str):
+        return JobRecord(
+            id=job_id,
+            name="overnight act",
+            state="interrupted",
+            config=TrainingRequest(dataset_repo_id="user/ds"),
+            output_dir=f"/nonexistent/{job_id}",
+            started_at=0.0,
+        )
+
+    def _raise(config, target):
+        raise JobAlreadyContinuedError("src", ["kid"])
+
+    monkeypatch.setattr(server_mod.job_registry, "start", _raise)
+    monkeypatch.setattr(server_mod.job_registry, "get", _fake_get)
+
+    assert "#0" not in _post_resume(client).json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# CHAIN REWIND. A resume continues the LEAF from ANY checkpoint on its lineage:
+# the edge points at the leaf (so chains stay linear), while the bytes are read
+# from whichever ancestor owns the chosen checkpoint. The empty-handed tip — a
+# run that died before saving anything — is the case this exists for.
+
+
+def _rewind_chain(tmp_path):
+    """A two-run chain: `trunk` with real checkpoints at 100 and 200, and
+    `tip` continuing it with none of its own (it died before its first save)."""
+    from makermodslab.jobs import JobRecord, JobRegistry
+    from makermodslab.train import TrainingRequest
+
+    trunk_dir = tmp_path / "trunk" / "run"
+    trunk_dir.mkdir(parents=True)
+    _make_checkpoint(trunk_dir, 100)
+    _make_checkpoint(trunk_dir, 200)
+    tip_dir = tmp_path / "tip" / "run"
+    tip_dir.mkdir(parents=True)
+
+    reg = JobRegistry(tmp_path / "root")
+    reg._records["trunk"] = JobRecord(
+        id="trunk",
+        name="run",
+        state="interrupted",
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=1000),
+        output_dir=str(trunk_dir),
+        started_at=0.0,
+        runner="local",
+    )
+    reg._records["tip"] = JobRecord(
+        id="tip",
+        name="run",
+        state="interrupted",
+        config=TrainingRequest(
+            dataset_repo_id="user/ds",
+            policy_type="act",
+            steps=1000,
+            resume=True,
+            resume_from_job_id="trunk",
+            resume_from_step=200,
+        ),
+        output_dir=str(tip_dir),
+        started_at=1.0,
+        runner="local",
+    )
+    return reg
+
+
+def _rewind_request(*, leaf: str, owner: str | None, step: int | None, steps: int = 1000):
+    from makermodslab.train import TrainingRequest
+
+    return TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        steps=steps,
+        resume=True,
+        resume_from_job_id=leaf,
+        resume_from_step=step,
+        resume_from_checkpoint_job_id=owner,
+    )
+
+
+def test_rewind_resumes_an_empty_tip_from_its_ancestors_checkpoint(tmp_path) -> None:
+    """THE case the redirect exists for. The tip saved nothing, so before rewind
+    it was a dead row; now it continues itself from the trunk's checkpoint —
+    and the new run is a child of the TIP, so the chain stays linear."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _rewind_chain(tmp_path)
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        record = reg.start(
+            _rewind_request(leaf="tip", owner="trunk", step=200),
+            JobTarget(runner="local"),
+        )
+
+    # The EDGE names the tip...
+    assert record.config.resume_from_job_id == "tip"
+    assert reg.get("tip").child_ids == [record.id]
+    # ...and the trunk gains no second child, which is what keeps it linear.
+    assert reg.get("trunk").child_ids == ["tip"]
+    # The BYTES come from the trunk's checkpoint dir.
+    assert "trunk" in record.config.config_path
+    assert "checkpoints/200" in record.config.config_path
+
+
+def test_rewind_can_reach_an_older_checkpoint_of_the_ancestor(tmp_path) -> None:
+    """Any checkpoint on the lineage, not just the newest — rewinding past a
+    bad stretch is the point."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _rewind_chain(tmp_path)
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        record = reg.start(
+            _rewind_request(leaf="tip", owner="trunk", step=100),
+            JobTarget(runner="local"),
+        )
+
+    assert "checkpoints/100" in record.config.config_path
+    assert record.config.resume_from_job_id == "tip"
+
+
+def test_a_plain_tip_resume_still_needs_no_owner(tmp_path) -> None:
+    """Backward compatibility: omitting the owner means the leaf owns the
+    checkpoint, which is every request written before rewind existed."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")  # checkpoint at step 100
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        record = reg.start(
+            _rewind_request(leaf="src", owner=None, step=100, steps=200),
+            JobTarget(runner="local"),
+        )
+
+    assert record.config.resume_from_checkpoint_job_id is None
+    assert "checkpoints/100" in record.config.config_path
+
+
+def test_rewind_naming_the_leaf_as_its_own_owner_is_accepted(tmp_path) -> None:
+    """The explicit spelling of the same thing — the UI omits it, but a caller
+    that sends it must not be refused for agreeing with the default."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    fake = MagicMock()
+    fake.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake):
+        record = reg.start(
+            _rewind_request(leaf="src", owner="src", step=100, steps=200),
+            JobTarget(runner="local"),
+        )
+
+    assert "checkpoints/100" in record.config.config_path
+
+
+def test_rewind_refuses_an_owner_off_the_leaf_lineage(tmp_path) -> None:
+    """The wrong-weights guard. A run that is not an ancestor has no business
+    seeding this chain — its bytes would enter a history claiming continuity
+    with them."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRecord, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _rewind_chain(tmp_path)
+    stranger_dir = tmp_path / "stranger" / "run"
+    stranger_dir.mkdir(parents=True)
+    _make_checkpoint(stranger_dir, 100)
+    reg._records["stranger"] = JobRecord(
+        id="stranger",
+        name="unrelated",
+        state="interrupted",
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=1000),
+        output_dir=str(stranger_dir),
+        started_at=2.0,
+        runner="local",
+    )
+
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="is not on 'tip''s lineage"),
+    ):
+        reg.start(
+            _rewind_request(leaf="tip", owner="stranger", step=100),
+            JobTarget(runner="local"),
+        )
+
+
+def test_rewind_refuses_an_owner_that_lacks_the_named_step(tmp_path) -> None:
+    """Naming a real ancestor is not enough — it must actually hold that
+    checkpoint, or the resolver's 'latest' fallback would silently substitute
+    different weights."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _rewind_chain(tmp_path)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="no checkpoint at step 999"),
+    ):
+        reg.start(
+            _rewind_request(leaf="tip", owner="trunk", step=999),
+            JobTarget(runner="local"),
+        )
+
+
+def test_rewind_refuses_an_unknown_owner(tmp_path) -> None:
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _rewind_chain(tmp_path)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="Resume checkpoint owner 'ghost' not found"),
+    ):
+        reg.start(
+            _rewind_request(leaf="tip", owner="ghost", step=100),
+            JobTarget(runner="local"),
+        )
+
+
+def test_rewind_requires_an_explicit_step(tmp_path) -> None:
+    """'Latest' has no meaning once an owner is named: a rewound lineage can
+    hold several checkpoints at one step, so the pair must be exact."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _rewind_chain(tmp_path)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="resume_from_step is required"),
+    ):
+        reg.start(
+            _rewind_request(leaf="tip", owner="trunk", step=None),
+            JobTarget(runner="local"),
+        )
+
+
+def test_rewind_still_refuses_a_second_continuation_of_the_leaf(tmp_path) -> None:
+    """The sticks 409 survives the redirect and is now pure API integrity: no
+    legitimate caller names a non-leaf as the edge, because the UI always seeds
+    the leaf. A leaf that already has a child is not a leaf."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobAlreadyContinuedError, JobTarget
+
+    reg = _rewind_chain(tmp_path)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(JobAlreadyContinuedError),
+    ):
+        # `trunk` is mid-chain — `tip` already continues it.
+        reg.start(
+            _rewind_request(leaf="trunk", owner="trunk", step=200),
+            JobTarget(runner="local"),
+        )
+
+
+def test_rewind_steps_guard_reads_the_chosen_checkpoint(tmp_path) -> None:
+    """The target must beat the step actually being resumed from, which after a
+    rewind is the ANCESTOR's step, not the leaf's progress."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _rewind_chain(tmp_path)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="would train nothing"),
+    ):
+        reg.start(
+            _rewind_request(leaf="tip", owner="trunk", step=200, steps=200),
+            JobTarget(runner="local"),
+        )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2135,6 +2135,258 @@ def test_start_still_resumes_a_run_that_stopped_short(tmp_path, state) -> None:
     assert "checkpoints/100" in record.config.config_path
 
 
+# ── …and only toward a target it can actually reach ─────────────────────────
+# lerobot trains `range(resumed_step, steps)`, so a target at or below the
+# checkpoint is an empty range: the run does nothing, exits 0, and the registry
+# gets a `done` phantom claiming a target it never trained toward. The endpoint
+# pre-flight in server.py catches the case where the REQUEST names its step;
+# these cover the registry's own guard, which runs after the step is resolved
+# and so also covers "latest checkpoint" (resume_from_step=None) requests.
+
+
+def _resume_request_at(steps: int, *, step: int | None = None):
+    from makermodslab.train import TrainingRequest
+
+    return TrainingRequest(
+        dataset_repo_id="user/ds",
+        policy_type="act",
+        resume=True,
+        resume_from_job_id="src",
+        resume_from_step=step,
+        steps=steps,
+    )
+
+
+@pytest.mark.parametrize("steps", [0, 50, 100])
+def test_start_refuses_a_resume_target_at_or_below_the_checkpoint(tmp_path, steps) -> None:
+    """The boundary is strict: equal to the checkpoint step trains nothing, and
+    so does anything below it. `steps=0` is refused with the rest — a request's
+    own target is a required field, so 0 means "train nothing", not "unset"."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")  # checkpoint at step 100
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="would train nothing"),
+    ):
+        reg.start(_resume_request_at(steps, step=100), JobTarget(runner="local"))
+
+    assert [r.id for r in reg.list(limit=10)] == ["src"]
+    _assert_nothing_was_created(reg)
+
+
+def test_start_allows_a_resume_target_one_step_above_the_checkpoint(tmp_path) -> None:
+    """Just past the boundary is a real (if short) continuation, and must not be
+    swept up by the guard."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_resume_request_at(101, step=100), JobTarget(runner="local"))
+
+    assert record.config.steps == 101
+
+
+def test_start_refuses_a_latest_checkpoint_resume_below_its_target(tmp_path) -> None:
+    """The hole the endpoint's pre-flight can't see: the request leaves the step
+    to the registry ("latest checkpoint"), so `resume_from_step` is None when
+    the endpoint looks. The registry re-checks once it has resolved step 100."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    request = _resume_request_at(100, step=None)
+    assert request.resume_from_step is None  # the pre-flight's blind spot
+
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="checkpoint step 100"),
+    ):
+        reg.start(request, JobTarget(runner="local"))
+
+    _assert_nothing_was_created(reg)
+
+
+def test_start_step_target_guard_leaves_fresh_runs_alone(tmp_path) -> None:
+    """It is a RESUME guard. A fresh run has no checkpoint step to be above, and
+    `_resume_start_step` returns None for it, so nothing is refused."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act", steps=100),
+            JobTarget(runner="local"),
+        )
+
+    assert record.config.resume is False
+
+
+# ── …and only ONCE: sticks, not forks ───────────────────────────────────────
+# User decision 2026-08-07. A run may be continued once, so a resume whose
+# source already has a child is refused at CREATION time. Legacy forks on disk
+# are untouched by this — nothing here runs at load or list time (the lineage
+# section at the end of this file covers that half).
+
+
+def _child_of(reg, parent_id: str, *, job_id: str = "child", state: str = "interrupted"):
+    """Register a run that continues `parent_id`, i.e. gives it a child."""
+    from makermodslab.jobs import JobRecord
+    from makermodslab.train import TrainingRequest
+
+    reg._records[job_id] = JobRecord(
+        id=job_id,
+        name="continuation",
+        state=state,
+        config=TrainingRequest(
+            dataset_repo_id="user/ds",
+            policy_type="act",
+            resume=True,
+            resume_from_job_id=parent_id,
+        ),
+        output_dir=f"/nonexistent/{job_id}",
+        started_at=1.0,
+        runner="local",
+    )
+    return reg._records[job_id]
+
+
+def test_start_refuses_to_resume_an_already_continued_run(tmp_path) -> None:
+    """The sticks rule: one continuation per run. A second would fork the
+    lineage, so it is refused — naming the child, which is what lets the HTTP
+    layer tell the user which run to delete first. No record created."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobAlreadyContinuedError, JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    _child_of(reg, "src")
+
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(JobAlreadyContinuedError) as excinfo,
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+    assert excinfo.value.job_id == "src"
+    assert excinfo.value.child_ids == ["child"]
+    assert set(reg._records) == {"src", "child"}
+    _assert_nothing_was_created(reg)
+
+
+def test_start_refusal_ignores_a_finetune_child(tmp_path) -> None:
+    """A fine-tune is not a resume edge anywhere else (the child index, the
+    delete guard), and it isn't one here either: its source keeps its own
+    identity and stays continuable."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRecord, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    reg._records["ft"] = JobRecord(
+        id="ft",
+        name="finetune",
+        # `done`, not `running` — a live local run would trip the one-at-a-time
+        # mutex and mask the thing under test.
+        state="done",
+        config=TrainingRequest(
+            dataset_repo_id="user/ds",
+            policy_type="act",
+            finetune_from_job_id="src",
+        ),
+        output_dir="/nonexistent/ft",
+        started_at=1.0,
+        runner="local",
+    )
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_resume_request(), JobTarget(runner="local"))
+
+    assert record.config.resume is True
+
+
+def test_start_refusal_defers_to_the_completed_source_refusal(tmp_path) -> None:
+    """Both refusals can be true of one legacy source. The `done` one wins, and
+    must: telling the user to delete a child to unlock a resume that would then
+    be refused for a spent LR schedule is worse guidance than "fine-tune"."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobTarget
+
+    reg = _resumable_source(tmp_path, "done")
+    _child_of(reg, "src")
+
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(ValueError, match="already reached its step target"),
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+
+def test_deleting_the_tip_frees_its_parent_to_be_resumed(tmp_path) -> None:
+    """The recovery the refusal's message promises, end to end at the registry
+    level: the fork is blocked, deleting the existing continuation makes its
+    parent a leaf again, and the same resume then succeeds."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobAlreadyContinuedError, JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    _child_of(reg, "src")
+
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(JobAlreadyContinuedError),
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+    reg.delete("child")
+
+    fake_runner = MagicMock()
+    fake_runner.pid.return_value = 4242
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: fake_runner):
+        record = reg.start(_resume_request(), JobTarget(runner="local"))
+
+    assert record.config.resume is True
+    assert "checkpoints/100" in record.config.config_path
+    # ...and the new continuation is now the one child `src` is allowed.
+    assert reg.get("src").child_ids == [record.id]
+
+
+def test_start_refuses_a_second_continuation_of_a_cloud_source(tmp_path) -> None:
+    """The refusal is on the LINEAGE, not the runner, so it lands before the
+    local/cloud branch that moves the checkpoint — same placement as the
+    completed-source refusal above."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobAlreadyContinuedError, JobTarget
+
+    reg = _resumable_source(tmp_path, "interrupted")
+    reg._records["src"].runner = "hf_cloud"
+    reg._records["src"].hf_repo_id = "user/some-model"
+    _child_of(reg, "src")
+
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        pytest.raises(JobAlreadyContinuedError),
+    ):
+        reg.start(_resume_request(), JobTarget(runner="local"))
+
+
 # ── …and on either runner, once the checkpoint can get there (F7) ───────────
 # A continuation may cross runners in both directions now. What each direction
 # has to do first is move the parent's checkpoint to wherever the trainer will
@@ -4548,8 +4800,11 @@ def test_build_child_index_maps_parents_to_children_newest_first() -> None:
 
 
 def test_build_child_index_keeps_every_child_of_a_fork_newest_first() -> None:
-    """Nothing stops two runs resuming one parent, so the lineage is a forest,
-    not a set of chains — both forks must be indexed, newest first."""
+    """LEGACY DATA. `start` now refuses a second resume off one parent (sticks
+    only, user decision 2026-08-07), so no new fork can appear — but registries
+    written before that rule hold real ones, and the index they load through
+    stays forest-capable: both children indexed, newest first. Rolling this
+    back to "one child" would silently drop a leaf from the list."""
     from makermodslab.jobs import build_child_index
 
     index = build_child_index(
@@ -4601,6 +4856,9 @@ def test_ancestor_ids_walk_nearest_parent_first() -> None:
 
 
 def test_ancestor_ids_of_forked_siblings_share_the_trunk() -> None:
+    """LEGACY DATA, same as the fork index above: the walk is per-record and
+    upward, so a trunk with two leaves hanging off it reads correctly from
+    either leaf. Unchanged by the sticks rule, which only refuses new forks."""
     from makermodslab.jobs import ancestor_ids_of
 
     records = {
@@ -4665,6 +4923,31 @@ def test_list_annotates_lineage_and_marks_leaves(tmp_path) -> None:
     assert by_id["B"].child_ids == ["C"] and by_id["B"].ancestor_ids == ["A"]
     # The tip of the chain is the leaf: no children, whole trunk behind it.
     assert by_id["C"].child_ids == [] and by_id["C"].ancestor_ids == ["B", "A"]
+
+
+def test_list_annotates_a_legacy_fork_unchanged(tmp_path) -> None:
+    """A registry that already holds a fork keeps listing exactly as it did:
+    the trunk names BOTH children (so it is superseded and hidden), and each
+    leaf carries the shared trunk behind it, so the UI renders one row per leaf.
+
+    This is the half of the sticks decision that is deliberately NOT enforced.
+    The refusal lives at creation time only — there is no migration, and no
+    load- or list-time rejection of data that predates it."""
+    from makermodslab.jobs import JobRegistry
+
+    reg = JobRegistry(tmp_path)
+    for rec in [
+        _lineage_record("trunk", started_at=1.0),
+        _lineage_record("older", parent="trunk", started_at=2.0),
+        _lineage_record("newer", parent="trunk", started_at=3.0),
+    ]:
+        reg._records[rec.id] = rec
+
+    by_id = {r.id: r for r in reg.list(limit=10)}
+
+    assert by_id["trunk"].child_ids == ["newer", "older"]
+    assert by_id["older"].child_ids == [] and by_id["older"].ancestor_ids == ["trunk"]
+    assert by_id["newer"].child_ids == [] and by_id["newer"].ancestor_ids == ["trunk"]
 
 
 def test_list_sees_a_child_that_fell_off_the_page(tmp_path) -> None:
@@ -4738,3 +5021,103 @@ def test_delete_is_unaffected_by_a_finetune_child(tmp_path) -> None:
     reg.delete("A")
 
     assert set(reg._records) == {"F"}
+
+
+# ---------------------------------------------------------------------------
+# The HTTP half of the second-resume refusal: POST /jobs/training turns
+# JobAlreadyContinuedError into a 409 whose message teaches the way out. The
+# registry is stubbed — what is under test is the routing and the wording, not
+# the rule (covered above).
+
+
+def _post_resume(client, source_id: str = "src"):
+    return client.post(
+        "/jobs/training",
+        json={
+            "dataset_repo_id": "user/ds",
+            "steps": 200,
+            "resume": True,
+            "resume_from_job_id": source_id,
+        },
+    )
+
+
+def test_endpoint_409s_a_second_continuation_and_names_the_way_out(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """409, not 400: a conflict with existing state, routed exactly like the
+    mid-chain delete refusal it is the mirror of. The message must name the run
+    to delete AND the run that frees up, because neither is guessable from
+    "resume refused"."""
+    import makermodslab.server as server_mod
+    from makermodslab.jobs import JobAlreadyContinuedError
+
+    def _raise(config, target):
+        raise JobAlreadyContinuedError("src", ["kid"])
+
+    monkeypatch.setattr(server_mod.job_registry, "start", _raise)
+
+    resp = _post_resume(client)
+
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert "src" in detail and "kid" in detail
+    assert "already continued" in detail
+    assert "delete" in detail.lower()
+
+
+def test_endpoint_409_labels_the_runs_by_their_display_name(client, monkeypatch) -> None:
+    """Telling the user to delete X is only actionable if X is findable in the
+    list, and the list shows the display alias — so the message resolves ids to
+    names when the registry still holds them."""
+    import makermodslab.server as server_mod
+    from makermodslab.jobs import JobAlreadyContinuedError, JobNotFoundError, JobRecord
+    from makermodslab.train import TrainingRequest
+
+    names = {"src": "overnight act", "kid": "overnight act v2"}
+
+    def _fake_get(job_id: str):
+        if job_id not in names:
+            raise JobNotFoundError(job_id)
+        return JobRecord(
+            id=job_id,
+            name="auto-generated",
+            display_name=names[job_id],
+            state="interrupted",
+            config=TrainingRequest(dataset_repo_id="user/ds"),
+            output_dir=f"/nonexistent/{job_id}",
+            started_at=0.0,
+        )
+
+    def _raise(config, target):
+        raise JobAlreadyContinuedError("src", ["kid"])
+
+    monkeypatch.setattr(server_mod.job_registry, "start", _raise)
+    monkeypatch.setattr(server_mod.job_registry, "get", _fake_get)
+
+    detail = _post_resume(client).json()["detail"]
+
+    assert "overnight act" in detail and "overnight act v2" in detail
+
+
+def test_endpoint_409_falls_back_to_the_id_when_a_run_is_gone(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The label lookup must not turn a refusal into a 500 when the registry
+    can't resolve an id (a record deleted between the failure and the message)."""
+    import makermodslab.server as server_mod
+    from makermodslab.jobs import JobAlreadyContinuedError, JobNotFoundError
+
+    def _raise(config, target):
+        raise JobAlreadyContinuedError("src", ["kid"])
+
+    def _fake_get(job_id: str):
+        raise JobNotFoundError(job_id)
+
+    monkeypatch.setattr(server_mod.job_registry, "start", _raise)
+    monkeypatch.setattr(server_mod.job_registry, "get", _fake_get)
+
+    resp = _post_resume(client)
+
+    assert resp.status_code == 409
+    assert "src" in resp.json()["detail"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -992,6 +992,42 @@ def test_delete_local_model_409_when_running(registry) -> None:
     assert (registry._output_root / "live_run").exists()
 
 
+def test_delete_local_model_409_when_resumed_by_another_run(registry) -> None:
+    """A MID-CHAIN delete reached from the model library is refused the same way
+    the /jobs route refuses it: 409, naming the continuation. Without its own
+    handler JobHasChildrenError fell into delete_local_model's catch-all and
+    surfaced as a 502 "Failed to delete model", which reads as a bug in the
+    app rather than as the deliberate guard it is."""
+    from makermodslab.jobs import JobRecord
+    from makermodslab.models import ModelError, delete_local_model
+    from makermodslab.train import TrainingRequest
+
+    _seed_run(registry, "parent_run", state="interrupted")
+    registry._records["child_run"] = JobRecord(
+        id="child_run",
+        name="child of parent_run",
+        state="done",
+        config=TrainingRequest(
+            dataset_repo_id="user/pick",
+            resume=True,
+            resume_from_job_id="parent_run",
+        ),
+        output_dir=str(registry._output_root / "child_run" / "run"),
+        started_at=2.0,
+        ended_at=3.0,
+        runner="local",
+    )
+
+    with pytest.raises(ModelError) as ei:
+        delete_local_model("parent_run")
+    assert ei.value.status == 409
+    assert "child_run" in ei.value.message
+    # The parent's dir — including the checkpoint the child resumed out of —
+    # must survive the refusal.
+    assert (registry._output_root / "parent_run").exists()
+    assert "parent_run" in registry._records
+
+
 def test_delete_local_model_refuses_path_outside_output_root(registry) -> None:
     """A record whose id resolves OUTSIDE outputs/train (traversal) is refused;
     no rmtree runs, so nothing outside the sandbox is touched."""


### PR DESCRIPTION
**Base is `main`. Both prerequisites — #42 (training resume semantics) and #58 (the jobs-UI generation) — are merged, and this branch is rebased on top of them.** It was authored as a stacked draft on `pr/jobs-ui`; that stack is gone, and what is left is five commits that apply directly to `main`.

A resume chain becomes one thing in the UI and one invariant in the backend: the jobs list shows one row per chain, the lineage is derived server-side, Continue is a single button that never asks which checkpoint, and every run carries a stable number so the refusals can name each other.

## The five commits

### 1. `669edc09` — one row per resume leaf; lineage server-derived; mid-chain delete refused

The jobs list collapses each resume chain to its leaf. Lineage is derived server-side over the **whole registry** at read time — `child_ids` (newest-first) and `ancestor_ids` (nearest-first) on every `JobRecord` — replacing a client-side approximation that lost a parent whose child sat past the 50-record page. A fine-tune is deliberately **not** an edge: it starts a fresh optimizer and LR schedule from a checkpoint's weights, so it is a new model and its source keeps its own row.

Deleting a run something resumed from is refused with a **409 naming the continuations, on both routes** — `/jobs/{id}` and `/models/delete`, where it previously surfaced as a 502. The delete would orphan the children's lineage and, for a local parent, take the checkpoint directory they resumed out of.

Resume becomes **one verb across both entry points**. The library row's quick-resume and the card's Continue share one lineage loader (`loadLineageCheckpoints`, walking the leaf's own ancestor path) and one rule (`resumableCheckpoints`), so they can no longer offer different checkpoints or reach different verdicts. The F7-stale runner-match filter is dropped — a resume may cross runners in either direction, and the owner's runner only seeds the form's default Compute. Empty results explain themselves via `noResumeReason` instead of a guessed toast.

### 2. `a376c72a` — resume is sticks-only: a run can be continued once

Branching (a second resume off an already-continued run) is refused at creation time. The forest-capable data model stays, so legacy forks render exactly as before; branching is deferred, not abolished (user decision 2026-08-07).

`JobAlreadyContinuedError` → **409** naming the continuation with delete-first guidance, derived under the registry lock so two concurrent resumes of one parent can't both pass, and ordered *after* the done-refusal so a finished-and-continued source gets "fine-tune" advice rather than a delete that would only buy the next refusal.

**Steps-guard fix:** the step-target guard is now authoritative in the registry, *after* the resume step is resolved. The server-side pre-flight read the request's `resume_from_step`, which is `None` on every latest-checkpoint resume — so those bypassed it entirely and could launch runs that completed instantly having trained nothing (lerobot's `range(step, cfg.steps)` is empty), landing in the registry as `done` phantoms that then poisoned their own source. This matters more, not less, under commit 4: latest-only Continue is exactly the shape that used to bypass it.

### 3. `43ce6c38` — the leaf/owner split, job numbers, and F7's fourth quadrant

A resume names **two** runs. `resume_from_job_id` stays the lineage edge and always points at the **leaf**; the new `resume_from_checkpoint_job_id` carries the run that **owns** the chosen checkpoint, as provenance, so the backend knows whose storage to read the bytes from.

That split is what lets a tip resume at all when it saved nothing of its own. `buildResumeSeed` used to be called with the checkpoint's **owner** as the job, so continuing from an ancestor's checkpoint created a continuation *of the ancestor* — a second child, i.e. a fork, which commit 2's sticks rule then refused outright. The offered checkpoint was never the problem; **the edge was.** With the two roles separate, the edge always targets the leaf, the chain grows `parent -> leaf -> new run`, and it stays linear no matter which run's storage the bytes came from.

`jobs.py` refuses an owner that is not on the leaf's ancestor path or does not hold the named step (`_resolve_checkpoint_owner` / `_owner_holds_step`). With the split in place, an empty-handed tip is simply resumable — it continues *itself* from whatever its ancestors saved — so commit 2's `blockedByContinuedOwner` rule and the frontend's delete-first hint are gone along with the state that stranded users. (The backend still emits delete-first guidance for the single-unfinished-child case, which is a different situation.)

Also here: persisted `job_number` per run (monotonic counter file beside the registry, never reissued after a delete, backfilled oldest-first for legacy records, tolerant of a lost or corrupt counter), owner attribution in the checkpoint dropdown (rendered only when the list actually spans more than one run), and the resumed step displayed beside the Run name label in the Train form.

**Scope flag for review, unchanged from the original draft:** this commit also carries F7's *fourth quadrant* — a fine-tune whose base lives only on this machine, staged weights-only to a private Hub repo for cloud compute (`missing_pretrained_files`, `hub_pretrained_missing_files`, `upload_local_pretrained`, `_resolve_upload_finetune`, `_upload_finetune_then_start`). It is carried as authored because the base supports it, but it is not part of the resume story and a reviewer may reasonably want it split out.

### 4. `87345bdd` — Continue is latest-checkpoint-only

**User decision 2026-08-10.** Continue stops being step-selectable. `JobCard`'s Resume no longer reads the checkpoint dropdown's selection; it takes `resumableCheckpoints(...)[0]` — the newest — which is exactly the entry the library row's one-click has always used. The two entry points can no longer pick a different checkpoint or build a different payload; what still differs is only how each *offers* the action (the row is shown on a cheap chain-count and explains an empty result with a toast, the card evaluates the exact rule and hides the button). The button labels the step it *will* use rather than one the user chose.

The dropdown stays, driving Run / Fine-tune / Download, where picking an older checkpoint is a real choice. Continuing *training* from one is not: it re-trains steps the chain already covered, and it blocks the intended end state where a continuation **absorbs** its parent (inheriting its checkpoints outright, so there is no ancestor left to reach back to). A rewound child re-writes steps its parent still holds, so absorbing it would have to collide or silently discard the superseded ones; continuing from the newest checkpoint is a pure append and does neither.

**The lineage reach survives, invisibly.** The newest resumable checkpoint may be owned by an ancestor, because a tip that died before saving anything has none of its own. The user presses one button and never learns which run held the bytes — but that reach is what keeps every row in the library done-or-resumable, and commit 3's split still records the owner separately from the lineage edge, so the chain stays linear.

Commit 3's plumbing is therefore kept, not reverted. **The API stays wider than the app:** `resume_from_step` and `resume_from_checkpoint_job_id` are still accepted and still guarded, so an arbitrary rewind is reachable by calling the endpoint directly. That is deliberate — it is what keeps commit 3's guards and their tests meaningful — and it means "you cannot resume from a non-latest checkpoint" is a statement about the UI, not the API. Noted at both the field and the guard.

**Also here, and originally reported on #58:** the Train configurator's remount key was built from the run id alone, but the seed is read once as initial state. Pressing Continue a second time for the same run at a different step updated the banner and the step validation while everything derived at mount — `resume_from_step`, the checkpoint owner, `steps`, the optimizer/W&B prefills, the compute default — stayed frozen at the first pick. The backend cannot catch it: that (step, owner) pair is internally valid. The key now carries the whole triple for resume and (run, step) for fine-tune, whose `finetune_from_step` is read at mount for the identical reason. Before #58 this could not happen, because Continue navigated away and rebuilt the form; making Continue in-place is what exposed it. Thanks @IsaacSinn.

### 5. `5914f528` — the prose describes a latest-only Continue again

Comment-only, no behaviour change. `resumableCheckpoints` opened on "the lineage is offered WHOLE: any checkpoint on the leaf's ancestor path can start a continuation"; `buildResumeSeed` named its caller "the job card's step-selectable Resume"; `JobsLibrary` promised that "choosing a specific step stays on the selected run's card below"; four gate comments justified counting the chain rather than the tip with "chain rewind lets a run continue from any checkpoint on its lineage". One user-visible string went with them — the row's Resume tooltip read "(pick a specific step in the card below)", pointing at an affordance that is gone.

The rewrite keeps the reach and says what it is *for* rather than what it offers.

## What this does about #58's review

#58 has since merged; both findings were raised against it and are answered here.

- **"Continuing the same run twice from different steps submits the first step"** — fixed in commit 4, as described above.
- **"One-click resume can continue somebody else's run"** — narrowed, not closed, and worth reading before approving. Both entry points now share one loader and one rule, and `cloudSiblingStepCap` excludes every checkpoint above the leaf's own furthest step — exactly the reported case (a leaf that died at 6k being offered a sibling's 30k). The half of the complaint that mattered most — *the warning only fired when nothing bad was going to happen* — is fixed by `noResumeReason`, which now has a dedicated `sibling-cap` message. **Two residual limits remain**, both documented in `resumeSeed.ts`: a sibling that forked *early* wrote its checkpoints inside the leaf's own step range, where nothing distinguishes them; and the cap is keyed on the **leaf's** runner, so a local leaf resuming a cloud parent enumerates that parent's shared Hub repo with no cap applied (deliberately kept leaf-keyed — owner-keying would hide a superseded ancestor's above-step checkpoints, which have no other access point in the UI). Both only bite **pre-existing** forks, since commit 2 refuses new ones. True per-run attribution of Hub checkpoints is a backend/identity change.

## Checks

Measured on this branch (`5914f528`) against its merge base, `origin/main`:

| | `origin/main` | this branch |
|---|---|---|
| `pytest` | 1389 passed, 0 failed | **1464 passed, 0 failed** |
| `npx tsc -b` | 5 errors | 5 errors (the same five files) |
| `npm run lint` | 27 problems (3 errors, 24 warnings) | 26 problems (3 errors, 23 warnings) |
| `npm run build` | succeeds | succeeds |
| `pre-commit run --all-files` | all 19 hooks pass | all 19 hooks pass |

**+75 collected tests, zero failures, nothing new from any other gate.** The five type errors are pre-existing and untouched (`RobotConfigDialog.tsx`, `JobsLibrary.tsx`, `ModelsLibrary.tsx`, `DatasetLibrary.tsx`, `meshLoaders.ts`); the lint count drops by one as a fast-refresh warning falls out. Every intermediate commit is green too — 1404 / 1419 / 1464 / 1464 / 1464 — so the series bisects.

**73 new test functions, none removed** — the +75 collected is those 73 plus two parametrized cases. Per-commit, the collected count goes 1389 → 1404 → 1419 → 1464 → 1464 → 1464: commits 4 and 5 add no tests (commit 4 is frontend-only and this repo has no frontend test harness; commit 5 is comments). Commit 4 does not remove any test either: the guards it stops exercising from the UI are still exercised through the API, which is the surface they now solely protect.

`frontend/dist` is **not** committed (`main`'s `build_frontend` workflow regenerates it) and `frontend/package-lock.json` is untouched.

**CI runs on this PR now, and it is green** — Build, Pytest and Quality all pass. This is the branch's first-ever CI: while it targeted `pr/jobs-ui`, every workflow was filtered on `pull_request: branches: [main]` and none ever fired. Retargeting to `main` and rebasing put the workflows in reach.

## Rebase notes

Authored on the rig integration branch, adapted onto `pr/jobs-ui`, and now rebased onto `main` (`git rebase --onto origin/main`, five commits replayed). A merge was not an option: #58 was **squash**-merged, so merging `main` in would have replayed its seven commits against their own squash.

Seven textual conflicts. Most were both-added-against-an-empty-base and kept both sides — `main`'s OOM post-mortem (#51) alongside commit 1's `build_child_index`/`ancestor_ids_of`, `_check_finetune_policy_type` alongside commit 3's `finetune_source`, the `isEmpty` empty-state wrapper (#79) around commit 1's `chainCheckpointCount`. Three were judgement calls worth naming:

- **`buildResumeSeed` takes both sides.** `main` widened `ResumeSeed` (NEW-12) so the seed now carries `hfJobTimeout` and the hyperparameters; commit 3 split the job argument into leaf and checkpoint owner. Neither side alone is right, and the split runs along what each field *describes*: the two that describe **the compute being rented** — `flavor` and `hfJobTimeout` — follow the checkpoint's **owner**, while everything describing **the run being continued** (dataset, policy, step budget, cadence, hyperparameters) follows the **leaf**. Taking commit 3 whole would have dropped `hfJobTimeout` entirely, which is the regression NEW-12 exists to prevent; sourcing it from the leaf instead — the first cut at this resolution — would have blanked it in precisely the cross-runner case, since a local leaf never persists a timeout at all. Caught in review; the docstring's scope note now states the rule.
- **`latestResumableStep` stays deleted.** Commit 1 removes it in favour of `resumableCheckpoints`; `main` only reflowed its signature. No callers remain.
- **Three duplicate definitions were removed after the replay.** `_FakeUploadApi`, `_fake_resume_snapshot`, `test_start_still_resumes_a_cloud_run_on_the_cloud` and `_complete_names` were *context* in the original diffs, not additions — `main` had relocated them, so the replay inserted second copies. Python's later definition wins, so the duplicated `_FakeUploadApi` shadowed commit 3's weights-only `upload_folder` and two fourth-quadrant tests failed on a base they never uploaded. Kept `main`'s copies in their own sections and carried commit 3's additions onto them.

Adaptation notes carried over from the `pr/jobs-ui` pass, all still true:

- **NEW-6 is the base's.** `dedupeCheckpointEntries` is consumed from `@/lib/checkpointsApi` rather than re-introduced.
- **JobCard keeps Run / Fine-tune / Download.** Upstream, commit 1 moves them to ModelCard. But `main`'s ModelCard is deliberately unreferenced, and `ModelsLibrary` still mounts **JobCard** with `onPlay` for imported and uploaded models — removing them here would make all three unreachable. The action row therefore stays gated on `showInferenceRow` rather than narrowing to `showResumeRow`. This is also why commit 4 keeps the checkpoint dropdown: those three actions still need it.
- **Panel re-siting.** The resumed-step display goes on the base's `EssentialsCard`, beside its existing **Run name** label; the label is not renamed to "Model name \*" (required human model names are separate rig work). The card title keeps the base's `DisplayName`, with the `#N` span added around it.
- **`CheckpointDropdown` gains the newest-first `ordered` sort** along with the attribution it renders.

The feature was UI-verified against a fixture registry by the user.

## Relationship to #66 / F7

Cross-runner resume (F7, #66, `491d4a9`) is already on `main` and this builds directly on it. Commit 1 **drops F7's now-stale runner-match filter** from the resume rule: since a continuation may cross runners in either direction — `jobs.py` materializes a cloud parent's Hub checkpoint onto local disk, or uploads a local parent's to the Hub with consent — the owner's runner is no longer a constraint on where the continuation may run. It only decides whether the checkpoint has to be **moved** first, and what the form defaults Compute to (still editable). Filtering on it hid every checkpoint from a local leaf whose parent ran on the cloud, leaving that card with no resume row while the library row still offered a resume it then refused.

Commit 3's leaf/owner split extends the same idea: the checkpoint's owner, not the leaf, decides where the bytes live.
