### PR TITLE
inference: ACT temporal ensembling option, and jobs library empty-state alignment

### DIFF
--- a/frontend/src/components/jobs/JobsLibrary.tsx
+++ b/frontend/src/components/jobs/JobsLibrary.tsx
@@ -7,7 +7,10 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import LibraryToolbar from "@/components/library/LibraryToolbar";
-import CappedGrid, { GRID_MIN_H } from "@/components/library/CappedGrid";
+import CappedGrid, {
+  GRID_MIN_H,
+  GRID_ROW_MIN_H,
+} from "@/components/library/CappedGrid";
 import LibraryHeader from "@/components/library/LibraryHeader";
 import { SLIDE } from "@/components/studio/panel/primitives";
 import { useStudio } from "@/contexts/StudioContext";
@@ -170,6 +173,29 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
         ? "No active online jobs."
         : "No active training jobs.";
 
+  // Nothing in the library at all, before any search or filter. The dataset and
+  // skills libraries answer that with a single dashed GRID_MIN_H box and no
+  // toolbar; jobs must too, or this panel's library is a toolbar taller than
+  // theirs and its header, search bar, and Start button sit above the other
+  // panels' (all three libraries are pinned to the panel foot, so extra height
+  // pushes everything up).
+  const isEmpty =
+    localJobs.length === 0 &&
+    trackedCloudJobs.length === 0 &&
+    untrackedHubJobs.length === 0;
+
+  // Why an empty library is empty, said inside the box instead of as a line
+  // above it — an extra line would make the panel taller again.
+  const emptyHint = !showOnline
+    ? ""
+    : hubError
+      ? ""
+      : !hubAuthenticated
+        ? " Sign in with Hugging Face to see your cloud jobs."
+        : !hubJobsPermission
+          ? " Your Hugging Face token is missing the job.read permission, so cloud jobs can't be listed."
+          : "";
+
   return (
     <Collapsible open={open} onOpenChange={onOpenChange} className="space-y-3">
       <LibraryHeader
@@ -191,14 +217,16 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
 
       <CollapsibleContent className={SLIDE}>
         <div className="space-y-3">
-          <LibraryToolbar
-            query={search}
-            onQueryChange={setSearch}
-            searchPlaceholder="Search jobs"
-            filters={FILTERS}
-            filter={filter}
-            onFilterChange={setFilter}
-          />
+          {isEmpty ? null : (
+            <LibraryToolbar
+              query={search}
+              onQueryChange={setSearch}
+              searchPlaceholder="Search jobs"
+              filters={FILTERS}
+              filter={filter}
+              onFilterChange={setFilter}
+            />
+          )}
 
           {error ? (
             <p className="text-sm text-destructive">
@@ -210,13 +238,13 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
               Couldn't load cloud jobs: {hubError}
             </p>
           ) : null}
-          {showOnline && !hubError && !hubAuthenticated &&
+          {!isEmpty && showOnline && !hubError && !hubAuthenticated &&
           trackedCloudJobs.length === 0 ? (
             <p className="text-sm text-muted-foreground">
               Sign in with Hugging Face to see your cloud jobs.
             </p>
           ) : null}
-          {showOnline && hubAuthenticated && !hubJobsPermission ? (
+          {!isEmpty && showOnline && hubAuthenticated && !hubJobsPermission ? (
             <p className="text-sm text-warn">
               Your Hugging Face token is missing the{" "}
               <code className="text-warn">job.read</code> permission, so cloud
@@ -229,12 +257,26 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
               says where it runs. The grid and the Untracked footer row share
               one space-y-2 stack so the footer sits exactly where the other
               libraries' "Show all" row sits. */}
+          {isEmpty ? (
+            <div
+              className={cn(
+                "flex items-center justify-center rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground",
+                GRID_MIN_H,
+              )}
+            >
+              No training jobs yet. Start one above.{emptyHint}
+            </div>
+          ) : (
           <div className="space-y-2">
           {activeCount === 0 ? (
+            // Only the card-row height when the Untracked toggle renders its
+            // own footer row below — the two together then equal one
+            // GRID_MIN_H block, so this library lines up with Collect's and
+            // Deploy's instead of standing 2.375rem taller.
             <p
               className={cn(
                 "flex items-center justify-center text-sm text-muted-foreground",
-                GRID_MIN_H,
+                showUntrackedToggle ? GRID_ROW_MIN_H : GRID_MIN_H,
               )}
             >
               {emptyMessage}
@@ -319,6 +361,7 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
             </Collapsible>
           ) : null}
           </div>
+          )}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/frontend/src/components/landing/InferenceModal.tsx
+++ b/frontend/src/components/landing/InferenceModal.tsx
@@ -3,6 +3,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { AdvancedSection } from "@/components/studio/panel/primitives";
+import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -43,6 +46,12 @@ interface Props {
   jobId: string;
   initialStep: number | null;
 }
+
+/** Coefficient of the original ACT paper's exponential weighting (see
+ * lerobot's ACTTemporalEnsembler). Offered as the starting point when the user
+ * switches temporal ensembling on. */
+const DEFAULT_TEMPORAL_ENSEMBLE_COEFF = 0.01;
+
 
 /** Small preview for verifying which physical camera a role binds to.
  *
@@ -166,6 +175,14 @@ const InferenceModal: React.FC<Props> = ({
   // behaviour; "rtc" is experimental (see StartInferenceRequest).
   const [inferenceEngine, setInferenceEngine] = useState<"sync" | "rtc">("sync");
   const [submitting, setSubmitting] = useState(false);
+  // ACT temporal ensembling — see DeployPanel, which carries the same pair.
+  // (on, coeff) rather than `number | null` so clearing the field mid-edit
+  // doesn't silently switch the feature off.
+  const [temporalEnsemble, setTemporalEnsemble] = useState(false);
+  const [temporalEnsembleCoeff, setTemporalEnsembleCoeff] = useState<
+    number | undefined
+  >(DEFAULT_TEMPORAL_ENSEMBLE_COEFF);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const [policyConfig, setPolicyConfig] = useState<PolicyConfigSummary | null>(null);
   const [policyConfigLoading, setPolicyConfigLoading] = useState(false);
@@ -367,6 +384,17 @@ const InferenceModal: React.FC<Props> = ({
 
   // Inference drives the follower(s) only — gate on follower_ready, not
   // is_clean, so a robot with no leader setup can still run a policy.
+  // Temporal ensembling is an ACT config field — no other policy type has it,
+  // and passing --policy.temporal_ensemble_coeff to one would fail the
+  // rollout's config parse. Show the control only for ACT checkpoints.
+  const isAct = policyConfig?.policy_type === "act";
+  // Empty field or a non-positive number: the backend rejects it (weights are
+  // exp(-coeff * i)), so block Start rather than round-trip a 400.
+  const temporalEnsembleInvalid =
+    isAct &&
+    temporalEnsemble &&
+    (temporalEnsembleCoeff === undefined || temporalEnsembleCoeff <= 0);
+
   const canStart =
     !!robot &&
     robot.follower_ready &&
@@ -374,6 +402,7 @@ const InferenceModal: React.FC<Props> = ({
     selectedRef != null &&
     !!policyConfig &&
     allCamerasBound &&
+    !temporalEnsembleInvalid &&
     !submitting;
 
   const handleStart = async () => {
@@ -436,6 +465,10 @@ const InferenceModal: React.FC<Props> = ({
         // observation.state — the server then defers to its shape check).
         checkpoint_state_dim: policyConfig.state_dim ?? undefined,
         inference_engine: inferenceEngine,
+        // ACT-only, and only while the switch is on — otherwise omitted so the
+        // checkpoint's own (ensembling-off) config stands.
+        temporal_ensemble_coeff:
+          isAct && temporalEnsemble ? temporalEnsembleCoeff : undefined,
       });
       onOpenChange(false);
       openInferenceSession();
@@ -715,6 +748,74 @@ const InferenceModal: React.FC<Props> = ({
               </div>
             )}
           </div>
+
+          {/* Advanced parameters — the shared AdvancedSection, same trigger and
+              inner eyebrow/label/help-text rhythm as the Train form's
+              AdvancedCard and the Deploy panel. ACT-only: temporal ensembling
+              is an ACT config field, so for every other policy type the block
+              has nothing to hold and stays hidden. ----------------------- */}
+          {isAct ? (
+            <AdvancedSection
+              open={advancedOpen}
+              onOpenChange={setAdvancedOpen}
+              summary="Temporal ensembling for ACT"
+            >
+              <div className="space-y-6">
+                <section className="space-y-3">
+                  <h4 className="eyebrow">Action selection</h4>
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      id="temporal-ensemble"
+                      checked={temporalEnsemble}
+                      onCheckedChange={setTemporalEnsemble}
+                      className="data-[state=checked]:bg-primary"
+                    />
+                    <Label htmlFor="temporal-ensemble">
+                      Temporal ensembling
+                    </Label>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Averages the overlapping action chunks the policy predicts
+                    at each step instead of executing one chunk open-loop —
+                    smoother motion, but the policy runs every control step, so
+                    it is slower.
+                  </p>
+                  {temporalEnsemble ? (
+                    <div className="space-y-2">
+                      <Label htmlFor="temporal-ensemble-coeff">
+                        Ensemble coefficient
+                      </Label>
+                      <NumberInput
+                        id="temporal-ensemble-coeff"
+                        integer={false}
+                        step="0.001"
+                        min={0}
+                        value={temporalEnsembleCoeff}
+                        onChange={setTemporalEnsembleCoeff}
+                        placeholder={`${DEFAULT_TEMPORAL_ENSEMBLE_COEFF} (ACT paper default)`}
+                        aria-invalid={temporalEnsembleInvalid}
+                        className={cn(
+                          "w-40",
+                          temporalEnsembleInvalid && "border-destructive",
+                        )}
+                      />
+                      {temporalEnsembleInvalid ? (
+                        <p className="text-xs text-destructive">
+                          Enter a number greater than 0.
+                        </p>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          Weights are exp(-coeff × age): higher favours the
+                          newest prediction, lower averages more evenly. The
+                          ACT paper uses {DEFAULT_TEMPORAL_ENSEMBLE_COEFF}.
+                        </p>
+                      )}
+                    </div>
+                  ) : null}
+                </section>
+              </div>
+            </AdvancedSection>
+          ) : null}
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
             <Button

--- a/frontend/src/components/library/CappedGrid.tsx
+++ b/frontend/src/components/library/CappedGrid.tsx
@@ -20,6 +20,12 @@ const WIDE_COLUMN_MIN_PX = 800;
  * can see as literals. */
 export const GRID_MIN_H = "min-h-[18.875rem]";
 
+/** Just the 16.5rem card row, without the footer slot. An empty/no-match state
+ * that renders its OWN footer row beneath it (jobs' Untracked toggle) must use
+ * this instead of GRID_MIN_H — otherwise message + footer stack to 21.25rem and
+ * that library sits 2.375rem taller than the other panels'. */
+export const GRID_ROW_MIN_H = "min-h-[16.5rem]";
+
 /**
  * The shared library grid, capped at one row. Every studio library (datasets,
  * training jobs, models) renders one row of cards by default — three where the

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Select,
@@ -45,6 +46,7 @@ import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
 import ModelsLibrary from "@/components/jobs/ModelsLibrary";
 import ImportModelModal from "@/components/jobs/ImportModelModal";
 import {
+  AdvancedSection,
   FormSection,
   LibrarySection,
   PANEL_ENTRY_CLASS,
@@ -77,6 +79,11 @@ const JOB_SCAN_LIMIT = 200;
 // Mirrors rollout.MAX_EVAL_EPISODES — the server clamps to the same bound, this
 // just stops the stepper from offering a number that would be silently reduced.
 const MAX_EVAL_EPISODES = 200;
+
+/** Coefficient of the original ACT paper's exponential weighting (see
+ * lerobot's ACTTemporalEnsembler). Offered as the starting point when the user
+ * switches temporal ensembling on. */
+const DEFAULT_TEMPORAL_ENSEMBLE_COEFF = 0.01;
 
 /** Small preview for verifying which physical camera a role binds to.
  *
@@ -194,6 +201,14 @@ const DeployPanel: React.FC = () => {
   // behaviour; "rtc" is experimental (see StartInferenceRequest).
   const [inferenceEngine, setInferenceEngine] = useState<"sync" | "rtc">("sync");
   const [submitting, setSubmitting] = useState(false);
+  // ACT temporal ensembling. Held as (on, coeff) rather than `number | null`
+  // so clearing the number field mid-edit doesn't silently switch the feature
+  // off; the request sends the coeff only while `on`.
+  const [temporalEnsemble, setTemporalEnsemble] = useState(false);
+  const [temporalEnsembleCoeff, setTemporalEnsembleCoeff] = useState<
+    number | undefined
+  >(DEFAULT_TEMPORAL_ENSEMBLE_COEFF);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const [policyConfig, setPolicyConfig] = useState<PolicyConfigSummary | null>(
     null,
@@ -531,6 +546,17 @@ const DeployPanel: React.FC = () => {
 
   const inferenceActive = status?.inference_active === true;
 
+  // Temporal ensembling is an ACT config field — no other policy type has it,
+  // and passing --policy.temporal_ensemble_coeff to one would fail the
+  // rollout's config parse. Show the control only for ACT checkpoints.
+  const isAct = policyConfig?.policy_type === "act";
+  // Empty field or a non-positive number: the backend rejects it (weights are
+  // exp(-coeff * i)), so block Start rather than round-trip a 400.
+  const temporalEnsembleInvalid =
+    isAct &&
+    temporalEnsemble &&
+    (temporalEnsembleCoeff === undefined || temporalEnsembleCoeff <= 0);
+
   // Inference drives the follower(s) only — gate on follower_ready, not
   // is_clean, so a robot with no leader port/calibration (which inference
   // never touches) can still deploy.
@@ -541,6 +567,7 @@ const DeployPanel: React.FC = () => {
     selectedRef != null &&
     !!policyConfig &&
     allCamerasBound &&
+    !temporalEnsembleInvalid &&
     !submitting &&
     !inferenceActive;
 
@@ -597,6 +624,10 @@ const DeployPanel: React.FC = () => {
         checkpoint_state_dim: policyConfig.state_dim ?? undefined,
         eval_episodes: evalEpisodes,
         inference_engine: inferenceEngine,
+        // ACT-only, and only while the switch is on — otherwise omitted so the
+        // checkpoint's own (ensembling-off) config stands.
+        temporal_ensemble_coeff:
+          isAct && temporalEnsemble ? temporalEnsembleCoeff : undefined,
       });
       // The run surfaces as the InferenceSessionDialog over this panel —
       // closing it lands back here (the studio stays open underneath).
@@ -989,6 +1020,74 @@ const DeployPanel: React.FC = () => {
                 </div>
               )}
           </FormSection>
+
+          {/* Advanced parameters — same AdvancedSection trigger and inner
+              eyebrow/label/help-text rhythm as the Train form's AdvancedCard,
+              so the two panels read as one form. ACT-only for now: temporal
+              ensembling is an ACT config field, so for every other policy type
+              the block has nothing to hold and stays hidden. ------------- */}
+          {isAct ? (
+            <AdvancedSection
+              open={advancedOpen}
+              onOpenChange={setAdvancedOpen}
+              summary="Temporal ensembling for ACT"
+            >
+              <div className="space-y-6">
+                <section className="space-y-3">
+                  <h4 className="eyebrow">Action selection</h4>
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      id="deploy-temporal-ensemble"
+                      checked={temporalEnsemble}
+                      onCheckedChange={setTemporalEnsemble}
+                      className="data-[state=checked]:bg-primary"
+                    />
+                    <Label htmlFor="deploy-temporal-ensemble">
+                      Temporal ensembling
+                    </Label>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Averages the overlapping action chunks the policy predicts
+                    at each step instead of executing one chunk open-loop —
+                    smoother motion, but the policy runs every control step, so
+                    it is slower.
+                  </p>
+                  {temporalEnsemble ? (
+                    <div className="space-y-2">
+                      <Label htmlFor="deploy-temporal-ensemble-coeff">
+                        Ensemble coefficient
+                      </Label>
+                      <NumberInput
+                        id="deploy-temporal-ensemble-coeff"
+                        integer={false}
+                        step="0.001"
+                        min={0}
+                        value={temporalEnsembleCoeff}
+                        onChange={setTemporalEnsembleCoeff}
+                        placeholder={`${DEFAULT_TEMPORAL_ENSEMBLE_COEFF} (ACT paper default)`}
+                        aria-invalid={temporalEnsembleInvalid}
+                        className={cn(
+                          "w-40",
+                          temporalEnsembleInvalid && "border-destructive",
+                        )}
+                      />
+                      {temporalEnsembleInvalid ? (
+                        <p className="text-xs text-destructive">
+                          Enter a number greater than 0.
+                        </p>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          Weights are exp(-coeff × age): higher favours the
+                          newest prediction, lower averages more evenly. The
+                          ACT paper uses {DEFAULT_TEMPORAL_ENSEMBLE_COEFF}.
+                        </p>
+                      )}
+                    </div>
+                  ) : null}
+                </section>
+              </div>
+            </AdvancedSection>
+          ) : null}
         </div>
       ) : null}
 

--- a/frontend/src/lib/inferenceApi.ts
+++ b/frontend/src/lib/inferenceApi.ts
@@ -45,6 +45,10 @@ export interface StartInferenceRequest {
   // with action playback on a background thread. Experimental: RTC changes the
   // policy's action-generation path, not just its scheduling.
   inference_engine?: "sync" | "rtc";
+  // ACT temporal ensembling. Omit (or undefined) to leave it off, matching
+  // lerobot's default. Any positive coefficient enables it — the server also
+  // pins n_action_steps=1, which ACT requires alongside it. ACT-only.
+  temporal_ensemble_coeff?: number;
 }
 
 // Structured startup sub-phase, mirrored from rollout.py's phase constants.

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -174,6 +174,11 @@ class InferenceRequest(BaseModel):
     # action-generation path than the one a checkpoint was evaluated under.
     # Experimental on purpose: A/B it per run, don't assume equivalence.
     inference_engine: Literal["sync", "rtc"] = "sync"
+    # ACT temporal ensembling (see _rollout_cli_args). None = off, which is
+    # also lerobot's own default. Any positive coefficient turns it on; the
+    # original ACT paper uses 0.01. Only ACT checkpoints have this field in
+    # their config, so the UI offers it for `policy_type == "act"` alone.
+    temporal_ensemble_coeff: float | None = None
 
 
 inference_active: bool = False
@@ -1091,7 +1096,7 @@ def _rollout_cli_args(request: InferenceRequest, policy_path: str, robot_args: l
     at a different entry point (`makermodslab.eval_runner`, which speaks
     `lerobot-rollout`'s argv verbatim). One list, two front-ends, so a flag
     added for one is never missing from the other."""
-    return [
+    args = [
         "--strategy.type=base",
         # Emitted unconditionally, including for the "sync" default — same
         # reasoning as --strategy.type=base above and the teardown pin below:
@@ -1113,6 +1118,26 @@ def _rollout_cli_args(request: InferenceRequest, policy_path: str, robot_args: l
         # it. Set it explicitly so the contract is ours, not upstream's.
         "--return_to_initial_position=true",
     ]
+    # ACT temporal ensembling. `--policy.*` flags are applied by lerobot as CLI
+    # overrides ON TOP of the checkpoint's saved config (RolloutConfig.__post_init__
+    # → PreTrainedConfig.from_pretrained(cli_overrides=...)), so this re-tunes a
+    # trained ACT policy at inference time without retraining.
+    #
+    # n_action_steps=1 is NOT optional: ACTConfig.__post_init__ raises
+    # NotImplementedError when temporal_ensemble_coeff is set alongside
+    # n_action_steps > 1, and checkpoints ship the default 100. Ensembling needs
+    # the policy queried every step to have overlapping chunks to average, so
+    # the two flags always travel together.
+    #
+    # Lives here rather than in _build_rollout_cmd so eval mode's separate entry
+    # point (_build_eval_runner_cmd) carries the flags too — the whole reason
+    # this list was split out.
+    if request.temporal_ensemble_coeff is not None:
+        args += [
+            f"--policy.temporal_ensemble_coeff={request.temporal_ensemble_coeff}",
+            "--policy.n_action_steps=1",
+        ]
+    return args
 
 
 def _build_rollout_cmd(request: InferenceRequest, policy_path: str, robot_args: list[str]) -> list[str]:
@@ -1721,6 +1746,21 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
     if mismatch is not None:
         _release_slot()
         return {"success": False, "status_code": 409, "message": mismatch}
+
+    # Temporal-ensemble coefficient: lerobot builds the ensemble weights as
+    # exp(-coeff * i), so a non-positive value is meaningless (0 weights every
+    # step of the chunk equally; negative inverts the decay so the STALEST
+    # prediction dominates). Reject here rather than letting draccus accept it
+    # and the arm move under a nonsense action.
+    if request.temporal_ensemble_coeff is not None and request.temporal_ensemble_coeff <= 0:
+        _release_slot()
+        return {
+            "success": False,
+            "status_code": 400,
+            "message": (
+                f"temporal_ensemble_coeff must be greater than 0 (got {request.temporal_ensemble_coeff})."
+            ),
+        }
 
     # Cheap policy-ref shape check so a malformed ref 4xxs in the modal instead
     # of failing later on the inference page (one is_dir stat, no network).

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -930,6 +930,73 @@ def test_build_rollout_cmd_wraps_robot_args_with_shared_flags() -> None:
     assert "--duration=60" in cmd
 
 
+def test_build_rollout_cmd_omits_temporal_ensemble_when_unset() -> None:
+    """Default (None) must leave the checkpoint's own config untouched — no
+    --policy.temporal_ensemble_coeff, and crucially no n_action_steps override
+    that would silently re-tune a policy the user didn't ask to change."""
+    from makermodslab.rollout import _build_rollout_cmd
+
+    cmd = _build_rollout_cmd(_stub_request(), "/local/pretrained_model", [])
+    assert not any(a.startswith("--policy.temporal_ensemble_coeff=") for a in cmd)
+    assert not any(a.startswith("--policy.n_action_steps=") for a in cmd)
+
+
+def test_build_rollout_cmd_pins_n_action_steps_with_temporal_ensemble() -> None:
+    """ACT raises NotImplementedError when temporal_ensemble_coeff is set with
+    n_action_steps > 1 (checkpoints ship 100), so the two flags must always
+    travel together."""
+    from makermodslab.rollout import InferenceRequest, _build_rollout_cmd
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        temporal_ensemble_coeff=0.01,
+    )
+    cmd = _build_rollout_cmd(req, "/local/pretrained_model", [])
+    assert "--policy.temporal_ensemble_coeff=0.01" in cmd
+    assert "--policy.n_action_steps=1" in cmd
+
+
+def test_eval_runner_cmd_carries_temporal_ensemble_flags() -> None:
+    """The flags live in the shared _rollout_cli_args, so evaluation mode's
+    separate entry point gets them too — a run scored over N episodes must use
+    the same action selection the single-rollout path would."""
+    from makermodslab.rollout import InferenceRequest, _build_eval_runner_cmd
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        eval_episodes=5,
+        temporal_ensemble_coeff=0.01,
+    )
+    cmd = _build_eval_runner_cmd(req, "/local/pretrained_model", [])
+    assert "makermodslab.eval_runner" in cmd
+    assert "--policy.temporal_ensemble_coeff=0.01" in cmd
+    assert "--policy.n_action_steps=1" in cmd
+
+
+def test_handle_start_inference_rejects_non_positive_ensemble_coeff() -> None:
+    """Weights are exp(-coeff * i): 0 weights the whole chunk equally and a
+    negative coefficient makes the STALEST prediction dominate. Reject before
+    the arm moves under it — and release the session slot on the way out."""
+    from makermodslab import rollout
+    from makermodslab.rollout import InferenceRequest, handle_start_inference
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        temporal_ensemble_coeff=0,
+    )
+    result = handle_start_inference(req)
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "temporal_ensemble_coeff" in result["message"]
+    assert rollout.inference_active is False
+
+
 # ---------------------------------------------------------------------------
 # handle_start_inference — the arm-count 409 guard (fires before any port opens)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two independent changes that happened to be in flight together: an ACT inference option, and a studio layout fix.

## 1. ACT temporal ensembling as a per-run option

ACT can average the overlapping action chunks it predicts at each step instead of executing one chunk open-loop, which smooths the motion. The coefficient is a policy config field, and lerobot applies `--policy.*` flags as CLI overrides on top of a checkpoint's saved config (`RolloutConfig.__post_init__` → `PreTrainedConfig.from_pretrained(cli_overrides=…)`), so a trained policy can be re-tuned at inference time without retraining.

- `n_action_steps=1` travels with it, always. `ACTConfig.__post_init__` raises `NotImplementedError` when `temporal_ensemble_coeff` is set alongside `n_action_steps > 1`, and checkpoints ship the default 100. Ensembling also needs the policy queried every step to have overlapping chunks to average.
- The flags are emitted from the shared `_rollout_cli_args`, so **evaluation mode's separate entry point (`_build_eval_runner_cmd`) carries them too** — a run scored over N episodes uses the same action selection the single-rollout path would.
- Weights are `exp(-coeff * i)`, so a non-positive coefficient is meaningless: 0 weights the whole chunk equally, and a negative value makes the *stalest* prediction dominate. `handle_start_inference` rejects those with a 400 rather than letting draccus accept it and the arm move under a nonsense action. The UI blocks Start on the same rule.
- Exposed in both the Deploy panel and the legacy `InferenceModal`, under Advanced parameters, **ACT-only** — no other policy type has the field, and passing the flag to one would fail the rollout's config parse.

### Caveats, please read before merging

- **This has not been run on real hardware.** The flag contract was verified by reading the pinned lerobot v0.6.0 source, not by driving an actual ACT rollout.
- **Expect a slower control loop when it is on**, since ensembling queries the policy every control step.

## 2. Jobs library empty-state alignment

All three studio panels pin their library to the panel foot, so the libraries only line up if their empty states are the same height. `GRID_MIN_H` (18.875rem) already budgets for the footer row — 16.5rem of cards + a 0.5rem gutter + a 1.875rem "Show all" slot — but the jobs library gave its "No active training jobs." message that full height and *then* stacked the Untracked toggle underneath, adding 2.375rem. That pushed `TRAINING JOBS`, the job search bar, and Start training 38px above Collect's `YOUR DATASETS` / Start recording, and out of line with Deploy.

- New `GRID_ROW_MIN_H` (the card row without the footer slot), used for the empty message whenever the Untracked toggle renders its own footer row below — the two then sum to exactly one `GRID_MIN_H` block.
- When the library is empty before any search or filter, it now matches the dataset and skills libraries: no toolbar, one dashed box, with the Hub sign-in / missing-`job.read` notices folded into that box's text instead of sitting above it as extra lines.

## Verification

- `pytest` — 1373 passed
- `npx tsc --noEmit` — clean
- `ruff check` + `ruff format --check` — clean

`frontend/dist/` is deliberately not rebuilt here; `build_frontend.yml` handles it on `main`.

## Note for reviewers

The ensembling work was originally written against a base 28 commits behind `main`, on which `rollout.py` has since changed by +1421/−287. Re-applying it here surfaced two conflicts that would otherwise have shipped as bugs:

1. `main` split `_build_rollout_cmd` into a shared `_rollout_cli_args` feeding two entry points. The original change appended the flags to the single-rollout builder only, so a multi-episode **evaluation run would have silently dropped them**. Moved to the shared builder, with a test covering that path.
2. The original change reintroduced `cameraKey` and `DEFAULT_FPS` into `DeployPanel.tsx` / `InferenceModal.tsx`, both of which `main` had removed from those files entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
