### PR TITLE
Fix random-weight scratch training: SmolVLA, pi0, pi05, pi0_fast

### DIFF
--- a/frontend/src/components/studio/TrainPanel.tsx
+++ b/frontend/src/components/studio/TrainPanel.tsx
@@ -61,6 +61,15 @@ const NONE = "__none__";
  * read — a display label, not an architecture. */
 const UNKNOWN_POLICY_TYPE = "model";
 
+/** Policies with no real "from scratch": each builds a pretrained backbone
+ * (a vision-language model for smolvla, a PaliGemma+expert stack for
+ * pi0/pi05/pi0_fast) that only receives real weights via an explicit
+ * pretrained path, so leaving Starting point unset fine-tunes the matching
+ * public foundation checkpoint instead of training with random weights (see
+ * jobs.start's `_POLICY_FOUNDATION_BASE_REPO_ID`). Keep in sync with that
+ * dict's keys. Every other policy's from-scratch run is normal. */
+const FOUNDATION_POLICY_TYPES = new Set(["smolvla", "pi0", "pi05", "pi0_fast"]);
+
 /** The architecture a job record trains (imported models record their
  * checkpoint's own `type`), or null when the record doesn't know it. Never
  * returns the "model" placeholder — pushing that into the form would select a
@@ -442,13 +451,9 @@ const TrainPanel: React.FC = () => {
       });
   };
 
-  // SmolVLA has no real "from scratch": its vision-language backbone is a
-  // pretrained VLM, so leaving Starting point unset fine-tunes the public
-  // SmolVLA base rather than training with random weights (see jobs.start's
-  // _SMOLVLA_BASE_REPO_ID default). Every other policy keeps the literal
-  // scratch label — a from-scratch ACT/diffusion/vqbet/tdmpc run is normal.
-  const noStartingPointLabel =
-    policyType === "smolvla" ? "SmolVLA base" : "Train from scratch";
+  const noStartingPointLabel = FOUNDATION_POLICY_TYPES.has(policyType)
+    ? "Train from base"
+    : "Train from scratch";
 
   return (
     <div className="flex flex-1 flex-col gap-5 p-5">
@@ -624,8 +629,8 @@ const TrainPanel: React.FC = () => {
                   </span>
                 ) : finetuneSeed ? (
                   "Fine-tunes from this skill's latest checkpoint."
-                ) : policyType === "smolvla" ? (
-                  "Fine-tune an existing skill, or the public SmolVLA base."
+                ) : FOUNDATION_POLICY_TYPES.has(policyType) ? (
+                  "Fine-tune an existing skill, or train from its public base."
                 ) : (
                   "Fine-tune an existing skill, or start fresh."
                 )}

--- a/frontend/src/components/studio/TrainPanel.tsx
+++ b/frontend/src/components/studio/TrainPanel.tsx
@@ -198,9 +198,10 @@ const TrainPanel: React.FC = () => {
     // Closing the form is the way out of a resume: resume mode hides the
     // dataset and starting-point controls (both are the parent run's and not
     // editable), so unlike a fine-tune — which can be dropped by setting
-    // Starting point back to "Train from scratch" — it has no in-form escape
-    // hatch. Reopening then gives a fresh form, which is also what the user
-    // gets after a launch (onStarted folds the form the same way).
+    // Starting point back to its no-selection state (NONE) — it has no
+    // in-form escape hatch. Reopening then gives a fresh form, which is also
+    // what the user gets after a launch (onStarted folds the form the same
+    // way).
     if (!open) setResumeSeed(null);
   };
 
@@ -441,6 +442,14 @@ const TrainPanel: React.FC = () => {
       });
   };
 
+  // SmolVLA has no real "from scratch": its vision-language backbone is a
+  // pretrained VLM, so leaving Starting point unset fine-tunes the public
+  // SmolVLA base rather than training with random weights (see jobs.start's
+  // _SMOLVLA_BASE_REPO_ID default). Every other policy keeps the literal
+  // scratch label — a from-scratch ACT/diffusion/vqbet/tdmpc run is normal.
+  const noStartingPointLabel =
+    policyType === "smolvla" ? "SmolVLA base" : "Train from scratch";
+
   return (
     <div className="flex flex-1 flex-col gap-5 p-5">
       <PanelHeader step="2" title="Train" dataTour="studio-train" />
@@ -595,11 +604,11 @@ const TrainPanel: React.FC = () => {
                   {baseModelId !== NONE && finetuneSeed ? (
                     <span className="truncate">{finetuneSeed.name}</span>
                   ) : (
-                    <SelectValue placeholder="Train from scratch" />
+                    <SelectValue placeholder={noStartingPointLabel} />
                   )}
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={NONE}>Train from scratch</SelectItem>
+                  <SelectItem value={NONE}>{noStartingPointLabel}</SelectItem>
                   {models.map((m) => (
                     <SelectItem key={m.id} value={m.id}>
                       {m.name}
@@ -615,6 +624,8 @@ const TrainPanel: React.FC = () => {
                   </span>
                 ) : finetuneSeed ? (
                   "Fine-tunes from this skill's latest checkpoint."
+                ) : policyType === "smolvla" ? (
+                  "Fine-tune an existing skill, or the public SmolVLA base."
                 ) : (
                   "Fine-tune an existing skill, or start fresh."
                 )}

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -2169,7 +2169,16 @@ def _check_pretrained_feature_space(pretrained_path: str, dataset_repo_id: str) 
       traceback after the dataset download. SmolVLA/pi0/pi05 pad the
       proprioceptive dims to 32, so a 6-dof checkpoint loads CLEANLY into a
       12-dof (bimanual) run and trains garbage that is recorded as a
-      fine-tune. Refused.
+      fine-tune. Refused for ordinary checkpoints.
+
+      KNOWN FOUNDATION BASE EXEMPTION: the public PI checkpoints publish
+      32-wide state/action features because 32 is their padding capacity, not
+      the degree of freedom of one robot. LeRobot deliberately pads a normal
+      6-dof SO-101 or 12-dof bimanual dataset to that width. SmolVLA uses the
+      same max-dimension padding. The exact repo ids in
+      _KNOWN_FOUNDATION_BASE_REPO_IDS therefore warn and continue; applying
+      the ordinary checkpoint rule to them would reject the canonical base
+      fine-tune before LeRobot gets a chance to pad the data.
     * RENAMED CAMERAS — the same number of cameras under different keys (the
       bimanual ``left_``-prefix case). Refused as a SELECTION mistake, not an
       architectural one: ACT drives every camera through one shared backbone
@@ -2232,9 +2241,13 @@ def _check_pretrained_feature_space(pretrained_path: str, dataset_repo_id: str) 
     if not dataset_features:
         return
 
+    is_known_foundation_base = pretrained_path in _KNOWN_FOUNDATION_BASE_REPO_IDS
+
     # -- state / action width ------------------------------------------------
     # The dataset's own dims are what lerobot will build the policy from, so a
-    # difference here is exactly the width the loaded weights won't fit.
+    # difference here is exactly the width the loaded weights won't fit for an
+    # ordinary checkpoint. Known foundation bases are different: LeRobot pads
+    # their dataset vectors to the policy's configured maximum width.
     for label, ckpt_feature, dataset_key in (
         ("robot state", ckpt_inputs.get("observation.state"), "observation.state"),
         ("action", ckpt_outputs.get("action"), "action"),
@@ -2242,6 +2255,19 @@ def _check_pretrained_feature_space(pretrained_path: str, dataset_repo_id: str) 
         ckpt_dim = _flat_feature_dim(ckpt_feature)
         dataset_dim = _flat_feature_dim(dataset_features.get(dataset_key))
         if ckpt_dim is None or dataset_dim is None or ckpt_dim == dataset_dim:
+            continue
+        if is_known_foundation_base:
+            logger.warning(
+                "Fine-tune feature space: checkpoint %s is a known foundation "
+                "base; allowing dataset %s's %d-dim %s to bind to its %d-dim "
+                "published feature because LeRobot pads foundation policies to "
+                "their configured maxima.",
+                pretrained_path,
+                dataset_repo_id,
+                dataset_dim,
+                label,
+                ckpt_dim,
+            )
             continue
         raise ValueError(
             f"The checkpoint this run starts from ({pretrained_path}) was trained "
@@ -2266,9 +2292,7 @@ def _check_pretrained_feature_space(pretrained_path: str, dataset_repo_id: str) 
     # to `renamed` first (its wording is accurate there), so this branch is in
     # practice the unequal-count case the rename rule alone would let through.
     disjoint = bool(ckpt_names) and bool(dataset_names) and ckpt_names.isdisjoint(dataset_names)
-    is_generic_base = (
-        _is_placeholder_camera_set(ckpt_names) or pretrained_path in _KNOWN_FOUNDATION_BASE_REPO_IDS
-    )
+    is_generic_base = _is_placeholder_camera_set(ckpt_names) or is_known_foundation_base
     if (renamed or disjoint) and is_generic_base:
         # A generic base being bound to a named rig for the first time — the
         # canonical fine-tune for whichever foundation model this is.

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -1551,14 +1551,33 @@ def _list_hub_checkpoints(api, repo_id: str) -> list[JobCheckpoint]:
 
 _LANGUAGE_CONDITIONED_POLICY_TYPES = {"smolvla", "pi0", "pi0_fast", "pi05"}
 
-# SmolVLA has no legitimate from-scratch mode: its vision-language backbone is
-# a full pretrained VLM, and lerobot only random-inits that backbone when no
-# pretrained_path is given (SmolVLAConfig.load_vlm_weights defaults to False —
-# see modeling_smolvla's own "unlikely to yield good results" warning). A
-# request that names neither a fine-tune source nor an explicit
-# policy_pretrained_path is defaulted onto this public foundation checkpoint
-# instead, in JobRegistry.start.
-_SMOLVLA_BASE_REPO_ID = "lerobot/smolvla_base"
+# None of _LANGUAGE_CONDITIONED_POLICY_TYPES has a legitimate from-scratch
+# mode: each builds a pretrained backbone (a vision-language model for
+# smolvla, a PaliGemma+expert stack for pi0/pi05/pi0_fast) from a bare config
+# object with no unconditional download anywhere in modeling_<policy>.py —
+# real weights only ever arrive via --policy.pretrained_path, which
+# lerobot_train never receives unless we pass one. (Contrast ACT, Diffusion
+# and VQ-BeT, whose vision backbone is a real torchvision checkpoint
+# downloaded unconditionally via `pretrained_backbone_weights`, and TDMPC,
+# which has no pretrained-checkpoint concept at all — "from scratch" is
+# already correct for those four.) A request that names neither a fine-tune
+# source nor an explicit policy_pretrained_path is defaulted onto the
+# matching public foundation checkpoint instead, in JobRegistry.start.
+_POLICY_FOUNDATION_BASE_REPO_ID = {
+    "smolvla": "lerobot/smolvla_base",
+    "pi0": "lerobot/pi0_base",
+    "pi05": "lerobot/pi05_base",
+    "pi0_fast": "lerobot/pi0fast-base",
+}
+
+# The subset of _POLICY_FOUNDATION_BASE_REPO_ID's values whose OWN camera keys
+# are known ahead of time (we chose them, above) rather than placeholders like
+# smolvla_base's camera1/camera2/camera3 — pi0/pi05/pi0_fast's public
+# checkpoints name their pretraining rig's real cameras (e.g.
+# observation.images.base_0_rgb), so _is_placeholder_camera_set can't
+# recognize them as a generic base. Checked by repo id instead, in
+# _check_pretrained_feature_space.
+_KNOWN_FOUNDATION_BASE_REPO_IDS = frozenset(_POLICY_FOUNDATION_BASE_REPO_ID.values())
 
 
 _HUB_CKPT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@checkpoints/(?P<step_dir>\d+)$")
@@ -2169,16 +2188,28 @@ def _check_pretrained_feature_space(pretrained_path: str, dataset_repo_id: str) 
       all dropped and the dataset's all start from scratch. Same selection
       mistake, so the same refusal.
 
-      ONE EXEMPTION — a GENERIC BASE. When every one of the CHECKPOINT's camera
-      keys is a placeholder (``camera1``/``camera2``/… — see
-      _is_placeholder_camera_set), the checkpoint was never tied to a rig at
-      all: ``lerobot/smolvla_base`` ships exactly that, and adapting it to a
-      named 3-camera rig is the CANONICAL SmolVLA fine-tune, not a mixup.
-      That case demotes to the warn path. The gate is checkpoint-side only —
-      a user's dataset always carries real mount names, so the dataset side
-      tells us nothing — and it is all-or-nothing, so a checkpoint mixing a
-      placeholder with a real mount stays refused. Phase 2 may replace this
-      exemption with an explicit confirm once there is a UI to confirm in.
+      TWO EXEMPTIONS — a GENERIC BASE, checkpoint-side, by two different
+      tells:
+
+      1. Every one of the CHECKPOINT's camera keys is a placeholder
+         (``camera1``/``camera2``/… — see _is_placeholder_camera_set): the
+         checkpoint was never tied to a rig at all. ``lerobot/smolvla_base``
+         ships exactly that, and adapting it to a named 3-camera rig is the
+         CANONICAL SmolVLA fine-tune, not a mixup. All-or-nothing: a
+         checkpoint mixing a placeholder with a real mount stays refused.
+      2. The pretrained_path IS one of _KNOWN_FOUNDATION_BASE_REPO_IDS. This
+         covers the pi0/pi05/pi0_fast public checkpoints, whose cameras name
+         their OWN pretraining rig (``observation.images.base_0_rgb``, …) —
+         real mount names, not placeholders, so tell 1 can't catch them. We
+         chose these exact repo ids ourselves (JobRegistry.start's
+         no-starting-point default), so knowing them ahead of time is exact,
+         not a heuristic.
+
+      Either tell demotes the pair to the warn path below instead of a
+      refusal. The gate is checkpoint-side only — a user's dataset always
+      carries real mount names, so the dataset side tells us nothing. Phase 2
+      may replace this exemption with an explicit confirm once there is a UI
+      to confirm in.
     * MISSING / EXTRA CAMERA, DIFFERENT RESOLUTION — legitimate choices
       (ACT's shared backbone handles a changed sensor count; resolution only
       moves the token count and VRAM). Phase 1 logs a warning; the
@@ -2235,11 +2266,15 @@ def _check_pretrained_feature_space(pretrained_path: str, dataset_repo_id: str) 
     # to `renamed` first (its wording is accurate there), so this branch is in
     # practice the unequal-count case the rename rule alone would let through.
     disjoint = bool(ckpt_names) and bool(dataset_names) and ckpt_names.isdisjoint(dataset_names)
-    if (renamed or disjoint) and _is_placeholder_camera_set(ckpt_names):
+    is_generic_base = (
+        _is_placeholder_camera_set(ckpt_names) or pretrained_path in _KNOWN_FOUNDATION_BASE_REPO_IDS
+    )
+    if (renamed or disjoint) and is_generic_base:
         # A generic base being bound to a named rig for the first time — the
-        # canonical smolvla_base fine-tune. Recorded, not refused.
+        # canonical fine-tune for whichever foundation model this is.
+        # Recorded, not refused.
         logger.warning(
-            "Fine-tune feature space: checkpoint %s carries placeholder camera "
+            "Fine-tune feature space: checkpoint %s carries generic-base camera "
             "names (%s); binding them to dataset %s's cameras (%s).",
             pretrained_path,
             _describe_cameras(ckpt_names),
@@ -2980,14 +3015,18 @@ class JobRegistry:
             config.policy_pretrained_path = _resolve_finetune_pretrained_path(
                 source, config.finetune_from_step
             )
-        elif config.policy_type == "smolvla" and not config.policy_pretrained_path and not config.resume:
-            # No starting point selected: default to the public SmolVLA
+        elif (
+            config.policy_type in _POLICY_FOUNDATION_BASE_REPO_ID
+            and not config.policy_pretrained_path
+            and not config.resume
+        ):
+            # No starting point selected: default to the matching public
             # foundation checkpoint rather than random weights (see
-            # _SMOLVLA_BASE_REPO_ID). Runs the same pretrained-path checks
-            # below as any other fine-tune — the placeholder-camera exemption
-            # in _check_pretrained_feature_space exists for exactly this
-            # checkpoint.
-            config.policy_pretrained_path = _SMOLVLA_BASE_REPO_ID
+            # _POLICY_FOUNDATION_BASE_REPO_ID). Runs the same pretrained-path
+            # checks below as any other fine-tune — the camera-name exemption
+            # in _check_pretrained_feature_space exists for exactly these
+            # checkpoints.
+            config.policy_pretrained_path = _POLICY_FOUNDATION_BASE_REPO_ID[config.policy_type]
 
         # Whatever put a pretrained_path on this request — the fine-tune
         # resolution above, or a caller setting the public field directly —

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -1551,6 +1551,15 @@ def _list_hub_checkpoints(api, repo_id: str) -> list[JobCheckpoint]:
 
 _LANGUAGE_CONDITIONED_POLICY_TYPES = {"smolvla", "pi0", "pi0_fast", "pi05"}
 
+# SmolVLA has no legitimate from-scratch mode: its vision-language backbone is
+# a full pretrained VLM, and lerobot only random-inits that backbone when no
+# pretrained_path is given (SmolVLAConfig.load_vlm_weights defaults to False —
+# see modeling_smolvla's own "unlikely to yield good results" warning). A
+# request that names neither a fine-tune source nor an explicit
+# policy_pretrained_path is defaulted onto this public foundation checkpoint
+# instead, in JobRegistry.start.
+_SMOLVLA_BASE_REPO_ID = "lerobot/smolvla_base"
+
 
 _HUB_CKPT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@checkpoints/(?P<step_dir>\d+)$")
 _HUB_ROOT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@root$")
@@ -2971,6 +2980,14 @@ class JobRegistry:
             config.policy_pretrained_path = _resolve_finetune_pretrained_path(
                 source, config.finetune_from_step
             )
+        elif config.policy_type == "smolvla" and not config.policy_pretrained_path and not config.resume:
+            # No starting point selected: default to the public SmolVLA
+            # foundation checkpoint rather than random weights (see
+            # _SMOLVLA_BASE_REPO_ID). Runs the same pretrained-path checks
+            # below as any other fine-tune — the placeholder-camera exemption
+            # in _check_pretrained_feature_space exists for exactly this
+            # checkpoint.
+            config.policy_pretrained_path = _SMOLVLA_BASE_REPO_ID
 
         # Whatever put a pretrained_path on this request — the fine-tune
         # resolution above, or a caller setting the public field directly —

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2429,6 +2429,86 @@ def test_start_refuses_a_finetune_step_without_a_finetune_source(tmp_path) -> No
         )
 
 
+def test_start_defaults_a_scratch_smolvla_run_to_the_public_base(tmp_path) -> None:
+    """SmolVLA has no legitimate from-scratch mode — its vision-language
+    backbone is a full pretrained VLM that lerobot only random-inits when no
+    pretrained_path is given. A request naming neither a fine-tune source nor
+    an explicit policy_pretrained_path must still land on the public
+    foundation checkpoint, not train that backbone from noise."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import _SMOLVLA_BASE_REPO_ID, JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = JobRegistry(tmp_path / "root")
+    fake_policy_type = MagicMock(return_value=None)
+    fake_feature_space = MagicMock(return_value=None)
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        patch("makermodslab.jobs.read_pretrained_policy_type", fake_policy_type),
+        patch("makermodslab.jobs.read_pretrained_feature_space", fake_feature_space),
+    ):
+        record = reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="smolvla"),
+            JobTarget(runner="local"),
+        )
+
+    assert record.config.policy_pretrained_path == _SMOLVLA_BASE_REPO_ID
+    # The defaulted path must run through the same pretrained-path checks as
+    # any other fine-tune — not skip them because it was assigned rather than
+    # user-selected.
+    fake_policy_type.assert_called_once_with(_SMOLVLA_BASE_REPO_ID)
+    fake_feature_space.assert_called_once_with(_SMOLVLA_BASE_REPO_ID)
+
+
+def test_start_leaves_non_smolvla_scratch_runs_alone(tmp_path) -> None:
+    """The default is scoped to SmolVLA specifically: ACT, diffusion, vqbet
+    and tdmpc all have a genuine from-scratch mode, so a bare `policy_type`
+    request for one of them must not gain a pretrained_path it never asked
+    for."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = JobRegistry(tmp_path / "root")
+    with patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()):
+        record = reg.start(
+            TrainingRequest(dataset_repo_id="user/ds", policy_type="act"),
+            JobTarget(runner="local"),
+        )
+
+    assert record.config.policy_pretrained_path is None
+
+
+def test_start_keeps_an_explicit_smolvla_pretrained_path(tmp_path) -> None:
+    """A caller who already named a pretrained_path directly (bypassing
+    finetune_from_job_id, same hole `_check_pretrained_policy_type`'s
+    docstring calls out) must not have it silently overwritten by the
+    public-base default."""
+    from unittest.mock import MagicMock, patch
+
+    from makermodslab.jobs import JobRegistry, JobTarget
+    from makermodslab.train import TrainingRequest
+
+    reg = JobRegistry(tmp_path / "root")
+    with (
+        patch("makermodslab.jobs.LocalJobRunner", lambda *a, **k: MagicMock()),
+        patch("makermodslab.jobs.read_pretrained_policy_type", lambda p: None),
+        patch("makermodslab.jobs.read_pretrained_feature_space", lambda p: None),
+    ):
+        record = reg.start(
+            TrainingRequest(
+                dataset_repo_id="user/ds",
+                policy_type="smolvla",
+                policy_pretrained_path="someone/custom_smolvla_run",
+            ),
+            JobTarget(runner="local"),
+        )
+
+    assert record.config.policy_pretrained_path == "someone/custom_smolvla_run"
+
+
 def test_start_refuses_to_resume_an_already_continued_run(tmp_path) -> None:
     """The sticks rule: one continuation per run. A second would fork the
     lineage, so it is refused — naming the child, which is what lets the HTTP

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2429,15 +2429,26 @@ def test_start_refuses_a_finetune_step_without_a_finetune_source(tmp_path) -> No
         )
 
 
-def test_start_defaults_a_scratch_smolvla_run_to_the_public_base(tmp_path) -> None:
-    """SmolVLA has no legitimate from-scratch mode — its vision-language
-    backbone is a full pretrained VLM that lerobot only random-inits when no
+@pytest.mark.parametrize(
+    "policy_type,base_repo_id",
+    [
+        ("smolvla", "lerobot/smolvla_base"),
+        ("pi0", "lerobot/pi0_base"),
+        ("pi05", "lerobot/pi05_base"),
+        ("pi0_fast", "lerobot/pi0fast-base"),
+    ],
+)
+def test_start_defaults_a_scratch_foundation_run_to_the_public_base(
+    tmp_path, policy_type, base_repo_id
+) -> None:
+    """None of smolvla/pi0/pi05/pi0_fast has a legitimate from-scratch mode —
+    each builds a pretrained backbone that lerobot only random-inits when no
     pretrained_path is given. A request naming neither a fine-tune source nor
-    an explicit policy_pretrained_path must still land on the public
+    an explicit policy_pretrained_path must still land on the matching public
     foundation checkpoint, not train that backbone from noise."""
     from unittest.mock import MagicMock, patch
 
-    from makermodslab.jobs import _SMOLVLA_BASE_REPO_ID, JobRegistry, JobTarget
+    from makermodslab.jobs import JobRegistry, JobTarget
     from makermodslab.train import TrainingRequest
 
     reg = JobRegistry(tmp_path / "root")
@@ -2449,23 +2460,24 @@ def test_start_defaults_a_scratch_smolvla_run_to_the_public_base(tmp_path) -> No
         patch("makermodslab.jobs.read_pretrained_feature_space", fake_feature_space),
     ):
         record = reg.start(
-            TrainingRequest(dataset_repo_id="user/ds", policy_type="smolvla"),
+            TrainingRequest(dataset_repo_id="user/ds", policy_type=policy_type),
             JobTarget(runner="local"),
         )
 
-    assert record.config.policy_pretrained_path == _SMOLVLA_BASE_REPO_ID
+    assert record.config.policy_pretrained_path == base_repo_id
     # The defaulted path must run through the same pretrained-path checks as
     # any other fine-tune — not skip them because it was assigned rather than
     # user-selected.
-    fake_policy_type.assert_called_once_with(_SMOLVLA_BASE_REPO_ID)
-    fake_feature_space.assert_called_once_with(_SMOLVLA_BASE_REPO_ID)
+    fake_policy_type.assert_called_once_with(base_repo_id)
+    fake_feature_space.assert_called_once_with(base_repo_id)
 
 
-def test_start_leaves_non_smolvla_scratch_runs_alone(tmp_path) -> None:
-    """The default is scoped to SmolVLA specifically: ACT, diffusion, vqbet
-    and tdmpc all have a genuine from-scratch mode, so a bare `policy_type`
-    request for one of them must not gain a pretrained_path it never asked
-    for."""
+def test_start_leaves_non_foundation_scratch_runs_alone(tmp_path) -> None:
+    """The default is scoped to the four foundation policies: ACT, diffusion,
+    vqbet and tdmpc all have a genuine from-scratch mode (a real torchvision
+    backbone or no pretrained-checkpoint concept at all), so a bare
+    `policy_type` request for one of them must not gain a pretrained_path it
+    never asked for."""
     from unittest.mock import MagicMock, patch
 
     from makermodslab.jobs import JobRegistry, JobTarget
@@ -2481,7 +2493,7 @@ def test_start_leaves_non_smolvla_scratch_runs_alone(tmp_path) -> None:
     assert record.config.policy_pretrained_path is None
 
 
-def test_start_keeps_an_explicit_smolvla_pretrained_path(tmp_path) -> None:
+def test_start_keeps_an_explicit_foundation_pretrained_path(tmp_path) -> None:
     """A caller who already named a pretrained_path directly (bypassing
     finetune_from_job_id, same hole `_check_pretrained_policy_type`'s
     docstring calls out) must not have it silently overwritten by the
@@ -4250,7 +4262,7 @@ def test_check_feature_space_exempts_a_generic_base_from_the_rename_rule(tmp_pat
         _patch_dataset_features(_dataset_features(cameras=("front", "wrist", "top"))),
     ):
         _check_pretrained_feature_space(str(ckpt), "user/named_rig_ds")
-    assert "placeholder camera names" in caplog.text
+    assert "generic-base camera names" in caplog.text
     assert "front, top, wrist" in caplog.text
 
 
@@ -4292,7 +4304,60 @@ def test_check_feature_space_exempts_a_generic_base_from_the_disjoint_rule(tmp_p
         _patch_dataset_features(_dataset_features(cameras=("front", "wrist"))),
     ):
         _check_pretrained_feature_space(str(ckpt), "user/two_cam_ds")
-    assert "placeholder camera names" in caplog.text
+    assert "generic-base camera names" in caplog.text
+
+
+def test_check_feature_space_exempts_a_known_foundation_base_by_repo_id(tmp_path, caplog) -> None:
+    """pi0/pi05/pi0_fast's public checkpoints name their OWN pretraining rig's
+    cameras (e.g. observation.images.base_0_rgb) — real mount names, not
+    placeholders — so _is_placeholder_camera_set can't recognize them as a
+    generic base. They're exempted by repo id instead: JobRegistry.start
+    chose these exact ids itself (its no-starting-point default), so the
+    match is exact, not a heuristic."""
+    import logging
+    from unittest.mock import patch
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    feature_space = (
+        {
+            "observation.state": {"type": "STATE", "shape": [32]},
+            "observation.images.base_0_rgb": {"type": "VISUAL", "shape": [3, 480, 640]},
+            "observation.images.left_wrist_0_rgb": {"type": "VISUAL", "shape": [3, 480, 640]},
+        },
+        {"action": {"type": "ACTION", "shape": [32]}},
+    )
+    with (
+        caplog.at_level(logging.WARNING, logger="makermodslab.jobs"),
+        patch("makermodslab.jobs.read_pretrained_feature_space", lambda p: feature_space),
+        _patch_dataset_features(_dataset_features(state_dim=32, action_dim=32, cameras=("top", "wrist"))),
+    ):
+        _check_pretrained_feature_space("lerobot/pi0_base", "user/so101_ds")
+    assert "generic-base camera names" in caplog.text
+
+
+def test_check_feature_space_does_not_exempt_an_unknown_repo_id(tmp_path) -> None:
+    """The repo-id exemption is a closed list (_KNOWN_FOUNDATION_BASE_REPO_IDS)
+    — an arbitrary Hub-hosted checkpoint with real camera names must still be
+    refused like any other rig mismatch, not waved through just for not being
+    a local path."""
+    from unittest.mock import patch
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    feature_space = (
+        {
+            "observation.state": {"type": "STATE", "shape": [6]},
+            "observation.images.front": {"type": "VISUAL", "shape": [3, 480, 640]},
+        },
+        {"action": {"type": "ACTION", "shape": [6]}},
+    )
+    with (
+        patch("makermodslab.jobs.read_pretrained_feature_space", lambda p: feature_space),
+        _patch_dataset_features(_dataset_features(cameras=("wrist",))),
+        pytest.raises(ValueError, match="under different names"),
+    ):
+        _check_pretrained_feature_space("someone/random_act_checkpoint", "user/wrist_only_ds")
 
 
 def test_check_feature_space_exemption_is_all_or_nothing(tmp_path) -> None:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4307,6 +4307,49 @@ def test_check_feature_space_exempts_a_generic_base_from_the_disjoint_rule(tmp_p
     assert "generic-base camera names" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "base_repo_id,checkpoint_dim,dataset_dim",
+    [
+        ("lerobot/smolvla_base", 6, 12),
+        ("lerobot/pi0_base", 32, 6),
+        ("lerobot/pi0_base", 32, 12),
+        ("lerobot/pi05_base", 32, 6),
+        ("lerobot/pi05_base", 32, 12),
+        ("lerobot/pi0fast-base", 32, 6),
+        ("lerobot/pi0fast-base", 32, 12),
+    ],
+)
+def test_check_feature_space_allows_foundation_base_dimension_padding(
+    base_repo_id, checkpoint_dim, dataset_dim, caplog
+) -> None:
+    """Foundation policies pad single-arm and bimanual vectors to their
+    configured maxima. A public base's published feature width is therefore
+    not evidence that it came from a different robot."""
+    import logging
+    from unittest.mock import patch
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    feature_space = (
+        {
+            "observation.state": {"type": "STATE", "shape": [checkpoint_dim]},
+            "observation.images.front": {"type": "VISUAL", "shape": [3, 480, 640]},
+        },
+        {"action": {"type": "ACTION", "shape": [checkpoint_dim]}},
+    )
+    with (
+        caplog.at_level(logging.WARNING, logger="makermodslab.jobs"),
+        patch("makermodslab.jobs.read_pretrained_feature_space", lambda p: feature_space),
+        _patch_dataset_features(
+            _dataset_features(state_dim=dataset_dim, action_dim=dataset_dim, cameras=("front",))
+        ),
+    ):
+        _check_pretrained_feature_space(base_repo_id, "user/lerobot_v3_ds")
+    assert "known foundation base" in caplog.text
+    assert "because LeRobot pads foundation policies" in caplog.text
+    assert f"{dataset_dim}-dim robot state" in caplog.text
+
+
 def test_check_feature_space_exempts_a_known_foundation_base_by_repo_id(tmp_path, caplog) -> None:
     """pi0/pi05/pi0_fast's public checkpoints name their OWN pretraining rig's
     cameras (e.g. observation.images.base_0_rgb) — real mount names, not
@@ -4334,6 +4377,25 @@ def test_check_feature_space_exempts_a_known_foundation_base_by_repo_id(tmp_path
     ):
         _check_pretrained_feature_space("lerobot/pi0_base", "user/so101_ds")
     assert "generic-base camera names" in caplog.text
+
+
+def test_check_feature_space_does_not_exempt_unknown_repo_from_dimension_rule() -> None:
+    """Only the public foundation bases get padding semantics. A normal
+    checkpoint with a different width still identifies a different robot."""
+    from unittest.mock import patch
+
+    from makermodslab.jobs import _check_pretrained_feature_space
+
+    feature_space = (
+        {"observation.state": {"type": "STATE", "shape": [32]}},
+        {"action": {"type": "ACTION", "shape": [32]}},
+    )
+    with (
+        patch("makermodslab.jobs.read_pretrained_feature_space", lambda p: feature_space),
+        _patch_dataset_features(_dataset_features(state_dim=6, action_dim=6, cameras=())),
+        pytest.raises(ValueError, match="32-dim robot state"),
+    ):
+        _check_pretrained_feature_space("someone/random_checkpoint", "user/so101_ds")
 
 
 def test_check_feature_space_does_not_exempt_an_unknown_repo_id(tmp_path) -> None:


### PR DESCRIPTION
## Summary
Training SmolVLA, pi0, pi05, or pi0_fast with no starting point selected silently trained that model's pretrained foundation backbone from fully random weights instead of the public checkpoint — lerobot itself warns this is "unlikely to yield good results." That option is now labeled "Train from base" for all four and always fine-tunes the matching public foundation checkpoint instead; ACT, diffusion, vqbet, and tdmpc are unaffected since none of them has this problem.

## Before
A bare request for any of the four foundation policies never got a `--policy.pretrained_path`, so lerobot built each one (backbone included) from random weights. ACT, shown for contrast, was always correct:
```
smolvla    policy_pretrained_path=None    (no --policy.pretrained_path)
pi0        policy_pretrained_path=None    (no --policy.pretrained_path)
pi05       policy_pretrained_path=None    (no --policy.pretrained_path)
pi0_fast   policy_pretrained_path=None    (no --policy.pretrained_path)
act        policy_pretrained_path=None    (no --policy.pretrained_path)   <- correct as-is
```

## After
The same requests now resolve to each policy's public foundation checkpoint; ACT (and diffusion/vqbet/tdmpc) is untouched:
```
$ python -c "
from unittest.mock import MagicMock, patch
from makermodslab.jobs import JobRegistry, JobTarget
from makermodslab.train import TrainingRequest, build_training_command
for policy_type in ['smolvla', 'pi0', 'pi05', 'pi0_fast', 'act']:
    reg = JobRegistry('/tmp/evidence')
    with patch('makermodslab.jobs.LocalJobRunner', lambda *a, **k: MagicMock()):
        record = reg.start(TrainingRequest(dataset_repo_id='user/ds', policy_type=policy_type), JobTarget(runner='local'))
    cmd = build_training_command(record.config, '/tmp/out')
    print(policy_type, record.config.policy_pretrained_path, any(a.startswith('--policy.pretrained_path') for a in cmd))
"
smolvla    lerobot/smolvla_base    True
pi0        lerobot/pi0_base        True
pi05       lerobot/pi05_base       True
pi0_fast   lerobot/pi0fast-base    True
act        None                    False
```

## Commits
1. Default a scratch SmolVLA run's `policy_pretrained_path` to the public `lerobot/smolvla_base` checkpoint, only when no fine-tune source or explicit pretrained path was given, with tests covering the default, its scoping to SmolVLA, and an explicit override.
2. Rename the starting-point dropdown's no-selection option to "SmolVLA base" when SmolVLA is the selected policy, leaving every other policy's "Train from scratch" wording unchanged.
3. Extend the same default to pi0, pi05, and pi0_fast, whose foundation backbones have the identical gap; since their public checkpoints name real cameras instead of SmolVLA base's placeholder names, also extend the fine-tune feature-space guard's generic-base exemption to recognize these checkpoints by repo id, and update its docstring and log wording accordingly. Tests cover all four policies' default, the exemption, and that it stays a closed list.
4. Generalize the frontend label to "Train from base" for all four foundation policies instead of a SmolVLA-specific name, and update the helper caption to match.

## Sensitive changes
None — this only changes which weights a training subprocess starts from; no servo, torque, or calibration code is touched.