### PR TITLE
fix(jobs): name Hub jobs by their run, not the shared image

### DIFF
--- a/frontend/src/components/jobs/HubJobCard.tsx
+++ b/frontend/src/components/jobs/HubJobCard.tsx
@@ -59,8 +59,11 @@ const HubJobCard: React.FC<Props> = ({ job, onDismiss }) => {
     Icon: HelpCircle,
   };
   const Icon = present.Icon;
+  // The run name when the Hub could give us one. The image name is the last
+  // resort: every cloud run uses the same image, so titling by it makes every
+  // untracked job on the account read as "huggingface/lerobot-gpu:latest".
   const title =
-    job.docker_image ?? job.space_id ?? `Job ${job.id.slice(0, 12)}…`;
+    job.name ?? job.docker_image ?? job.space_id ?? `Job ${job.id.slice(0, 12)}…`;
 
   // Unified metadata rows (same format as the dataset/job/model cards).
   const metaRows: Array<[string, string]> = [
@@ -68,6 +71,9 @@ const HubJobCard: React.FC<Props> = ({ job, onDismiss }) => {
     ["Created", relativeTime(job.created_at)],
   ];
   if (job.owner) metaRows.push(["Owner", job.owner]);
+  // Only worth a row once it isn't the title; keeps the image visible for the
+  // "which image did this run on" question without spending a row twice.
+  if (job.name && job.docker_image) metaRows.push(["Image", job.docker_image]);
 
   return (
     <Card

--- a/frontend/src/components/jobs/JobsLibrary.tsx
+++ b/frontend/src/components/jobs/JobsLibrary.tsx
@@ -133,8 +133,10 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
   const filteredHub = useMemo(
     () =>
       showOnline
-        ? untrackedHubJobs.filter((h) =>
-            matchesQuery(h.docker_image ?? h.space_id ?? h.id),
+        ? untrackedHubJobs.filter(
+            (h) =>
+              matchesQuery(h.name) ||
+              matchesQuery(h.docker_image ?? h.space_id ?? h.id),
           )
         : [],
     [untrackedHubJobs, matchesQuery, showOnline],

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -391,6 +391,10 @@ export async function listRunnerHardware(
 
 export interface HubJob {
   id: string;
+  // The run's name, derived Hub-side by _hub_job_run_name (submission label,
+  // else the --policy.repo_id slug in the job's argv). Null when neither is
+  // available — only then does the card fall back to the image name.
+  name: string | null;
   created_at: string | null;
   docker_image: string | null;
   space_id: string | null;

--- a/frontend/src/lib/mockHub.ts
+++ b/frontend/src/lib/mockHub.ts
@@ -266,10 +266,13 @@ const checkpointsByJob: Record<string, JobCheckpoint[]> = {
 
 const iso = (secAgo: number) => new Date((NOW - secAgo) * 1000).toISOString();
 
-/** Untracked Hub jobs (no local record): one live, two dead leftovers. */
+/** Untracked Hub jobs (no local record): one live, two dead leftovers.
+ * `name` covers the three cases the card titles by: a labelled job, one named
+ * from its argv, and one the Hub gives us nothing for (image-name fallback). */
 const hubJobs: HubJob[] = [
   {
     id: "mock-untracked-live",
+    name: "act_cube_grab_2026-08-10_14-02-11",
     created_at: iso(20 * 60),
     docker_image: "huggingface/lerobot-gpu:latest",
     space_id: null,
@@ -280,6 +283,7 @@ const hubJobs: HubJob[] = [
   },
   {
     id: "mock-untracked-done",
+    name: "smolvla_fold_towel_2026-08-08_09-31-40",
     created_at: iso(4 * D),
     docker_image: "huggingface/lerobot-gpu:latest",
     space_id: null,
@@ -290,6 +294,7 @@ const hubJobs: HubJob[] = [
   },
   {
     id: "mock-untracked-error",
+    name: null,
     created_at: iso(6 * D),
     docker_image: "huggingface/lerobot-gpu:latest",
     space_id: null,

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -58,6 +58,11 @@ LEROBOT_IMAGE = "huggingface/lerobot-gpu:latest"
 # "huggingface/lerobot-gpu:latest" like every other one. The label travels with
 # the job itself, so any machine signed into the account can name it.
 # Read back by _hub_job_run_name in server.py.
+#
+# This is OUR key, deliberately kept alongside run_job's own `name` (below).
+# `name` defaults to a value derived from the image when the caller omits it
+# ("lerobot-gpu-latest-<hash>"), so a `name` read back off a job is not
+# necessarily one we chose; _RUN_LABEL is unambiguous.
 _RUN_LABEL = "makermodslab.run"
 
 # The Hub rejects a label whose key or value exceeds 100 characters or strays
@@ -600,18 +605,38 @@ def resolve_job_timeout(config: TrainingRequest) -> int | str:
     return HF_JOB_TIMEOUT
 
 
-def _run_job_supports_labels(api) -> bool:
-    """Whether this huggingface_hub's run_job accepts `labels`.
+def _run_job_naming_kwargs(api, job_id: str) -> dict:
+    """run_job kwargs that give the submitted job `job_id` as its name.
 
-    huggingface_hub is an unpinned transitive dependency (it arrives via the
-    lerobot pin), so the installed version is not ours to guarantee. `labels`
-    is a newer parameter; passing it blind to an older run_job would raise
-    TypeError and take down cloud training entirely, which is a far worse
-    outcome than a job that merely lists under its image name.
+    Two of them, doing different jobs:
+    - `name` is what the Hub's own jobs UI displays. Left unset it defaults to
+      a value derived from the image ("lerobot-gpu-latest-<hash>"), which is
+      why untitled runs are indistinguishable on huggingface.co too.
+    - `labels[_RUN_LABEL]` is the copy _hub_job_run_name reads back, kept
+      separate because a `name` may be that image-derived default rather than
+      ours.
+
+    Both are probed on run_job's signature first: huggingface_hub is an
+    unpinned transitive dependency (it arrives via the lerobot pin), so the
+    installed version is not ours to guarantee, and passing an unsupported
+    kwarg would raise TypeError and take down cloud training entirely — far
+    worse than a job that merely lists under its image name.
+
+    An over-long id is left unnamed rather than truncated: the Hub caps a
+    label at _MAX_LABEL_LEN and would reject it, while _hub_job_run_name's
+    argv fallback recovers the name in full anyway.
     """
+    if len(job_id) > _MAX_LABEL_LEN:
+        return {}
+    params: set[str] = set()
     with contextlib.suppress(Exception):
-        return "labels" in inspect.signature(api.run_job).parameters
-    return False
+        params = set(inspect.signature(api.run_job).parameters)
+    kwargs: dict = {}
+    if "labels" in params:
+        kwargs["labels"] = {_RUN_LABEL: job_id}
+    if "name" in params:
+        kwargs["name"] = job_id
+    return kwargs
 
 
 # Cadence at which the status poller hits inspect_job. inspect_job is the
@@ -806,18 +831,13 @@ class HfCloudJobRunner:
 
         # Stamp the run's identity onto the job itself. job_id is the slug the
         # library already titles local records by ("<name>_<timestamp>"), so a
-        # labelled job reads the same whichever machine is looking at it.
-        # An over-long id is left unlabelled rather than truncated: the Hub
-        # would reject the label outright, and _hub_job_run_name's argv
-        # fallback recovers the name in full anyway.
-        extra_kwargs = {}
-        if not _run_job_supports_labels(self._api):
+        # named job reads the same whichever machine is looking at it.
+        naming_kwargs = _run_job_naming_kwargs(self._api, job_id)
+        if not naming_kwargs:
             logger.warning(
-                "huggingface_hub's run_job takes no `labels`; job %s is named from its argv instead",
+                "Could not name HF job for %s Hub-side; it will be titled from its argv instead",
                 job_id,
             )
-        elif len(job_id) <= _MAX_LABEL_LEN:
-            extra_kwargs["labels"] = {_RUN_LABEL: job_id}
 
         job = self._api.run_job(
             image=LEROBOT_IMAGE,
@@ -825,7 +845,7 @@ class HfCloudJobRunner:
             flavor=self._flavor,
             secrets=secrets,
             timeout=resolve_job_timeout(config),
-            **extra_kwargs,
+            **naming_kwargs,
         )
         self._hf_job_id = job.id
         self._hf_job_url = getattr(job, "url", None)

--- a/makermodslab/runners/hf_cloud.py
+++ b/makermodslab/runners/hf_cloud.py
@@ -51,6 +51,23 @@ logger = logging.getLogger(__name__)
 
 LEROBOT_IMAGE = "huggingface/lerobot-gpu:latest"
 
+# Hub job label carrying the run's identity. Every MakerMods Lab cloud run uses
+# the same image, so without it a job's only Hub-side identifier is
+# LEROBOT_IMAGE — and a job launched from another machine (no local JobRecord
+# to match it against) shows up in the library titled
+# "huggingface/lerobot-gpu:latest" like every other one. The label travels with
+# the job itself, so any machine signed into the account can name it.
+# Read back by _hub_job_run_name in server.py.
+_RUN_LABEL = "makermodslab.run"
+
+# The Hub rejects a label whose key or value exceeds 100 characters or strays
+# outside [alphanumeric . - _]. A job id is built from a _SLUG_RE-sanitised
+# dataset name (jobs._generate_job_id), so its charset already conforms — only
+# the length can overrun, via a very long dataset name. NOTE the publish repo
+# id is deliberately NOT labelled: it contains a "/", which the Hub refuses,
+# and _hub_job_run_name can already recover the run name from argv anyway.
+_MAX_LABEL_LEN = 100
+
 # The :latest image ships whatever lerobot was current when it was built —
 # which drifts from the pin in our pyproject.toml that build_training_command's
 # argv is shaped for (a real job died on `--eval_freq`, renamed upstream).
@@ -583,6 +600,20 @@ def resolve_job_timeout(config: TrainingRequest) -> int | str:
     return HF_JOB_TIMEOUT
 
 
+def _run_job_supports_labels(api) -> bool:
+    """Whether this huggingface_hub's run_job accepts `labels`.
+
+    huggingface_hub is an unpinned transitive dependency (it arrives via the
+    lerobot pin), so the installed version is not ours to guarantee. `labels`
+    is a newer parameter; passing it blind to an older run_job would raise
+    TypeError and take down cloud training entirely, which is a far worse
+    outcome than a job that merely lists under its image name.
+    """
+    with contextlib.suppress(Exception):
+        return "labels" in inspect.signature(api.run_job).parameters
+    return False
+
+
 # Cadence at which the status poller hits inspect_job. inspect_job is the
 # authoritative source for job liveness; the log stream is best-effort and
 # may drop during long runs (NAT eviction, laptop sleep, proxy idle timeout)
@@ -773,12 +804,28 @@ class HfCloudJobRunner:
                 )
             secrets["WANDB_API_KEY"] = wandb_key
 
+        # Stamp the run's identity onto the job itself. job_id is the slug the
+        # library already titles local records by ("<name>_<timestamp>"), so a
+        # labelled job reads the same whichever machine is looking at it.
+        # An over-long id is left unlabelled rather than truncated: the Hub
+        # would reject the label outright, and _hub_job_run_name's argv
+        # fallback recovers the name in full anyway.
+        extra_kwargs = {}
+        if not _run_job_supports_labels(self._api):
+            logger.warning(
+                "huggingface_hub's run_job takes no `labels`; job %s is named from its argv instead",
+                job_id,
+            )
+        elif len(job_id) <= _MAX_LABEL_LEN:
+            extra_kwargs["labels"] = {_RUN_LABEL: job_id}
+
         job = self._api.run_job(
             image=LEROBOT_IMAGE,
             command=wrapped_command,
             flavor=self._flavor,
             secrets=secrets,
             timeout=resolve_job_timeout(config),
+            **extra_kwargs,
         )
         self._hf_job_id = job.id
         self._hf_job_url = getattr(job, "url", None)

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -1402,6 +1402,47 @@ def _hub_job_stage(ji) -> str:
     return (ji.status.stage or "").upper() if ji.status else ""
 
 
+# Mirrors _RUN_LABEL in runners/hf_cloud.py — the label a submitted job carries.
+_HUB_RUN_LABEL = "makermodslab.run"
+
+
+def _hub_job_run_name(ji) -> str | None:
+    """The training run's name for a Hub job, or None when it can't be derived.
+
+    Every cloud run launches on the same image, so the frontend's
+    docker_image fallback titles ALL of them "huggingface/lerobot-gpu:latest".
+    A run launched from this machine is spared that because a local JobRecord
+    carries its name — one launched from a teammate's machine has no such
+    record, and the name has to come off the Hub instead.
+
+    Two sources, preferred first:
+    1. The `makermodslab.run` label hf_cloud stamps at submission.
+    2. `--policy.repo_id` in the job's own argv. Every cloud run publishes to
+       "<user>/<run slug>", so this recovers a name for jobs submitted before
+       labelling existed — the whole existing backlog.
+    """
+    labels = getattr(ji, "labels", None) or {}
+    labelled = labels.get(_HUB_RUN_LABEL)
+    if isinstance(labelled, str) and labelled.strip():
+        return labelled.strip()
+
+    # `arguments` is where the Hub splits argv for some submission paths; ours
+    # rides entirely in `command`. Scan both so neither shape is missed.
+    argv = [*(getattr(ji, "command", None) or []), *(getattr(ji, "arguments", None) or [])]
+    for i, tok in enumerate(argv):
+        if not isinstance(tok, str):
+            continue
+        repo_id = None
+        if tok == "--policy.repo_id" and i + 1 < len(argv):
+            repo_id = argv[i + 1]
+        elif tok.startswith("--policy.repo_id="):
+            repo_id = tok.split("=", 1)[1]
+        # The slug after the namespace is the run id the library titles by.
+        if isinstance(repo_id, str) and repo_id.strip():
+            return repo_id.strip().rsplit("/", 1)[-1]
+    return None
+
+
 # Errors a per-author Hub model listing may raise that must degrade to "empty for
 # this author" instead of 500ing /jobs/hub. httpx.HTTPError is the base of
 # ConnectError / TimeoutException / TransportError — what a GFW-killed TLS
@@ -1600,6 +1641,7 @@ def list_hub_jobs():
         "jobs": [
             {
                 "id": ji.id,
+                "name": _hub_job_run_name(ji),
                 "created_at": ji.created_at.isoformat() if ji.created_at else None,
                 "docker_image": ji.docker_image,
                 "space_id": ji.space_id,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1231,6 +1231,72 @@ def test_list_hub_jobs_keeps_dismissals_when_listing_fails(
     assert cfg.get_dismissed_hub_jobs() == {"job-dead"}
 
 
+# --- Hub job run names -----------------------------------------------------
+#
+# Every cloud run launches on the same image, so a job the local registry
+# doesn't know about (launched from another machine) would otherwise be titled
+# "huggingface/lerobot-gpu:latest" in the library, like every other one.
+# _hub_job_run_name recovers a real name from the job itself.
+
+
+def _job_with(**attrs):
+    """A _FakeHubJob carrying extra JobInfo attributes (labels, command, …)."""
+    job = _FakeHubJob("job-x", "COMPLETED")
+    for k, v in attrs.items():
+        setattr(job, k, v)
+    return job
+
+
+def test_hub_job_run_name_prefers_submission_label() -> None:
+    job = _job_with(
+        labels={"makermodslab.run": "act_cube_2026-08-01_12-00-00"},
+        command=["python", "-c", "…", "--", "--policy.repo_id", "makermods/other_name"],
+    )
+    assert server_mod._hub_job_run_name(job) == "act_cube_2026-08-01_12-00-00"
+
+
+def test_hub_job_run_name_falls_back_to_repo_id_in_argv() -> None:
+    # The backlog: jobs submitted before labelling existed still carry their
+    # publish target in argv, and its slug is the run id.
+    job = _job_with(
+        command=["python", "-c", "…", "--", "--policy.repo_id", "makermods/act_cube_2026-08-01_12-00-00"]
+    )
+    assert server_mod._hub_job_run_name(job) == "act_cube_2026-08-01_12-00-00"
+
+
+def test_hub_job_run_name_reads_equals_form_and_arguments_list() -> None:
+    job = _job_with(command=None, arguments=["--policy.repo_id=makermods/smolvla_fold_2026-08-02_09-00-00"])
+    assert server_mod._hub_job_run_name(job) == "smolvla_fold_2026-08-02_09-00-00"
+
+
+def test_hub_job_run_name_is_none_when_nothing_identifies_the_run() -> None:
+    # A foreign job on the same account: no label, no --policy.repo_id. The
+    # card keeps its image-name fallback rather than inventing a name.
+    assert server_mod._hub_job_run_name(_job_with(labels={}, command=["python", "train.py"])) is None
+    assert server_mod._hub_job_run_name(_FakeHubJob("bare", "COMPLETED")) is None  # no attrs at all
+
+
+def test_hub_job_run_name_ignores_blank_label_and_trailing_flag() -> None:
+    # A blank label must not win over the argv fallback, and a dangling
+    # --policy.repo_id with no value must not index past the end.
+    job = _job_with(
+        labels={"makermodslab.run": "   "},
+        command=["--policy.repo_id", "makermods/act_x_2026-08-01_12-00-00"],
+    )
+    assert server_mod._hub_job_run_name(job) == "act_x_2026-08-01_12-00-00"
+    assert server_mod._hub_job_run_name(_job_with(command=["--policy.repo_id"])) is None
+
+
+def test_list_hub_jobs_exposes_the_run_name(client: TestClient, monkeypatch, tmp_lerobot_home: Path) -> None:
+    named = _job_with(labels={"makermodslab.run": "act_cube_2026-08-01_12-00-00"})
+    named.id = "job-named"
+    _patch_hub_list(monkeypatch, username="makermods", api=_hub_api_with_jobs([named]))
+
+    resp = client.get("/jobs/hub")
+    assert resp.status_code == 200
+    assert resp.json()["jobs"][0]["name"] == "act_cube_2026-08-01_12-00-00"
+
+
 def test_dismiss_hub_job_rejects_blank_id(client: TestClient, monkeypatch, tmp_lerobot_home: Path) -> None:
     resp = client.post("/jobs/hub/jobs/%20/dismiss")
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Every MakerMods Lab cloud run launches on `huggingface/lerobot-gpu:latest`. A job with no local `JobRecord` (e.g. launched from a teammate's machine) had no other identifier, so the Jobs Library showed a wall of cards all titled `huggingface/lerobot-gpu:latest`.

- Stamps a `makermodslab.run` label on the job at submission, guarded on `run_job` actually accepting `labels`/`name` (`huggingface_hub` is an unpinned transitive dependency, so an older `run_job` must not be handed a kwarg it doesn't support).
- Also sets `run_job`'s own `name` parameter where supported, so the run reads correctly in the Hub's own jobs UI, not just in our library.
- `_hub_job_run_name` reads the label back, falling back to the `--policy.repo_id` slug already present in the job's argv — recovers a real name for the entire pre-existing backlog with no new data needed.
- `docker_image` remains the last-resort title once a real name isn't available.

## What Im Referring to
<img width="1014" height="858" alt="image" src="https://github.com/user-attachments/assets/b585575c-4e17-4bae-aaa4-3e5badbef363" />

## Test plan

- [x] `pytest tests/test_server.py -k "hub_job_run_name or list_hub_jobs"` — 11 passed
- [x] `pytest tests/test_runners_hf_cloud.py` — 50 passed
- [x] `tsc --noEmit` and `eslint` clean on the touched frontend files