### PR TITLE
TEST ONLY — verifying stacked-PR CI (close me)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,6 +21,24 @@
 #   2. Lockfile churn most often arrives as an accident inside an unrelated PR —
 #      c18d42c was a rename commit that swept up local npm churn. Running on
 #      every PR is what catches that.
+#
+# And deliberately NOT base-filtered, for the same family of reason. `branches:
+# [main]` used to sit under `pull_request`, which meant a *stacked* PR — one
+# whose base is another PR branch rather than `main` — matched nothing and got
+# zero checks. The repo uses stacks routinely (there is a `stacked-prs` skill;
+# #72/#73/#74 were all open with non-main bases and all reported "no checks"),
+# so the file this workflow exists to guard was going unguarded on exactly the
+# PRs that are hardest to re-check later: the gate only arrived when the PR was
+# retargeted at main, after review had already happened. Tests and Quality drop
+# their base filter for the same reason.
+#
+# The cost of running on every base is nil here: this repo is public, so
+# standard-runner minutes are free, and every merged PR to date has been
+# `main`-based — the extra runs are the handful of stacked layers themselves.
+#
+# `build_frontend.yml` is the deliberate exception and must stay `push:
+# branches: [main]` only — it commits `frontend/dist` back to the branch it runs
+# on, which must never be a PR branch.
 
 name: Frontend
 
@@ -30,11 +48,13 @@ permissions:
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
 
+# `base_ref` is part of the key because one head branch can have two open PRs
+# against different bases (a stack in flight), and those are separate runs that
+# must not cancel each other — cancelling one would leave the required `Build`
+# check stuck as `cancelled` on a PR nobody touched.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.base_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lockfile_registry_guard.yml
+++ b/.github/workflows/lockfile_registry_guard.yml
@@ -9,6 +9,11 @@ permissions:
 # it hangs `npm ci` for ~8 min and then crashes ("Exit handler never called!").
 # Running `npm install` locally with a global ~/.npmrc pointing at the mirror is
 # what bakes those URLs in, so guard against it on every PR.
+#
+# `pull_request` carries no `branches:` filter, so this already covers stacked
+# PRs (base is another PR branch, not `main`). Keep it that way — adding one
+# would exempt exactly the PRs that get the least scrutiny. Tests, Quality and
+# Frontend dropped theirs to match; see the note in frontend.yml.
 
 on:
   pull_request:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,18 +40,23 @@ name: Quality
 permissions:
   contents: read
 
+#
+# `pull_request` has no `branches:` filter on purpose — see the note in
+# frontend.yml. Stacked PRs need this signal as much as main-based ones; a
+# `branches: [main]` filter silently exempted them.
 on:
   workflow_dispatch:
   push:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 # Ensures that only the latest commit for a PR or branch is built, canceling older runs.
+# `base_ref` is part of the key because one head branch can have two open PRs
+# against different bases (a stack in flight), and those are separate runs that
+# must not cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.base_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,14 @@
 
 # This workflow runs the pytest suite on every PR and push to main.
 # Modeled on LeRobot's fast_tests.yml, collapsed to a single dependency tier.
+#
+# `pull_request` has no `branches:` filter on purpose — see the note in
+# frontend.yml. A stacked PR (base is another PR branch, not `main`) is skipped
+# entirely by a `branches: [main]` filter, so it gets reviewed and iterated on
+# with no gate and is only ever tested once it is retargeted at `main` — the
+# worst possible moment to find out the tests broke. The `paths:` filter below
+# still keeps this cheap: on a stacked PR it is evaluated against that PR's own
+# base, so a frontend-only layer does not drag pytest along.
 name: Tests
 permissions:
   contents: read
@@ -21,8 +29,6 @@ permissions:
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     paths:
       - "makermodslab/**"
       - "tests/**"
@@ -40,8 +46,11 @@ on:
 env:
   PYTHON_VERSION: "3.12"
 
+# `base_ref` is part of the key because one head branch can have two open PRs
+# against different bases (a stack in flight), and those are separate runs that
+# must not cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.base_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/tests/test_ci_probe.py
+++ b/tests/test_ci_probe.py
@@ -1,0 +1,5 @@
+"""Throwaway probe so this PR's diff matches tests.yml's paths filter."""
+
+
+def test_ci_probe() -> None:
+    assert True


### PR DESCRIPTION
Throwaway draft verifying that dropping the `branches: [main]` filter makes checks run on a stacked PR (base is `wip/ci-probe-base`, not `main`).

The base branch deliberately does **not** contain the workflow fix; only this head does. That tests the realistic case and tells us whether existing stacked PRs need a rebase.

Will be closed and both branches deleted as soon as checks report.