### PR TITLE
feat(jobs): queue local training runs instead of refusing them

### DIFF
--- a/makermodslab/auto_calibrate.py
+++ b/makermodslab/auto_calibrate.py
@@ -243,6 +243,15 @@ class _AutoCalArmRunner:
             if _replay.replay_active:
                 return {"success": False, "message": "Replay is currently active. Stop it first."}
 
+            # Lazy, because jobs imports this module back the same way.
+            from . import jobs as _jobs
+
+            if (training := _jobs.training_is_active()) is not None:
+                return {
+                    "success": False,
+                    "message": f"Training run '{training}' is using this machine. Stop it first.",
+                }
+
             if request.device_type not in ("teleop", "robot"):
                 return {"success": False, "message": "Invalid device type"}
             if not request.port:
@@ -605,6 +614,15 @@ class AutoCalibrationBatchManager:
                 }
             if _replay.replay_active:
                 return {"success": False, "message": "Replay is currently active. Stop it first."}
+
+            # Lazy, because jobs imports this module back the same way.
+            from . import jobs as _jobs
+
+            if (training := _jobs.training_is_active()) is not None:
+                return {
+                    "success": False,
+                    "message": f"Training run '{training}' is using this machine. Stop it first.",
+                }
 
             arms = request.arms
             # --- Fail-fast validation, before touching any hardware. ---

--- a/makermodslab/calibrate.py
+++ b/makermodslab/calibrate.py
@@ -305,6 +305,15 @@ class CalibrationManager:
                 if _replay.replay_active:
                     return {"success": False, "message": "Replay is currently active. Stop it first."}
 
+                # Lazy, because jobs imports this module back the same way.
+                from . import jobs as _jobs
+
+                if (training := _jobs.training_is_active()) is not None:
+                    return {
+                        "success": False,
+                        "message": (f"Training run '{training}' is using this machine. Stop it first."),
+                    }
+
                 # Refuse to silently overwrite an existing config file. Completing a
                 # calibration saves "<config_file>.json"; if that name is taken, the
                 # caller must pass overwrite=True (after confirming) or pick another

--- a/makermodslab/datasets.py
+++ b/makermodslab/datasets.py
@@ -1165,16 +1165,23 @@ def _dataset_in_use(repo_id: str) -> str | None:
     if mgr.state == "running" and mgr.output_repo_id == repo_id:
         return "A merge is producing this dataset right now. Wait for it to finish first."
 
-    # Local training: a running local job whose config trains on this dataset.
+    # Local training: a running OR QUEUED local job whose config trains on this
+    # dataset. Queued counts because a queued run has already been validated
+    # against this dataset (the submit-time preflight even confirms it is on
+    # disk) and will train on it when the slot frees, but nothing re-checks at
+    # launch — so renaming or deleting it here produced a bare "exited with
+    # code 1" hours later, with nothing tying the failure to this action. Before
+    # the queue existed a second local submit was refused outright, so a
+    # not-yet-started consumer of a dataset could not exist.
     from .jobs import job_registry
 
     for record in job_registry.list(limit=200):
         if (
-            record.state == "running"
+            record.state in ("running", "queued")
             and record.runner == "local"
             and record.config.dataset_repo_id == repo_id
         ):
-            return "A local training run is using this dataset. Stop it first."
+            return "A local training run is using this dataset, or is queued to. Stop or cancel it first."
 
     return None
 

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -5134,17 +5134,43 @@ class JobRegistry:
             # than 1..N, so a reorder can never collide with a job enqueued
             # concurrently (which took a seq from the same counter).
             base = self._take_queue_seq(count=len(job_ids))
-            for offset, jid in enumerate(job_ids):
-                record = by_id[jid]
-                record.queue_seq = base + offset
-                # Cleared before the write: `_annotate_queue` stamps this onto
-                # the live record on every read, so without this the file keeps
-                # the PRE-drag position — after a reversal, exactly the inverted
-                # order. Nothing in-repo believes the persisted value (every
-                # path re-derives it), but a job.json that contradicts itself is
-                # a trap for the next reader.
-                record.queue_position = 0
-                self._persist(record, force=True)
+            # A reorder is all-or-nothing. Each iteration mutates memory and
+            # then writes, so a persist that throws partway (ENOSPC, EIO on an
+            # external volume — the failure class `_drain_queue` grew a handler
+            # for) used to leave THREE orders in play: the prefix that wrote,
+            # the suffix that never moved, and an in-memory order matching
+            # neither disk nor the drag. The user sees a 500 and reasonably
+            # concludes nothing happened, while the head of the queue — the run
+            # `_drain_queue` promotes next — has silently changed under them.
+            previous = {jid: by_id[jid].queue_seq for jid in job_ids}
+            try:
+                for offset, jid in enumerate(job_ids):
+                    record = by_id[jid]
+                    record.queue_seq = base + offset
+                    # Cleared before the write: `_annotate_queue` stamps this onto
+                    # the live record on every read, so without this the file keeps
+                    # the PRE-drag position — after a reversal, exactly the inverted
+                    # order. Nothing in-repo believes the persisted value (every
+                    # path re-derives it), but a job.json that contradicts itself is
+                    # a trap for the next reader.
+                    record.queue_position = 0
+                    self._persist(record, force=True)
+            except Exception:
+                # Memory first, so the queue is coherent even if re-writing the
+                # prefix fails too; the seq values are the authority and every
+                # position is re-derived from them. A record whose rewrite also
+                # throws is left for the next `_persist` to correct — it can
+                # only be one this call already touched, so disk cannot end up
+                # holding an order that was never requested.
+                logger.exception("Could not persist the queue reorder; restoring the previous order")
+                for jid, seq in previous.items():
+                    by_id[jid].queue_seq = seq
+                for jid in job_ids:
+                    try:
+                        self._persist(by_id[jid], force=True)
+                    except Exception:
+                        logger.exception("Could not restore the queue order of %s", jid)
+                raise
             snapshot = dict(self._records)
             ordered = self._queued_records()
         positions = self._queue_positions(snapshot)

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -269,10 +269,11 @@ class JobRunner(Protocol):
 # `exit_code` for anyone debugging.
 STOPPED_BY_REQUEST_MESSAGE = "Stopped at your request, not by a training error."
 
-# The queued twin of the message above. A cancelled-in-queue run shares the
-# `interrupted` state with a stopped one, so the state alone can't tell the
-# user that this one never trained a single step — the message has to.
-CANCELLED_IN_QUEUE_MESSAGE = "Removed from the queue before it started, so it never trained."
+# Written to `error_message` when the loader retires a `queued` record that
+# only a local run could ever have been: see _load_from_disk. It shares the
+# `interrupted` state with a stopped run, so the state alone cannot tell the
+# user this one never trained a single step — the message has to.
+UNQUEUEABLE_RUNNER_MESSAGE = "Only local runs wait in the queue, so this one never started."
 
 # Written to `error_message` for a run that ended while we weren't watching and
 # left no evidence of how: no exit status from the wrapper (see
@@ -2586,6 +2587,16 @@ def ancestor_ids_of(records: Mapping[str, JobRecord], job_id: str) -> list[str]:
     return out
 
 
+def _queue_order(record: JobRecord) -> tuple[int, float]:
+    """Sort key for the queue: enqueue order, `started_at` breaking ties.
+
+    Defined once and used by everything that puts queued runs in order, so the
+    positions the UI shows cannot drift from the order `_drain_queue` promotes
+    in — two copies of this key would be two orders the moment either changed.
+    """
+    return (record.queue_seq, record.started_at)
+
+
 def _owner_holds_step(owner: JobRecord, step: int) -> bool:
     """Whether `owner` has a checkpoint at `step`, for the rewind guard.
 
@@ -2913,10 +2924,9 @@ class JobRegistry:
         container, so any number can be in flight in parallel — this says
         nothing about them.
 
-        It used to RAISE (`_assert_no_running_local`), and a second local start
-        was a 409 the user had to retry by hand once the first finished. Now a
-        busy slot means the new run is accepted as `queued` and the watchdog
-        starts it when the slot frees — so this reports, and the callers decide.
+        A busy slot refuses nothing: the new run is accepted as `queued` and the
+        watchdog starts it once the slot frees. So this reports, and the callers
+        decide what that means.
 
         Takes NO lock, so it is callable both inside and outside the registry's
         critical section (self._lock is a plain Lock — re-entering it would
@@ -2930,26 +2940,24 @@ class JobRegistry:
     def _queued_records(self) -> builtins.list[JobRecord]:
         """Every queued job, in the order they will run. Caller holds the lock
         (or accepts a snapshot's staleness)."""
-        return sorted(
-            (r for r in self._records.values() if r.state == "queued"),
-            key=lambda r: (r.queue_seq, r.started_at),
-        )
+        return sorted((r for r in self._records.values() if r.state == "queued"), key=_queue_order)
 
-    def _annotate_queue(self, record: JobRecord, snapshot: Mapping[str, JobRecord]) -> None:
+    @staticmethod
+    def _queue_positions(snapshot: Mapping[str, JobRecord]) -> dict[str, int]:
+        """Map job id to its 1-based queue position.
+
+        Built once per read and shared across the records being annotated:
+        sorting inside the per-record stamp instead made a queue read O(N² log N)
+        on an endpoint the UI polls.
+        """
+        ordered = sorted((r for r in snapshot.values() if r.state == "queued"), key=_queue_order)
+        return {r.id: i for i, r in enumerate(ordered, start=1)}
+
+    @staticmethod
+    def _annotate_queue(record: JobRecord, positions: Mapping[str, int]) -> None:
         """Stamp the derived 1-based `queue_position`, in place. 0 for anything
-        not queued."""
-        if record.state != "queued":
-            record.queue_position = 0
-            return
-        ordered = sorted(
-            (r for r in snapshot.values() if r.state == "queued"),
-            key=lambda r: (r.queue_seq, r.started_at),
-        )
-        for i, r in enumerate(ordered, start=1):
-            if r.id == record.id:
-                record.queue_position = i
-                return
-        record.queue_position = 0
+        not queued — which `positions` expresses by simply not holding it."""
+        record.queue_position = positions.get(record.id, 0)
 
     def _annotate_lineage(
         self,
@@ -2974,10 +2982,11 @@ class JobRegistry:
         # Indexed over the whole snapshot, then applied to the page: a run's
         # leaf-ness is a fact about the registry, not about what fits on a page.
         children = build_child_index(snapshot.values())
+        positions = self._queue_positions(snapshot)
         for r in records:
             r.checkpoint_count = self._count_checkpoints(r)
             self._annotate_lineage(r, snapshot, children)
-            self._annotate_queue(r, snapshot)
+            self._annotate_queue(r, positions)
         return records
 
     def get(self, job_id: str) -> JobRecord:
@@ -2988,7 +2997,7 @@ class JobRegistry:
             raise JobNotFoundError(job_id)
         record.checkpoint_count = self._count_checkpoints(record)
         self._annotate_lineage(record, snapshot, build_child_index(snapshot.values()))
-        self._annotate_queue(record, snapshot)
+        self._annotate_queue(record, self._queue_positions(snapshot))
         return record
 
     def start(self, config: TrainingRequest, target: JobTarget | None = None) -> JobRecord:
@@ -3065,13 +3074,12 @@ class JobRegistry:
                 "or drop finetune_from_step to train from scratch."
             )
 
-        # NOTE: no local-slot pre-flight here any more. It used to fail the
-        # request fast (`_assert_no_running_local`) to spare a doomed download,
-        # but a busy slot no longer dooms anything — the run is accepted and
-        # queued. Every VALIDATION below still runs synchronously, so a bad
-        # request is still refused at submit time rather than surfacing minutes
-        # later when the queue reaches it; only the launch is deferred. The
-        # authoritative slot check is under the lock at record creation.
+        # Deliberately no local-slot pre-flight: a busy slot does not doom a
+        # submit any more, it queues it. Every VALIDATION below still runs
+        # synchronously, so a bad request is refused at submit time rather than
+        # surfacing minutes later when the queue reaches it — only the launch is
+        # deferred. The authoritative slot check is under the lock at record
+        # creation.
 
         # ------------------------------------------------------------------
         # Pretrained-path resolution runs OUTSIDE the registry lock.
@@ -3435,7 +3443,7 @@ class JobRegistry:
                 # position 0 — so the UI could not tell the user where in line
                 # the run it just accepted actually is. Annotated AFTER the
                 # persist, so the derived value is not what reaches disk.
-                self._annotate_queue(record, self._records)
+                self._annotate_queue(record, self._queue_positions(self._records))
             else:
                 self._persist(record, force=True)
                 self._launch_locked(
@@ -3446,11 +3454,10 @@ class JobRegistry:
                     deferred_resume_upload=deferred_resume_upload,
                     deferred_finetune_upload=deferred_finetune_upload,
                 )
-        # Both paths converge here, OUTSIDE the lock — the queued branch used to
-        # fire its own notify and return early from inside the critical section,
-        # the one _notify_change in this file that did. Every other call site
-        # defers it (see the `notify` flag in _start_after_prepare) because a
-        # listener that reads the registry would deadlock on a plain Lock.
+        # Both paths converge here, OUTSIDE the lock. Every _notify_change in
+        # this file is deferred until the critical section is over (see the
+        # `notify` flag in _start_after_prepare): a listener that reads the
+        # registry would deadlock on a plain Lock.
         self._notify_change()
         return record
 
@@ -3500,9 +3507,10 @@ class JobRegistry:
         # running, from `stop`'s point of view) nor delete it (it IS running). The
         # queue would be dead for the life of the process with no way out of the UI.
         #
-        # This used to guard `runner.start()` alone, which left the whole deferred
-        # branch — the PreparingJobRunner registration and `thread.start()` — and the
-        # `_persist` + `_runners` bookkeeping after a SUCCESSFUL start uncovered.
+        # So the try must cover the WHOLE launch: the deferred branch's
+        # PreparingJobRunner registration and `thread.start()`, and the `_persist`
+        # + `_runners` bookkeeping after a SUCCESSFUL start — not `runner.start()`
+        # alone.
         try:
             if deferred:
                 # Something still has to move (GBs, minutes). Hand the caller its
@@ -3582,11 +3590,12 @@ class JobRegistry:
                 # only THEN starts its stdout thread, and `HfCloudJobRunner.start`
                 # sets `_hf_job_id` and only then starts two worker threads. A
                 # throw from the second half of either (a thread-table
-                # exhaustion is the realistic one) used to land in the handler
-                # with `started` still None — so it skipped `stop()`, released
-                # the slot, and the next drain put a SECOND trainer on the same
-                # GPU. `process_pid`/`hf_job_id` are assigned further down, so
-                # that orphan was unreachable from the UI and survived a restart.
+                # exhaustion is the realistic one) would otherwise reach the
+                # handler with `started` still None — skipping `stop()`,
+                # releasing the slot, and letting the next drain put a SECOND
+                # trainer on the same GPU. `process_pid`/`hf_job_id` are
+                # assigned further down, so that orphan would be unreachable
+                # from the UI and would survive a restart.
                 #
                 # Binding first costs nothing when the runner never started:
                 # `LocalJobRunner.stop` returns immediately while `_process is
@@ -4392,39 +4401,28 @@ class JobRegistry:
             # the very race it exists to close.
             if expect_state is not None and record.state != expect_state:
                 raise JobStateChangedError(job_id, expect_state, record.state)
-            # A QUEUED job has no process to signal and no runner to ask, so
-            # Stop means CANCEL — and cancelling one removes it outright rather
-            # than leaving a record behind.
+            # A queued job has no process to signal and no runner to ask, so
+            # Stop means CANCEL: the record is removed outright. It never
+            # executed — no logs, no metrics, no checkpoints, an output dir
+            # holding nothing but its own job.json — so there is no history a
+            # tombstone could preserve, only a record that every later question
+            # about runs would have to special-case.
             #
-            # It never executed: no process, no logs, no metrics, no checkpoint,
-            # and an output dir containing nothing but its own job.json. So
-            # there is no history to preserve, and a tombstone was not free — a
-            # record that looks like a run but never was has to be specially
-            # excused from every question the registry asks about runs. The
-            # version that kept one needed a persisted "never started" flag, a
-            # contraction rule in BOTH directions of the resume graph, a guard
-            # refusing to continue it, and a matching salvage path in the
-            # loader — machinery whose entire purpose was to make a record mean
-            # nothing. Removing it is the same outcome with none of that.
-            #
-            # Identical to `delete()`'s effect, done inline because `delete`
-            # takes this same lock and re-entering a plain Lock deadlocks.
+            # Removal is exactly `delete()`'s effect, done inline because
+            # `delete` takes this same lock and re-entering a plain Lock
+            # deadlocks.
             if record.state == "queued":
-                # The SAME guards `delete()` applies, because this has the same
-                # effect: the record is removed, and removing a record does not
-                # remove the references to it.
-                #
-                # A queued run looks like it can hold nothing — it has no
-                # checkpoints of its own — but `_resolve_checkpoint_owner` lets
-                # a continuation attach to a leaf that saved nothing and read
-                # the bytes from an ANCESTOR, and only a `done` source is
-                # refused. So a queued run is a legal resume parent. Cancelling
-                # one unguarded severed its child's lineage, left a phantom
-                # parent id in `build_child_index` (so both ends read as
-                # leaves), un-forked the `JobAlreadyContinuedError` guard so the
-                # grandparent could be continued a second time, and — worst —
-                # made the grandparent deletable while a queued run was still
-                # waiting to resume from its checkpoints.
+                # So it needs `delete()`'s guards too: removing a record does
+                # not remove the references to it. A queued run holds no
+                # checkpoints of its own, but `_resolve_checkpoint_owner` lets a
+                # continuation attach to a leaf that saved nothing and read the
+                # bytes from an ANCESTOR — only a `done` source is refused — so
+                # a queued run is a legal resume parent. Cancelling one
+                # unguarded severed its child's lineage, left a phantom parent
+                # id in `build_child_index` (both ends then read as leaves),
+                # un-forked `JobAlreadyContinuedError` so the grandparent could
+                # be continued twice, and made that grandparent deletable while
+                # a queued run was still waiting to resume from its checkpoints.
                 children = build_child_index(self._records.values()).get(job_id, [])
                 if children:
                     raise JobHasChildrenError(job_id, children)
@@ -4436,8 +4434,8 @@ class JobRegistry:
             else:
                 cancelled = None
                 runner = self._runners.get(job_id)
-                # Raised under the lock (it used to be checked outside it) so the
-                # intent below can't be recorded for a job that just finalised.
+                # Raised under the lock, not outside it, so the intent below
+                # cannot be recorded for a job that just finalised.
                 if record.state != "running" or runner is None:
                     raise JobNotRunningError(job_id)
                 self._stop_requested.add(job_id)
@@ -4834,7 +4832,7 @@ class JobRegistry:
                     record.state = "interrupted"
                     record.ended_at = time.time()
                     if record.error_message is None:
-                        record.error_message = CANCELLED_IN_QUEUE_MESSAGE
+                        record.error_message = UNQUEUEABLE_RUNNER_MESSAGE
                     # Queue fields released: nothing that will never run keeps
                     # a place in line on disk.
                     record.queue_seq = 0
@@ -4988,6 +4986,7 @@ class JobRegistry:
         # under a heading that says "queued" is the exact confusion the cancel
         # guard in the UI exists to catch, so don't ship it in the first place.
         ordered = [r for r in ordered if r.state == "queued"]
+        positions = self._queue_positions(snapshot)
         for r in ordered:
             # The same annotations `list()` applies, so a record means the same
             # thing whichever endpoint returned it — a queued CONTINUATION
@@ -4995,7 +4994,7 @@ class JobRegistry:
             # that only looks right until someone reads it.
             r.checkpoint_count = self._count_checkpoints(r)
             self._annotate_lineage(r, snapshot, children)
-            self._annotate_queue(r, snapshot)
+            self._annotate_queue(r, positions)
         return ordered
 
     def reorder_queue(self, job_ids: builtins.list[str]) -> builtins.list[JobRecord]:
@@ -5054,8 +5053,9 @@ class JobRegistry:
                 self._persist(record, force=True)
             snapshot = dict(self._records)
             ordered = self._queued_records()
+        positions = self._queue_positions(snapshot)
         for r in ordered:
-            self._annotate_queue(r, snapshot)
+            self._annotate_queue(r, positions)
         self._notify_change()
         return ordered
 
@@ -5650,6 +5650,6 @@ __all__ = [
     "parse_metrics_into",
     "classify_terminal_state",
     "STOPPED_BY_REQUEST_MESSAGE",
-    "CANCELLED_IN_QUEUE_MESSAGE",
+    "UNQUEUEABLE_RUNNER_MESSAGE",
     "UNCONFIRMED_OUTCOME_MESSAGE",
 ]

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -4412,7 +4412,17 @@ class JobRegistry:
             if record is None:
                 raise JobNotFoundError(job_id)
             record.display_name = name
+            # Zeroed before the write, then restamped after it, exactly as
+            # `start` and `reorder_queue` do. `queue_position` is DERIVED and is
+            # stamped onto the live record by every read, so renaming a job that
+            # a `GET /jobs/queue` had just annotated wrote that read's position
+            # into job.json — the self-contradicting file `reorder_queue` calls
+            # "a trap for the next reader", reintroduced through a path that fix
+            # did not consider. Restamped afterwards because this record is the
+            # rename response, and an un-annotated one reports position 0.
+            record.queue_position = 0
             self._persist(record, force=True)
+            self._annotate_queue(record, self._queue_positions(self._records))
         self._notify_change()
         return record
 

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -2660,6 +2660,27 @@ class JobSourceOfQueuedRunError(Exception):
         super().__init__(f"{job_id} holds the checkpoint {len(queued_ids)} queued run(s) will train from.")
 
 
+class JobRemovalFailedError(Exception):
+    """Raised when a job's `job.json` could not be removed.
+
+    The record is LEFT EXACTLY AS IT WAS when this fires — in memory, on disk,
+    in whatever state the caller found it. Removal is durable or it does not
+    happen: a record dropped from memory while its `job.json` survives is read
+    straight back by the next restart, so the run REAPPEARS. For a cancelled
+    queued run that is the sharp case — it comes back in the queue and trains,
+    the one outcome a cancel exists to prevent — but a deleted run returning to
+    the history is the same failure with a smaller blast radius.
+
+    Reporting the failure and keeping the record lets the user retry against a
+    state that still matches what they see.
+    """
+
+    def __init__(self, job_id: str, reason: OSError) -> None:
+        self.job_id = job_id
+        self.reason = reason
+        super().__init__(f"Could not remove {job_id}'s record from disk: {reason}")
+
+
 class JobHasChildrenError(Exception):
     """Raised when delete() is called on a run something else resumed from.
 
@@ -4370,9 +4391,8 @@ class JobRegistry:
         instead of hours of lost work.
 
         The intent is registered under the lock BEFORE any signal or cancel
-        leaves this process, so the watchdog can never finalise a stop it
-        doesn't know about — the reason every Stop press used to land in
-        history as `failed`.
+        leaves this process, so the watchdog can never finalise a stop it does
+        not know about and file a deliberate stop as `failed`.
 
         Intent alone does not decide the outcome: the runner still gets to
         report that it finished on its own, or that it was already dead when we
@@ -4429,7 +4449,10 @@ class JobRegistry:
                 dependents = self._queued_dependents_of(record)
                 if dependents:
                     raise JobSourceOfQueuedRunError(job_id, dependents)
-                self._forget_locked(job_id)
+                # Disk first, then memory — see `_remove_locked`. A cancel that
+                # only reached memory comes back as a queued run on the next
+                # restart and trains.
+                self._remove_locked(job_id)
                 cancelled = record
             else:
                 cancelled = None
@@ -4440,8 +4463,7 @@ class JobRegistry:
                     raise JobNotRunningError(job_id)
                 self._stop_requested.add(job_id)
         if cancelled is not None:
-            with contextlib.suppress(FileNotFoundError):
-                shutil.rmtree(_job_dir(self._output_root, job_id))
+            self._discard_job_dir(job_id)
             self._notify_change()
             return cancelled
         runner.stop()
@@ -4639,16 +4661,63 @@ class JobRegistry:
     def _forget_locked(self, job_id: str) -> None:
         """Drop every in-memory trace of a job. CALLER HOLDS `self._lock`.
 
-        Shared by `delete()` and by `stop()`'s cancel-a-queued-run path, so the
-        two cannot drift apart about what "gone" means. The caller removes the
-        job DIRECTORY afterwards, outside the lock (rmtree is filesystem I/O and
-        has no business inside the critical section).
+        In-memory only: this makes a job invisible, not deleted, and nothing it
+        does survives a restart. Its one caller is `_remove_locked`, which takes
+        `job.json` first so the durable half can never be skipped; the job
+        DIRECTORY goes later via `_discard_job_dir`, outside the lock (rmtree is
+        filesystem I/O and has no business in a critical section).
         """
         self._records.pop(job_id, None)
         self._runners.pop(job_id, None)
         self._last_persist_at.pop(job_id, None)
         self._stop_requested.discard(job_id)
         self._prepare_threads.pop(job_id, None)
+
+    def _remove_locked(self, job_id: str) -> None:
+        """Remove a job from DISK and then from memory. CALLER HOLDS `self._lock`.
+
+        The order is the point. `job.json` is the only trace of a job that
+        outlives the process, so it goes first: forgetting the record and
+        unlinking afterwards means any failure but "already gone" leaves a
+        job.json on disk with no record behind it, and `_load_from_disk` reads
+        it straight back on the next restart. A cancelled queued run returns to
+        the queue and TRAINS; a deleted run returns to the history.
+
+        Raises `JobRemovalFailedError` with the record untouched if the unlink
+        fails, so a caller that cannot finish reports a state the user can still
+        act on. Both `delete()` and `stop()`'s cancel path go through here, so
+        the two cannot drift apart about what "gone" means.
+
+        One unlink of a local file, the same class of I/O `_persist` already
+        does inside this critical section — and done under the lock so no reader
+        can observe a record whose file is already gone.
+        """
+        try:
+            _job_meta_path(self._output_root, job_id).unlink()
+        except FileNotFoundError:
+            pass  # Already gone: the removal is durable by definition.
+        except OSError as exc:
+            raise JobRemovalFailedError(job_id, exc) from exc
+        self._forget_locked(job_id)
+
+    def _discard_job_dir(self, job_id: str) -> None:
+        """Delete a removed job's directory. Call OUTSIDE the lock.
+
+        Best effort, and deliberately not fatal: `_remove_locked` has already
+        taken `job.json`, so nothing left here can bring the run back. What
+        survives a failure is a directory the loader skips, which is not a
+        reason to fail an operation that has already taken effect.
+        """
+        try:
+            shutil.rmtree(_job_dir(self._output_root, job_id))
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.exception(
+                "Removed %s, but could not delete its directory. The run is gone and "
+                "cannot come back; the leftover directory is inert.",
+                job_id,
+            )
 
     def delete(self, job_id: str) -> None:
         with self._lock:
@@ -4671,9 +4740,10 @@ class JobRegistry:
             dependents = self._queued_dependents_of(record)
             if dependents:
                 raise JobSourceOfQueuedRunError(job_id, dependents)
-            self._forget_locked(job_id)
-        with contextlib.suppress(FileNotFoundError):
-            shutil.rmtree(_job_dir(self._output_root, job_id))
+            # Disk first, then memory — see `_remove_locked`. A delete that only
+            # reached memory comes back in the history on the next restart.
+            self._remove_locked(job_id)
+        self._discard_job_dir(job_id)
         self._notify_change()
 
     def shutdown(self) -> None:
@@ -5640,6 +5710,7 @@ __all__ = [
     "PreparingJobRunner",
     "JobRegistry",
     "make_snapshot_progress_tqdm",
+    "JobRemovalFailedError",
     "JobNotFoundError",
     "JobSourceOfQueuedRunError",
     "JobStateChangedError",

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -5121,13 +5121,29 @@ class JobRegistry:
                     f"The queue order lists {', '.join(repr(d) for d in duplicates)} more "
                     "than once; each queued run must appear exactly once."
                 )
-            unknown = sorted(set(job_ids) - set(current))
-            if unknown:
+            # "Not in the queue" is TWO different answers and they were sharing
+            # one. An id the registry has never heard of is a malformed body:
+            # 400, and retrying it unchanged can never work. An id that names a
+            # REAL run which merely LEFT the queue — it started, finished, or was
+            # cancelled between the drag and the request — is the ordinary race
+            # this endpoint exists to absorb, and it needs the 409 that says
+            # refresh, which is advice that succeeds on the next try. Answering
+            # it with 400 told the user their drag was malformed when the queue
+            # had simply moved on, and that is by far the likelier of the two:
+            # it is what happens every time the watchdog promotes the head
+            # mid-drag. It is also what this endpoint's docstring always claimed
+            # happened.
+            not_queued = sorted(set(job_ids) - set(current))
+            never_a_job = [u for u in not_queued if u not in self._records]
+            if never_a_job:
                 raise ValueError(
-                    f"{', '.join(repr(u) for u in unknown)} is not a queued run, so it "
+                    f"{', '.join(repr(u) for u in never_a_job)} is not a run at all, so it "
                     "cannot be given a place in the queue."
                 )
-            if sorted(job_ids) != sorted(current):
+            # Left the queue, or the queue gained a run the client had not seen
+            # (a subset). Both mean the client's picture is out of date, and
+            # both are answered the same way: refresh and drag again.
+            if not_queued or sorted(job_ids) != sorted(current):
                 raise QueueChangedError(current)
             by_id = {r.id: r for r in self._records.values()}
             # Renumbered from a fresh block at the TOP of the counter rather

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -3222,6 +3222,28 @@ class JobRegistry:
             deferred_finetune_upload, hub_ref = self._resolve_upload_finetune(finetune_source, config)
             config.policy_pretrained_path = hub_ref
 
+        # Asked BEFORE the lock, and for the same reason `_drain_queue` phase 1
+        # asks before its own: `_robot_busy` reads six feature modules whose
+        # `training_is_active()` calls take THIS lock from inside their own
+        # `_state_lock`. Reading them while holding it closes the cycle and
+        # deadlocks. Never move this inside.
+        #
+        # Why `start` asks at all, when it historically did not: the mutex was
+        # one-way. All six features now refuse while a training run is live, but
+        # nothing stopped the reverse — a submit made during a recording or a
+        # rollout still launched a trainer straight on top of it, and inference
+        # is the pairing this file calls the worst one (both want several GB of
+        # VRAM; hours of work end as "exited with code 1"). The old rationale was
+        # that a direct submit meant the user was present and knew what else they
+        # had running, which is exactly the reasoning the six features stopped
+        # accepting from each other.
+        #
+        # It QUEUES rather than refuses, which is what makes this safe on a
+        # branch whose premise is that a busy machine queues: the run keeps its
+        # place and `_drain_queue` starts it when the robot is idle — the same
+        # thing that already happens when the slot itself is busy.
+        robot_busy = self._robot_busy() if (target.runner == "local") else None
+
         with self._lock:
             # Resume: turn the selected source run + step into the config_path
             # lerobot needs. Do this under the lock (source lookup) and before
@@ -3440,7 +3462,7 @@ class JobRegistry:
             # immediately and jump every run already waiting, which is the one
             # promise a queue exists to make.
             queued = target.runner == "local" and (
-                self._local_slot_busy() is not None or bool(self._queued_records())
+                self._local_slot_busy() is not None or bool(self._queued_records()) or robot_busy is not None
             )
 
             record = JobRecord(

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -3988,26 +3988,47 @@ class JobRegistry:
                     self._finalize_prepare_locked(job_id, "failed", f"Failed to start runner: {exc}")
                     notify = True
                     return
-                if target.runner == "local":
-                    record.process_pid = runner.pid()
-                else:
-                    record.hf_job_id = runner.hf_job_id()
-                    record.hf_job_url = runner.hf_job_url()
-                    # config was mutated by HfCloudJobRunner.start to set
-                    # policy_repo_id; mirror it onto the record for the UI.
-                    record.hf_repo_id = record.config.policy_repo_id
-                self._runners[job_id] = runner
-                # A real trainer exists now, so the promoted-but-never-launched
-                # marker can go — and with it the transfer refs, which are the
-                # other half of that marker: `_drain_queue` leaves both set
-                # precisely so a crash during the transfer above returns the run
-                # to the queue WITH what it still needs to download, instead of
-                # filing it as a run that trained. A no-op for a direct submit,
-                # where they are already 0/None.
-                record.queue_seq = 0
-                record.queued_hub_ref = None
-                record.queued_resume_ref = None
-                self._persist(record, force=True)
+                # Inside a try for the same reason `_launch_locked` covers its
+                # WHOLE launch rather than `runner.start()` alone: the trainer is
+                # already live and detached here, so a throw between its birth
+                # and its pid reaching disk leaves the durable record saying
+                # `running`, `queue_seq > 0`, `process_pid: None` — precisely
+                # what `_load_from_disk` reads as "promoted but never launched".
+                # It would demote the run and hand the queue a SECOND trainer for
+                # the same output dir while the first is still on the GPU. This
+                # is the one path where a live trainer's pid can fail to reach
+                # disk, so the handler stops what it started rather than trusting
+                # a write that has already failed once.
+                try:
+                    if target.runner == "local":
+                        record.process_pid = runner.pid()
+                    else:
+                        record.hf_job_id = runner.hf_job_id()
+                        record.hf_job_url = runner.hf_job_url()
+                        # config was mutated by HfCloudJobRunner.start to set
+                        # policy_repo_id; mirror it onto the record for the UI.
+                        record.hf_repo_id = record.config.policy_repo_id
+                    self._runners[job_id] = runner
+                    # A real trainer exists now, so the promoted-but-never-launched
+                    # marker can go — and with it the transfer refs, which are the
+                    # other half of that marker: `_drain_queue` leaves both set
+                    # precisely so a crash during the transfer above returns the
+                    # run to the queue WITH what it still needs to download,
+                    # instead of filing it as a run that trained. A no-op for a
+                    # direct submit, where they are already 0/None.
+                    record.queue_seq = 0
+                    record.queued_hub_ref = None
+                    record.queued_resume_ref = None
+                    self._persist(record, force=True)
+                except Exception as exc:
+                    logger.exception("Failed to record the started runner for job %s", job_id)
+                    try:
+                        runner.stop()
+                    except Exception:
+                        logger.exception("Could not stop the half-recorded runner for job %s", job_id)
+                    self._finalize_prepare_locked(job_id, "failed", f"Failed to start runner: {exc}")
+                    notify = True
+                    return
                 notify = True
         finally:
             if notify:

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -2587,6 +2587,22 @@ def ancestor_ids_of(records: Mapping[str, JobRecord], job_id: str) -> list[str]:
     return out
 
 
+_NAMED_IDS_LIMIT = 10
+
+
+def _name_some(ids: builtins.list[str]) -> str:
+    """Render ids for an error message, naming at most `_NAMED_IDS_LIMIT`.
+
+    An error body exists to tell a human which id to fix; echoing every one of
+    a caller-sized list instead produced a 360 KB response that helps nobody and
+    is the caller's own input read back. The count still gives them the scale of
+    what they sent.
+    """
+    shown = ", ".join(repr(i) for i in ids[:_NAMED_IDS_LIMIT])
+    extra = len(ids) - _NAMED_IDS_LIMIT
+    return f"{shown} and {extra} more" if extra > 0 else shown
+
+
 def _queue_order(record: JobRecord) -> tuple[int, float]:
     """Sort key for the queue: enqueue order, `started_at` breaking ties.
 
@@ -5104,23 +5120,27 @@ class JobRegistry:
         Refuses nothing about WHERE the user dropped things: any permutation is
         legitimate, including moving a run that was queued last to the front.
         """
+        # A MALFORMED list and a STALE one are different failures and must not
+        # share an answer. `sorted(a) != sorted(b)` collapses "you named a job
+        # that isn't queued", "you sent the same id twice" and "the queue moved
+        # under your drag" into one refusal whose message says "the list has been
+        # refreshed; try again" — advice that can never work for the first two,
+        # so a non-UI caller retries the same impossible body forever. Name the
+        # bad ids instead; only a genuine set mismatch against a live queue is
+        # the race.
+        #
+        # The duplicate check is pure — it reads only the request — so it runs
+        # BEFORE the lock. Validating a caller-sized body inside the registry
+        # lock made every /jobs* request and the watchdog wait on it.
+        seen: set[str] = set()
+        duplicates = sorted({jid for jid in job_ids if jid in seen or seen.add(jid)})
+        if duplicates:
+            raise ValueError(
+                f"The queue order lists {_name_some(duplicates)} more than once; "
+                "each queued run must appear exactly once."
+            )
         with self._lock:
             current = [r.id for r in self._queued_records()]
-            # A MALFORMED list and a STALE one are different failures and must
-            # not share an answer. `sorted(a) != sorted(b)` collapses "you named
-            # a job that isn't queued", "you sent the same id twice" and "the
-            # queue moved under your drag" into one refusal whose message says
-            # "the list has been refreshed; try again" — advice that can never
-            # work for the first two, so a non-UI caller retries the same
-            # impossible body forever. Name the bad ids instead; only a genuine
-            # set mismatch against a live queue is the race.
-            seen: set[str] = set()
-            duplicates = sorted({jid for jid in job_ids if jid in seen or seen.add(jid)})
-            if duplicates:
-                raise ValueError(
-                    f"The queue order lists {', '.join(repr(d) for d in duplicates)} more "
-                    "than once; each queued run must appear exactly once."
-                )
             # "Not in the queue" is TWO different answers and they were sharing
             # one. An id the registry has never heard of is a malformed body:
             # 400, and retrying it unchanged can never work. An id that names a
@@ -5137,7 +5157,7 @@ class JobRegistry:
             never_a_job = [u for u in not_queued if u not in self._records]
             if never_a_job:
                 raise ValueError(
-                    f"{', '.join(repr(u) for u in never_a_job)} is not a run at all, so it "
+                    f"{_name_some(never_a_job)} is not a run at all, so it "
                     "cannot be given a place in the queue."
                 )
             # Left the queue, or the queue gained a run the client had not seen

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -3998,12 +3998,15 @@ class JobRegistry:
                     record.hf_repo_id = record.config.policy_repo_id
                 self._runners[job_id] = runner
                 # A real trainer exists now, so the promoted-but-never-launched
-                # marker can go. For a run that came off the QUEUE this is the
-                # moment that window actually closes — `_drain_queue` leaves
-                # `queue_seq` set precisely so a crash during the transfer above
-                # returns the run to the queue instead of filing it as a run
-                # that trained. A no-op for a direct submit, where it is 0.
+                # marker can go — and with it the transfer refs, which are the
+                # other half of that marker: `_drain_queue` leaves both set
+                # precisely so a crash during the transfer above returns the run
+                # to the queue WITH what it still needs to download, instead of
+                # filing it as a run that trained. A no-op for a direct submit,
+                # where they are already 0/None.
                 record.queue_seq = 0
+                record.queued_hub_ref = None
+                record.queued_resume_ref = None
                 self._persist(record, force=True)
                 notify = True
         finally:
@@ -5373,8 +5376,20 @@ class JobRegistry:
                 # a real trainer exists: below for an immediate launch, and in
                 # `_start_after_prepare` for a deferred one.
                 record.queue_position = 0
-                record.queued_hub_ref = None
-                record.queued_resume_ref = None
+                # The transfer refs are deliberately NOT cleared here, for the
+                # same reason and on the same schedule as `queue_seq`: they are
+                # the half of the marker that says WHAT the promotion still owes.
+                # `start` parks them on the record because they are the only part
+                # of submit-time resolution a later process cannot recompute
+                # (see the comment there). Clearing them at promotion persisted
+                # `None`, so a crash during the deferred download came back from
+                # `_load_from_disk` as a queued run with no refs — and the next
+                # drain, reading them as None, took `_launch_locked`'s IMMEDIATE
+                # branch and spawned a trainer with no download at all: a
+                # fine-tune handed lerobot the unresolvable `repo@checkpoints/N`
+                # form, a continuation a `resume=True` with no config_path. The
+                # recovery path destroyed the run it existed to save. They are
+                # cleared where `queue_seq` is, once a real trainer exists.
                 # Set BEFORE the persist rather than after it. A persist that
                 # throws (ENOSPC, EIO on an external volume) would otherwise
                 # leave the record mutated in memory with `notify` still False,
@@ -5395,8 +5410,8 @@ class JobRegistry:
                         record.id,
                     )
                     record.state = "queued"
-                    record.queued_hub_ref = hub_ref
-                    record.queued_resume_ref = resume_ref
+                    # The refs need no restoring — the promotion above no longer
+                    # clears them. `state` is the only field this has to undo.
                     return
                 try:
                     self._launch_locked(

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -54,7 +54,16 @@ from .utils.naming import (
 logger = logging.getLogger(__name__)
 
 
-JobState = Literal["running", "done", "failed", "interrupted"]
+# "queued" is a LOCAL-ONLY state: accepted, validated, and waiting for the one
+# local training slot to free up. Cloud runs never enter it — each HF Job gets
+# its own container, so any number can be in flight and HF's own scheduler owns
+# the waiting (its QUEUED *stage*, which is a different thing living on HubJob).
+#
+# It is a pre-start state, so it is not terminal and not "running": the
+# watchdog skips it, models.py's ("done", "interrupted") gate skips it (a job
+# that never started has no checkpoints), and cancelling one lands it in
+# `interrupted` like any other stop.
+JobState = Literal["queued", "running", "done", "failed", "interrupted"]
 
 
 class JobTarget(BaseModel):
@@ -162,6 +171,32 @@ class JobRecord(BaseModel):
     child_ids: list[str] = []
     ancestor_ids: list[str] = []
 
+    # ---- local training queue (state == "queued") ----
+    #
+    # Sort key for the queue, ascending. Assigned from a monotonic counter at
+    # enqueue and rewritten wholesale by `reorder_queue`. PERSISTED, unlike
+    # `queue_position` below, because the order is a user decision that has to
+    # survive a restart — a drag that evaporates on reload is worse than no
+    # drag at all. 0 on every record that has never been queued.
+    queue_seq: int = 0
+    # 1-based place in line, derived at list/get time over the whole registry —
+    # same deal as checkpoint_count and the lineage fields (it depends on the
+    # OTHER queued records, so a value frozen into job.json would be stale the
+    # moment anything ahead of it starts). 0 ⇒ not queued.
+    queue_position: int = 0
+    # The one piece of `start`'s deferred-work resolution that has to outlive
+    # the request, because a queued job launches later — possibly in a later
+    # PROCESS. At most one is ever set, and only for local runs (the two
+    # upload paths are cloud-only, and cloud never queues):
+    #   * `queued_hub_ref` — a fine-tune whose base checkpoint is a hub ref
+    #     still to be downloaded (`deferred_hub_ref`).
+    #   * `queued_resume_ref` — a cloud parent's checkpoint to download for a
+    #     local continuation (`deferred_resume_ref`).
+    # Cleared when the job leaves the queue, so a finished record never claims
+    # transfers it already did.
+    queued_hub_ref: str | None = None
+    queued_resume_ref: str | None = None
+
 
 class JobCheckpoint(BaseModel):
     """One checkpoint produced by a training job.
@@ -233,6 +268,11 @@ class JobRunner(Protocol):
 # "Subprocess exited with code 1" used to be. The real code stays in
 # `exit_code` for anyone debugging.
 STOPPED_BY_REQUEST_MESSAGE = "Stopped at your request, not by a training error."
+
+# The queued twin of the message above. A cancelled-in-queue run shares the
+# `interrupted` state with a stopped one, so the state alone can't tell the
+# user that this one never trained a single step — the message has to.
+CANCELLED_IN_QUEUE_MESSAGE = "Removed from the queue before it started, so it never trained."
 
 # Written to `error_message` for a run that ended while we weren't watching and
 # left no evidence of how: no exit status from the wrapper (see
@@ -2561,16 +2601,52 @@ def _owner_holds_step(owner: JobRecord, step: int) -> bool:
     return any(c.step == step for c in _list_local_checkpoints(owner.output_dir))
 
 
-class JobAlreadyRunningError(Exception):
-    """Raised when start() is called while another local job is running."""
-
-
 class JobNotFoundError(Exception):
     """Raised when a lookup hits an unknown id."""
 
 
+class QueueChangedError(Exception):
+    """A reorder named a set of jobs that is no longer the queue.
+
+    Carries the CURRENT queue for logging and for callers that want it. NOT
+    shipped as a response header: it was, and nothing ever read it — the
+    frontend refetches on 409, which is simpler and always right — while a deep
+    queue made the header big enough (~14 KB at 300 jobs) to trip the 8 KB
+    header cap on any reverse proxy in front of a `--lan` deployment, turning a
+    409 into a 502.
+    """
+
+    def __init__(self, current_ids: builtins.list[str]) -> None:
+        self.current_ids = current_ids
+        super().__init__("The queue changed while you were reordering it.")
+
+
 class JobNotRunningError(Exception):
     """Raised when stop() is called on a non-running job."""
+
+
+class JobSourceOfQueuedRunError(Exception):
+    """Raised when delete() would take the checkpoint a QUEUED run will read.
+
+    A fine-tune resolves its base checkpoint to an ABSOLUTE PATH at submit time
+    and carries only that string; nothing re-resolves it at launch. So deleting
+    the source run wipes the directory out from under a run that has not started
+    — and, because `build_child_index` deliberately excludes fine-tune edges (a
+    fine-tune is a new model, not a continuation), `JobHasChildrenError` does
+    not see it.
+
+    Before the queue existed the exposure was the seconds between the request
+    returning and lerobot loading the weights. Now it is however long the queue
+    is, which turns a near-impossible race into an ordinary sequence of clicks:
+    fine-tune from A, then tidy up by deleting A, then wait. The run would fail
+    hours later with a raw path-not-found traceback naming a directory the user
+    deliberately removed and has no reason to connect to it.
+    """
+
+    def __init__(self, job_id: str, queued_ids: builtins.list[str]) -> None:
+        self.job_id = job_id
+        self.queued_ids = queued_ids
+        super().__init__(f"{job_id} holds the checkpoint {len(queued_ids)} queued run(s) will train from.")
 
 
 class JobHasChildrenError(Exception):
@@ -2591,6 +2667,29 @@ class JobHasChildrenError(Exception):
         super().__init__(job_id)
         self.job_id = job_id
         self.child_ids = child_ids
+
+
+class JobStateChangedError(Exception):
+    """Raised when stop() is given an `expect_state` the record no longer has.
+
+    "Cancel this queued run" and "kill this training run" are the same request
+    on the wire, and the client decided which one it was rendering some time
+    ago. Between that decision and the click, the watchdog can promote the run:
+    a blocking `window.confirm` holds the JS thread but not the server, and a
+    queue list can be left stale indefinitely by a single failed fetch. Without
+    a precondition the click SIGTERMs a live training run and the UI cheerfully
+    reports "Removed from the queue", because it picks its wording from the same
+    stale record.
+
+    Carries what the caller expected and what is actually there; the HTTP layer
+    turns them into the message.
+    """
+
+    def __init__(self, job_id: str, expected: str, actual: str) -> None:
+        super().__init__(job_id)
+        self.job_id = job_id
+        self.expected = expected
+        self.actual = actual
 
 
 class JobAlreadyContinuedError(Exception):
@@ -2668,6 +2767,12 @@ class JobRegistry:
         # and only ever written forward; guarded by _lock, like _records.
         self._next_job_number: int = 1
 
+        # Next value `_take_queue_seq` will hand out. Unlike the job number
+        # this needs no counter file: queue keys only have to order the jobs
+        # CURRENTLY queued, so restarting from one above the highest seq on
+        # disk is enough, and a registry with an empty queue starts over at 1.
+        self._next_queue_seq: int = 1
+
         # job_id -> the thread materializing that job's base checkpoint before
         # its trainer can start (see _materialize_then_start). Entries are left
         # behind once the thread finishes — a finished Thread object is inert
@@ -2689,6 +2794,11 @@ class JobRegistry:
         # running job (id, state, metrics, wandb url, checkpoint count) so
         # the dashboard keeps the progress bar live without refetching /jobs.
         self._on_progress: Callable[[builtins.list[dict]], None] | None = None
+
+        # Latches once the first time `_robot_busy` cannot answer, so a
+        # permanently broken robot module logs a single traceback instead of
+        # one per watchdog tick (~86k/day).
+        self._robot_check_failed = False
 
         self._migrate_legacy_cwd_jobs()
         self._load_from_disk()
@@ -2794,24 +2904,52 @@ class JobRegistry:
 
     # -- public API --
 
-    def _assert_no_running_local(self, target: JobTarget) -> None:
-        """Raise JobAlreadyRunningError if a local training is already running.
+    def _local_slot_busy(self) -> str | None:
+        """The id of the local run currently holding the single local slot, or
+        None if it is free.
 
         Local trainings are bounded by this machine's GPU/USB resources, so at
         most one runs at a time. Cloud trainings each get their own remote
-        container, so any number can be in flight in parallel.
+        container, so any number can be in flight in parallel — this says
+        nothing about them.
+
+        It used to RAISE (`_assert_no_running_local`), and a second local start
+        was a 409 the user had to retry by hand once the first finished. Now a
+        busy slot means the new run is accepted as `queued` and the watchdog
+        starts it when the slot frees — so this reports, and the callers decide.
 
         Takes NO lock, so it is callable both inside and outside the registry's
         critical section (self._lock is a plain Lock — re-entering it would
         deadlock). Iterates a snapshot, so a concurrent mutation can't break the
-        walk. `start` calls it twice on purpose: once early to fail fast, and
-        once under the lock that inserts the record — the latter is the one that
-        actually enforces the invariant."""
-        if target.runner != "local":
-            return
+        walk."""
         for r in list(self._records.values()):
             if r.state == "running" and r.runner == "local":
-                raise JobAlreadyRunningError(r.id)
+                return r.id
+        return None
+
+    def _queued_records(self) -> builtins.list[JobRecord]:
+        """Every queued job, in the order they will run. Caller holds the lock
+        (or accepts a snapshot's staleness)."""
+        return sorted(
+            (r for r in self._records.values() if r.state == "queued"),
+            key=lambda r: (r.queue_seq, r.started_at),
+        )
+
+    def _annotate_queue(self, record: JobRecord, snapshot: Mapping[str, JobRecord]) -> None:
+        """Stamp the derived 1-based `queue_position`, in place. 0 for anything
+        not queued."""
+        if record.state != "queued":
+            record.queue_position = 0
+            return
+        ordered = sorted(
+            (r for r in snapshot.values() if r.state == "queued"),
+            key=lambda r: (r.queue_seq, r.started_at),
+        )
+        for i, r in enumerate(ordered, start=1):
+            if r.id == record.id:
+                record.queue_position = i
+                return
+        record.queue_position = 0
 
     def _annotate_lineage(
         self,
@@ -2839,6 +2977,7 @@ class JobRegistry:
         for r in records:
             r.checkpoint_count = self._count_checkpoints(r)
             self._annotate_lineage(r, snapshot, children)
+            self._annotate_queue(r, snapshot)
         return records
 
     def get(self, job_id: str) -> JobRecord:
@@ -2849,11 +2988,10 @@ class JobRegistry:
             raise JobNotFoundError(job_id)
         record.checkpoint_count = self._count_checkpoints(record)
         self._annotate_lineage(record, snapshot, build_child_index(snapshot.values()))
+        self._annotate_queue(record, snapshot)
         return record
 
     def start(self, config: TrainingRequest, target: JobTarget | None = None) -> JobRecord:
-        from .runners.hf_cloud import HfCloudJobRunner  # lazy import to avoid circular import
-
         target = target or JobTarget()
         if target.runner == "hf_cloud" and not target.flavor:
             raise ValueError("flavor is required when runner is hf_cloud")
@@ -2927,11 +3065,13 @@ class JobRegistry:
                 "or drop finetune_from_step to train from scratch."
             )
 
-        # Fail fast on the local-run mutex before any of the (possibly slow)
-        # pretrained-path work below. Re-checked under the lock at record
-        # creation — THAT is the authoritative check; this one only spares a
-        # doomed request a needless download.
-        self._assert_no_running_local(target)
+        # NOTE: no local-slot pre-flight here any more. It used to fail the
+        # request fast (`_assert_no_running_local`) to spare a doomed download,
+        # but a busy slot no longer dooms anything — the run is accepted and
+        # queued. Every VALIDATION below still runs synchronously, so a bad
+        # request is still refused at submit time rather than surfacing minutes
+        # later when the queue reaches it; only the launch is deferred. The
+        # authoritative slot check is under the lock at record creation.
 
         # ------------------------------------------------------------------
         # Pretrained-path resolution runs OUTSIDE the registry lock.
@@ -3038,11 +3178,6 @@ class JobRegistry:
             config.policy_pretrained_path = hub_ref
 
         with self._lock:
-            # Authoritative local-run mutex: re-checked here, under the lock
-            # that also inserts the record, so two concurrent starts can't both
-            # pass. (The pre-flight copy above is only a fail-fast.)
-            self._assert_no_running_local(target)
-
             # Resume: turn the selected source run + step into the config_path
             # lerobot needs. Do this under the lock (source lookup) and before
             # creating the record so a bad selection fails cleanly with no
@@ -3246,13 +3381,30 @@ class JobRegistry:
                 if (config.job_name and config.job_name.strip())
                 else f"{config.policy_type.upper()} · {config.dataset_repo_id}"
             )
+            # The one local training slot decides whether this run starts now
+            # or waits. Checked HERE, under the lock that also inserts the
+            # record, so two concurrent starts can't both read a free slot and
+            # both launch. Cloud runs never queue — see the JobState comment.
+            #
+            # A NON-EMPTY QUEUE COUNTS AS BUSY, not just an occupied slot. The
+            # slot is genuinely free for a moment on every handover — `_tick`
+            # finalises the ending run and only reaches `_drain_queue` at the
+            # end of the same tick, and a slot released by a prepare thread
+            # waits up to a full second for the next tick. Asking only "is
+            # something running" let a run submitted inside that window start
+            # immediately and jump every run already waiting, which is the one
+            # promise a queue exists to make.
+            queued = target.runner == "local" and (
+                self._local_slot_busy() is not None or bool(self._queued_records())
+            )
+
             record = JobRecord(
                 id=job_id,
                 # Allocated here, inside the same lock that inserts the record,
                 # so two concurrent starts can't be handed the same number.
                 job_number=self._take_job_number(),
                 name=name,
-                state="running",
+                state="queued" if queued else "running",
                 config=config,
                 output_dir=lerobot_output_dir,
                 started_at=time.time(),
@@ -3266,16 +3418,92 @@ class JobRegistry:
 
             job_dir.mkdir(parents=True, exist_ok=True)
             self._records[job_id] = record
-            self._persist(record, force=True)
 
-            log_path = _job_log_path(self._output_root, job_id)
+            if queued:
+                # Everything that could refuse this run has already run — only
+                # the launch is deferred. Park the resolved transfer refs on the
+                # record (they are the sole part of the resolution above that a
+                # later process can't recompute) and let the watchdog's
+                # _drain_queue start it when the slot frees.
+                record.queue_seq = self._take_queue_seq()
+                record.queued_hub_ref = deferred_hub_ref
+                record.queued_resume_ref = deferred_resume_ref
+                self._persist(record, force=True)
+                # Stamp the derived position before handing the record back.
+                # This response is the ONLY thing the submitting client has
+                # until a refetch lands, and an un-annotated record reports
+                # position 0 — so the UI could not tell the user where in line
+                # the run it just accepted actually is. Annotated AFTER the
+                # persist, so the derived value is not what reaches disk.
+                self._annotate_queue(record, self._records)
+            else:
+                self._persist(record, force=True)
+                self._launch_locked(
+                    record,
+                    target,
+                    deferred_hub_ref=deferred_hub_ref,
+                    deferred_resume_ref=deferred_resume_ref,
+                    deferred_resume_upload=deferred_resume_upload,
+                    deferred_finetune_upload=deferred_finetune_upload,
+                )
+        # Both paths converge here, OUTSIDE the lock — the queued branch used to
+        # fire its own notify and return early from inside the critical section,
+        # the one _notify_change in this file that did. Every other call site
+        # defers it (see the `notify` flag in _start_after_prepare) because a
+        # listener that reads the registry would deadlock on a plain Lock.
+        self._notify_change()
+        return record
 
-            deferred = (
-                deferred_hub_ref is not None
-                or deferred_resume_ref is not None
-                or deferred_resume_upload is not None
-                or deferred_finetune_upload is not None
-            )
+    def _launch_locked(
+        self,
+        record: JobRecord,
+        target: JobTarget,
+        *,
+        deferred_hub_ref: str | None = None,
+        deferred_resume_ref: str | None = None,
+        deferred_resume_upload: tuple[Path, str, str] | None = None,
+        deferred_finetune_upload: tuple[Path, str, str] | None = None,
+    ) -> None:
+        """Put a `running` record on a runner. CALLER HOLDS `self._lock`.
+
+        Split out of `start` so the queue can reach it: a dequeued job takes
+        exactly this path, minutes (or a restart) after the validation and
+        path-resolution that `start` did once. Everything it needs is either on
+        the record or in the deferred-* arguments, which is why the two
+        local-relevant refs are persisted on the record itself.
+
+        Does NOT fire `_notify_change` — both callers do, after their own
+        bookkeeping.
+        """
+        from .runners.hf_cloud import HfCloudJobRunner  # lazy: circular import
+
+        job_id = record.id
+        config = record.config
+        lerobot_output_dir = record.output_dir
+        log_path = _job_log_path(self._output_root, job_id)
+
+        # The runner whose process is actually live, once one is. See the
+        # method-wide handler below.
+        started: JobRunner | None = None
+        deferred = (
+            deferred_hub_ref is not None
+            or deferred_resume_ref is not None
+            or deferred_resume_upload is not None
+            or deferred_finetune_upload is not None
+        )
+        # EVERY failure below has to release the slot. The caller (`_drain_queue`,
+        # and `start`'s direct path) has ALREADY flipped this record to "running"
+        # so the slot closes behind the promotion — so a throw that leaves it
+        # `running` with no usable runner pins the slot forever: `_tick` skips a
+        # record with no runner, `_local_slot_busy` keeps naming it, `_drain_queue`
+        # early-returns on every later tick, and the user can neither stop it (not
+        # running, from `stop`'s point of view) nor delete it (it IS running). The
+        # queue would be dead for the life of the process with no way out of the UI.
+        #
+        # This used to guard `runner.start()` alone, which left the whole deferred
+        # branch — the PreparingJobRunner registration and `thread.start()` — and the
+        # `_persist` + `_runners` bookkeeping after a SUCCESSFUL start uncovered.
+        try:
             if deferred:
                 # Something still has to move (GBs, minutes). Hand the caller its
                 # job id NOW — the record exists, is "running", and has a log
@@ -3345,15 +3573,31 @@ class JobRegistry:
                         _resume_total_steps(config),
                     )
 
-                try:
-                    runner.start(job_id, config, lerobot_output_dir)
-                except Exception as exc:
-                    logger.exception("Failed to start runner for job %s", job_id)
-                    record.state = "failed"
-                    record.ended_at = time.time()
-                    record.error_message = f"Failed to start runner: {exc}"
-                    self._persist(record, force=True)
-                    raise
+                # No local handler: the method-wide one below covers this and
+                # every other failure on both branches, and additionally drops
+                # the half-registered runner that a bare re-raise left behind.
+                #
+                # Recorded BEFORE the call, not after. Neither runner's `start`
+                # is atomic: `LocalJobRunner.start` spawns the subprocess and
+                # only THEN starts its stdout thread, and `HfCloudJobRunner.start`
+                # sets `_hf_job_id` and only then starts two worker threads. A
+                # throw from the second half of either (a thread-table
+                # exhaustion is the realistic one) used to land in the handler
+                # with `started` still None — so it skipped `stop()`, released
+                # the slot, and the next drain put a SECOND trainer on the same
+                # GPU. `process_pid`/`hf_job_id` are assigned further down, so
+                # that orphan was unreachable from the UI and survived a restart.
+                #
+                # Binding first costs nothing when the runner never started:
+                # `LocalJobRunner.stop` returns immediately while `_process is
+                # None`, as does `HfCloudJobRunner.stop` while `_hf_job_id is
+                # None`.
+                started = runner
+                runner.start(job_id, config, lerobot_output_dir)
+                # From here the PROCESS EXISTS. Anything that throws below —
+                # `pid()`, the cloud id reads, `_persist` — must stop it again,
+                # or the handler's release of the slot hands the machine to a
+                # second trainer while this one is still on the GPU.
 
                 # Capture runner-specific identifiers.
                 if target.runner == "local":
@@ -3367,8 +3611,40 @@ class JobRegistry:
 
                 self._persist(record, force=True)
                 self._runners[job_id] = runner
-        self._notify_change()
-        return record
+        except Exception as exc:
+            logger.exception("Failed to launch job %s", job_id)
+            # Stop anything that actually started before releasing the slot.
+            # Marking the record `failed` is what lets `_local_slot_busy` hand
+            # the machine to the next run, so a trainer still alive here would
+            # be a SECOND local training on the same GPU and arms — the one
+            # invariant this whole feature exists to hold — and an orphan the
+            # UI could never reach (`stop` refuses a non-running record, while
+            # `delete` would rmtree the output dir under the live process).
+            # For a cloud run the same throw would otherwise leave an HF Job
+            # billing with no `hf_job_id` persisted to cancel it by.
+            if started is not None:
+                with contextlib.suppress(Exception):
+                    started.stop()
+            record.state = "failed"
+            record.ended_at = time.time()
+            record.error_message = f"Failed to start runner: {exc}"
+            # Release the queue bookkeeping: this record is terminal, so it must
+            # not keep a sort key or claim transfers it never performed.
+            # `queue_seq` in particular doubles as `_drain_queue`'s
+            # promoted-but-not-yet-launched marker, and a terminal record has no
+            # business carrying it.
+            record.queue_seq = 0
+            record.queue_position = 0
+            record.queued_hub_ref = None
+            record.queued_resume_ref = None
+            # Drop the half-registered launch. A PreparingJobRunner left here
+            # reports is_running() forever, which is precisely what wedges the
+            # slot; a real runner whose bookkeeping never completed is already
+            # orphaned and must not be mistaken for a live job.
+            self._runners.pop(job_id, None)
+            self._prepare_threads.pop(job_id, None)
+            self._persist(record, force=True)
+            raise
 
     def _materialize_then_start(
         self,
@@ -3691,6 +3967,13 @@ class JobRegistry:
                     # policy_repo_id; mirror it onto the record for the UI.
                     record.hf_repo_id = record.config.policy_repo_id
                 self._runners[job_id] = runner
+                # A real trainer exists now, so the promoted-but-never-launched
+                # marker can go. For a run that came off the QUEUE this is the
+                # moment that window actually closes — `_drain_queue` leaves
+                # `queue_seq` set precisely so a crash during the transfer above
+                # returns the run to the queue instead of filing it as a run
+                # that trained. A no-op for a direct submit, where it is 0.
+                record.queue_seq = 0
                 self._persist(record, force=True)
                 notify = True
         finally:
@@ -4063,8 +4346,19 @@ class JobRegistry:
         self._notify_change()
         return record
 
-    def stop(self, job_id: str) -> JobRecord:
+    def stop(self, job_id: str, expect_state: JobState | None = None) -> JobRecord:
         """Ask a running job to stop, and record that we asked.
+
+        `expect_state` is an optimistic-concurrency precondition, and it exists
+        because "cancel this queued run" and "kill this training run" are the
+        same request on the wire. A client that renders a Cancel button decided
+        the job was `queued` at render time; by the time the user clicks — after
+        a blocking `window.confirm`, or against a queue list left stale by one
+        failed fetch — the watchdog may have promoted it. Without the
+        precondition that click SIGTERMs a live training run and the UI reports
+        "Removed from the queue", because the caller picks its wording from the
+        same stale record. Passing what the caller believed makes that a 409
+        instead of hours of lost work.
 
         The intent is registered under the lock BEFORE any signal or cancel
         leaves this process, so the watchdog can never finalise a stop it
@@ -4093,12 +4387,65 @@ class JobRegistry:
             record = self._records.get(job_id)
             if record is None:
                 raise JobNotFoundError(job_id)
-            runner = self._runners.get(job_id)
-            # Raised under the lock (it used to be checked outside it) so the
-            # intent below can't be recorded for a job that just finalised.
-            if record.state != "running" or runner is None:
-                raise JobNotRunningError(job_id)
-            self._stop_requested.add(job_id)
+            # Checked under the lock, so the state it approves is the state the
+            # rest of this critical section acts on — a check outside would be
+            # the very race it exists to close.
+            if expect_state is not None and record.state != expect_state:
+                raise JobStateChangedError(job_id, expect_state, record.state)
+            # A QUEUED job has no process to signal and no runner to ask, so
+            # Stop means CANCEL — and cancelling one removes it outright rather
+            # than leaving a record behind.
+            #
+            # It never executed: no process, no logs, no metrics, no checkpoint,
+            # and an output dir containing nothing but its own job.json. So
+            # there is no history to preserve, and a tombstone was not free — a
+            # record that looks like a run but never was has to be specially
+            # excused from every question the registry asks about runs. The
+            # version that kept one needed a persisted "never started" flag, a
+            # contraction rule in BOTH directions of the resume graph, a guard
+            # refusing to continue it, and a matching salvage path in the
+            # loader — machinery whose entire purpose was to make a record mean
+            # nothing. Removing it is the same outcome with none of that.
+            #
+            # Identical to `delete()`'s effect, done inline because `delete`
+            # takes this same lock and re-entering a plain Lock deadlocks.
+            if record.state == "queued":
+                # The SAME guards `delete()` applies, because this has the same
+                # effect: the record is removed, and removing a record does not
+                # remove the references to it.
+                #
+                # A queued run looks like it can hold nothing — it has no
+                # checkpoints of its own — but `_resolve_checkpoint_owner` lets
+                # a continuation attach to a leaf that saved nothing and read
+                # the bytes from an ANCESTOR, and only a `done` source is
+                # refused. So a queued run is a legal resume parent. Cancelling
+                # one unguarded severed its child's lineage, left a phantom
+                # parent id in `build_child_index` (so both ends read as
+                # leaves), un-forked the `JobAlreadyContinuedError` guard so the
+                # grandparent could be continued a second time, and — worst —
+                # made the grandparent deletable while a queued run was still
+                # waiting to resume from its checkpoints.
+                children = build_child_index(self._records.values()).get(job_id, [])
+                if children:
+                    raise JobHasChildrenError(job_id, children)
+                dependents = self._queued_dependents_of(record)
+                if dependents:
+                    raise JobSourceOfQueuedRunError(job_id, dependents)
+                self._forget_locked(job_id)
+                cancelled = record
+            else:
+                cancelled = None
+                runner = self._runners.get(job_id)
+                # Raised under the lock (it used to be checked outside it) so the
+                # intent below can't be recorded for a job that just finalised.
+                if record.state != "running" or runner is None:
+                    raise JobNotRunningError(job_id)
+                self._stop_requested.add(job_id)
+        if cancelled is not None:
+            with contextlib.suppress(FileNotFoundError):
+                shutil.rmtree(_job_dir(self._output_root, job_id))
+            self._notify_change()
+            return cancelled
         runner.stop()
         # The watchdog will finalise the record (state, ended_at, exit_code).
         # Wait briefly so the caller sees the new state in the response.
@@ -4257,6 +4604,54 @@ class JobRegistry:
             "action_dim": _flat_feature_dim((cfg.get("output_features") or {}).get("action")),
         }
 
+    def _queued_dependents_of(self, record: JobRecord) -> builtins.list[str]:
+        """Ids of QUEUED runs that will read `record`'s checkpoints when they
+        launch. Caller holds `self._lock`.
+
+        Three ways a queued run can depend on this one:
+          * it named this run as its fine-tune source (`finetune_from_job_id`);
+          * its resolved `policy_pretrained_path` points INSIDE this run's
+            output dir, which is how a CHAIN REWIND fine-tune reaches an
+            ancestor's checkpoint without naming that ancestor as its source;
+          * its frozen `config_path` points inside this run's output dir, which
+            is how a local→local RESUME reaches the checkpoint OWNER — which is
+            not always its parent. A tip-resume's owner is its parent, so
+            `JobHasChildrenError` usually covers it; that stops being true the
+            moment the node in between is itself removable.
+        """
+        out_dir = (record.output_dir or "").rstrip("/")
+        dependents: builtins.list[str] = []
+        for other in self._records.values():
+            if other.state != "queued" or other.id == record.id:
+                continue
+            if other.config.finetune_from_job_id == record.id:
+                dependents.append(other.id)
+                continue
+            pretrained = other.config.policy_pretrained_path or ""
+            # Path containment, not prefix-matching on the raw string: a
+            # sibling dir like "<root>/run-12-old" starts with "<root>/run-12".
+            if out_dir and (pretrained == out_dir or pretrained.startswith(out_dir + "/")):
+                dependents.append(other.id)
+                continue
+            config_path = other.config.config_path or ""
+            if out_dir and (config_path == out_dir or config_path.startswith(out_dir + "/")):
+                dependents.append(other.id)
+        return dependents
+
+    def _forget_locked(self, job_id: str) -> None:
+        """Drop every in-memory trace of a job. CALLER HOLDS `self._lock`.
+
+        Shared by `delete()` and by `stop()`'s cancel-a-queued-run path, so the
+        two cannot drift apart about what "gone" means. The caller removes the
+        job DIRECTORY afterwards, outside the lock (rmtree is filesystem I/O and
+        has no business inside the critical section).
+        """
+        self._records.pop(job_id, None)
+        self._runners.pop(job_id, None)
+        self._last_persist_at.pop(job_id, None)
+        self._stop_requested.discard(job_id)
+        self._prepare_threads.pop(job_id, None)
+
     def delete(self, job_id: str) -> None:
         with self._lock:
             record = self._records.get(job_id)
@@ -4272,17 +4667,27 @@ class JobRegistry:
             children = build_child_index(self._records.values()).get(job_id, [])
             if children:
                 raise JobHasChildrenError(job_id, children)
-            self._records.pop(job_id, None)
-            self._runners.pop(job_id, None)
-            self._last_persist_at.pop(job_id, None)
-            self._stop_requested.discard(job_id)
-            self._prepare_threads.pop(job_id, None)
+            # Same protection for the edge build_child_index deliberately does
+            # NOT model: a queued fine-tune froze this run's checkpoint path at
+            # submit and will read it when the slot frees.
+            dependents = self._queued_dependents_of(record)
+            if dependents:
+                raise JobSourceOfQueuedRunError(job_id, dependents)
+            self._forget_locked(job_id)
         with contextlib.suppress(FileNotFoundError):
             shutil.rmtree(_job_dir(self._output_root, job_id))
         self._notify_change()
 
     def shutdown(self) -> None:
-        """For tests / orderly process exit. Not wired to FastAPI lifespan today."""
+        """Stop the watchdog. Called from FastAPI's shutdown hook and by tests.
+
+        Stops only the WATCHDOG, never a run: a training already in flight is
+        left alone, exactly as it is across a restart (it is reattached by
+        `_load_from_disk`). What this prevents is the queue promoting a NEW run
+        while the server is going away — `LocalJobRunner` spawns a detached
+        wrapper, so such a run would outlive the process that started it with no
+        UI left to stop it.
+        """
         self._stop_watchdog.set()
 
     # -- internals --
@@ -4297,6 +4702,46 @@ class JobRegistry:
                 record = JobRecord.model_validate(data)
             except Exception as exc:
                 logger.warning("Skipping malformed job.json at %s: %s", meta, exc)
+                continue
+            if (
+                record.state == "running"
+                and record.runner == "local"
+                and record.queue_seq > 0
+                and record.process_pid is None
+            ):
+                # PROMOTED BUT NEVER LAUNCHED. `_drain_queue` flips a queued run
+                # to `running` and persists BEFORE launching, so the slot closes
+                # behind the promotion — and it deliberately leaves `queue_seq`
+                # set until a real trainer exists, precisely so a crash in that
+                # window is recognisable here. For a DEFERRED launch that window
+                # is not a hairline: the whole base-checkpoint download happens
+                # before any process exists, so this is an ordinary-reboot-sized
+                # hole, not a microsecond one.
+                #
+                # `process_pid is None` is the other half of the test and is not
+                # optional. An IMMEDIATE launch persists a live pid while
+                # `queue_seq` is still set (`_launch_locked` writes the pid, and
+                # only then does `_drain_queue` clear the marker), so on
+                # `queue_seq` alone a hard kill in that gap would demote a run
+                # whose detached trainer is still on the GPU, erase the only pid
+                # recording it, and hand the queue a second trainer for the same
+                # output dir.
+                #
+                # Without this the run was filed as `interrupted` with
+                # "restarted while this run was training" — untrue, since it
+                # never trained a step — and silently left the queue, which for
+                # a continuation also stranded its parent as superseded. Put it
+                # back where it was instead; it keeps its place because
+                # `queue_seq` is exactly the sort key it was queued under.
+                logger.info(
+                    "Job %s was promoted but never launched; returning it to the queue.",
+                    record.id,
+                )
+                record.state = "queued"
+                record.process_pid = None
+                self._write_meta(record)
+                self._next_queue_seq = max(self._next_queue_seq, record.queue_seq + 1)
+                self._records[record.id] = record
                 continue
             if record.state == "running":
                 if record.runner == "local":
@@ -4368,6 +4813,37 @@ class JobRegistry:
                     if record.ended_at is None:
                         record.ended_at = time.time()
                     self._write_meta(record)
+            elif record.state == "queued":
+                # A queued job survives a restart as itself: nothing was
+                # started, so there is nothing to reattach or reconcile — the
+                # first watchdog tick's _drain_queue picks it up in the same
+                # order it had. Only the sort counter has to be recovered, so a
+                # job enqueued after the restart lands BEHIND the ones already
+                # waiting rather than jumping the line with a fresh seq of 1.
+                #
+                # Cloud can't legitimately be here (it never queues), but a
+                # hand-edited or downgraded-then-upgraded record could be, and
+                # leaving one parked forever behind a slot it does not wait for
+                # is the one outcome with no way out from the UI.
+                if record.runner != "local":
+                    logger.warning(
+                        "Queued job %s has runner %r; only local runs queue. Marking interrupted.",
+                        record.id,
+                        record.runner,
+                    )
+                    record.state = "interrupted"
+                    record.ended_at = time.time()
+                    if record.error_message is None:
+                        record.error_message = CANCELLED_IN_QUEUE_MESSAGE
+                    # Queue fields released: nothing that will never run keeps
+                    # a place in line on disk.
+                    record.queue_seq = 0
+                    record.queue_position = 0
+                    record.queued_hub_ref = None
+                    record.queued_resume_ref = None
+                    self._write_meta(record)
+                else:
+                    self._next_queue_seq = max(self._next_queue_seq, record.queue_seq + 1)
             self._records[record.id] = record
 
     def _dedupe_imported_records(self) -> None:
@@ -4488,6 +4964,409 @@ class JobRegistry:
             record.name = resolved
             self._write_meta(record)
 
+    # -- local training queue --
+
+    def list_queue(self) -> builtins.list[JobRecord]:
+        """The WHOLE local queue, in run order, annotated with positions.
+
+        Deliberately UNCAPPED, unlike `list()`. The queue is not a page of
+        history — it is the machine's plan, and a truncated plan is worse than
+        no plan: the frontend derived it from `list(limit=10)` and, past ten
+        queued runs, showed neither the run about to start nor a correct
+        position, while every reorder sent a partial list that `reorder_queue`
+        (correctly) refused with a 409 the user could do nothing about. It is
+        also bounded by construction — only runs a user explicitly submitted and
+        has not yet cancelled are in it.
+        """
+        with self._lock:
+            snapshot = dict(self._records)
+            ordered = self._queued_records()
+            children = build_child_index(snapshot.values())
+        # Re-filtered after the lock: `snapshot` is a SHALLOW copy, so it holds
+        # the live record objects and one of them can be promoted out of the
+        # queue between the two statements above. Returning a `running` record
+        # under a heading that says "queued" is the exact confusion the cancel
+        # guard in the UI exists to catch, so don't ship it in the first place.
+        ordered = [r for r in ordered if r.state == "queued"]
+        for r in ordered:
+            # The same annotations `list()` applies, so a record means the same
+            # thing whichever endpoint returned it — a queued CONTINUATION
+            # carries its lineage here too, rather than an empty ancestor list
+            # that only looks right until someone reads it.
+            r.checkpoint_count = self._count_checkpoints(r)
+            self._annotate_lineage(r, snapshot, children)
+            self._annotate_queue(r, snapshot)
+        return ordered
+
+    def reorder_queue(self, job_ids: builtins.list[str]) -> builtins.list[JobRecord]:
+        """Rewrite the queue order to `job_ids`, first to run first.
+
+        `job_ids` must name exactly the currently queued jobs — the frontend
+        sends the whole list back after a drag, and accepting a partial one
+        would leave the omitted jobs' positions to chance. A stale list (the job
+        at the head started, or one was cancelled, between the drag and the
+        request) is refused rather than half-applied, because the alternative is
+        silently reordering around a job the user could still see on screen.
+
+        Refuses nothing about WHERE the user dropped things: any permutation is
+        legitimate, including moving a run that was queued last to the front.
+        """
+        with self._lock:
+            current = [r.id for r in self._queued_records()]
+            # A MALFORMED list and a STALE one are different failures and must
+            # not share an answer. `sorted(a) != sorted(b)` collapses "you named
+            # a job that isn't queued", "you sent the same id twice" and "the
+            # queue moved under your drag" into one refusal whose message says
+            # "the list has been refreshed; try again" — advice that can never
+            # work for the first two, so a non-UI caller retries the same
+            # impossible body forever. Name the bad ids instead; only a genuine
+            # set mismatch against a live queue is the race.
+            seen: set[str] = set()
+            duplicates = sorted({jid for jid in job_ids if jid in seen or seen.add(jid)})
+            if duplicates:
+                raise ValueError(
+                    f"The queue order lists {', '.join(repr(d) for d in duplicates)} more "
+                    "than once; each queued run must appear exactly once."
+                )
+            unknown = sorted(set(job_ids) - set(current))
+            if unknown:
+                raise ValueError(
+                    f"{', '.join(repr(u) for u in unknown)} is not a queued run, so it "
+                    "cannot be given a place in the queue."
+                )
+            if sorted(job_ids) != sorted(current):
+                raise QueueChangedError(current)
+            by_id = {r.id: r for r in self._records.values()}
+            # Renumbered from a fresh block at the TOP of the counter rather
+            # than 1..N, so a reorder can never collide with a job enqueued
+            # concurrently (which took a seq from the same counter).
+            base = self._take_queue_seq(count=len(job_ids))
+            for offset, jid in enumerate(job_ids):
+                record = by_id[jid]
+                record.queue_seq = base + offset
+                # Cleared before the write: `_annotate_queue` stamps this onto
+                # the live record on every read, so without this the file keeps
+                # the PRE-drag position — after a reversal, exactly the inverted
+                # order. Nothing in-repo believes the persisted value (every
+                # path re-derives it), but a job.json that contradicts itself is
+                # a trap for the next reader.
+                record.queue_position = 0
+                self._persist(record, force=True)
+            snapshot = dict(self._records)
+            ordered = self._queued_records()
+        for r in ordered:
+            self._annotate_queue(r, snapshot)
+        self._notify_change()
+        return ordered
+
+    def _take_queue_seq(self, count: int = 1) -> int:
+        """Reserve `count` consecutive queue sort keys and return the first.
+        Caller holds `self._lock`. Monotonic and never reused, so ordering is
+        total even across a reorder that races an enqueue."""
+        seq = self._next_queue_seq
+        self._next_queue_seq += count
+        return seq
+
+    def _queued_launch_refusal(self, record: JobRecord) -> str | None:
+        """Why this queued run must NOT launch now, or None if it still may.
+
+        Re-runs the two submit-time checks whose answer can change while a run
+        waits, and returns the refusal as the `error_message` to finalise with.
+
+        Only `ValueError` counts as a refusal — that is what the checks raise
+        for a genuine contradiction, and what `start` surfaces as a 400. Any
+        OTHER exception (an unreadable config.json, a Hub hiccup, a dataset
+        directory momentarily absent) is logged and treated as "no opinion":
+        failing a legitimate run on a transient read would be a worse bug than
+        the one this guards against, and the trainer itself still refuses a
+        checkpoint it genuinely cannot load.
+
+        That `except Exception` is close to unreachable, and pretending
+        otherwise is how this check reads as stronger than it is: both helpers
+        swallow their own read failures (`read_pretrained_config` suppresses
+        everything; `read_dataset_features` catches OSError/ValueError and
+        returns None outright while offline) and answer "no opinion" by
+        returning None. So the common failure is not an exception — it is
+        SILENCE, precisely when the network is worse at promotion time than it
+        was at submit time, which for a run that waited hours is ordinary.
+
+        That silence is dangerous because lerobot loads weights with
+        `strict=False`: a checkpoint whose feature space no longer matches the
+        dataset loads cleanly and trains garbage recorded as a fine-tune. It
+        still launches — refusing every run whose base cannot be re-read would
+        make the queue unusable offline — but it must not do so quietly, so an
+        unverifiable base is logged as such.
+        """
+        config = record.config
+        if not config.policy_pretrained_path or config.resume:
+            return None
+        try:
+            _check_pretrained_policy_type(config.policy_pretrained_path, config.policy_type)
+            _check_pretrained_feature_space(config.policy_pretrained_path, config.dataset_repo_id)
+        except ValueError as exc:
+            return (
+                f"{exc} This was valid when the run was queued; something it depends on "
+                "changed while it waited."
+            )
+        except Exception:
+            logger.exception("Could not re-validate queued job %s at launch; launching anyway", record.id)
+            return None
+        # Reached only when neither check objected — which includes the case
+        # where neither could READ anything and said nothing. Asked afterwards
+        # so a real refusal above still wins, and so the checks keep their own
+        # ordering; the read is cached by huggingface_hub on the path where it
+        # succeeds, so this costs a local stat rather than a second fetch.
+        if read_pretrained_config(config.policy_pretrained_path) is None:
+            logger.warning(
+                "Could not re-read the base checkpoint for queued job %s (%s) at launch, so "
+                "policy type and feature space were NOT re-verified. Starting anyway; note "
+                "lerobot loads weights with strict=False, so a base that no longer matches "
+                "this dataset will load cleanly and train from mismatched weights.",
+                record.id,
+                config.policy_pretrained_path,
+            )
+        return None
+
+    def _robot_busy(self) -> str | None:
+        """What the robot is doing right now, or None if it is idle.
+
+        Local training is bounded by this machine's GPU/USB (the premise
+        `_local_slot_busy` is built on), and teleoperation, recording,
+        inference, calibration, auto-calibration and wiggle are all mutually
+        exclusive with each other for exactly that reason — each checks the
+        other five before starting (CLAUDE.md: "New features that drive the
+        robot must add the same reciprocal checks against every existing one").
+        Training never joined that set, which was survivable while a training
+        could only begin from an explicit user submit: the user was present and
+        knew what else they had running.
+
+        The queue removes that. `_drain_queue` starts a trainer from a WATCHDOG
+        THREAD, at an arbitrary moment, with nobody at the keyboard — several GB
+        of VRAM and four dataloader workers arriving under a live rollout or a
+        recording session. So the queue asks first, and simply waits: the run
+        stays queued and the next tick tries again, which is the same thing that
+        happens while the slot itself is busy.
+
+        Imported lazily and read without their locks: these are plain module
+        globals, this is an advisory "is now a good moment" check rather than a
+        mutex, and the cost of a stale read is one second's delay.
+
+        Never raises. These six modules pull in cv2, av and the lerobot robot
+        backends, none of which `jobs` depended on before the queue existed, and
+        this runs as the FIRST statement of `_drain_queue` — so an ImportError
+        here (a headless install, a half-installed optional extra, a broken cv2)
+        would propagate out through `_tick` to `_watchdog_loop`'s blanket
+        handler and `_drain_queue` would never complete again for the life of
+        the process. Queued runs would sit forever against an idle GPU while the
+        UI looked perfectly healthy, because job finalisation runs earlier in
+        the tick and would keep working.
+
+        A failure is reported as IDLE rather than busy, which is both the
+        fail-safe direction and the accurate one: a robot module that cannot be
+        imported is a robot module whose feature cannot be running.
+        """
+        try:
+            from . import (
+                auto_calibrate as _auto_calibrate,
+                calibrate as _calibrate,
+                record as _record,
+                rollout as _rollout,
+                teleoperate as _teleoperate,
+                wiggle as _wiggle,
+            )
+
+            if _record.recording_active:
+                return "a recording session"
+            if _rollout.inference_active:
+                return "an inference session"
+            if _teleoperate.teleoperation_active:
+                return "teleoperation"
+            if _calibrate.calibration_is_active():
+                return "calibration"
+            if _auto_calibrate.auto_calibration_is_active():
+                return "auto-calibration"
+            if _wiggle.wiggle_active:
+                return "a wiggle"
+        except Exception:
+            if not self._robot_check_failed:
+                self._robot_check_failed = True
+                logger.exception(
+                    "Cannot tell whether the robot is in use; the training queue will "
+                    "promote runs without waiting for it. This is logged once."
+                )
+        return None
+
+    def _drain_queue(self) -> None:
+        """Start the next queued job if the single local slot is free.
+
+        Called from every watchdog tick (cheap: one dict scan) rather than only
+        from the finalisation path, so the queue also moves after a cancel, a
+        delete, a launch failure, and a process restart that came up with
+        queued records on disk and nothing running.
+
+        THREE PHASES, because the middle one must not hold the lock:
+
+          1. under the lock, pick the head and read what validating it needs;
+          2. OUTSIDE the lock, re-validate it (see `_queued_launch_refusal` —
+             this reads the dataset and the checkpoint's config, which for a
+             hub ref is a NETWORK round-trip). Holding the registry lock across
+             that froze every job endpoint and the watchdog itself for the
+             length of a Hub call plus its retries — the same MT23 coupling
+             `start` documents and avoids by resolving outside the lock;
+          3. re-take the lock, confirm the head has not changed underneath us,
+             then promote and launch.
+
+        A launch that throws does NOT stall the queue: `_launch_locked` marks
+        that record `failed`, and the next tick tries the one behind it.
+        """
+        # -- phase 1: pick the head --------------------------------------
+        # Asked BEFORE the lock: it reads other modules' globals and must not
+        # widen this lock's reach. Waiting rather than failing — the run keeps
+        # its place and the next tick tries again.
+        busy_with = self._robot_busy()
+        if busy_with is not None:
+            logger.debug("Holding the training queue: %s is using the robot", busy_with)
+            return
+
+        with self._lock:
+            if self._local_slot_busy() is not None:
+                return
+            queue = self._queued_records()
+            if not queue:
+                return
+            head_id = queue[0].id
+
+        # -- phase 2: validate it, lock RELEASED --------------------------
+        # `_queued_launch_refusal` reads a snapshot-free live record, which is
+        # safe: it only reads config fields, and a record's config is fixed at
+        # submit. If the record leaves the queue while we are out here, phase 3
+        # notices and does nothing.
+        record = self._records.get(head_id)
+        if record is None:
+            return
+        stale = self._queued_launch_refusal(record)
+
+        # -- phase 3: promote and launch ----------------------------------
+        notify = False
+        try:
+            with self._lock:
+                record = self._records.get(head_id)
+                # Re-checked because phases 1 and 2 were not atomic: the head
+                # may have been cancelled, deleted, reordered behind another
+                # run, or already promoted while we were validating. Any of
+                # those means this call has nothing left to do — the next tick
+                # picks up whatever the truth now is.
+                if record is None or record.state != "queued":
+                    return
+                if self._local_slot_busy() is not None:
+                    return
+                if [r.id for r in self._queued_records()][:1] != [head_id]:
+                    return
+
+                if stale is not None:
+                    record.state = "failed"
+                    # Restamped like the promotion below, and for the same
+                    # reason: `started_at` is still the ENQUEUE time here, so
+                    # leaving it would file a run that never executed a step as
+                    # having lasted however long it sat in the queue.
+                    record.started_at = time.time()
+                    record.ended_at = record.started_at
+                    record.error_message = stale
+                    record.queue_seq = 0
+                    record.queue_position = 0
+                    record.queued_hub_ref = None
+                    record.queued_resume_ref = None
+                    self._persist(record, force=True)
+                    logger.warning("Queued job %s no longer valid at launch: %s", record.id, stale)
+                    # Return rather than falling through to the next queued job:
+                    # the slot is still free, so the next tick drains again in a
+                    # second and the queue keeps moving without this method
+                    # having to loop.
+                    notify = True
+                    return
+
+                hub_ref = record.queued_hub_ref
+                resume_ref = record.queued_resume_ref
+                # Promoted BEFORE the launch so `_local_slot_busy` closes behind
+                # it — otherwise a second caller reaching this line would see a
+                # free slot and start a second trainer. `started_at` is
+                # restamped to the moment it actually began: it is what the UI
+                # shows as the run's start and what elapsed-time readings
+                # subtract from, and leaving it at enqueue time would report a
+                # run that waited an hour as an hour old the second it started.
+                record.state = "running"
+                record.started_at = time.time()
+                # `queue_seq` is deliberately NOT cleared yet — it is what tells
+                # a restart that landed in this window that the promotion never
+                # completed, so the run goes back in the queue instead of being
+                # filed as an interrupted run that never ran. It is cleared once
+                # a real trainer exists: below for an immediate launch, and in
+                # `_start_after_prepare` for a deferred one.
+                record.queue_position = 0
+                record.queued_hub_ref = None
+                record.queued_resume_ref = None
+                # Set BEFORE the persist rather than after it. A persist that
+                # throws (ENOSPC, EIO on an external volume) would otherwise
+                # leave the record mutated in memory with `notify` still False,
+                # so no client is ever told.
+                notify = True
+                try:
+                    self._persist(record, force=True)
+                except Exception:
+                    # Put it back in the queue rather than leaving it `running`
+                    # with no runner, which pins the slot for the LIFE OF THE
+                    # PROCESS: `_tick` skips a runner-less record,
+                    # `_local_slot_busy` keeps naming it, every later drain
+                    # early-returns at the slot check, and the user can neither
+                    # stop it (not running, as far as `stop` is concerned) nor
+                    # delete it (it IS running). The next tick simply retries.
+                    logger.exception(
+                        "Could not persist the promotion of %s; returning it to the queue",
+                        record.id,
+                    )
+                    record.state = "queued"
+                    record.queued_hub_ref = hub_ref
+                    record.queued_resume_ref = resume_ref
+                    return
+                try:
+                    self._launch_locked(
+                        record,
+                        JobTarget(runner="local"),
+                        deferred_hub_ref=hub_ref,
+                        deferred_resume_ref=resume_ref,
+                    )
+                except Exception as exc:
+                    # `_launch_locked` guarantees — for EVERY failure, on both
+                    # its branches — that the record is left `failed`, with any
+                    # runner it managed to start stopped and deregistered, which
+                    # is what frees the slot again. Without that guarantee this
+                    # handler would be the thing that killed the queue: it
+                    # swallows the error, and a record stuck `running` with no
+                    # runner pins the slot for the life of the process.
+                    logger.exception("Queued job %s failed to launch: %s", record.id, exc)
+                else:
+                    if hub_ref is None and resume_ref is None:
+                        # Launched. The record is now a normal running job and
+                        # owes the queue nothing.
+                        record.queue_seq = 0
+                        self._persist(record, force=True)
+                    # Otherwise the launch was DEFERRED: `_launch_locked`
+                    # returned as soon as it started the prepare thread, and the
+                    # transfer it is about to do (GBs, minutes) has not moved a
+                    # byte — the prepare thread is still blocked on this very
+                    # lock. Clearing the marker here left the single LONGEST
+                    # crash window in the feature uncovered: a reboot during the
+                    # download found `running` with no pid and no exit status,
+                    # and filed the run `interrupted` with "restarted while this
+                    # run was training" — which it never did — dropping it from
+                    # the queue and, for a continuation, stranding its parent as
+                    # superseded. `_start_after_prepare` clears it once a real
+                    # trainer exists.
+        finally:
+            # Outside the lock, like every other _notify_change in this file.
+            if notify:
+                self._notify_change()
+
     def _start_watchdog(self) -> None:
         self._watchdog_thread = threading.Thread(
             target=self._watchdog_loop, name="job-registry-watchdog", daemon=True
@@ -4599,6 +5478,9 @@ class JobRegistry:
             self._notify_change()
 
         self._notify_progress(progress_snapshots)
+        # After finalisations, so a run that just ended frees its slot within
+        # the same tick that ended it rather than a second later.
+        self._drain_queue()
 
     def _persist(self, record: JobRecord, force: bool) -> None:
         now = time.time()
@@ -4713,6 +5595,38 @@ _DEFAULT_OUTPUT_ROOT = Path(
 ).expanduser()
 job_registry = JobRegistry(_DEFAULT_OUTPUT_ROOT)
 
+
+def training_is_active() -> str | None:
+    """The name of the local training run using this machine, or None.
+
+    The reciprocal of `JobRegistry._robot_busy`, and the other half of the
+    mutual exclusion CLAUDE.md requires ("New features that drive the robot must
+    add the same reciprocal checks against every existing one"). Training sat
+    outside that set for as long as a run could only begin from an explicit
+    submit — the user was present and knew what else they had running. The queue
+    starts runs from a watchdog thread with nobody at the keyboard, so the six
+    robot features have to be able to see one coming.
+
+    Reports only LOCAL runs that are actually `running`. A cloud run is somebody
+    else's GPU, and a `queued` run has not claimed anything yet.
+
+    LOCK ORDER, and it is load-bearing: this takes the registry lock, and its
+    callers hold their own feature lock when they call it. `_robot_busy` must
+    therefore keep reading their flags from OUTSIDE the registry lock, exactly
+    as it does today — moving that check inside the critical section (a tempting
+    way to tighten the promotion race) closes the cycle and deadlocks the
+    watchdog against whichever feature is starting.
+    """
+    with job_registry._lock:
+        busy_id = job_registry._local_slot_busy()
+        if busy_id is None:
+            return None
+        record = job_registry._records.get(busy_id)
+        if record is None:
+            return busy_id
+        return record.display_name or record.name or record.id
+
+
 __all__ = [
     "JobState",
     "JobTarget",
@@ -4726,12 +5640,16 @@ __all__ = [
     "PreparingJobRunner",
     "JobRegistry",
     "make_snapshot_progress_tqdm",
-    "JobAlreadyRunningError",
     "JobNotFoundError",
+    "JobSourceOfQueuedRunError",
+    "JobStateChangedError",
     "JobNotRunningError",
+    "QueueChangedError",
     "job_registry",
+    "training_is_active",
     "parse_metrics_into",
     "classify_terminal_state",
     "STOPPED_BY_REQUEST_MESSAGE",
+    "CANCELLED_IN_QUEUE_MESSAGE",
     "UNCONFIRMED_OUTCOME_MESSAGE",
 ]

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -5642,7 +5642,17 @@ class JobRegistry:
                         record.error_message = oom_reason or reason or f"Subprocess exited with code {rc}"
                 self._runners.pop(jid, None)
                 self._stop_requested.discard(jid)
-            self._persist(record, force=True)
+                # Inside the lock, unlike every other _persist-then-notify in
+                # this file, because this one races `delete()`. `_write_meta`
+                # opens with `mkdir(parents=True, exist_ok=True)`, so a persist
+                # that lands after a concurrent delete recreates the directory
+                # AND the job.json of a job the user just removed: it vanishes
+                # from the UI and returns on the next restart. That is the
+                # resurrection `_remove_locked` was written to end — it unlinks
+                # under the lock so no reader can see a record whose file is
+                # gone — but a WRITER holding a reference from a previous
+                # acquisition slipped past it.
+                self._persist(record, force=True)
             self._notify_change()
 
         self._notify_progress(progress_snapshots)

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -683,6 +683,16 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
             }
         if _replay.replay_active:
             return {"success": False, "message": "Replay is currently active. Stop it first."}
+
+        # Lazy, because jobs imports this module back the same way.
+        from . import jobs as _jobs
+
+        if (training := _jobs.training_is_active()) is not None:
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": f"Training run '{training}' is using this machine. Stop it first.",
+            }
         # Refuse a malformed dataset name up front (before claiming the flag or
         # touching hardware). Rejecting beats silent sanitization: "whoo/" used to
         # smuggle in a namespace and land the dataset at "user/whoo/".

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -1710,6 +1710,18 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
                 "status_code": 409,
                 "message": "Replay is currently active. Stop it first.",
             }
+        # Lazy, because jobs imports this module back the same way. Inference is
+        # the worst pairing: both want several GB of VRAM, and whichever loses
+        # takes a CUDA OOM — if that is the trainer, hours of work end as
+        # "Subprocess exited with code 1" with nothing tying it to this click.
+        from . import jobs as _jobs
+
+        if (training := _jobs.training_is_active()) is not None:
+            return {
+                "success": False,
+                "status_code": 409,
+                "message": f"Training run '{training}' is using this machine. Stop it first.",
+            }
         # Claim the slot now so a concurrent caller losing the race sees us, and
         # seed the meta + timer so the phase is visible from the very first
         # status poll (the download runs on the inference page — the UI must be

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -73,6 +73,7 @@ from .jobs import (
     JobNotRunningError,
     JobRemovalFailedError,
     JobSourceOfQueuedRunError,
+    JobState,
     JobStateChangedError,
     JobTarget,
     QueueChangedError,
@@ -1956,13 +1957,19 @@ def reorder_job_queue(body: ReorderQueueRequest):
 
 
 @app.post("/jobs/{job_id}/stop")
-def stop_job(job_id: str, expect_state: str | None = None):
+def stop_job(job_id: str, expect_state: JobState | None = None):
     """Stop a running job, or cancel a queued one.
 
     `expect_state` is optional and is the caller's precondition: pass the state
     the UI was showing when it drew the button. Cancel and kill are the same
     request here, so a Cancel drawn against a stale queue would otherwise
     SIGTERM a run the watchdog promoted in the meantime.
+
+    Typed as `JobState`, not `str`, to match `JobRegistry.stop`: an unknown value
+    used to reach the comparison, fail it, and come back as a 409 saying the job
+    "changed while you were looking at it" — reporting a client's typo as a race,
+    which no retry can ever clear. It is now a 422, and `/openapi.json`
+    advertises the real member set instead of "any string".
     """
     try:
         return job_registry.stop(job_id, expect_state=expect_state)

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -36,7 +36,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from huggingface_hub.errors import HfHubHTTPError
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.datastructures import Headers
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response
@@ -1911,7 +1911,13 @@ def rename_job(job_id: str, body: RenameJobBody):
 class ReorderQueueRequest(BaseModel):
     # The WHOLE queue, first to run first. A partial list is refused rather
     # than merged — see JobRegistry.reorder_queue.
-    job_ids: list[str]
+    #
+    # Bounded because the queue is: it holds runs a user submitted by hand, one
+    # at a time, and a machine with a single local training slot will not have
+    # thousands waiting. Unbounded, a 20k-id body was validated INSIDE the
+    # registry lock (freezing every /jobs* request behind the set math) and came
+    # back as a 360 KB error detail echoing every bad id. 422 here costs neither.
+    job_ids: list[str] = Field(max_length=512)
 
 
 # Declared before /jobs/{job_id}/... so the intent is readable together with

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -2011,12 +2011,16 @@ def stop_job(job_id: str, expect_state: JobState | None = None):
         # the run is untouched, because the alternative reading — "cancel
         # half-worked" — is what would make a user walk away from a run that is
         # still going to train.
+        logger.exception("Could not cancel job %s", job_id)
         raise HTTPException(
             status_code=500,
+            # `strerror` only — see the delete twin below. The full OSError
+            # carries the job directory's absolute path, and this body is
+            # returned to the caller.
             detail=(
-                f"Could not cancel job {job_id!r}: {exc.reason}. The run is still queued "
-                "and will still start when the slot frees — nothing was removed, so it is "
-                "safe to try again."
+                f"Could not cancel job {job_id!r}: {exc.reason.strerror}. The run is still "
+                "queued and will still start when the slot frees — nothing was removed, so "
+                "it is safe to try again."
             ),
         ) from exc
 
@@ -2059,11 +2063,24 @@ def delete_job(job_id: str):
         # 500, not 409: nothing about the request was wrong. Say that the run is
         # untouched, because the alternative reading — "delete half-worked" — is
         # what would leave a user surprised to see it again after a restart.
+        # Where it is untouched depends on what it was: `delete` refuses only a
+        # RUNNING run, so a queued one reaches here, and telling that user it is
+        # "still in your history" describes the wrong place — it is still in the
+        # queue and still going to train, which is the part they need to act on.
+        logger.exception("Could not delete job %s", job_id)
+        still = (
+            "still queued and will still start when the slot frees"
+            if record.state == "queued"
+            else "untouched and still in your history"
+        )
         raise HTTPException(
             status_code=500,
+            # `strerror` only: the full OSError carries the absolute path of the
+            # job directory, and this body goes to whoever made the request —
+            # including anyone on the LAN under `--lan`. The path is in the log.
             detail=(
-                f"Could not delete job {job_id!r}: {exc.reason}. The run is untouched and "
-                "still in your history — nothing was removed, so it is safe to try again."
+                f"Could not delete job {job_id!r}: {exc.reason.strerror}. The run is "
+                f"{still} — nothing was removed, so it is safe to try again."
             ),
         ) from exc
     # Deleting a tracked cloud run removes the local record, but its Hub job

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -68,11 +68,13 @@ from .identify import identify_arm_by_motion
 from .jobs import (
     DatasetNotOnHubError,
     JobAlreadyContinuedError,
-    JobAlreadyRunningError,
     JobHasChildrenError,
     JobNotFoundError,
     JobNotRunningError,
+    JobSourceOfQueuedRunError,
+    JobStateChangedError,
     JobTarget,
+    QueueChangedError,
     _list_local_checkpoints,
     job_registry,
 )
@@ -1323,11 +1325,17 @@ async def create_training_job(req: Request):
         from .datasets import is_dataset_available_locally
 
         if not is_dataset_available_locally(cfg.dataset_repo_id):
-            # 400 (matching this endpoint's other preflight rejections — the
-            # resume-steps guard above and the ValueError->400 below), NOT 409:
-            # startTrainingJob (jobsApi.ts) rewrites EVERY 409 into "Another
-            # training is already running", which would mask this message. 400
-            # lets FastAPI's `detail` reach the toast verbatim.
+            # 400, matching this endpoint's other preflight rejections (the
+            # resume-steps guard above and the ValueError->400 below). It is a
+            # malformed request for this server's configuration, not a conflict
+            # with some other state — nothing is holding the dataset; it simply
+            # isn't here and can't be fetched.
+            #
+            # (This used to be justified instead by startTrainingJob rewriting
+            # EVERY 409 into "Another training is already running", which would
+            # have masked the message. That rewrite is gone — the local mutex it
+            # served was replaced by the queue — so the reasoning above is what
+            # holds the 400 in place now. The conclusion is unchanged.)
             raise HTTPException(
                 status_code=400,
                 detail=(
@@ -1339,8 +1347,6 @@ async def create_training_job(req: Request):
             )
     try:
         record = job_registry.start(body.config, body.target)
-    except JobAlreadyRunningError as exc:
-        raise HTTPException(status_code=409, detail=f"Job already running: {exc}") from exc
     except DatasetNotOnHubError as exc:
         # Cloud run on a local-only dataset. 409: the caller must upload the
         # dataset first (the browser flow does this automatically before
@@ -1741,6 +1747,26 @@ def dismiss_hub_job(job_id: str):
     return {"status": "success", "job_id": job_id.strip()}
 
 
+# MUST be declared before GET /jobs/{job_id}: FastAPI matches in declaration
+# order, and that route's single {job_id} segment happily matches the literal
+# "queue", answering this request with a 404 for a job of that name. Same
+# reason /jobs/hub sits above it. (The POST twin, /jobs/queue/reorder, is not
+# at risk — every POST /jobs/{job_id}/… route ends in a literal segment.)
+@app.get("/jobs/queue")
+def list_job_queue():
+    """The whole local training queue, in the order it will run.
+
+    Separate from `GET /jobs` because that is a capped, newest-first PAGE of
+    history and this is a complete list. Deriving the queue from that page was
+    wrong twice over: a queued record carries its SUBMIT time, so queued runs
+    crowd the top of the page and pushed the actually-running job off it, and
+    past the page size the queue itself was truncated — which silently dropped
+    the runs at the HEAD of the line and made every reorder a 409, since
+    `reorder_queue` requires the whole list.
+    """
+    return {"jobs": [r.model_dump() for r in job_registry.list_queue()]}
+
+
 @app.get("/jobs/{job_id}")
 def get_job(job_id: str):
     try:
@@ -1887,14 +1913,89 @@ def rename_job(job_id: str, body: RenameJobBody):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@app.post("/jobs/{job_id}/stop")
-def stop_job(job_id: str):
+class ReorderQueueRequest(BaseModel):
+    # The WHOLE queue, first to run first. A partial list is refused rather
+    # than merged — see JobRegistry.reorder_queue.
+    job_ids: list[str]
+
+
+# Declared before /jobs/{job_id}/... so the intent is readable together with
+# stop; FastAPI matches this path fine either way, since every {job_id} route
+# ends in a literal segment ("rename", "stop", …) that "queue" isn't.
+@app.post("/jobs/queue/reorder")
+def reorder_job_queue(body: ReorderQueueRequest):
+    """Set the order of the local training queue.
+
+    Local runs are one-at-a-time, so a second Start enqueues rather than
+    failing; this is how the user changes their mind about what goes next.
+    Only queued jobs can be reordered — the run already on the GPU is not in
+    the list, and a job that started while the drag was in flight makes the
+    request stale (409).
+    """
     try:
-        return job_registry.stop(job_id)
+        return {"jobs": job_registry.reorder_queue(body.job_ids)}
+    except ValueError as exc:
+        # The request itself is wrong — an unknown id, or one listed twice.
+        # 400, not the 409 below: retrying it unchanged can never succeed, and
+        # the detail names the offending ids so a non-UI caller can fix them.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except QueueChangedError as exc:
+        # A well-formed list that lost its race. Retrying after a refetch is
+        # exactly the right advice here, which is why it only appears here.
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "The training queue changed while you were reordering it — "
+                "a job started, finished, or was cancelled. The list has been "
+                "refreshed; try again."
+            ),
+        ) from exc
+
+
+@app.post("/jobs/{job_id}/stop")
+def stop_job(job_id: str, expect_state: str | None = None):
+    """Stop a running job, or cancel a queued one.
+
+    `expect_state` is optional and is the caller's precondition: pass the state
+    the UI was showing when it drew the button. Cancel and kill are the same
+    request here, so a Cancel drawn against a stale queue would otherwise
+    SIGTERM a run the watchdog promoted in the meantime.
+    """
+    try:
+        return job_registry.stop(job_id, expect_state=expect_state)
     except JobNotFoundError as exc:
         raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found") from exc
+    except JobStateChangedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Job {job_id!r} is {exc.actual!r}, not {exc.expected!r} — it changed while "
+                "you were looking at it. Refresh and decide again."
+            ),
+        ) from exc
     except JobNotRunningError as exc:
-        raise HTTPException(status_code=409, detail=f"Job {job_id!r} is not running") from exc
+        raise HTTPException(status_code=409, detail=f"Job {job_id!r} is neither running nor queued") from exc
+    # Cancelling a QUEUED run removes its record, so it carries the same two
+    # refusals as DELETE. Stopping a running run does not — it leaves a record
+    # behind — so these can only fire on the cancel path.
+    except JobHasChildrenError as exc:
+        continued_by = ", ".join(repr(cid) for cid in exc.child_ids)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Job {job_id!r} was continued by {continued_by}, which would be left "
+                "pointing at a cancelled run. Cancel the continuation(s) first."
+            ),
+        ) from exc
+    except JobSourceOfQueuedRunError as exc:
+        waiting = ", ".join(repr(qid) for qid in exc.queued_ids)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Job {job_id!r} holds the checkpoint queued run(s) {waiting} will train "
+                "from. Cancel those first."
+            ),
+        ) from exc
 
 
 @app.delete("/jobs/{job_id}", status_code=204)
@@ -1915,6 +2016,20 @@ def delete_job(job_id: str):
             detail=(
                 f"Job {job_id!r} was continued by {continued_by}, which would be left "
                 "pointing at a deleted run. Delete the continuation(s) first."
+            ),
+        ) from exc
+    except JobSourceOfQueuedRunError as exc:
+        # Same shape as the mid-chain refusal above, for the dependency
+        # build_child_index does not model: a queued fine-tune froze this run's
+        # checkpoint PATH at submit time and reads it when the slot frees, so
+        # deleting the directory now fails that run hours from now with a
+        # not-found traceback the user could not connect to this click.
+        waiting = ", ".join(repr(qid) for qid in exc.queued_ids)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Job {job_id!r} holds the checkpoint queued run(s) {waiting} will train "
+                "from. Cancel them first, or wait for them to finish."
             ),
         ) from exc
     # Deleting a tracked cloud run removes the local record, but its Hub job
@@ -2902,6 +3017,23 @@ async def start_avfoundation_pump():
 async def shutdown_event():
     """Clean up resources when FastAPI shuts down"""
     logger.info("🔄 FastAPI shutting down, cleaning up...")
+
+    # FIRST, before anything below takes its (bounded but real) time: stop the
+    # job watchdog, so the local training queue cannot promote a run while we
+    # are shutting down.
+    #
+    # `_drain_queue` runs every second from a thread uvicorn does not manage,
+    # and `LocalJobRunner` spawns a DETACHED wrapper — that detachment is
+    # deliberate (it is what `process_pid` + `exit_status` reattachment exists
+    # for), so a trainer started here outlives the server. The user would close
+    # MakerMods Lab and be left with a GPU training they never saw start and no
+    # UI able to stop it until they relaunch. Before the queue this was
+    # impossible: starting a run required an HTTP request, and uvicorn stops
+    # accepting those before this handler runs.
+    #
+    # Only the watchdog stops. A run already training is left alone on purpose,
+    # exactly as it is across a restart today.
+    job_registry.shutdown()
 
     # Stop the AVFoundation pump first so its next tick can't interleave with
     # shutdown (and so --reload restarts don't log a destroyed-pending-task).

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -71,6 +71,7 @@ from .jobs import (
     JobHasChildrenError,
     JobNotFoundError,
     JobNotRunningError,
+    JobRemovalFailedError,
     JobSourceOfQueuedRunError,
     JobStateChangedError,
     JobTarget,
@@ -1330,12 +1331,6 @@ async def create_training_job(req: Request):
             # malformed request for this server's configuration, not a conflict
             # with some other state — nothing is holding the dataset; it simply
             # isn't here and can't be fetched.
-            #
-            # (This used to be justified instead by startTrainingJob rewriting
-            # EVERY 409 into "Another training is already running", which would
-            # have masked the message. That rewrite is gone — the local mutex it
-            # served was replaced by the queue — so the reasoning above is what
-            # holds the 400 in place now. The conclusion is unchanged.)
             raise HTTPException(
                 status_code=400,
                 detail=(
@@ -1996,6 +1991,19 @@ def stop_job(job_id: str, expect_state: str | None = None):
                 "from. Cancel those first."
             ),
         ) from exc
+    except JobRemovalFailedError as exc:
+        # 500, not 409: nothing about the request was wrong. Say plainly that
+        # the run is untouched, because the alternative reading — "cancel
+        # half-worked" — is what would make a user walk away from a run that is
+        # still going to train.
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Could not cancel job {job_id!r}: {exc.reason}. The run is still queued "
+                "and will still start when the slot frees — nothing was removed, so it is "
+                "safe to try again."
+            ),
+        ) from exc
 
 
 @app.delete("/jobs/{job_id}", status_code=204)
@@ -2030,6 +2038,17 @@ def delete_job(job_id: str):
             detail=(
                 f"Job {job_id!r} holds the checkpoint queued run(s) {waiting} will train "
                 "from. Cancel them first, or wait for them to finish."
+            ),
+        ) from exc
+    except JobRemovalFailedError as exc:
+        # 500, not 409: nothing about the request was wrong. Say that the run is
+        # untouched, because the alternative reading — "delete half-worked" — is
+        # what would leave a user surprised to see it again after a restart.
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Could not delete job {job_id!r}: {exc.reason}. The run is untouched and "
+                "still in your history — nothing was removed, so it is safe to try again."
             ),
         ) from exc
     # Deleting a tracked cloud run removes the local record, but its Hub job

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -1930,9 +1930,11 @@ def reorder_job_queue(body: ReorderQueueRequest):
     try:
         return {"jobs": job_registry.reorder_queue(body.job_ids)}
     except ValueError as exc:
-        # The request itself is wrong — an unknown id, or one listed twice.
-        # 400, not the 409 below: retrying it unchanged can never succeed, and
-        # the detail names the offending ids so a non-UI caller can fix them.
+        # The request itself is wrong — an id that names no run at all, or one
+        # listed twice. 400, not the 409 below: retrying it unchanged can never
+        # succeed, and the detail names the offending ids so a non-UI caller can
+        # fix them. An id that names a real run which has LEFT the queue is not
+        # this case: that is the race below, and it retries successfully.
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except QueueChangedError as exc:
         # A well-formed list that lost its race. Retrying after a refetch is

--- a/makermodslab/teleoperate.py
+++ b/makermodslab/teleoperate.py
@@ -832,6 +832,14 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
                 "success": False,
                 "message": "Replay is currently active. Stop it first.",
             }
+        # Lazy, because jobs imports this module back the same way.
+        from . import jobs as _jobs
+
+        if (training := _jobs.training_is_active()) is not None:
+            return {
+                "success": False,
+                "message": f"Training run '{training}' is using this machine. Stop it first.",
+            }
         # Per-session state reset, under the same lock that claims the active
         # flag: a stale _release_now from a previous session's double-stop
         # would otherwise cut EVERY later grace/return short until the server

--- a/makermodslab/wiggle.py
+++ b/makermodslab/wiggle.py
@@ -157,6 +157,16 @@ async def wiggle_gripper(port: str) -> dict:
             "success": False,
             "message": "Replay is currently active — wait for it to stop before wiggling.",
         }
+    # Lazy, because jobs imports this module back the same way.
+    from . import jobs as _jobs
+
+    if (training := _jobs.training_is_active()) is not None:
+        return {
+            "success": False,
+            "message": (
+                f"Training run '{training}' is using this machine — wait for it to stop before wiggling."
+            ),
+        }
 
     wiggle_active = True
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,34 @@
 
 from __future__ import annotations
 
+import atexit
+import os
+import shutil
+import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+
+# Redirect the module-level `job_registry` singleton away from real training
+# history. This CANNOT be a fixture: `makermodslab.jobs` resolves
+# `_DEFAULT_OUTPUT_ROOT` from this variable at import time and constructs the
+# singleton (watchdog and all) at module scope, so by the time any fixture runs
+# the root is already bound. conftest is imported before test modules, which is
+# the only hook early enough.
+#
+# Without it the singleton points at ~/.cache/huggingface/lerobot/outputs/train,
+# and any test that drives it writes job records into the developer's real
+# history — and, because that registry's watchdog is a live thread, can promote
+# an injected `queued` record and spawn an ACTUAL lerobot subprocess against it.
+# `setdefault` so an explicit root set by the caller still wins.
+_TEST_OUTPUT_ROOT = tempfile.mkdtemp(prefix="makermodslab-tests-")
+if os.environ.setdefault("MAKERMODSLAB_OUTPUT_ROOT", _TEST_OUTPUT_ROOT) == _TEST_OUTPUT_ROOT:
+    atexit.register(shutil.rmtree, _TEST_OUTPUT_ROOT, ignore_errors=True)
+else:  # pragma: no cover - only when the caller pinned a root themselves
+    shutil.rmtree(_TEST_OUTPUT_ROOT, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7601,3 +7601,26 @@ def test_reorder_calls_a_run_that_left_the_queue_a_race_not_a_bad_id(tmp_path) -
     with pytest.raises(ValueError) as bad:
         reg.reorder_queue(["b", "ghost"])
     assert not isinstance(bad.value, QueueChangedError)
+
+
+def test_rename_does_not_persist_a_derived_queue_position(tmp_path) -> None:
+    """`queue_position` is derived and stamped onto the LIVE record by every
+    read, so a rename that followed a queue read wrote that read's position into
+    job.json. Nothing in-repo believes the persisted value, but `reorder_queue`
+    goes out of its way to zero it for exactly this reason — "a job.json that
+    contradicts itself is a trap for the next reader" — and rename is a path
+    that fix did not consider."""
+    reg = _quiet_registry(tmp_path)
+    for jid, seq in (("a", 10), ("b", 20)):
+        _inject_queued(reg, jid, seq=seq, persist=True)
+
+    # A read stamps the derived position onto the live records.
+    assert [r.queue_position for r in reg.list_queue()] == [1, 2]
+
+    renamed = reg.rename("b", "second")
+
+    on_disk = _json.loads((tmp_path / "root" / "b" / "job.json").read_text())
+    assert on_disk["display_name"] == "second"
+    assert on_disk["queue_position"] == 0, "a derived field must not reach disk"
+    # The response still carries the real position for the caller.
+    assert renamed.queue_position == 2

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3609,10 +3609,14 @@ def test_stop_during_the_download_is_interrupted(monkeypatch, tmp_path) -> None:
     assert record.id not in reg._runners
 
 
-def test_a_download_bound_job_refuses_a_second_local_run(monkeypatch, tmp_path) -> None:
-    """The local mutex covers the download window too — the machine is spoken
-    for from the moment the record exists, not from the trainer's first step."""
-    from makermodslab.jobs import JobAlreadyRunningError, JobRegistry, JobTarget
+def test_a_download_bound_job_queues_a_second_local_run(monkeypatch, tmp_path) -> None:
+    """The slot is taken for the download window too — the machine is spoken for
+    from the moment the record exists, not from the trainer's first step.
+
+    It used to be a refusal (`JobAlreadyRunningError` → 409). Now the second run
+    is ACCEPTED and parked: same invariant (one local trainer at a time), but the
+    user does not have to come back and resubmit by hand when the first ends."""
+    from makermodslab.jobs import JobRegistry, JobTarget
     from makermodslab.train import TrainingRequest
 
     started, release = threading.Event(), threading.Event()
@@ -3624,16 +3628,20 @@ def test_a_download_bound_job_refuses_a_second_local_run(monkeypatch, tmp_path) 
 
     reg = JobRegistry(tmp_path / "root")
     source = _cloud_finetune_source(reg)
-    _fake_local_runner(monkeypatch)
+    fake_runner = _fake_local_runner(monkeypatch)
 
     record = reg.start(_hub_finetune_request(source.id), JobTarget(runner="local"))
     assert started.wait(timeout=10), "the download never started"
 
-    with pytest.raises(JobAlreadyRunningError):
-        reg.start(
-            TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
-            JobTarget(runner="local"),
-        )
+    second = reg.start(
+        TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        JobTarget(runner="local"),
+    )
+    assert second.state == "queued"
+    assert reg.get(second.id).queue_position == 1
+    # Parked, not started: the one slot still belongs to the download above.
+    assert fake_runner.start.call_count == 0
+    assert second.id not in reg._runners
 
     release.set()
     _join_prepare(reg, record.id)
@@ -6253,3 +6261,1101 @@ def test_rewind_steps_guard_reads_the_chosen_checkpoint(tmp_path) -> None:
             _rewind_request(leaf="tip", owner="trunk", step=200, steps=200),
             JobTarget(runner="local"),
         )
+
+
+# ---------------------------------------------------------------------------
+# The local training queue.
+#
+# One local trainer at a time is still the invariant; what changed is what a
+# second request gets. It used to be a 409 the user had to resubmit by hand;
+# now it is accepted as `queued` and the watchdog starts it when the slot frees.
+# These cover the pure/idle branches of that machinery — the ordering maths, the
+# reorder contract, cancel-while-queued, and the restart round-trip. The launch
+# path itself (_drain_queue → _launch_locked → a real subprocess) is a thread +
+# subprocess happy path, deliberately out of scope per CLAUDE.md.
+# ---------------------------------------------------------------------------
+
+
+def _quiet_registry(tmp_path):
+    """A registry whose watchdog never starts, so a background _tick() can't
+    drain the queue underneath an assertion. Every test here drives
+    `_drain_queue` by hand when it wants it to run.
+
+    Suppressed at construction rather than stopped afterwards (the usual
+    `shutdown()` + join): __init__ starts the watchdog, so by the time a test
+    could call shutdown() a tick may already have promoted and LAUNCHED the head
+    of a queue loaded from disk. That is exactly right in production and exactly
+    a race in a test."""
+    from unittest.mock import patch
+
+    from makermodslab.jobs import JobRegistry
+
+    with patch.object(JobRegistry, "_start_watchdog", lambda self: None):
+        return JobRegistry(tmp_path / "root")
+
+
+def _inject_queued(reg, job_id: str, seq: int, *, persist: bool = False):
+    """Splice a `queued` record straight into the registry — the same shape
+    start() produces when it finds the slot busy, without the pile of Hub
+    patching a real start needs."""
+    from makermodslab.jobs import JobRecord, _job_dir
+    from makermodslab.train import TrainingRequest
+
+    record = JobRecord(
+        id=job_id,
+        name=job_id,
+        state="queued",
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        # A real `start()` always claims a job dir before queuing, and two
+        # checks read it: `_queued_dependents_of` guards on `if out_dir and …`,
+        # so `""` made the path-containment half of the dependency check
+        # structurally unreachable for every injected record, and
+        # `_count_checkpoints("")` resolved to `Path("checkpoints")` in the
+        # pytest CWD — the repo itself.
+        output_dir=str(_job_dir(reg._output_root, job_id) / "run"),
+        started_at=0.0,
+        runner="local",
+        queue_seq=seq,
+    )
+    with reg._lock:
+        reg._records[job_id] = record
+        reg._next_queue_seq = max(reg._next_queue_seq, seq + 1)
+        if persist:
+            reg._write_meta(record)
+    return record
+
+
+def _inject_running_local(reg, job_id: str = "busy"):
+    """A local run holding the single slot. No runner is registered: nothing
+    here asks the runner anything, and stop() is never called on it."""
+    from makermodslab.jobs import JobRecord
+    from makermodslab.train import TrainingRequest
+
+    record = JobRecord(
+        id=job_id,
+        name=job_id,
+        state="running",
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        output_dir="",
+        started_at=0.0,
+        runner="local",
+    )
+    with reg._lock:
+        reg._records[job_id] = record
+    return record
+
+
+def test_queue_positions_number_by_seq_not_by_insertion(tmp_path) -> None:
+    """queue_position is DERIVED, 1-based, and ordered by queue_seq — not by the
+    order records happen to sit in the dict. Anything not queued reads 0, so the
+    field never claims a place in line for a run that has one."""
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg)
+    # Inserted out of order on purpose: seq decides, insertion does not.
+    _inject_queued(reg, "third", seq=30)
+    _inject_queued(reg, "first", seq=10)
+    _inject_queued(reg, "second", seq=20)
+
+    by_id = {r.id: r for r in reg.list(limit=50)}
+
+    assert by_id["first"].queue_position == 1
+    assert by_id["second"].queue_position == 2
+    assert by_id["third"].queue_position == 3
+    # The running job is not in the queue and must not be numbered as if it were.
+    assert by_id["busy"].queue_position == 0
+    # get() annotates the same way list() does.
+    assert reg.get("second").queue_position == 2
+
+
+def test_reorder_queue_permutes_the_waiting_order(tmp_path) -> None:
+    """Any permutation is legitimate, including hauling the last-queued run to
+    the front. The new order is returned already numbered and survives a
+    re-read, because queue_seq is persisted."""
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg)
+    for jid, seq in (("a", 10), ("b", 20), ("c", 30)):
+        _inject_queued(reg, jid, seq=seq, persist=True)
+
+    ordered = reg.reorder_queue(["c", "a", "b"])
+
+    assert [r.id for r in ordered] == ["c", "a", "b"]
+    assert [r.queue_position for r in ordered] == [1, 2, 3]
+    # Re-derived from the registry, not just from the return value.
+    assert [r.id for r in reg._queued_records()] == ["c", "a", "b"]
+
+
+def test_reorder_queue_refuses_a_stale_list_rather_than_half_applying(tmp_path) -> None:
+    """The frontend sends the whole queue back after a drag. If the queue moved
+    in between — the head started, or one was cancelled — applying the part that
+    still matches would reorder around a job the user could still see on screen.
+    Refuse, and hand back the CURRENT ids so the caller can re-render."""
+    from makermodslab.jobs import QueueChangedError
+
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg)
+    for jid, seq in (("a", 10), ("b", 20)):
+        _inject_queued(reg, jid, seq=seq)
+
+    # Omits one that is queued: a well-formed list that lost its race. THIS is
+    # the staleness case, and the only one whose "refresh and try again" advice
+    # can actually succeed.
+    with pytest.raises(QueueChangedError) as excinfo:
+        reg.reorder_queue(["a"])
+    assert sorted(excinfo.value.current_ids) == ["a", "b"]
+
+    # A list naming something that was never queued is a MALFORMED request, not
+    # a race — see test_reorder_names_a_bad_id_instead_of_blaming_a_race. It is
+    # refused here too; what matters is that it is a different refusal.
+    with pytest.raises(ValueError) as bad:
+        reg.reorder_queue(["a", "b", "ghost"])
+    assert not isinstance(bad.value, QueueChangedError)
+
+    # Nothing moved.
+    assert [r.id for r in reg._queued_records()] == ["a", "b"]
+
+
+def test_stop_on_a_queued_job_removes_it(tmp_path) -> None:
+    """Stop on a queued run means cancel, and cancelling one REMOVES it.
+
+    It never executed — no process, no runner, no logs, no checkpoint, and an
+    output dir holding nothing but its own job.json — so there is no history to
+    keep. An earlier version left an `interrupted` tombstone, which then had to
+    be excused from every question the registry asks about runs (most sharply:
+    a cancelled continuation permanently superseded the parent it was going to
+    continue). Removing it is the same outcome without the special cases."""
+    from makermodslab.jobs import JobNotFoundError
+
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg)
+    _inject_queued(reg, "a", seq=10, persist=True)
+    queued = _inject_queued(reg, "b", seq=20, persist=True)
+    queued.queued_hub_ref = "user/repo@checkpoints/003000"
+    job_dir = tmp_path / "root" / "b"
+    assert job_dir.exists()
+
+    removed = reg.stop("b")
+
+    # The caller still gets the record it asked about.
+    assert removed.id == "b"
+    # But it is gone from the registry, from disk, and from the queue.
+    with pytest.raises(JobNotFoundError):
+        reg.get("b")
+    assert not job_dir.exists()
+    assert "b" not in reg._stop_requested
+    assert [r.id for r in reg._queued_records()] == ["a"]
+    assert reg.get("a").queue_position == 1
+    # A restart does not resurrect it.
+    assert "b" not in _quiet_registry(tmp_path)._records
+
+
+def test_drain_queue_is_a_no_op_while_the_local_slot_is_busy(tmp_path) -> None:
+    """The whole point of the queue: while a local run holds the slot, nothing
+    behind it starts, however many ticks go by."""
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg)
+    _inject_queued(reg, "a", seq=10)
+
+    reg._drain_queue()
+    reg._drain_queue()
+
+    assert reg.get("a").state == "queued"
+    assert reg.get("a").queue_position == 1
+    assert "a" not in reg._runners
+
+
+def test_drain_queue_does_nothing_with_an_empty_queue(tmp_path) -> None:
+    """A free slot and nothing waiting is the ordinary idle case — it must not
+    trip over the empty queue on every single tick."""
+    reg = _quiet_registry(tmp_path)
+
+    reg._drain_queue()  # no records at all
+
+    assert reg.list() == []
+
+
+def test_a_queued_job_survives_a_restart_and_keeps_its_place(tmp_path) -> None:
+    """Nothing was started, so there is nothing to reattach — a queued record
+    comes back as itself, in the order it had. The seq counter is recovered too,
+    so a run enqueued after the restart lands BEHIND the ones already waiting
+    instead of jumping the line with a fresh seq of 1."""
+    reg = _quiet_registry(tmp_path)
+    _inject_queued(reg, "a", seq=10, persist=True)
+    _inject_queued(reg, "b", seq=20, persist=True)
+
+    reloaded = _quiet_registry(tmp_path)
+
+    assert [r.id for r in reloaded._queued_records()] == ["a", "b"]
+    assert reloaded.get("a").state == "queued"
+    assert reloaded.get("b").queue_position == 2
+    assert reloaded._next_queue_seq > 20
+    # The next enqueue goes to the back, not the front.
+    assert _inject_queued(reloaded, "c", seq=reloaded._take_queue_seq()).queue_seq > 20
+
+
+def test_a_queued_cloud_record_is_not_left_parked_forever(tmp_path) -> None:
+    """Cloud never queues, so a `queued` cloud record can only come from a
+    hand-edited file or a downgrade-then-upgrade. It waits on a slot it does not
+    need and nothing will ever start it, and there is no way out from the UI —
+    so the loader retires it rather than leaving it stuck."""
+    from makermodslab.jobs import CANCELLED_IN_QUEUE_MESSAGE
+
+    reg = _quiet_registry(tmp_path)
+    record = _inject_queued(reg, "cloudy", seq=10)
+    record.runner = "hf_cloud"
+    with reg._lock:
+        reg._write_meta(record)
+
+    reloaded = _quiet_registry(tmp_path)
+
+    recovered = reloaded.get("cloudy")
+    assert recovered.state == "interrupted"
+    assert recovered.error_message == CANCELLED_IN_QUEUE_MESSAGE
+    assert reloaded._queued_records() == []
+
+
+# ---------------------------------------------------------------------------
+# Queue regressions.
+#
+# Each of these is a bug that shipped in the first cut of the queue and was
+# found by review, not by the tests above. They are the cases where the queue
+# turned a previously-impossible situation into an ordinary one: before it, a
+# busy slot refused the second local run outright, so there was no such thing as
+# an accepted-but-not-started run to strand, starve, or invalidate.
+# ---------------------------------------------------------------------------
+
+
+def test_a_launch_that_throws_frees_the_slot_instead_of_wedging_the_queue(monkeypatch, tmp_path) -> None:
+    """The single worst outcome this machinery has: a launch that dies OUTSIDE
+    `runner.start()` used to leave the record `running` with no usable runner.
+    `_local_slot_busy` then named it forever, so `_drain_queue` returned early on
+    every later tick and the queue was dead for the life of the process — while
+    `stop()` refused it (not running, to stop's eyes) and `delete()` refused it
+    (it IS running), leaving no way out short of editing job.json.
+
+    The deferred branch is the one that was uncovered: `PreparingJobRunner` is
+    registered before the thread starts, and its `is_running()` is hardcoded
+    True, so nothing could ever finalise it."""
+    from unittest.mock import patch
+
+    reg = _quiet_registry(tmp_path)
+    # Faked BEFORE the drains below: the "queue advances" assertion promotes a
+    # record with no deferred ref, which takes the direct branch and would
+    # otherwise spawn a real lerobot subprocess (and, with the helper's empty
+    # output_dir, drop an `exit_status` file into the pytest CWD). Subprocess
+    # happy paths are deliberately out of the suite — see CLAUDE.md.
+    fake_runner = _fake_local_runner(monkeypatch)
+    head = _inject_queued(reg, "head", seq=10)
+    head.queued_hub_ref = "user/repo@checkpoints/003000"  # forces the deferred branch
+    _inject_queued(reg, "next", seq=20)
+
+    with patch.object(threading.Thread, "start", side_effect=RuntimeError("can't start new thread")):
+        reg._drain_queue()
+
+    failed = reg.get("head")
+    assert failed.state == "failed"
+    assert "can't start new thread" in (failed.error_message or "")
+    # The slot is the whole point: it must be free again.
+    assert reg._local_slot_busy() is None
+    assert "head" not in reg._runners
+    # The corpse releases its queue bookkeeping too, so nothing that will never
+    # run keeps a place in line or claims transfers it never did.
+    assert failed.queue_seq == 0
+    assert failed.queued_hub_ref is None
+    assert "head" not in reg._prepare_threads
+    # And the queue actually moves on rather than starving behind the corpse.
+    reg._drain_queue()
+    assert reg.get("next").state == "running"
+    assert fake_runner.start.call_count == 1
+
+
+def test_a_new_run_does_not_jump_a_queue_that_is_already_waiting(monkeypatch, tmp_path) -> None:
+    """FIFO has to survive the handover window. `_drain_queue` runs at the END of
+    a watchdog tick, so between the finalisation that frees the slot and the
+    promotion that fills it the slot reads FREE with jobs still waiting — for a
+    whole second when the release came from a prepare thread. Deciding purely on
+    "is something running" let a run submitted in that window start immediately,
+    ahead of everything already in line."""
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _quiet_registry(tmp_path)
+    _fake_local_runner(monkeypatch)
+    # Nothing is running — the slot is genuinely free — but two runs are waiting.
+    _inject_queued(reg, "first", seq=10)
+    _inject_queued(reg, "second", seq=20)
+    assert reg._local_slot_busy() is None
+
+    latecomer = reg.start(
+        TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        JobTarget(runner="local"),
+    )
+
+    assert latecomer.state == "queued"
+    assert [r.id for r in reg._queued_records()] == ["first", "second", latecomer.id]
+    assert reg.get(latecomer.id).queue_position == 3
+
+
+def test_the_submit_response_knows_its_place_in_line(monkeypatch, tmp_path) -> None:
+    """`queue_position` is derived, and `start()` used to return the record
+    without deriving it — so the ONE response the submitting client gets said
+    position 0 for a run that was third in line, and the UI could only say
+    "waiting to start" at the exact moment the user wanted a number."""
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _quiet_registry(tmp_path)
+    _fake_local_runner(monkeypatch)
+    _inject_running_local(reg)
+    _inject_queued(reg, "ahead", seq=10)
+
+    submitted = reg.start(
+        TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        JobTarget(runner="local"),
+    )
+
+    # The returned object itself, not a re-read of the registry.
+    assert submitted.state == "queued"
+    assert submitted.queue_position == 2
+
+
+def test_cancelling_a_queued_continuation_leaves_the_parent_continuable(tmp_path) -> None:
+    """The bug this closes: a continuation cancelled before it ever started left
+    its parent permanently `JobAlreadyContinuedError` and filed as superseded,
+    so the parent vanished from the library — superseded by a run that never
+    trained a step, with no way back but finding and deleting the cancelled
+    record. Removing the record on cancel means the edge goes with it, with no
+    flag, no graph rule and no special case anywhere."""
+    from makermodslab.jobs import JobRecord, build_child_index
+    from makermodslab.train import TrainingRequest
+
+    reg = _quiet_registry(tmp_path)
+    parent = JobRecord(
+        id="parent",
+        name="parent",
+        state="interrupted",
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        output_dir="",
+        started_at=0.0,
+        runner="local",
+    )
+    with reg._lock:
+        reg._records[parent.id] = parent
+    child = _inject_queued(reg, "child", seq=10, persist=True)
+    child.config.resume_from_job_id = "parent"
+    with reg._lock:
+        reg._write_meta(child)
+
+    assert build_child_index(reg._records.values()).get("parent") == ["child"]
+
+    reg.stop("child")
+
+    # The parent is a leaf again — continuable, deletable, visible.
+    assert build_child_index(reg._records.values()).get("parent") is None
+    # And still so after a restart: the record is gone, not merely hidden.
+    reloaded = _quiet_registry(tmp_path)
+    assert "child" not in reloaded._records
+    assert build_child_index(reloaded._records.values()).get("parent") is None
+
+
+def test_deleting_the_source_a_queued_finetune_will_read_is_refused(tmp_path) -> None:
+    """A fine-tune freezes its base checkpoint as an absolute PATH at submit and
+    nothing re-resolves it at launch, while `build_child_index` deliberately
+    excludes fine-tune edges — so `delete()` could take the directory out from
+    under a run that had not started. The queue turned that from a seconds-wide
+    race into an ordinary sequence of clicks: fine-tune from A, tidy up by
+    deleting A, wait."""
+    from makermodslab.jobs import JobRecord, JobSourceOfQueuedRunError
+    from makermodslab.train import TrainingRequest
+
+    reg = _quiet_registry(tmp_path)
+    source_dir = tmp_path / "source-run"
+    source_dir.mkdir()
+    source = JobRecord(
+        id="source",
+        name="source",
+        state="done",
+        config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        output_dir=str(source_dir),
+        started_at=0.0,
+        runner="local",
+    )
+    with reg._lock:
+        reg._records[source.id] = source
+
+    # Named as the fine-tune source.
+    waiting = _inject_queued(reg, "waiting", seq=10)
+    waiting.config.finetune_from_job_id = "source"
+    with pytest.raises(JobSourceOfQueuedRunError) as excinfo:
+        reg.delete("source")
+    assert excinfo.value.queued_ids == ["waiting"]
+
+    # A CHAIN REWIND fine-tune never names the ancestor it reads — it just holds
+    # a path inside it — so containment has to be checked too.
+    waiting.config.finetune_from_job_id = None
+    waiting.config.policy_pretrained_path = f"{source_dir}/checkpoints/010000/pretrained_model"
+    with pytest.raises(JobSourceOfQueuedRunError):
+        reg.delete("source")
+
+    # A sibling directory that merely shares a prefix is NOT containment.
+    waiting.config.policy_pretrained_path = f"{source_dir}-old/checkpoints/010000"
+    reg.delete("source")
+    assert "source" not in reg._records
+
+
+def test_a_queued_run_is_revalidated_before_it_launches(monkeypatch, tmp_path) -> None:
+    """The feature-space guard reads the LOCAL DATASET, whose answer changes if
+    that dataset is deleted and re-recorded with a camera added while the run
+    waits. lerobot sizes the policy from the dataset and loads the checkpoint
+    with strict=False, so nothing downstream notices — it trains with
+    randomly-initialised inputs and only shows up as bad rollouts (MT44)."""
+    import makermodslab.jobs as jobs_mod
+
+    reg = _quiet_registry(tmp_path)
+    record = _inject_queued(reg, "stale", seq=10)
+    record.config.policy_pretrained_path = "/some/checkpoint"
+    _inject_queued(reg, "behind", seq=20)
+
+    def _refuse(pretrained_path: str, dataset_repo_id: str) -> None:
+        raise ValueError("Checkpoint expects 2 cameras; the dataset has 3.")
+
+    monkeypatch.setattr(jobs_mod, "_check_pretrained_policy_type", lambda *a: None)
+    monkeypatch.setattr(jobs_mod, "_check_pretrained_feature_space", _refuse)
+
+    reg._drain_queue()
+
+    failed = reg.get("stale")
+    assert failed.state == "failed"
+    assert "the dataset has 3" in (failed.error_message or "")
+    # Says WHY it is only failing now — the request was valid when accepted.
+    assert "changed while it waited" in (failed.error_message or "")
+    # It never reached a runner, and the queue is free to move on.
+    assert "stale" not in reg._runners
+    assert reg._local_slot_busy() is None
+
+
+def test_a_transient_revalidation_error_does_not_fail_a_legitimate_run(monkeypatch, tmp_path) -> None:
+    """Only a ValueError — the checks' own verdict — refuses a launch. An
+    unreadable config.json or a Hub hiccup is "no opinion": failing a legitimate
+    run on a transient read would be worse than the bug being guarded against,
+    and the trainer still refuses a checkpoint it genuinely cannot load."""
+    import makermodslab.jobs as jobs_mod
+
+    reg = _quiet_registry(tmp_path)
+    record = _inject_queued(reg, "fine", seq=10)
+    record.config.policy_pretrained_path = "/some/checkpoint"
+
+    def _boom(*args) -> None:
+        raise OSError("connection reset by peer")
+
+    monkeypatch.setattr(jobs_mod, "_check_pretrained_policy_type", _boom)
+    monkeypatch.setattr(jobs_mod, "LocalJobRunner", lambda *a, **k: _fake_runner_obj())
+
+    reg._drain_queue()
+
+    assert reg.get("fine").state == "running"
+
+
+def test_list_queue_is_the_whole_queue_not_a_page(tmp_path) -> None:
+    """The queue widget used to derive itself from `list(limit=10)`. A queued
+    record carries its SUBMIT time, so queued runs crowd the top of that
+    newest-first page and, past the page size, the runs at the HEAD of the line
+    fell off it — hiding the run about to start and making every reorder a 409,
+    because `reorder_queue` requires the whole list."""
+    reg = _quiet_registry(tmp_path)
+    for i in range(15):
+        record = _inject_queued(reg, f"q{i:02d}", seq=(i + 1) * 10)
+        # Distinct submit times, ascending with the queue order — which is what
+        # real submissions have, and what makes `list()`'s newest-first page
+        # drop the OLDEST queued runs: the ones at the head of the line.
+        record.started_at = float(i)
+
+    page = reg.list(limit=10)
+    queue = reg.list_queue()
+
+    assert len(page) == 10  # unchanged: /jobs is still a page
+    assert len(queue) == 15  # the queue is not
+    assert [r.id for r in queue] == [f"q{i:02d}" for i in range(15)]
+    assert [r.queue_position for r in queue] == list(range(1, 16))
+    # The head of the line is exactly what the page loses.
+    assert "q00" not in {r.id for r in page}
+
+
+def _fake_runner_obj():
+    from unittest.mock import MagicMock
+
+    runner = MagicMock()
+    runner.pid.return_value = 4242
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Round-2 regressions.
+#
+# These are bugs found IN THE FIXES for the round-1 bugs above — the queue's
+# second review pass. Several are cases where a fix closed one hole and opened
+# another, which is why each of them gets a test rather than a comment.
+# ---------------------------------------------------------------------------
+
+
+def test_a_launch_that_throws_after_spawning_stops_the_process_it_started(tmp_path) -> None:
+    """Releasing the slot is only safe if nothing is still using it.
+
+    The handler that frees the slot on a failed launch marks the record
+    `failed`, which is exactly what lets the NEXT run start. If the trainer was
+    already spawned when the throw happened, that is two local trainings on one
+    GPU — the single invariant this whole feature exists to hold — plus an
+    orphan the UI cannot reach (`stop` refuses a non-running record; `delete`
+    would wipe the output dir under the live process)."""
+    from unittest.mock import MagicMock, patch
+
+    reg = _quiet_registry(tmp_path)
+    _inject_queued(reg, "head", seq=10)
+
+    runner = MagicMock()
+    runner.pid.side_effect = RuntimeError("could not read pid")  # throws AFTER start()
+
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: runner):
+        reg._drain_queue()
+
+    assert reg.get("head").state == "failed"
+    # The process that was started is stopped before the slot is handed on.
+    assert runner.start.call_count == 1
+    assert runner.stop.call_count == 1
+    assert reg._local_slot_busy() is None
+    assert "head" not in reg._runners
+
+
+def test_a_launch_whose_start_throws_midway_stops_what_it_already_spawned(tmp_path) -> None:
+    """The sibling above covers a throw AFTER `start()` returned. This covers a
+    throw from inside it, which is the reachable one.
+
+    Neither runner's `start` is atomic. `LocalJobRunner.start` calls `Popen` and
+    only then starts its stdout thread; `HfCloudJobRunner.start` sets
+    `_hf_job_id` and only then starts two workers. A `RuntimeError: can't start
+    new thread` from that second half leaves a live trainer behind. While
+    `started` was recorded only after `start()` returned, the handler saw None,
+    skipped `stop()`, and released the slot to a second trainer — with
+    `process_pid` never assigned, so the first was unreachable from the UI and
+    survived a restart."""
+    from unittest.mock import MagicMock, patch
+
+    reg = _quiet_registry(tmp_path)
+    _inject_queued(reg, "head", seq=10)
+
+    runner = MagicMock()
+    # Spawns, then dies partway through its own start() — the process is live.
+    runner.start.side_effect = RuntimeError("can't start new thread")
+
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: runner):
+        reg._drain_queue()
+
+    assert reg.get("head").state == "failed"
+    assert runner.start.call_count == 1
+    assert runner.stop.call_count == 1, "a half-started runner must still be stopped"
+    assert reg._local_slot_busy() is None
+    assert "head" not in reg._runners
+
+
+def test_the_queue_waits_while_the_robot_is_in_use(monkeypatch, tmp_path) -> None:
+    """Every robot feature checks the other five before starting, because they
+    share this machine's GPU and USB. Training never joined that set, which was
+    survivable while a run could only begin from an explicit submit — the user
+    was present. The queue starts runs from a watchdog thread with nobody at the
+    keyboard, so it has to ask."""
+    import makermodslab.record as record_mod
+
+    reg = _quiet_registry(tmp_path)
+    _fake_local_runner(monkeypatch)
+    _inject_queued(reg, "waiting", seq=10)
+
+    monkeypatch.setattr(record_mod, "recording_active", True, raising=False)
+    reg._drain_queue()
+    assert reg.get("waiting").state == "queued", "a recording session must hold the queue"
+
+    # It waits rather than failing: the run keeps its place and starts later.
+    monkeypatch.setattr(record_mod, "recording_active", False, raising=False)
+    reg._drain_queue()
+    assert reg.get("waiting").state == "running"
+
+
+def test_a_robot_module_that_cannot_answer_does_not_kill_the_queue(monkeypatch, tmp_path) -> None:
+    """`_robot_busy` is the FIRST statement of `_drain_queue`, and it reaches
+    into six modules that pull in cv2, av and the lerobot robot backends —
+    none of which `jobs` depended on before the queue existed.
+
+    Unguarded, one raise there propagates through `_tick` to `_watchdog_loop`'s
+    blanket handler, which keeps the loop alive but means `_drain_queue` never
+    completes again for the life of the process: queued runs sit forever against
+    an idle GPU, one traceback per second, while the UI looks healthy because
+    finalisation runs earlier in the tick. Idle is both the fail-safe answer and
+    the true one — a module that cannot be imported cannot be running."""
+    import makermodslab.calibrate as calibrate_mod
+
+    reg = _quiet_registry(tmp_path)
+    _fake_local_runner(monkeypatch)
+    _inject_queued(reg, "blocked", seq=10)
+
+    def _explode() -> bool:
+        raise ImportError("simulated: no serial backend")
+
+    monkeypatch.setattr(calibrate_mod, "calibration_is_active", _explode)
+
+    assert reg._robot_busy() is None
+    reg._drain_queue()
+    assert reg.get("blocked").state == "running", "a broken robot module must not stall the queue"
+    # Latched, so a permanently broken module logs once rather than ~86k/day.
+    assert reg._robot_check_failed is True
+
+
+def test_the_watchdog_actually_drains_the_queue(monkeypatch, tmp_path) -> None:
+    """The one test here that lets a real watchdog thread run.
+
+    Every other queue test uses `_quiet_registry` and calls `_drain_queue()` by
+    hand, which means the suite verified the drain's LOGIC exhaustively while
+    nothing checked that anything in the product ever calls it: deleting the
+    `self._drain_queue()` at the end of `_tick` — its only production call site,
+    without which no queued run ever starts and the feature is inert — left all
+    314 queue tests green.
+
+    CLAUDE.md says thread happy paths are deliberately not unit-tested, and this
+    is a deliberate exception rather than an oversight: the runner is faked and
+    the robot check stubbed, so nothing here spawns a process or touches
+    hardware. What it exercises is one wire."""
+    import time as _time
+
+    from makermodslab.jobs import JobRegistry
+
+    _fake_local_runner(monkeypatch)
+    # Hermetic and fast: the real one imports six robot modules (cv2, av, the
+    # lerobot backends) on the first tick.
+    monkeypatch.setattr(JobRegistry, "_robot_busy", lambda self: None)
+
+    reg = JobRegistry(tmp_path / "root")
+    try:
+        _inject_queued(reg, "waiting", seq=10)
+
+        # The tick is 1.0s; the margin is for a loaded CI box, and the loop
+        # exits as soon as it sees the promotion rather than sleeping it out.
+        deadline = _time.time() + 15.0
+        while _time.time() < deadline and reg.get("waiting").state == "queued":
+            _time.sleep(0.05)
+
+        assert reg.get("waiting").state == "running", "the watchdog never drained the queue"
+    finally:
+        reg.shutdown()
+
+
+def test_a_base_checkpoint_that_cannot_be_re_read_is_logged_not_silent(monkeypatch, tmp_path, caplog) -> None:
+    """The launch-time re-validation's real failure mode is silence, not an
+    exception.
+
+    Both helpers swallow their own read failures and return None, so "the Hub is
+    unreachable right now" is indistinguishable from "everything checks out" —
+    and that happens exactly when the network is worse at promotion time than it
+    was at submit, which for a run that waited hours is ordinary. It matters
+    because lerobot loads weights with `strict=False`: a base whose feature
+    space no longer matches loads cleanly and trains garbage recorded as a
+    fine-tune. The run still starts (refusing every unverifiable run would make
+    the queue useless offline), but it may not start quietly."""
+    import makermodslab.jobs as jobs_mod
+
+    reg = _quiet_registry(tmp_path)
+    _fake_local_runner(monkeypatch)
+    record = _inject_queued(reg, "finetune", seq=10)
+    record.config.policy_pretrained_path = "user/base"
+
+    # Both checks answer "no opinion", which is what they do when they cannot
+    # read either side.
+    monkeypatch.setattr(jobs_mod, "_check_pretrained_policy_type", lambda *a, **k: None)
+    monkeypatch.setattr(jobs_mod, "_check_pretrained_feature_space", lambda *a, **k: None)
+    monkeypatch.setattr(jobs_mod, "read_pretrained_config", lambda _path: None)
+
+    with caplog.at_level("WARNING"):
+        reg._drain_queue()
+
+    assert reg.get("finetune").state == "running", "an unverifiable base must not block the queue"
+    assert "NOT re-verified" in caplog.text
+    assert "user/base" in caplog.text
+
+
+def test_stop_refuses_when_the_run_left_the_state_the_caller_saw(tmp_path) -> None:
+    """Cancel and kill are the same request on the wire.
+
+    A UI draws Cancel because the run was queued when the list was fetched, then
+    the user takes a moment — a blocking `window.confirm` holds the JS thread
+    but not the server, and a stale queue list holds forever. If the watchdog
+    promotes the run in between, that click SIGTERMs a live training run, and
+    the UI says "Removed from the queue" because it picks the wording from the
+    same stale record. The caller's belief has to travel with the request."""
+    from makermodslab.jobs import JobStateChangedError
+
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg, "promoted")
+
+    with pytest.raises(JobStateChangedError) as refused:
+        reg.stop("promoted", expect_state="queued")
+
+    assert refused.value.expected == "queued"
+    assert refused.value.actual == "running"
+    # Untouched: no stop intent recorded, so the watchdog cannot finalise it as
+    # a stop nobody asked for.
+    assert reg.get("promoted").state == "running"
+    assert "promoted" not in reg._stop_requested
+
+    # Without a belief to check, behaviour is exactly as before.
+    _inject_queued(reg, "waiting", seq=10)
+    assert reg.stop("waiting").id == "waiting"
+
+
+def test_cancelling_a_queued_run_something_resumes_from_is_refused(tmp_path) -> None:
+    """Cancelling a queued run REMOVES its record — and removing a record does
+    not remove the references to it.
+
+    A queued run looks unreferenceable: it has no checkpoints of its own. But
+    `_resolve_checkpoint_owner` lets a continuation attach to a leaf that saved
+    nothing and read the bytes from an ancestor, and only a `done` source is
+    refused — so a queued run is a legal resume parent. Cancelling one
+    unguarded severed the child's lineage, left a phantom parent id in
+    `build_child_index` (both ends then read as leaves), un-forked
+    `JobAlreadyContinuedError` so the grandparent could be continued twice, and
+    made the grandparent deletable while a queued run still needed its
+    checkpoints."""
+    from makermodslab.jobs import JobHasChildrenError, build_child_index
+
+    reg = _quiet_registry(tmp_path)
+    owner = _inject_queued(reg, "owner", seq=5)
+    owner.state = "interrupted"  # a real run, with checkpoints on disk
+    mid = _inject_queued(reg, "mid", seq=10)
+    mid.config.resume_from_job_id = "owner"
+    tip = _inject_queued(reg, "tip", seq=20)
+    tip.config.resume_from_job_id = "mid"
+
+    with pytest.raises(JobHasChildrenError):
+        reg.stop("mid")
+
+    # Still there, and the chain is still whole.
+    assert reg.get("mid") is not None
+    assert reg.get("tip").config.resume_from_job_id == "mid"
+    assert build_child_index(reg._records.values()).get("owner") == ["mid"]
+
+
+def test_deleting_the_owner_a_queued_resume_froze_a_path_into_is_refused(tmp_path) -> None:
+    """The third dependency edge, and the one `_queued_dependents_of` missed.
+
+    A local→local resume freezes its base as an absolute `config_path` into the
+    checkpoint OWNER's directory at submit. The owner is not always the parent,
+    so `JobHasChildrenError` does not always cover it — and the docstring
+    claimed there were two ways to depend on a run when there are three. Deleting
+    the owner rmtree'd checkpoints a queued run was still waiting to train from;
+    it then launched and died on a missing `--config_path`."""
+    from makermodslab.jobs import JobSourceOfQueuedRunError, build_child_index
+
+    reg = _quiet_registry(tmp_path)
+    owner = _inject_queued(reg, "owner", seq=5)
+    owner.state = "interrupted"
+    waiting = _inject_queued(reg, "waiting", seq=10)
+    # Names no parent, so build_child_index sees nothing — only the frozen path
+    # ties these two records together.
+    waiting.config.config_path = f"{owner.output_dir}/checkpoints/001000/pretrained_model/train_config.json"
+
+    assert build_child_index(reg._records.values()).get("owner") is None
+    with pytest.raises(JobSourceOfQueuedRunError):
+        reg.delete("owner")
+    assert reg.get("owner") is not None
+
+
+def test_training_is_active_reports_only_a_running_local_run(monkeypatch, tmp_path) -> None:
+    """The reciprocal of `_robot_busy`, read by the six robot features.
+
+    Only a LOCAL run that is actually `running` owns this machine: a cloud run
+    is somebody else's GPU, and a queued run has not claimed anything yet.
+    Reporting a queued run here would block recording behind a queue that is
+    waiting for recording to finish — a deadlock made of politeness."""
+    import makermodslab.jobs as jobs_mod
+
+    reg = _quiet_registry(tmp_path)
+    monkeypatch.setattr(jobs_mod, "job_registry", reg)
+
+    assert jobs_mod.training_is_active() is None
+
+    _inject_queued(reg, "waiting", seq=10)
+    assert jobs_mod.training_is_active() is None, "a queued run has claimed nothing yet"
+
+    _inject_running_local(reg, "busy")
+    assert jobs_mod.training_is_active() is not None
+
+
+def test_every_robot_feature_checks_for_a_running_training(  # noqa: D401
+    monkeypatch, tmp_path
+) -> None:
+    """CLAUDE.md: "New features that drive the robot must add the same
+    reciprocal checks against every existing one."
+
+    Training was the exception for as long as a run could only begin from an
+    explicit submit. The queue promotes runs from a watchdog thread, so the gate
+    has to close in both directions — `_robot_busy` is only half of it, and a
+    one-directional gate let inference start on top of a promoted trainer.
+
+    This asserts on source text, which is blunt, but the behavioural half is
+    covered per-module in test_record.py / test_rollout.py and what this pins is
+    the thing most easily lost: a seventh feature, or a deleted call."""
+    import importlib
+    import inspect
+
+    for name in ("record", "rollout", "teleoperate", "calibrate", "auto_calibrate", "wiggle"):
+        module = importlib.import_module(f"makermodslab.{name}")
+        assert "training_is_active()" in inspect.getsource(module), (
+            f"{name} can start the robot without checking for a running training run"
+        )
+
+
+def test_reorder_names_a_bad_id_instead_of_blaming_a_race(tmp_path) -> None:
+    """A malformed list and a stale one are different failures. Collapsing them
+    into one refusal told a caller to "refresh and try again" about a body that
+    could never succeed, with nothing saying which id was wrong."""
+    from makermodslab.jobs import QueueChangedError
+
+    reg = _quiet_registry(tmp_path)
+    for jid, seq in (("a", 10), ("b", 20)):
+        _inject_queued(reg, jid, seq=seq)
+
+    with pytest.raises(ValueError, match="not a queued run") as unknown:
+        reg.reorder_queue(["a", "b", "ghost"])
+    assert "ghost" in str(unknown.value)
+    assert not isinstance(unknown.value, QueueChangedError)
+
+    with pytest.raises(ValueError, match="more than once") as dupe:
+        reg.reorder_queue(["a", "a"])
+    assert not isinstance(dupe.value, QueueChangedError)
+
+    # A well-formed list that genuinely lost its race is still the 409 case.
+    with pytest.raises(QueueChangedError):
+        reg.reorder_queue(["a"])
+
+
+def test_list_queue_never_returns_a_run_that_left_the_queue(tmp_path) -> None:
+    """The snapshot is a SHALLOW copy, so it holds live record objects: the head
+    can be promoted between picking the list and annotating it. A `running`
+    record served under a heading that says "queued" is the exact confusion the
+    UI's cancel guard exists to catch — don't ship it."""
+    reg = _quiet_registry(tmp_path)
+    _inject_queued(reg, "gone", seq=10)
+    _inject_queued(reg, "stays", seq=20)
+
+    # Simulate the promotion landing mid-call.
+    reg._records["gone"].state = "running"
+
+    queue = reg.list_queue()
+
+    assert [r.id for r in queue] == ["stays"]
+    assert queue[0].queue_position == 1
+
+
+def test_a_promotion_interrupted_by_a_restart_goes_back_to_the_queue(tmp_path) -> None:
+    """`_drain_queue` persists `running` BEFORE launching, so the slot closes
+    behind the promotion. A crash in that window — which for a deferred launch
+    spans the entire base-checkpoint download, not a hairline — used to come
+    back as `interrupted` with "restarted while this run was training", which it
+    never was, silently dropping it out of the queue (and, for a continuation,
+    stranding its parent as superseded). `queue_seq` survives the promotion
+    precisely so this is recognisable."""
+    reg = _quiet_registry(tmp_path)
+    record = _inject_queued(reg, "midflight", seq=10, persist=True)
+    # Exactly what _drain_queue leaves on disk between promoting and launching.
+    record.state = "running"
+    record.started_at = 1_700_000_000.0
+    record.queue_position = 0
+    with reg._lock:
+        reg._write_meta(record)
+
+    reloaded = _quiet_registry(tmp_path)
+
+    recovered = reloaded.get("midflight")
+    assert recovered.state == "queued"
+    assert recovered.process_pid is None
+    # It keeps its place, and the counter still moves past it.
+    assert recovered.queue_position == 1
+    assert reloaded._next_queue_seq > 10
+
+
+def test_a_deferred_promotion_keeps_its_marker_until_a_real_trainer_exists(monkeypatch, tmp_path) -> None:
+    """The sibling above hand-writes the mid-promotion state. This one PRODUCES
+    it, which is the half that was wrong.
+
+    `_launch_locked`'s deferred branch returns as soon as it starts the prepare
+    thread, so `_drain_queue` used to clear `queue_seq` before the multi-GB
+    download had moved a byte — leaving the single longest crash window in the
+    feature uncovered by the very marker written for it. An ordinary reboot
+    during the download then filed the run `interrupted` with "restarted while
+    this run was training", dropped it from the queue, and stranded its parent
+    as superseded if it was a continuation."""
+    import threading as _threading
+
+    reg = _quiet_registry(tmp_path)
+    _inject_queued(reg, "dl", seq=10, persist=True)
+    # What makes the launch deferred: the base checkpoint has to be fetched
+    # first, so `_launch_locked` hands off to a prepare thread.
+    reg._records["dl"].queued_hub_ref = "user/base@checkpoints/001000"
+    with reg._lock:
+        reg._write_meta(reg._records["dl"])
+
+    # The prepare thread never runs, which IS the state on disk for the whole
+    # length of the download.
+    monkeypatch.setattr(_threading.Thread, "start", lambda self: None)
+    reg._drain_queue()
+
+    on_disk = _json.loads((tmp_path / "root" / "dl" / "job.json").read_text())
+    assert on_disk["state"] == "running"
+    assert on_disk["process_pid"] is None
+    assert on_disk["queue_seq"] == 10, "the marker must outlive the transfer, not the handoff"
+
+    # So a restart mid-download returns it to the queue rather than reporting a
+    # run that never trained a step as one that did.
+    reloaded = _quiet_registry(tmp_path)
+    assert reloaded.get("dl").state == "queued"
+    assert reloaded.get("dl").queue_position == 1
+
+
+def test_a_restart_does_not_requeue_a_promotion_whose_trainer_is_alive(tmp_path) -> None:
+    """`queue_seq > 0` alone does not mean "never launched".
+
+    An immediate launch persists a live `process_pid` while the marker is still
+    set — `_launch_locked` writes the pid, and only then does `_drain_queue`
+    clear it. A hard kill in that gap leaves a durable record with both. Demoted
+    on the marker alone, the run goes back in the queue with its pid erased and
+    the next tick starts a SECOND trainer against the same output dir, while the
+    first is still on the GPU and now unreachable from any record."""
+    reg = _quiet_registry(tmp_path)
+    record = _inject_queued(reg, "live", seq=10, persist=True)
+    record.state = "running"
+    # This test process: certainly alive, so `_pid_alive` cannot be flaky.
+    record.process_pid = os.getpid()
+    with reg._lock:
+        reg._write_meta(record)
+
+    reloaded = _quiet_registry(tmp_path)
+
+    assert reloaded.get("live").state != "queued", "a live trainer must not be re-queued"
+    assert reloaded.get("live").process_pid == os.getpid()
+    assert reloaded.list_queue() == []
+
+
+def test_notify_never_fires_while_the_registry_lock_is_held(tmp_path) -> None:
+    """A listener is entitled to read the registry when told something changed.
+
+    `self._lock` is a plain Lock, so a `_notify_change()` raised while holding it
+    deadlocks the caller the moment any listener does that — and on the queue's
+    paths the caller is the WATCHDOG, which would take the whole job API down
+    with it. This has been re-introduced once already, by a later fix that added
+    a notify to a path inside the critical section, so it gets a test rather
+    than a comment: the callback below is exactly the listener that would hang.
+    """
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _quiet_registry(tmp_path)
+    seen: list[int] = []
+
+    def _reads_the_registry() -> None:
+        # Would deadlock instantly if fired under the lock.
+        seen.append(len(reg.list_queue()))
+
+    reg.set_on_change(_reads_the_registry)
+    _inject_running_local(reg)
+
+    # Enqueue (start), cancel (stop), reorder, and the drain's refusal path all
+    # notify; each must do so with the lock released.
+    queued = reg.start(
+        TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+        JobTarget(runner="local"),
+    )
+    _inject_queued(reg, "other", seq=queued.queue_seq + 5)
+    reg.reorder_queue(["other", queued.id])
+    reg.stop(queued.id)
+
+    assert len(seen) >= 3, "the listener never ran, so this proved nothing"
+
+
+def test_a_queued_run_protects_its_dataset(monkeypatch, tmp_path) -> None:
+    """A queued run has already been validated against its dataset and will
+    train on it when the slot frees, but nothing re-resolves the dataset at
+    launch — so renaming or deleting it here surfaced hours later as a bare
+    exit code with nothing tying it to the action that caused it."""
+    import makermodslab.datasets as datasets_mod
+    from makermodslab.jobs import job_registry
+
+    reg = _quiet_registry(tmp_path)
+    record = _inject_queued(reg, "waiting", seq=10)
+    record.config.dataset_repo_id = "user/ds"
+    monkeypatch.setattr(job_registry, "list", lambda limit=10: [record])
+
+    blocked = datasets_mod._dataset_in_use("user/ds")
+
+    assert blocked is not None
+    assert "cancel" in blocked.lower()
+    # An unrelated dataset is untouched.
+    assert datasets_mod._dataset_in_use("user/other") is None
+
+
+def test_the_queue_endpoints_are_reachable_and_say_why_they_refuse(client, tmp_path, monkeypatch) -> None:
+    """Route ORDER is the point here, not just the handlers.
+
+    `GET /jobs/queue` is a literal path competing with `GET /jobs/{job_id}`, and
+    FastAPI matches in declaration order — declared after it, the queue endpoint
+    answers "Job 'queue' not found" instead. Nothing but an HTTP-level test
+    catches that, and a future edit that moves a route would reintroduce it
+    silently."""
+    from makermodslab.jobs import JobRecord, JobRegistry, job_registry
+    from makermodslab.train import TrainingRequest
+
+    # Unlike every other queue test, this one drives the module-level singleton
+    # (it has to — the routes close over it), and that registry's watchdog is a
+    # REAL running thread. The records injected below are therefore a live
+    # queue: a tick between here and the assertions promotes the head and
+    # `_launch_locked` spawns an actual `lerobot-train` subprocess. Route order
+    # is the point of this test, so the drain is switched off outright rather
+    # than faking a runner. Patched on the class, so `monkeypatch` restores it
+    # even though `shutdown()` is one-way.
+    monkeypatch.setattr(JobRegistry, "_drain_queue", lambda self: None)
+
+    def _queued(jid: str, seq: int) -> JobRecord:
+        return JobRecord(
+            id=jid,
+            name=jid,
+            state="queued",
+            config=TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+            # A real queued record always carries its own job dir; `""` here
+            # resolved `_count_checkpoints` to `Path("checkpoints")` in the
+            # pytest CWD, i.e. the repo itself.
+            output_dir=str(tmp_path / jid / "run"),
+            started_at=float(seq),
+            runner="local",
+            queue_seq=seq,
+        )
+
+    original = dict(job_registry._records)
+    try:
+        job_registry._records.clear()
+        job_registry._records.update({"a": _queued("a", 10), "b": _queued("b", 20)})
+
+        listed = client.get("/jobs/queue")
+        assert listed.status_code == 200, listed.json()
+        assert [j["id"] for j in listed.json()["jobs"]] == ["a", "b"]
+        assert [j["queue_position"] for j in listed.json()["jobs"]] == [1, 2]
+
+        assert client.post("/jobs/queue/reorder", json={"job_ids": ["b", "a"]}).status_code == 200
+
+        # A malformed list is 400 and NAMES the offender; only a well-formed
+        # list that lost its race is the retry-after-refresh 409.
+        unknown = client.post("/jobs/queue/reorder", json={"job_ids": ["b", "a", "ghost"]})
+        assert unknown.status_code == 400
+        assert "ghost" in unknown.json()["detail"]
+
+        stale = client.post("/jobs/queue/reorder", json={"job_ids": ["b"]})
+        assert stale.status_code == 409
+
+        # A queued run is deletable (it holds nothing), unlike a running one.
+        assert client.delete("/jobs/a").status_code == 204
+    finally:
+        job_registry._records.clear()
+        job_registry._records.update(original)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3613,9 +3613,9 @@ def test_a_download_bound_job_queues_a_second_local_run(monkeypatch, tmp_path) -
     """The slot is taken for the download window too — the machine is spoken for
     from the moment the record exists, not from the trainer's first step.
 
-    It used to be a refusal (`JobAlreadyRunningError` → 409). Now the second run
-    is ACCEPTED and parked: same invariant (one local trainer at a time), but the
-    user does not have to come back and resubmit by hand when the first ends."""
+    The second run is ACCEPTED and parked rather than refused: the same
+    invariant (one local trainer at a time), without the user having to come
+    back and resubmit by hand once the first ends."""
     from makermodslab.jobs import JobRegistry, JobTarget
     from makermodslab.train import TrainingRequest
 
@@ -6419,10 +6419,9 @@ def test_stop_on_a_queued_job_removes_it(tmp_path) -> None:
 
     It never executed — no process, no runner, no logs, no checkpoint, and an
     output dir holding nothing but its own job.json — so there is no history to
-    keep. An earlier version left an `interrupted` tombstone, which then had to
-    be excused from every question the registry asks about runs (most sharply:
-    a cancelled continuation permanently superseded the parent it was going to
-    continue). Removing it is the same outcome without the special cases."""
+    keep, only a record that every later question the registry asks about runs
+    would have to excuse (most sharply: a cancelled continuation permanently
+    superseding the parent it was going to continue)."""
     from makermodslab.jobs import JobNotFoundError
 
     reg = _quiet_registry(tmp_path)
@@ -6497,7 +6496,7 @@ def test_a_queued_cloud_record_is_not_left_parked_forever(tmp_path) -> None:
     hand-edited file or a downgrade-then-upgrade. It waits on a slot it does not
     need and nothing will ever start it, and there is no way out from the UI —
     so the loader retires it rather than leaving it stuck."""
-    from makermodslab.jobs import CANCELLED_IN_QUEUE_MESSAGE
+    from makermodslab.jobs import UNQUEUEABLE_RUNNER_MESSAGE
 
     reg = _quiet_registry(tmp_path)
     record = _inject_queued(reg, "cloudy", seq=10)
@@ -6509,7 +6508,7 @@ def test_a_queued_cloud_record_is_not_left_parked_forever(tmp_path) -> None:
 
     recovered = reloaded.get("cloudy")
     assert recovered.state == "interrupted"
-    assert recovered.error_message == CANCELLED_IN_QUEUE_MESSAGE
+    assert recovered.error_message == UNQUEUEABLE_RUNNER_MESSAGE
     assert reloaded._queued_records() == []
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7624,3 +7624,42 @@ def test_rename_does_not_persist_a_derived_queue_position(tmp_path) -> None:
     assert on_disk["queue_position"] == 0, "a derived field must not reach disk"
     # The response still carries the real position for the caller.
     assert renamed.queue_position == 2
+
+
+def test_a_direct_submit_queues_behind_a_busy_robot(monkeypatch, tmp_path) -> None:
+    """The mutex used to be one-way for a DIRECT submit.
+
+    All six robot features refuse while a training run is live, but nothing
+    stopped the reverse: with the slot free and the queue empty — the common
+    case — `start()` went straight to `_launch_locked` without ever asking
+    `_robot_busy()`, so clicking Start during a recording or a rollout put a
+    trainer on top of it. Inference is the pairing this file calls the worst
+    one: both want several GB of VRAM.
+
+    It QUEUES rather than refusing, matching what already happens when the slot
+    itself is busy — the run keeps its place and starts when the robot is idle.
+
+    The check must stay OUTSIDE the registry lock (`training_is_active()` takes
+    that lock from inside each feature's `_state_lock`); this test would deadlock
+    rather than fail if that regressed."""
+    import makermodslab.rollout as rollout
+    from makermodslab.jobs import JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = _quiet_registry(tmp_path)
+    _fake_local_runner(monkeypatch)
+
+    # Slot free, queue empty — the path that had no guard at all.
+    assert reg._local_slot_busy() is None
+    assert reg._queued_records() == []
+
+    monkeypatch.setattr(rollout, "inference_active", True, raising=False)
+    cfg = TrainingRequest(dataset_repo_id="user/ds", policy_type="act")
+    record = reg.start(cfg, JobTarget(runner="local"))
+    assert record.state == "queued", "a submit must not launch on top of a live inference session"
+    assert record.queue_position == 1
+
+    # And it starts on its own once the robot frees up — it waited, it did not fail.
+    monkeypatch.setattr(rollout, "inference_active", False, raising=False)
+    reg._drain_queue()
+    assert reg.get(record.id).state == "running"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7533,3 +7533,39 @@ def test_the_queue_endpoints_are_reachable_and_say_why_they_refuse(client, tmp_p
     finally:
         job_registry._records.clear()
         job_registry._records.update(original)
+
+
+def test_a_failed_reorder_leaves_the_previous_order_intact(monkeypatch, tmp_path) -> None:
+    """A reorder is all-or-nothing.
+
+    Each iteration mutated memory and then wrote, with no rollback, so a persist
+    that threw partway left three orders in play: the prefix that wrote, the
+    suffix that never moved, and an in-memory order matching neither disk nor
+    the drag. The user gets a 500 and reasonably concludes nothing happened —
+    while the head of the queue, the run `_drain_queue` promotes next, silently
+    changed under them."""
+    reg = _quiet_registry(tmp_path)
+    for jid, seq in (("a", 1), ("b", 2), ("c", 3)):
+        _inject_queued(reg, jid, seq=seq, persist=True)
+
+    real_persist = reg._persist
+    calls: list[str] = []
+
+    def _persist_failing_on_b(record, force):
+        calls.append(record.id)
+        # Fail on the SECOND write of the reorder, so a prefix has landed.
+        if record.id == "b" and calls.count("b") == 1:
+            raise OSError(28, "No space left on device")
+        return real_persist(record, force=force)
+
+    monkeypatch.setattr(reg, "_persist", _persist_failing_on_b)
+
+    with pytest.raises(OSError):
+        reg.reorder_queue(["c", "b", "a"])
+
+    # In memory: the order the user had before the drag, not a third one.
+    assert [r.id for r in reg._queued_records()] == ["a", "b", "c"]
+
+    # And on disk too, so a restart agrees with the running process.
+    reloaded = _quiet_registry(tmp_path)
+    assert [r.id for r in reloaded._queued_records()] == ["a", "b", "c"]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7243,7 +7243,7 @@ def test_reorder_names_a_bad_id_instead_of_blaming_a_race(tmp_path) -> None:
     for jid, seq in (("a", 10), ("b", 20)):
         _inject_queued(reg, jid, seq=seq)
 
-    with pytest.raises(ValueError, match="not a queued run") as unknown:
+    with pytest.raises(ValueError, match="not a run at all") as unknown:
         reg.reorder_queue(["a", "b", "ghost"])
     assert "ghost" in str(unknown.value)
     assert not isinstance(unknown.value, QueueChangedError)
@@ -7569,3 +7569,35 @@ def test_a_failed_reorder_leaves_the_previous_order_intact(monkeypatch, tmp_path
     # And on disk too, so a restart agrees with the running process.
     reloaded = _quiet_registry(tmp_path)
     assert [r.id for r in reloaded._queued_records()] == ["a", "b", "c"]
+
+
+def test_reorder_calls_a_run_that_left_the_queue_a_race_not_a_bad_id(tmp_path) -> None:
+    """ "Not in the queue" is two different answers, and they used to share one.
+
+    An id the registry never heard of is a malformed body — 400, and retrying it
+    unchanged can never work. But an id naming a REAL run that merely left the
+    queue (it started, finished, or was cancelled between the drag and the
+    request) is the ordinary race this endpoint exists to absorb, and it needs
+    the 409 that says refresh — advice that succeeds on the next try. Answering
+    it with 400 told the user their drag was malformed when the queue had simply
+    moved on, which is the likelier of the two by far: it is what happens every
+    time the watchdog promotes the head mid-drag.
+
+    It is also what the endpoint docstring always claimed happened."""
+    from makermodslab.jobs import QueueChangedError
+
+    reg = _quiet_registry(tmp_path)
+    for jid, seq in (("a", 10), ("b", 20)):
+        _inject_queued(reg, jid, seq=seq)
+
+    # The watchdog promotes the head while the user is dragging. "a" is still a
+    # real record — it is just running now.
+    reg._records["a"].state = "running"
+
+    with pytest.raises(QueueChangedError):
+        reg.reorder_queue(["b", "a"])
+
+    # And a genuinely unknown id in the same position is still the 400.
+    with pytest.raises(ValueError) as bad:
+        reg.reorder_queue(["b", "ghost"])
+    assert not isinstance(bad.value, QueueChangedError)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6447,6 +6447,131 @@ def test_stop_on_a_queued_job_removes_it(tmp_path) -> None:
     assert "b" not in _quiet_registry(tmp_path)._records
 
 
+def test_a_cancel_that_cannot_reach_disk_leaves_the_run_alone(monkeypatch, tmp_path) -> None:
+    """A cancel is durable or it does not happen.
+
+    `job.json` is the only trace that outlives the process, so if it cannot be
+    removed the record must STAY — in memory, in the queue, and on disk. The
+    order this protects against is drop-then-unlink: that leaves a `queued`
+    job.json with no record behind it, and the next restart loads it back into
+    the queue and trains a run the user cancelled."""
+    from makermodslab.jobs import JobRemovalFailedError
+
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg)
+    _inject_queued(reg, "a", seq=10, persist=True)
+    _inject_queued(reg, "b", seq=20, persist=True)
+    meta = tmp_path / "root" / "b" / "job.json"
+    assert meta.exists()
+
+    real_unlink = Path.unlink
+
+    def refuse_this_one(self, *args, **kwargs):
+        if self == meta:
+            raise PermissionError(13, "Permission denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", refuse_this_one)
+
+    with pytest.raises(JobRemovalFailedError):
+        reg.stop("b")
+
+    # Untouched, so what the user is looking at is still true.
+    assert reg.get("b").state == "queued"
+    assert [r.id for r in reg._queued_records()] == ["a", "b"]
+    assert meta.exists()
+    # And a restart still finds it queued — not lost, not duplicated.
+    assert _quiet_registry(tmp_path).get("b").state == "queued"
+
+
+def test_a_cancel_stands_even_if_the_directory_will_not_delete(monkeypatch, tmp_path) -> None:
+    """Once `job.json` is gone the cancel has happened and cannot be undone by
+    anything left on disk, so a failing rmtree must not fail the request. What
+    survives is an empty directory the loader skips."""
+    from makermodslab.jobs import JobNotFoundError
+
+    reg = _quiet_registry(tmp_path)
+    _inject_running_local(reg)
+    _inject_queued(reg, "a", seq=10, persist=True)
+
+    def refuse(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("makermodslab.jobs.shutil.rmtree", refuse)
+
+    removed = reg.stop("a")
+
+    assert removed.id == "a"
+    with pytest.raises(JobNotFoundError):
+        reg.get("a")
+    # The durable half went first, so the leftover directory is inert.
+    assert not (tmp_path / "root" / "a" / "job.json").exists()
+    assert "a" not in _quiet_registry(tmp_path)._records
+
+
+def _inject_done(reg, job_id: str):
+    """A finished record, persisted — the shape `delete()` is normally given."""
+    record = _inject_queued(reg, job_id, seq=0)
+    record.state = "done"
+    record.queue_seq = 0
+    record.ended_at = 1.0
+    with reg._lock:
+        reg._write_meta(record)
+    return record
+
+
+def test_a_delete_that_cannot_reach_disk_leaves_the_run_alone(monkeypatch, tmp_path) -> None:
+    """`delete()` is durable on the same terms as a cancel.
+
+    Milder than the queued case — what comes back is a finished run in the
+    history, not one that starts training — but it is the same failure, so it
+    goes through the same `_remove_locked` and gets the same guarantee."""
+    from makermodslab.jobs import JobRemovalFailedError
+
+    reg = _quiet_registry(tmp_path)
+    _inject_done(reg, "old")
+    meta = tmp_path / "root" / "old" / "job.json"
+    assert meta.exists()
+
+    real_unlink = Path.unlink
+
+    def refuse_this_one(self, *args, **kwargs):
+        if self == meta:
+            raise PermissionError(13, "Permission denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", refuse_this_one)
+
+    with pytest.raises(JobRemovalFailedError):
+        reg.delete("old")
+
+    # Untouched, so the history the user is looking at is still true.
+    assert reg.get("old").state == "done"
+    assert meta.exists()
+    assert _quiet_registry(tmp_path).get("old").state == "done"
+
+
+def test_a_delete_stands_even_if_the_directory_will_not_delete(monkeypatch, tmp_path) -> None:
+    """Once `job.json` is gone the delete has happened, so a failing rmtree must
+    not fail the request."""
+    from makermodslab.jobs import JobNotFoundError
+
+    reg = _quiet_registry(tmp_path)
+    _inject_done(reg, "old")
+
+    def refuse(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("makermodslab.jobs.shutil.rmtree", refuse)
+
+    reg.delete("old")
+
+    with pytest.raises(JobNotFoundError):
+        reg.get("old")
+    assert not (tmp_path / "root" / "old" / "job.json").exists()
+    assert "old" not in _quiet_registry(tmp_path)._records
+
+
 def test_drain_queue_is_a_no_op_while_the_local_slot_is_busy(tmp_path) -> None:
     """The whole point of the queue: while a local run holds the slot, nothing
     behind it starts, however many ticks go by."""

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -16,6 +16,7 @@ LocalJobRunner.start() (see plan, "Discovered issue")."""
 
 from __future__ import annotations
 
+import asyncio
 import json as _json
 import os
 import threading
@@ -7220,9 +7221,13 @@ def test_every_robot_feature_checks_for_a_running_training(  # noqa: D401
     has to close in both directions — `_robot_busy` is only half of it, and a
     one-directional gate let inference start on top of a promoted trainer.
 
-    This asserts on source text, which is blunt, but the behavioural half is
-    covered per-module in test_record.py / test_rollout.py and what this pins is
-    the thing most easily lost: a seventh feature, or a deleted call."""
+    This asserts on source text, which catches only the crudest loss: a seventh
+    feature that never wired itself in, or a deleted import. It CANNOT see a
+    check that is present but dead, present but in the wrong position (after the
+    active flag is claimed, or after Popen), or one whose branch no longer
+    returns. `test_each_feature_refuses_to_start_while_training_runs` below is
+    the half with teeth — five of the six guards this greps for were silently
+    deletable with a green suite until it existed."""
     import importlib
     import inspect
 
@@ -7663,3 +7668,118 @@ def test_a_direct_submit_queues_behind_a_busy_robot(monkeypatch, tmp_path) -> No
     monkeypatch.setattr(rollout, "inference_active", False, raising=False)
     reg._drain_queue()
     assert reg.get(record.id).state == "running"
+
+
+def test_each_feature_refuses_to_start_while_training_runs(monkeypatch) -> None:
+    """The behavioural half of the mutex, one case per feature-side call site.
+
+    The source-text check above passed against five of these six guards rewritten
+    to `if False and ...` — the text survives a dead branch. Auto-calibration
+    matters most: it drives the arm under torque and WRITES SERVO EEPROM, and it
+    is the one feature with two independent entry points (single and batch), so
+    the batch manager can lose its guard while the single one keeps it.
+
+    Each case asserts the refusal names the training run, which is what makes the
+    message actionable — and is also what proves the training guard, rather than
+    some later validation, is what refused."""
+    import makermodslab.auto_calibrate as auto_calibrate
+    import makermodslab.calibrate as calibrate
+    import makermodslab.jobs as jobs_mod
+    import makermodslab.record as record_mod
+    import makermodslab.rollout as rollout
+    import makermodslab.teleoperate as teleop
+    import makermodslab.wiggle as wiggle
+
+    # Every OTHER feature idle, so the training guard is the only thing that can
+    # refuse. Without this a passing test could be some earlier check firing.
+    monkeypatch.setattr(record_mod, "recording_active", False, raising=False)
+    monkeypatch.setattr(rollout, "inference_active", False, raising=False)
+    monkeypatch.setattr(teleop, "teleoperation_active", False, raising=False)
+    monkeypatch.setattr(wiggle, "wiggle_active", False, raising=False)
+    monkeypatch.setattr(calibrate, "calibration_is_active", lambda: False, raising=False)
+    monkeypatch.setattr(auto_calibrate, "auto_calibration_is_active", lambda: False, raising=False)
+    monkeypatch.setattr(jobs_mod, "training_is_active", lambda: "ACT · user/ds")
+
+    def _refused(result) -> str:
+        assert result["success"] is False, "started the robot while a training run was live"
+        return result["message"]
+
+    assert "ACT · user/ds" in _refused(
+        teleop.handle_start_teleoperation(
+            teleop.TeleoperateRequest(
+                leader_port="/dev/l",
+                follower_port="/dev/f",
+                leader_config="L",
+                follower_config="F",
+            )
+        )
+    )
+
+    assert "ACT · user/ds" in _refused(
+        calibrate.calibration_manager.start_calibration(
+            calibrate.CalibrationRequest(device_type="robot", port="/dev/arm", config_file="c")
+        )
+    )
+
+    # Both auto-calibration entry points — this one writes EEPROM.
+    assert "ACT · user/ds" in _refused(
+        auto_calibrate.auto_calibration_manager.start(
+            auto_calibrate.AutoCalibrationRequest(device_type="robot", port="/dev/arm", config_file="c")
+        )
+    )
+    assert "ACT · user/ds" in _refused(
+        auto_calibrate.auto_calibration_batch_manager.start(
+            auto_calibrate.AutoCalibrationBatchRequest(
+                arms=[
+                    auto_calibrate.AutoCalibrationBatchArm(
+                        device_type="robot", port="/dev/arm", config_file="c"
+                    )
+                ]
+            )
+        )
+    )
+
+    assert "ACT · user/ds" in _refused(asyncio.run(wiggle.wiggle_gripper("/dev/arm")))
+
+
+@pytest.mark.parametrize(
+    "module_name, attr, busy_value, label",
+    [
+        ("record", "recording_active", True, "a recording session"),
+        ("rollout", "inference_active", True, "an inference session"),
+        ("teleoperate", "teleoperation_active", True, "teleoperation"),
+        ("calibrate", "calibration_is_active", lambda: True, "calibration"),
+        ("auto_calibrate", "auto_calibration_is_active", lambda: True, "auto-calibration"),
+        ("wiggle", "wiggle_active", True, "a wiggle"),
+    ],
+)
+def test_every_robot_activity_holds_the_queue(
+    monkeypatch, tmp_path, module_name, attr, busy_value, label
+) -> None:
+    """`_robot_busy`'s six legs, one case each — the queue side of the mutex.
+
+    Only the `recording_active` leg was exercised; the other four could be
+    deleted outright with a green suite, which matters because they are read from
+    a WATCHDOG THREAD with nobody at the keyboard. The failure they prevent is a
+    trainer claiming several GB of VRAM and four dataloader workers underneath a
+    live rollout or recording session.
+
+    Also asserts the run WAITS rather than failing: it keeps its place and starts
+    once the robot is idle, which is the promise that distinguishes this from the
+    old 409."""
+    import importlib
+
+    module = importlib.import_module(f"makermodslab.{module_name}")
+
+    reg = _quiet_registry(tmp_path)
+    _fake_local_runner(monkeypatch)
+    _inject_queued(reg, "waiting", seq=10)
+
+    monkeypatch.setattr(module, attr, busy_value, raising=False)
+    reg._drain_queue()
+    assert reg.get("waiting").state == "queued", f"{label} must hold the queue"
+
+    idle = (lambda: False) if callable(busy_value) else False
+    monkeypatch.setattr(module, attr, idle, raising=False)
+    reg._drain_queue()
+    assert reg.get("waiting").state == "running", f"the run must start once {label} ends"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7332,12 +7332,62 @@ def test_a_deferred_promotion_keeps_its_marker_until_a_real_trainer_exists(monke
     assert on_disk["state"] == "running"
     assert on_disk["process_pid"] is None
     assert on_disk["queue_seq"] == 10, "the marker must outlive the transfer, not the handoff"
+    # The refs are the other half of the marker and must outlive it too: they
+    # say WHAT the promotion still owes, and nothing can recompute them.
+    assert on_disk["queued_hub_ref"] == "user/base@checkpoints/001000"
 
     # So a restart mid-download returns it to the queue rather than reporting a
     # run that never trained a step as one that did.
     reloaded = _quiet_registry(tmp_path)
     assert reloaded.get("dl").state == "queued"
     assert reloaded.get("dl").queue_position == 1
+
+
+def test_a_requeued_promotion_still_knows_what_it_has_to_download(monkeypatch, tmp_path) -> None:
+    """Returning the run to the queue is only half a recovery — it has to come
+    back with what it still needs.
+
+    The promotion used to clear `queued_hub_ref`/`queued_resume_ref` and persist
+    that, keeping them only as locals. `_load_from_disk`'s demotion restored the
+    STATE but could not restore the refs: `None` was already on disk. The
+    requeued run then computed `deferred == False` and took `_launch_locked`'s
+    IMMEDIATE branch — spawning a trainer with no download, against a
+    `policy_pretrained_path` still holding the `repo@checkpoints/N` form that
+    only `localize_pretrained_path` understands and lerobot 404s on. (For a
+    continuation the twin failure is a `resume=True` with no `config_path`.)
+
+    `start` parks these on the record precisely because they are the one part of
+    submit-time resolution a later process cannot recompute."""
+    import threading as _threading
+
+    from makermodslab.jobs import JobRegistry
+
+    reg = _quiet_registry(tmp_path)
+    _inject_queued(reg, "dl", seq=10, persist=True)
+    reg._records["dl"].queued_hub_ref = "user/base@checkpoints/001000"
+    with reg._lock:
+        reg._write_meta(reg._records["dl"])
+
+    monkeypatch.setattr(_threading.Thread, "start", lambda self: None)
+    reg._drain_queue()
+
+    # Crash during the download, restart.
+    reloaded = _quiet_registry(tmp_path)
+    recovered = reloaded.get("dl")
+    assert recovered.state == "queued"
+    assert recovered.queued_hub_ref == "user/base@checkpoints/001000", (
+        "the requeued run lost the checkpoint it was going to download"
+    )
+
+    # And the next drain therefore DEFERS again rather than launching bare.
+    deferred: list[tuple] = []
+    monkeypatch.setattr(
+        JobRegistry,
+        "_launch_locked",
+        lambda self, r, t, **kw: deferred.append((kw.get("deferred_hub_ref"), kw.get("deferred_resume_ref"))),
+    )
+    reloaded._drain_queue()
+    assert deferred == [("user/base@checkpoints/001000", None)]
 
 
 def test_a_restart_does_not_requeue_a_promotion_whose_trainer_is_alive(tmp_path) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -2234,6 +2234,31 @@ def test_start_recording_rejects_with_409_when_inference_active(
     assert "Inference is currently active" in result["message"]
 
 
+def test_start_recording_rejects_with_409_when_a_training_run_is_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Training stayed outside the robot mutex for as long as a run could only
+    begin from an explicit submit — the user was present and knew what else they
+    had running. The queue starts runs from a watchdog thread with nobody at the
+    keyboard, so the gate has to be mutual: the queue already waits for a
+    recording session, and now a recording session waits for it."""
+    import makermodslab.jobs as jobs
+    import makermodslab.record as record
+    import makermodslab.rollout as rollout
+    import makermodslab.teleoperate as teleop
+
+    monkeypatch.setattr(record, "recording_active", False)
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(jobs, "training_is_active", lambda: "ACT · user/ds")
+
+    result = record.handle_start_recording(_stub_recording_request())
+
+    assert result["success"] is False
+    assert result["status_code"] == 409
+    assert "ACT · user/ds" in result["message"]
+
+
 def test_start_recording_rejects_with_400_for_invalid_dataset_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -640,6 +640,22 @@ def test_handle_start_inference_blocked_when_recording_active(monkeypatch) -> No
     assert "Recording" in result["message"]
 
 
+def test_handle_start_inference_blocked_when_a_training_run_is_active(monkeypatch) -> None:
+    """The worst pairing of the six: both want several GB of VRAM.
+
+    The training queue already waits for inference. Until it was mutual, this
+    direction walked straight over a run the watchdog had just promoted — and
+    whichever process lost the OOM lost hours, reported only as "Subprocess
+    exited with code 1" with nothing tying it to this click."""
+    from makermodslab.rollout import handle_start_inference
+
+    monkeypatch.setattr("makermodslab.jobs.training_is_active", lambda: "ACT · user/ds")
+    result = handle_start_inference(_stub_request())
+    assert result["success"] is False
+    assert result["status_code"] == 409
+    assert "ACT · user/ds" in result["message"]
+
+
 def test_handle_start_inference_blocked_when_already_active(monkeypatch) -> None:
     from makermodslab import rollout
 


### PR DESCRIPTION
## Summary
A second local training submit used to be refused outright while the local slot was busy. This PR makes it queue instead, with a background watchdog that starts it once the slot frees, and lets the user cancel or reorder the queue.

## Before
```bash
curl -s -X POST http://localhost:8000/jobs/training -d '{...}'
# local slot already busy:
# -> 409 {"detail": "Job already running: <name>"}
```

## After
```bash
curl -s -X POST http://localhost:8000/jobs/training -d '{...}'
# local slot already busy:
# -> 201 {"id": "...", "state": "queued", "queue_position": 1, ...}

curl -s http://localhost:8000/jobs/queue
# -> {"jobs": [{"id": "...", "state": "queued", "queue_position": 1, ...}]}

curl -s -X POST http://localhost:8000/jobs/queue/reorder \
  -d '{"job_ids": ["b", "a"]}'
# -> 200, queue reordered (409 instead if the list is stale)
```

## Commits
1. Queue a second local submit instead of refusing it; watchdog promotes the head when the slot frees; queue and reorder endpoints added.
2. Rename a stale message constant and derive queue positions once instead of per record.
3. Make record removal durable so a deleted or cancelled run can't resurrect after a restart.
4. Keep a promoted run's Hub/resume refs until a trainer actually exists, so a crash mid-download can't destroy the run.
5. Stop a trainer whose post-start bookkeeping failed, instead of leaving a live, unreachable process behind.
6. Roll back a queue reorder if a persist fails partway through, instead of leaving it half-applied.
7. Return 409 (not 400) when a reorder names a run that already left the queue, matching the endpoint's own docstring.
8. Bound the reorder request to 512 ids and validate it before taking the registry lock.
9. Persist a finalised run's record under the lock so it can't be recreated after deletion.
10. Type `expect_state` as a real job state so a typo returns 422 instead of a misleading 409.
11. Stop a rename from persisting a stale, derived queue position into job.json.
12. Fix a removal-failure error message that told a queued run's owner it was "in your history", and stop leaking the job directory's path.
13. Queue a direct submit made while the robot is busy (recording, rollout, teleop, calibration), instead of racing it.
14. Add real behavioural test coverage for the robot/training mutex; the existing test only grepped for guard text.

## Sensitive changes
None. This PR only touches local training-job orchestration (`makermodslab/jobs.py`, `server.py`) and does not drive the robot, touch calibration files, or write servo EEPROM.
