### PR TITLE
Fix tab-conflict overlay unclickable under an open modal dialog

### DIFF
--- a/frontend/src/components/SingleTabGuard.test.tsx
+++ b/frontend/src/components/SingleTabGuard.test.tsx
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SingleTabGuard from "./SingleTabGuard";
+
+describe("SingleTabGuard", () => {
+  afterEach(() => {
+    document.body.style.pointerEvents = "";
+  });
+
+  it("stays clickable when a modal dialog elsewhere on the page has disabled pointer events on <body> (regression: Radix's modal Dialog sets body { pointer-events: none } while open — e.g. the update-available popup — and since pointer-events is inherited, the visually-topmost tab-conflict overlay silently became unclickable, leaving the dialog underneath as the only interactive element)", async () => {
+    // A peer tab that opened first wins the election, making this instance
+    // non-primary and showing the "already open in another tab" overlay.
+    const peer = new BroadcastChannel("makermodslab-tabs-v1");
+    render(<SingleTabGuard>{null}</SingleTabGuard>);
+
+    peer.postMessage({ type: "HEARTBEAT", id: "peer-1", openedAt: 0 });
+
+    const overlay = await screen.findByRole("dialog");
+
+    // Mirrors what @radix-ui/react-dismissable-layer does to <body> for the
+    // duration any modal Dialog (like UpdateNotice) is open.
+    document.body.style.pointerEvents = "none";
+
+    expect(overlay).toHaveClass("pointer-events-auto");
+
+    peer.close();
+  });
+});

--- a/frontend/src/components/SingleTabGuard.tsx
+++ b/frontend/src/components/SingleTabGuard.tsx
@@ -121,7 +121,12 @@ const SingleTabGuard = ({ children }: { children: ReactNode }) => {
       {children}
       {!isPrimary && (
         <div
-          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          // Radix's modal Dialog (e.g. UpdateNotice) sets `body { pointer-events:
+          // none }` while open to enforce its own modality, and pointer-events is
+          // inherited — without this override, this overlay would visually paint
+          // on top (z-[9999]) but silently stop receiving clicks, leaving the
+          // dialog underneath as the only interactive element.
+          className="pointer-events-auto fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
         >


### PR DESCRIPTION
## Summary
The "already open in another tab" overlay painted on top of the update-available popup but couldn't be clicked — Radix's modal Dialog disables clicks everywhere else on the page while it's open, and the overlay never opted back in, leaving the update popup underneath as the only interactive thing.

## Before
No screenshot captured this session — no browser tooling was connected. To reproduce: open the app in two tabs with an outdated version, so both the "already open in another tab" overlay and the update-available popup are showing at once. The tab overlay renders visually on top, but clicking "Use this tab" does nothing; the click passes through to the update popup underneath.

## After
No screenshot captured this session, same reason. `SingleTabGuard`'s overlay now carries `pointer-events-auto`, so it keeps receiving clicks regardless of any modal dialog's page-wide pointer-events lock. `npx vitest run src/components/SingleTabGuard.test.tsx` shows the before/after directly: the added test fails against the pre-fix code (overlay missing `pointer-events-auto`) and passes after.

## Commits
1. Adds `pointer-events-auto` to the tab-conflict overlay so it stays clickable when a modal dialog (like the update popup) has disabled pointer events on `<body>`, plus a regression test covering it.

## Sensitive changes
None.