### PR TITLE
nodes: install a policy's extra on the peer, and restart it from there

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3199,6 +3199,24 @@
         "title": "ReplayRequest",
         "type": "object"
       },
+      "RestartResponse": {
+        "properties": {
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "restarting": {
+            "title": "Restarting",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "restarting",
+          "message"
+        ],
+        "title": "RestartResponse",
+        "type": "object"
+      },
       "RobotPortResponse": {
         "description": "server.py get_robot_port — saved_port is null (not absent) when no\nport file exists, so None must NOT be excluded on this route.",
         "properties": {
@@ -7529,6 +7547,205 @@
         ]
       }
     },
+    "/api/v1/nodes/{instance_id}/policy-extra/{policy_type}": {
+      "get": {
+        "description": "Environment proxy: the peer's own GET /api/v1/system/policy-extra/\n{policy_type}, passed through — whether the extra the policy needs is\nimportable in THE PEER's environment, the one an offloaded run imports\nfrom (the local answer is irrelevant to it). Same error mapping as the\nother GET proxies: 404 node.not_found for an unknown instance_id, 502\nnode.unreachable for ANY failure to read the peer.",
+        "operationId": "get_node_policy_extra",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "title": "Instance Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "policy_type",
+            "required": true,
+            "schema": {
+              "title": "Policy Type",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyExtraStatus"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Node Policy Extra",
+        "tags": [
+          "nodes"
+        ]
+      }
+    },
+    "/api/v1/nodes/{instance_id}/policy-extra/{policy_type}/install": {
+      "post": {
+        "description": "Forward the install to the peer: `pip install lerobot[<extra>]` runs\nTHERE, in the environment its training subprocesses import from. Mutation\nstance, like the stop/delete proxies: the peer's own refusals keep THEIR\nstatus and body; only transport-level failure is 502 node.unreachable,\nand 404 node.not_found names an unknown node.",
+        "operationId": "install_node_policy_extra",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "title": "Instance Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "policy_type",
+            "required": true,
+            "schema": {
+              "title": "Policy Type",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallStartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Install Node Policy Extra",
+        "tags": [
+          "nodes"
+        ]
+      }
+    },
+    "/api/v1/nodes/{instance_id}/policy-extra/{policy_type}/install-status": {
+      "get": {
+        "description": "The peer's own install-status, passed through. The peer drains pending\npip log lines per call, so this proxy is inherently incremental — like\nthe job-log proxy. Same error mapping as the GET proxies.",
+        "operationId": "get_node_policy_extra_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "title": "Instance Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "policy_type",
+            "required": true,
+            "schema": {
+              "title": "Policy Type",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Node Policy Extra Status",
+        "tags": [
+          "nodes"
+        ]
+      }
+    },
+    "/api/v1/nodes/{instance_id}/restart": {
+      "post": {
+        "description": "Forward a restart to the peer (its own POST /api/v1/system/restart).\n200 means the peer ANSWERED and scheduled its re-exec — expect it to flap\nunreachable for a few seconds; the registry's probes pick it back up. The\npeer's coded refusals (409 session.held / robot.busy.training /\nsystem.restart_unsupported — or a plain 404 from a peer too old to have\nthe endpoint) pass through with THEIR status and body; only transport\nfailure is 502 node.unreachable.",
+        "operationId": "restart_node",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "title": "Instance Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restart Node",
+        "tags": [
+          "nodes"
+        ]
+      }
+    },
     "/api/v1/open-calibration-folder": {
       "post": {
         "description": "Open a side's calibration folder in the OS file browser (Finder/Explorer/\nxdg-open). LOCAL, non-network action — spawns a GUI on the host machine only.\nThe dir is created if missing so a fresh install opens an empty folder rather\nthan failing. An unknown device_type is rejected with 400.",
@@ -8640,6 +8857,28 @@
           }
         },
         "summary": "Install Policy Extra Status",
+        "tags": [
+          "system"
+        ]
+      }
+    },
+    "/api/v1/system/restart": {
+      "post": {
+        "description": "Re-exec this server process in place (same argv/env/PID), so a remote\noperator — the node-proxy POST /api/v1/nodes/{id}/restart — can bounce a\nheadless station without a shell on it. Answers FIRST, re-execs after a\nshort grace delay so this response reaches the client.\n\nRefusals, all 409: a live robot flow (robot.busy.<feature> — killing the\nserver mid-flow drops the hardware threads with it), a running or queued\ntraining run (robot.busy.training — the loader retires both on startup),\nand a process that cannot safely re-exec (system.restart_unsupported: a\ndev reload worker, a non-entry-point launch, or Windows).",
+        "operationId": "restart_server",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Restart Server",
         "tags": [
           "system"
         ]

--- a/frontend/src/components/training/PolicyExtraDialog.tsx
+++ b/frontend/src/components/training/PolicyExtraDialog.tsx
@@ -24,6 +24,11 @@ interface Props {
   installTarget: string; // e.g. "lerobot[smolvla]"
   installHint: string; // e.g. "pip install 'lerobot[smolvla]'"
   purpose: "training" | "inference"; // what the caller was about to do
+  /** When set, the install runs on THIS LAN node (through the server-to-server
+   * proxy) instead of the local environment — the offloaded run imports from
+   * the peer's site-packages, so that is where the extra must land. `name` is
+   * the node's display name (data, rendered verbatim). */
+  node?: { instanceId: string; name: string };
 }
 
 /**
@@ -49,6 +54,14 @@ const PURPOSE_KEYS = {
   },
 } as const satisfies Record<Props["purpose"], Record<string, string>>;
 
+// The node variant owns complete sentences too — the extra lands on the PEER,
+// and every line must say so or the user "fixes" the wrong machine.
+const NODE_KEYS = {
+  srDescription: "training.policyExtra.srDescriptionTrainingNode",
+  description: "training.policyExtra.descriptionTrainingNode",
+  ready: "training.install.readyPolicyTrainingNode",
+} as const;
+
 // Some policies (smolvla, pi0, pi0_fast, pi05, diffusion) need an optional
 // LeRobot extra. This catches the missing package before training/inference
 // starts and offers a one-click install, instead of the run dying with a
@@ -61,13 +74,24 @@ const PolicyExtraDialog: React.FC<Props> = ({
   installTarget,
   installHint,
   purpose,
+  node,
 }) => {
-  const install = useInstallExtra(`system/policy-extra/${policyType}`, open);
+  // On a node target the whole flow — status seed, install POST, progress
+  // poll — runs through the server-to-server proxy; the pip subprocess runs
+  // on the peer, in the environment its training subprocesses import from.
+  const install = useInstallExtra(
+    node
+      ? `nodes/${node.instanceId}/policy-extra/${policyType}`
+      : `system/policy-extra/${policyType}`,
+    open,
+  );
   const { t } = useTranslation();
   // A product name (ACT, SmolVLA…) — never translated.
   const shortLabel = policyTypeShortLabel(policyType);
-  const title = t("training.policyExtra.title", { policy: shortLabel });
-  const keys = PURPOSE_KEYS[purpose];
+  const title = node
+    ? t("training.policyExtra.titleNode", { policy: shortLabel, node: node.name })
+    : t("training.policyExtra.title", { policy: shortLabel });
+  const keys = node ? NODE_KEYS : PURPOSE_KEYS[purpose];
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -81,6 +105,7 @@ const PolicyExtraDialog: React.FC<Props> = ({
             {t(keys.srDescription, {
               target: installTarget,
               policy: shortLabel,
+              node: node?.name ?? "",
             })}
           </DialogDescription>
         </DialogHeader>
@@ -103,6 +128,7 @@ const PolicyExtraDialog: React.FC<Props> = ({
                   policy: shortLabel,
                   packageName,
                   target: installTarget,
+                  node: node?.name ?? "",
                 }}
                 components={[
                   <span key="0" className="font-semibold" />,
@@ -114,11 +140,17 @@ const PolicyExtraDialog: React.FC<Props> = ({
                     key="2"
                     className="px-1 py-0.5 rounded bg-muted text-info"
                   />,
+                  <span key="3" className="font-semibold" />,
                 ]}
               />
             }
             doneDescription={
-              <ReadyInstructions text={t(keys.ready, { policy: shortLabel })} />
+              <ReadyInstructions
+                text={t(keys.ready, {
+                  policy: shortLabel,
+                  node: node?.name ?? "",
+                })}
+              />
             }
           />
         </div>

--- a/frontend/src/components/training/TrainingConfigurator.tsx
+++ b/frontend/src/components/training/TrainingConfigurator.tsx
@@ -32,6 +32,11 @@ import {
 } from "@/lib/jobsApi";
 import { useDatasets } from "@/hooks/useDatasets";
 import { useDatasetUpload } from "@/hooks/useDatasetUpload";
+import {
+  getNodePolicyExtra,
+  listNodes,
+  nodeDisplayName,
+} from "@/lib/nodesApi";
 import { getDatasetInfo } from "@/lib/replayApi";
 
 // Passed by the "Continue" button on a completed local job, or the "Resume"
@@ -326,6 +331,9 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     packageName: string;
     installTarget: string;
     installHint: string;
+    // Set when the missing extra is on a LAN NODE's environment (the chosen
+    // compute target), not the local one — the dialog then installs there.
+    node?: { instanceId: string; name: string };
   } | null>(null);
   const [authenticated, setAuthenticated] = useState<boolean>(false);
   const [flavors, setFlavors] = useState<RunnerFlavor[]>([]);
@@ -573,9 +581,11 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
     }
 
     // Pre-flight: smolvla/pi0/pi0_fast/pi05/diffusion need an optional package
-    // installed locally. Catch it here with a one-click installer instead of a buried
-    // ImportError after the job has already started. Cloud jobs run in their
-    // own environment, so the local package is irrelevant — skip the check.
+    // installed WHERE THE RUN EXECUTES — locally for a local run, on the peer
+    // for a LAN-node run (read through the server-to-server proxy). Catch it
+    // here with a one-click installer instead of a buried ImportError after
+    // the job has already started. Cloud jobs run in their own container
+    // environment, so neither answer applies — skip the check.
     if (config.target.runner === "local") {
       try {
         const r = await fetchWithHeaders(
@@ -596,6 +606,45 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
       } catch {
         // Check failed (offline / older backend) — fall through and let the
         // job report any problem itself.
+      }
+    } else if (
+      config.target.runner === "lan_node" &&
+      config.target.node_instance_id
+    ) {
+      const instanceId = config.target.node_instance_id;
+      try {
+        const extra = await getNodePolicyExtra(
+          baseUrl,
+          fetchWithHeaders,
+          instanceId,
+          config.policy_type,
+        );
+        if (extra.needs_extra && !extra.available) {
+          // The dialog names the node so the user knows WHERE the install
+          // lands; resolve its display name from the registry, falling back
+          // to a short instance id when the listing can't be read.
+          let name = instanceId.slice(0, 8);
+          try {
+            const listing = await listNodes(baseUrl, fetchWithHeaders);
+            const entry = listing.nodes.find(
+              (n) => n.instance_id === instanceId,
+            );
+            if (entry) name = nodeDisplayName(entry);
+          } catch {
+            // Name lookup is cosmetic — the short id is enough.
+          }
+          setPolicyExtra({
+            policyType: config.policy_type,
+            packageName: extra.package,
+            installTarget: extra.install_target,
+            installHint: extra.install_hint,
+            node: { instanceId, name },
+          });
+          return;
+        }
+      } catch {
+        // Node unreachable or an older peer without the endpoint — fall
+        // through and let the peer's own job validation report the problem.
       }
     }
 
@@ -902,6 +951,7 @@ const TrainingConfigurator: React.FC<TrainingConfiguratorProps> = ({
           installTarget={policyExtra.installTarget}
           installHint={policyExtra.installHint}
           purpose="training"
+          node={policyExtra.node}
         />
       )}
     </div>

--- a/frontend/src/components/training/config/NodeDetailPanel.tsx
+++ b/frontend/src/components/training/config/NodeDetailPanel.tsx
@@ -1,9 +1,16 @@
 import React, { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Loader2 } from "lucide-react";
+import { Loader2, RotateCw } from "lucide-react";
 import { useApi } from "@/contexts/ApiContext";
+import { ApiError } from "@/lib/apiClient";
 import { JobRecord, jobDisplayName } from "@/lib/jobsApi";
-import { NodeEntry, getNodeJobs, getNodeQueue, nodeDisplayName } from "@/lib/nodesApi";
+import {
+  NodeEntry,
+  getNodeJobs,
+  getNodeQueue,
+  nodeDisplayName,
+  restartNode,
+} from "@/lib/nodesApi";
 import { relativeTimeAgo } from "@/lib/relativeTime";
 import NodeJobDialog from "./NodeJobDialog";
 
@@ -55,6 +62,14 @@ const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({
   // Bumped when the dialog stopped/deleted something, so the workload line
   // catches up without waiting out the 15s poll.
   const [changeToken, setChangeToken] = useState(0);
+  // The remote-restart flow: an armed two-step button (idle → confirm), then
+  // "requested" while the node bounces. The peer's refusal prose (its own 409
+  // detail — server prose, rendered in English like all of it) lands in
+  // `restartError`.
+  const [restart, setRestart] = useState<"idle" | "confirm" | "requested">(
+    "idle",
+  );
+  const [restartError, setRestartError] = useState<string | null>(null);
 
   const reachable = node != null && node.status === "ok";
 
@@ -76,6 +91,9 @@ const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({
             running: jobs.find((j) => j.state === "running") ?? null,
             queued: queue,
           });
+          // A successful read through the proxy means the node is answering
+          // again — a pending restart has completed.
+          setRestart((r) => (r === "requested" ? "idle" : r));
         })
         .catch(() => {
           // node.unreachable / node.not_found / network — one honest word.
@@ -89,6 +107,38 @@ const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({
       clearInterval(timer);
     };
   }, [baseUrl, fetchWithHeaders, instanceId, reachable, refreshToken, changeToken]);
+
+  // The armed confirm disarms itself: an unclicked "Confirm restart?" must
+  // not linger as a landmine for a later stray click.
+  useEffect(() => {
+    if (restart !== "confirm") return;
+    const timer = setTimeout(() => setRestart("idle"), 5_000);
+    return () => clearTimeout(timer);
+  }, [restart]);
+
+  const handleRestart = async () => {
+    if (restart === "idle") {
+      setRestartError(null);
+      setRestart("confirm");
+      return;
+    }
+    setRestartError(null);
+    setRestart("requested");
+    try {
+      await restartNode(baseUrl, fetchWithHeaders, instanceId);
+    } catch (e) {
+      // The peer's own refusal (409 robot.busy.* / system.restart_unsupported,
+      // or a plain 404 from a peer without the endpoint) — its prose says why.
+      setRestart("idle");
+      setRestartError(
+        e instanceof ApiError && e.detail
+          ? e.detail
+          : e instanceof Error
+            ? e.message
+            : String(e),
+      );
+    }
+  };
 
   const name = node ? nodeDisplayName(node) : instanceId.slice(0, 8);
 
@@ -230,6 +280,40 @@ const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({
           ]}
         />
       </p>
+
+      {/* Remote restart: re-exec the node's server in place (e.g. after an
+          environment change). Two-step arm/confirm; disabled while the node
+          has work — the peer would refuse anyway, no point inviting the
+          click. The peer's refusal prose renders verbatim. */}
+      {reachable ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handleRestart}
+            disabled={
+              restart === "requested" ||
+              running != null ||
+              (workload.kind === "ok" && workload.queued.length > 0)
+            }
+            className="flex items-center gap-1 rounded border border-border bg-background px-1.5 py-0.5 text-[11px] text-muted-foreground hover:border-ring/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RotateCw
+              className={`h-3 w-3 ${restart === "requested" ? "animate-spin" : ""}`}
+            />
+            {restart === "confirm"
+              ? t("training.target.detail.restartConfirm")
+              : t("training.target.detail.restartAction")}
+          </button>
+          {restart === "requested" ? (
+            <span className="text-[11px] text-muted-foreground">
+              {t("training.target.detail.restartRequested", { name })}
+            </span>
+          ) : null}
+          {restartError ? (
+            <span className="text-[11px] text-warn">{restartError}</span>
+          ) : null}
+        </div>
+      ) : null}
 
       {/* Drill-in dialog for the clicked run. Keyed by run id so switching
           runs remounts it with fresh state; it polls its own record + log

--- a/frontend/src/i18n/locales/en/training.ts
+++ b/frontend/src/i18n/locales/en/training.ts
@@ -178,6 +178,12 @@ export default {
         "The job runs on <0>{{name}}</0>; datasets sync via the Hub — this dataset uploads to your HF account first, and <1>{{name}}</1> pulls it from there.",
       goneBody:
         "This node is no longer in the registry. Pick another compute target — starting the run would be refused.",
+      // The remote-restart button (two-step arm/confirm) and its status line.
+      // {{name}} is the node's display name — data, rendered verbatim.
+      restartAction: "Restart node",
+      restartConfirm: "Confirm restart?",
+      restartRequested:
+        "Restart requested — {{name}} will drop off for a few seconds and come back.",
     },
     // The drill-in dialog for one run ON a peer node (NodeJobDialog). Run
     // names, numbers and log lines are data, rendered verbatim; the state
@@ -359,6 +365,9 @@ export default {
       "Install complete — {{policy}} training is available immediately, no restart needed. Reload the page if it doesn't unlock on its own.",
     readyPolicyInference:
       "Install complete — {{policy}} inference is available immediately, no restart needed. Reload the page if it doesn't unlock on its own.",
+    // {{node}} is a LAN node's display name — data, rendered verbatim.
+    readyPolicyTrainingNode:
+      "Install complete on {{node}} — {{policy}} training is available there immediately, no restart needed. Start the run again.",
   },
 
   extraGate: {
@@ -390,6 +399,13 @@ export default {
       "Training a <0>{{policy}}</0> policy needs the <1>{{packageName}}</1> package (installed via <2>{{target}}</2>), which isn't in this environment yet. Install it to train this policy.",
     descriptionInference:
       "Running a <0>{{policy}}</0> policy needs the <1>{{packageName}}</1> package (installed via <2>{{target}}</2>), which isn't in this environment yet. Install it to run this policy.",
+    // The LAN-node variant: the extra lands on the PEER's environment, and
+    // every sentence says so. {{node}} is the node's display name (data).
+    titleNode: "{{policy}} needs an extra package on {{node}}",
+    srDescriptionTrainingNode:
+      "Install {{target}} on the node {{node}} for training with {{policy}}.",
+    descriptionTrainingNode:
+      "Training a <0>{{policy}}</0> policy on <3>{{node}}</3> needs the <1>{{packageName}}</1> package (installed via <2>{{target}}</2>), which isn't in that node's environment yet. Install it there — the pip install runs on the node.",
   },
 
   monitoring: {

--- a/frontend/src/i18n/locales/zh-CN/training.ts
+++ b/frontend/src/i18n/locales/zh-CN/training.ts
@@ -137,6 +137,11 @@ export default {
       hubSyncHint:
         "任务在 <0>{{name}}</0> 上运行；数据集经 Hub 同步 —— 该数据集会先上传到你的 HF 账号，再由 <1>{{name}}</1> 从那里拉取。",
       goneBody: "该节点已不在注册表中。请改选其他算力目标 —— 否则启动会被拒绝。",
+      // 远程重启按钮（两步：先武装再确认）及其状态行。
+      // {{name}} 是节点的显示名 —— 数据，按原样呈现。
+      restartAction: "重启节点",
+      restartConfirm: "确认重启？",
+      restartRequested: "已请求重启 —— {{name}} 会离线几秒后自动恢复。",
     },
     // 节点上单次运行的详情对话框（NodeJobDialog）。运行名、编号与日志行都是
     // 数据，原样渲染；状态标签复用 jobs.jobState，停止/删除提示复用 jobs.jobsData。
@@ -282,6 +287,9 @@ export default {
       "安装完成 —— {{policy}} 训练已立即可用，无需重启。如果没有自动解锁，刷新页面即可。",
     readyPolicyInference:
       "安装完成 —— {{policy}} 推理已立即可用，无需重启。如果没有自动解锁，刷新页面即可。",
+    // {{node}} 是局域网节点的显示名 —— 数据，按原样呈现。
+    readyPolicyTrainingNode:
+      "已在 {{node}} 上安装完成 —— {{policy}} 训练在该节点上已立即可用，无需重启。重新启动运行即可。",
   },
 
   extraGate: {
@@ -305,6 +313,13 @@ export default {
       "训练 <0>{{policy}}</0> 策略需要 <1>{{packageName}}</1> 包（通过 <2>{{target}}</2> 安装），而当前环境中还没有它。安装后即可训练该策略。",
     descriptionInference:
       "运行 <0>{{policy}}</0> 策略需要 <1>{{packageName}}</1> 包（通过 <2>{{target}}</2> 安装），而当前环境中还没有它。安装后即可运行该策略。",
+    // 局域网节点变体：软件包安装到对端节点的环境中，每句话都要说明这一点。
+    // {{node}} 是节点的显示名（数据）。
+    titleNode: "{{policy}} 需要在 {{node}} 上安装额外的软件包",
+    srDescriptionTrainingNode:
+      "在节点 {{node}} 上安装 {{target}} 以使用 {{policy}} 进行训练。",
+    descriptionTrainingNode:
+      "在 <3>{{node}}</3> 上训练 <0>{{policy}}</0> 策略需要 <1>{{packageName}}</1> 包（通过 <2>{{target}}</2> 安装），而该节点的环境中还没有它。在此安装 —— pip 安装会在该节点上执行。",
   },
 
   monitoring: {

--- a/frontend/src/lib/nodesApi.ts
+++ b/frontend/src/lib/nodesApi.ts
@@ -188,6 +188,54 @@ export async function deleteNodeJob(
   );
 }
 
+/** The PEER's answer to "can your environment import what this policy
+ * needs?" — its own GET /api/v1/system/policy-extra/{policy_type}, proxied
+ * server-to-server. The offloaded run imports from the peer's site-packages,
+ * so the local answer is irrelevant to it. */
+export interface NodePolicyExtraStatus {
+  policy_type: string;
+  needs_extra: boolean;
+  available: boolean;
+  package: string;
+  install_target: string;
+  install_hint: string;
+}
+
+export async function getNodePolicyExtra(
+  baseUrl: string,
+  fetcher: Fetcher,
+  instanceId: string,
+  policyType: string,
+  signal?: AbortSignal,
+): Promise<NodePolicyExtraStatus> {
+  return apiRequest<NodePolicyExtraStatus>(
+    baseUrl,
+    fetcher,
+    `/api/v1/nodes/${encodeURIComponent(instanceId)}/policy-extra/${encodeURIComponent(policyType)}`,
+    { signal, action: "Get node policy extra" },
+  );
+}
+
+/** Ask the peer to restart its server process (re-exec in place), so a
+ * just-installed extra environment or config change lands without a shell on
+ * the node. 200 means the restart is SCHEDULED — expect the node to read
+ * unreachable for a few seconds before the registry's probes pick it back up.
+ * Coded refusals pass through from the peer (409 robot.busy.* /
+ * session.held / system.restart_unsupported); a peer too old to have the
+ * endpoint answers a plain 404. */
+export async function restartNode(
+  baseUrl: string,
+  fetcher: Fetcher,
+  instanceId: string,
+): Promise<{ restarting: boolean; message: string }> {
+  return apiRequest<{ restarting: boolean; message: string }>(
+    baseUrl,
+    fetcher,
+    `/api/v1/nodes/${encodeURIComponent(instanceId)}/restart`,
+    { method: "POST", action: "Restart node" },
+  );
+}
+
 /** A node the Compute selector can offer a training to: reachable, verified
  * (it has an identity to route by), and advertising that it accepts jobs. */
 export function isSelectableNode(node: NodeEntry): boolean {

--- a/makermodslab/api_errors.py
+++ b/makermodslab/api_errors.py
@@ -129,6 +129,14 @@ class ErrorCode(StrEnum):
     SESSION_LEASE_EXPIRED = "session.lease_expired"
     SESSION_NOT_FOUND = "session.not_found"
 
+    # system.* — the server process itself. `restart_unsupported`: this
+    # process cannot safely re-exec (a dev reload worker, or a launch whose
+    # argv isn't one of our entry points) — the remedy is restarting it the
+    # way it was started, not retrying. `install_in_progress`: a restart
+    # would orphan a live pip subprocess mid-write — retry once it finishes.
+    SYSTEM_RESTART_UNSUPPORTED = "system.restart_unsupported"
+    SYSTEM_INSTALL_IN_PROGRESS = "system.install_in_progress"
+
     # The residual 500.
     INTERNAL_UNEXPECTED = "internal.unexpected"
 

--- a/makermodslab/nodes.py
+++ b/makermodslab/nodes.py
@@ -77,6 +77,10 @@ HEALTH_PATH = "/api/v1/health"
 JOBS_PATH = "/api/v1/jobs"
 QUEUE_PATH = "/api/v1/jobs/queue"
 
+# The peer's system group: policy-extra install + self-restart, proxied by the
+# /api/v1/nodes/{instance_id}/policy-extra/* and /restart routes.
+SYSTEM_PATH = "/api/v1/system"
+
 # A peer verified within this window is trusted without a re-probe; listing
 # re-probes anything older. Also the back-off floor for unreachable peers, so
 # a down host is retried once per window instead of on every list().
@@ -446,6 +450,35 @@ class NodeRegistry:
         """Forward DELETE /api/v1/jobs/{job_id} to the peer (204, no body)."""
         return self._send_peer_request(instance_id, "DELETE", self._job_path(job_id))
 
+    @staticmethod
+    def _policy_extra_path(policy_type: str) -> str:
+        """The peer's own path for one policy's extra; the type is data."""
+        return f"{SYSTEM_PATH}/policy-extra/{quote(policy_type, safe='')}"
+
+    def fetch_peer_policy_extra(self, instance_id: str, policy_type: str) -> Any:
+        """The peer's own GET /api/v1/system/policy-extra/{policy_type} body —
+        whether the extra a policy needs is importable in THE PEER's
+        environment, which is the one the offloaded run will import from."""
+        return self._fetch_peer_path(instance_id, self._policy_extra_path(policy_type))
+
+    def fetch_peer_policy_extra_status(self, instance_id: str, policy_type: str) -> Any:
+        """The peer's own GET .../policy-extra/{policy_type}/install-status
+        body. The peer drains pending log lines per call, so this is
+        incremental, like the job-log proxy."""
+        return self._fetch_peer_path(instance_id, self._policy_extra_path(policy_type) + "/install-status")
+
+    def install_peer_policy_extra(self, instance_id: str, policy_type: str) -> Any:
+        """Forward POST .../policy-extra/{policy_type}/install to the peer:
+        the pip subprocess runs THERE, in the peer's own environment."""
+        return self._send_peer_request(instance_id, "POST", self._policy_extra_path(policy_type) + "/install")
+
+    def restart_peer(self, instance_id: str) -> Any:
+        """Forward POST /api/v1/system/restart to the peer. The peer answers
+        first and re-execs after a grace delay, so a 200 here means the
+        restart is SCHEDULED — the registry will see the node flap
+        unreachable and recover on its own probes."""
+        return self._send_peer_request(instance_id, "POST", SYSTEM_PATH + "/restart")
+
     def _peer_client(self) -> httpx.Client:
         """An httpx client for PEER traffic: trust_env=False, always.
 
@@ -787,6 +820,63 @@ def handle_delete_node_job(instance_id: str, job_id: str) -> None:
     node.unreachable, and 404 node.not_found names an unknown node."""
     try:
         node_registry.delete_peer_job(instance_id, job_id)
+    except NodeNotFoundError as exc:
+        raise ApiError(status_code=404, detail=str(exc), code=ErrorCode.NODE_NOT_FOUND) from exc
+    except PeerJobRefusalError as exc:
+        raise _peer_refusal_to_api_error(exc) from exc
+    except NodeUnreachableError as exc:
+        raise ApiError(status_code=502, detail=str(exc), code=ErrorCode.NODE_UNREACHABLE) from exc
+
+
+def handle_get_node_policy_extra(instance_id: str, policy_type: str) -> Any:
+    """Extra-status proxy for GET /api/v1/nodes/{instance_id}/policy-extra/
+    {policy_type}: whether the PEER's environment can import what the policy
+    needs — the local answer is irrelevant to an offloaded run. Same error
+    mapping as the other GET proxies."""
+    try:
+        return node_registry.fetch_peer_policy_extra(instance_id, policy_type)
+    except NodeNotFoundError as exc:
+        raise ApiError(status_code=404, detail=str(exc), code=ErrorCode.NODE_NOT_FOUND) from exc
+    except NodeUnreachableError as exc:
+        raise ApiError(status_code=502, detail=str(exc), code=ErrorCode.NODE_UNREACHABLE) from exc
+
+
+def handle_get_node_policy_extra_status(instance_id: str, policy_type: str) -> Any:
+    """Install-progress proxy for GET .../policy-extra/{policy_type}/
+    install-status; incremental per call (the peer drains its pending log
+    lines), same error mapping as the GET proxies."""
+    try:
+        return node_registry.fetch_peer_policy_extra_status(instance_id, policy_type)
+    except NodeNotFoundError as exc:
+        raise ApiError(status_code=404, detail=str(exc), code=ErrorCode.NODE_NOT_FOUND) from exc
+    except NodeUnreachableError as exc:
+        raise ApiError(status_code=502, detail=str(exc), code=ErrorCode.NODE_UNREACHABLE) from exc
+
+
+def handle_install_node_policy_extra(instance_id: str, policy_type: str) -> Any:
+    """Forwarded install for POST .../policy-extra/{policy_type}/install: the
+    pip subprocess runs on the peer, in the environment its jobs import from.
+    Mutation stance, like the stop/delete proxies: the peer's own refusals
+    pass through with THEIR status and body; only transport failure is 502
+    node.unreachable, and 404 node.not_found names an unknown node."""
+    try:
+        return node_registry.install_peer_policy_extra(instance_id, policy_type)
+    except NodeNotFoundError as exc:
+        raise ApiError(status_code=404, detail=str(exc), code=ErrorCode.NODE_NOT_FOUND) from exc
+    except PeerJobRefusalError as exc:
+        raise _peer_refusal_to_api_error(exc) from exc
+    except NodeUnreachableError as exc:
+        raise ApiError(status_code=502, detail=str(exc), code=ErrorCode.NODE_UNREACHABLE) from exc
+
+
+def handle_restart_node(instance_id: str) -> Any:
+    """Forwarded restart for POST /api/v1/nodes/{instance_id}/restart. Same
+    mutation stance: the peer's coded refusals (409 session.held /
+    robot.busy.training / system.restart_unsupported — and a plain 404 from
+    a peer too old to have the endpoint) keep THEIR status and body; only
+    transport failure is 502 node.unreachable."""
+    try:
+        return node_registry.restart_peer(instance_id)
     except NodeNotFoundError as exc:
         raise ApiError(status_code=404, detail=str(exc), code=ErrorCode.NODE_NOT_FOUND) from exc
     except PeerJobRefusalError as exc:

--- a/makermodslab/schemas/system.py
+++ b/makermodslab/schemas/system.py
@@ -29,7 +29,12 @@ from makermodslab.update import UpdateResult, UpdateStatus
 
 # Handlers in makermodslab/utils/system.py return dicts with exactly these
 # fields (InstallManager.start / .get_status and handle_get_*_extra).
-from makermodslab.utils.system import ExtraStatus, InstallStartResponse, InstallStatusResponse
+from makermodslab.utils.system import (
+    ExtraStatus,
+    InstallStartResponse,
+    InstallStatusResponse,
+    RestartResponse,
+)
 
 __all__ = [
     "AvailableCamerasResponse",
@@ -45,6 +50,7 @@ __all__ = [
     "PolicyExtraStatus",
     "PolicyOptimizerDefaultsResponse",
     "PolicyOptimizerPreset",
+    "RestartResponse",
     "RobotPortResponse",
     "SupplyVoltageResponse",
     "UpdateResult",

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -85,6 +85,7 @@ from .jobs import (
     _list_local_checkpoints,
     hub_ref_repo_id,
     job_registry,
+    training_is_active,
 )
 from .merge import MergeRequest, handle_merge_status, handle_start_merge
 from .motor_power import read_supply_voltage
@@ -96,10 +97,14 @@ from .nodes import (
     handle_get_node_job,
     handle_get_node_job_logs,
     handle_get_node_jobs,
+    handle_get_node_policy_extra,
+    handle_get_node_policy_extra_status,
     handle_get_node_queue,
+    handle_install_node_policy_extra,
     handle_list_node_sources,
     handle_list_nodes,
     handle_remove_node,
+    handle_restart_node,
     handle_stop_node_job,
 )
 
@@ -202,6 +207,7 @@ from .schemas.system import (
     InstallStatusResponse,
     PolicyExtraStatus,
     PolicyOptimizerDefaultsResponse,
+    RestartResponse,
     RobotPortResponse,
     SupplyVoltageResponse,
     UpdateResult,
@@ -212,6 +218,7 @@ from .sessions import (
     handle_heartbeat_session,
     handle_start_session,
     handle_stop_session,
+    held_by,
 )
 
 # Import our custom teleoperation functionality
@@ -275,8 +282,11 @@ from .utils.system import (
     handle_install_training_extra_status,
     handle_install_wandb_extra,
     handle_install_wandb_extra_status,
+    install_in_progress,
     open_folder_in_file_browser,
     probe_gpu,
+    restart_supported,
+    schedule_restart,
     warn_if_cuda_mismatch,
 )
 from .wiggle import wiggle_gripper
@@ -1024,6 +1034,57 @@ def delete_node_job(instance_id: str, job_id: str):
     job.not_found, …) keep THEIR status and body; only transport-level failure
     is 502 node.unreachable, and 404 node.not_found names an unknown node."""
     handle_delete_node_job(instance_id, job_id)
+
+
+@v1_router.get(
+    "/nodes/{instance_id}/policy-extra/{policy_type}", response_model=PolicyExtraStatus, tags=["nodes"]
+)
+def get_node_policy_extra(instance_id: str, policy_type: str):
+    """Environment proxy: the peer's own GET /api/v1/system/policy-extra/
+    {policy_type}, passed through — whether the extra the policy needs is
+    importable in THE PEER's environment, the one an offloaded run imports
+    from (the local answer is irrelevant to it). Same error mapping as the
+    other GET proxies: 404 node.not_found for an unknown instance_id, 502
+    node.unreachable for ANY failure to read the peer."""
+    return handle_get_node_policy_extra(instance_id, policy_type)
+
+
+@v1_router.get(
+    "/nodes/{instance_id}/policy-extra/{policy_type}/install-status",
+    response_model=InstallStatusResponse,
+    tags=["nodes"],
+)
+def get_node_policy_extra_status(instance_id: str, policy_type: str):
+    """The peer's own install-status, passed through. The peer drains pending
+    pip log lines per call, so this proxy is inherently incremental — like
+    the job-log proxy. Same error mapping as the GET proxies."""
+    return handle_get_node_policy_extra_status(instance_id, policy_type)
+
+
+@v1_router.post(
+    "/nodes/{instance_id}/policy-extra/{policy_type}/install",
+    response_model=InstallStartResponse,
+    tags=["nodes"],
+)
+def install_node_policy_extra(instance_id: str, policy_type: str):
+    """Forward the install to the peer: `pip install lerobot[<extra>]` runs
+    THERE, in the environment its training subprocesses import from. Mutation
+    stance, like the stop/delete proxies: the peer's own refusals keep THEIR
+    status and body; only transport-level failure is 502 node.unreachable,
+    and 404 node.not_found names an unknown node."""
+    return handle_install_node_policy_extra(instance_id, policy_type)
+
+
+@v1_router.post("/nodes/{instance_id}/restart", response_model=RestartResponse, tags=["nodes"])
+def restart_node(instance_id: str):
+    """Forward a restart to the peer (its own POST /api/v1/system/restart).
+    200 means the peer ANSWERED and scheduled its re-exec — expect it to flap
+    unreachable for a few seconds; the registry's probes pick it back up. The
+    peer's coded refusals (409 session.held / robot.busy.training /
+    system.restart_unsupported — or a plain 404 from a peer too old to have
+    the endpoint) pass through with THEIR status and body; only transport
+    failure is 502 node.unreachable."""
+    return handle_restart_node(instance_id)
 
 
 @v1_router.delete("/nodes/{instance_id}", response_model=NodeRemoveResponse, tags=["nodes"])
@@ -2848,6 +2909,70 @@ def install_policy_extra(policy_type: str):
 def install_policy_extra_status(policy_type: str):
     """Return the policy extra's install state plus any pending log lines (drained on read)."""
     return handle_install_policy_extra_status(policy_type)
+
+
+# The busy matrix's discriminants, for the restart refusal: the same
+# robot.busy.<feature> code the holder's own start-refusals use, so a client
+# learns WHAT holds the machine from the code alone.
+_HOLDER_BUSY_CODES: dict[str, ErrorCode] = {
+    "recording": ErrorCode.ROBOT_BUSY_RECORDING,
+    "teleoperation": ErrorCode.ROBOT_BUSY_TELEOPERATION,
+    "inference": ErrorCode.ROBOT_BUSY_INFERENCE,
+    "replay": ErrorCode.ROBOT_BUSY_REPLAY,
+    "calibration": ErrorCode.ROBOT_BUSY_CALIBRATION,
+    "auto_calibration": ErrorCode.ROBOT_BUSY_AUTO_CALIBRATION,
+    "wiggle": ErrorCode.ROBOT_BUSY_WIGGLE,
+}
+
+
+@v1_router.post("/system/restart", response_model=RestartResponse, tags=["system"])
+def restart_server():
+    """Re-exec this server process in place (same argv/env/PID), so a remote
+    operator — the node-proxy POST /api/v1/nodes/{id}/restart — can bounce a
+    headless station without a shell on it. Answers FIRST, re-execs after a
+    short grace delay so this response reaches the client.
+
+    Refusals, all 409: a live robot flow (robot.busy.<feature> — killing the
+    server mid-flow drops the hardware threads with it), a running or queued
+    training run (robot.busy.training — the loader retires both on startup),
+    and a process that cannot safely re-exec (system.restart_unsupported: a
+    dev reload worker, a non-entry-point launch, or Windows)."""
+    holder = held_by()
+    if holder is not None:
+        raise ApiError(
+            status_code=409,
+            detail=f"Cannot restart while {holder} is active — stop it first.",
+            code=_HOLDER_BUSY_CODES.get(holder, ErrorCode.SESSION_HELD),
+        )
+    running = training_is_active()
+    if running is not None:
+        raise ApiError(
+            status_code=409,
+            detail=f"Cannot restart while a local training run ({running}) is active — stop it first.",
+            code=ErrorCode.ROBOT_BUSY_TRAINING,
+        )
+    queued = job_registry.list_queue()
+    if queued:
+        raise ApiError(
+            status_code=409,
+            detail=(
+                f"Cannot restart with {len(queued)} queued training run(s) — "
+                "the restart would retire the queue. Cancel them first."
+            ),
+            code=ErrorCode.ROBOT_BUSY_TRAINING,
+        )
+    installing = install_in_progress()
+    if installing is not None:
+        raise ApiError(
+            status_code=409,
+            detail=f"Cannot restart while '{installing}' is installing — wait for it to finish.",
+            code=ErrorCode.SYSTEM_INSTALL_IN_PROGRESS,
+        )
+    supported, why = restart_supported()
+    if not supported:
+        raise ApiError(status_code=409, detail=why, code=ErrorCode.SYSTEM_RESTART_UNSUPPORTED)
+    schedule_restart()
+    return {"restarting": True, "message": "Restarting — the server will be back in a few seconds."}
 
 
 @router.get("/system/update-check", response_model=UpdateStatus, tags=["system"])

--- a/makermodslab/sessions.py
+++ b/makermodslab/sessions.py
@@ -441,6 +441,12 @@ def _held_by() -> str | None:
     return None
 
 
+def held_by() -> str | None:
+    """Public read of the busy matrix, for callers OUTSIDE the session surface
+    (the restart guard): which feature's flag holds the hardware, or None."""
+    return _held_by()
+
+
 def _raise_held(holder_kind: str | None, message: str) -> None:
     """409 session.held, with details naming the holder as precisely as the
     tracker can: its session id when the tracker saw the claim, else null

--- a/makermodslab/utils/system.py
+++ b/makermodslab/utils/system.py
@@ -72,16 +72,42 @@ def _extra_available(module: str) -> bool:
         return False
 
 
+# Where the standard installers put uv when it is NOT on this process's PATH —
+# a headless server started over ssh/nohup gets a minimal PATH without
+# ~/.local/bin, and the whole point of the uv branch below is that a uv venv
+# has no pip to fall back to (field-debugged on a remote node whose installs
+# all died with "pip exited with code 1"). Same disease, same cure as the
+# macOS tailscale CLI lookup in node_sources.py.
+_UV_FALLBACK_PATHS = (
+    os.path.expanduser("~/.local/bin/uv"),  # the uv installer's default target
+    "/opt/homebrew/bin/uv",
+    "/usr/local/bin/uv",
+)
+
+
+def _find_uv() -> str | None:
+    """The uv binary to run: PATH first, then the standard install locations."""
+    found = shutil.which("uv")
+    if found:
+        return found
+    for candidate in _UV_FALLBACK_PATHS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def _build_install_cmd(package: str) -> list[str]:
     """Pick the best installer for the running Python.
 
     Venvs created with `uv venv` don't ship pip, so `python -m pip` fails with
-    `No module named pip`. Detect uv on PATH and use it with --python pinned to
-    sys.executable so the install lands in this Python's site-packages.
-    Otherwise fall back to `python -m pip`.
+    `No module named pip`. Find uv (PATH, then the standard install
+    locations) and use it with --python pinned to sys.executable so the
+    install lands in this Python's site-packages. Otherwise fall back to
+    `python -m pip`.
     """
-    if shutil.which("uv"):
-        return ["uv", "pip", "install", "--python", sys.executable, package]
+    uv = _find_uv()
+    if uv:
+        return [uv, "pip", "install", "--python", sys.executable, package]
     return [sys.executable, "-m", "pip", "install", package]
 
 
@@ -312,6 +338,82 @@ def handle_install_policy_extra_status(policy_type: str) -> dict[str, Any]:
     if mgr is None:
         return {"state": "done", "error": None, "logs": []}
     return mgr.get_status()
+
+
+# --------------------------------------------------------------------------- #
+# Self-restart
+# --------------------------------------------------------------------------- #
+# POST /api/v1/system/restart re-execs this process in place so a remote
+# operator (the node proxies) can bounce a headless station without a shell on
+# it. os.execv keeps PID, argv, env, cwd and the std FDs (a nohup log redirect
+# survives), while every other FD — the uvicorn listen socket included — closes
+# on exec (PEP 446), so the relaunched process binds the port cleanly.
+
+RESTART_DELAY_S = 1.0
+# The launcher entry points (pyproject [project.scripts]) — the only argv[0]s
+# we KNOW re-run the launcher when re-executed.
+_RESTART_ENTRY_POINTS = ("makermodslab", "makermodslab-station")
+
+
+def install_in_progress() -> str | None:
+    """The package a live InstallManager is installing right now, or None.
+
+    A restart guard: re-exec would orphan the pip subprocess mid-write and
+    leave a half-installed site-packages, so the restart route refuses while
+    any install (training/wandb/policy extras) is running.
+    """
+    managers = [training_install_manager, wandb_install_manager, *_policy_install_managers.values()]
+    for mgr in managers:
+        if mgr.state == "installing":
+            return mgr.package
+    return None
+
+
+def restart_supported() -> tuple[bool, str]:
+    """Whether this process can safely re-exec itself; (False, why) if not.
+
+    Only a POSIX process whose argv[0] is one of our launcher entry points
+    qualifies: there, ``execv(sys.executable, [sys.executable, *sys.argv])``
+    re-runs the launcher with identical arguments. A dev-mode reload worker
+    (uvicorn --reload spawns it via multiprocessing; argv is not the
+    launcher) must never execv — uvicorn's reloader already restarts it on
+    any code change. Windows is excluded: its execv spawns a NEW process and
+    returns in the caller, which would leave two servers fighting over the
+    port.
+    """
+    if os.name != "posix":
+        return False, "restart-in-place is not supported on this platform"
+    argv0 = os.path.basename(sys.argv[0]) if sys.argv and sys.argv[0] else ""
+    if argv0 not in _RESTART_ENTRY_POINTS:
+        return False, (
+            f"this process was not started by a MakerMods Lab entry point (argv[0]={argv0!r}) — "
+            "restart it the way it was started (dev mode auto-reloads on code changes)"
+        )
+    return True, ""
+
+
+def schedule_restart(delay_s: float = RESTART_DELAY_S, execv=os.execv) -> threading.Thread:
+    """Re-exec this process after ``delay_s`` (from a daemon thread).
+
+    The delay lets the HTTP response that announced the restart actually
+    reach the client before the connection dies with the process. ``execv``
+    is injectable for tests — the real one never returns. Returns the thread
+    so a test can join an injected no-op execv.
+    """
+
+    def _restart() -> None:
+        time.sleep(delay_s)
+        logger.info("🔄 Restarting: re-exec %s %s", sys.executable, " ".join(sys.argv))
+        execv(sys.executable, [sys.executable, *sys.argv])
+
+    thread = threading.Thread(target=_restart, name="self-restart", daemon=True)
+    thread.start()
+    return thread
+
+
+class RestartResponse(BaseModel):
+    restarting: bool
+    message: str
 
 
 # Detect the common Windows/MakerMods Lab mismatch where an NVIDIA GPU is visible to the

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -235,6 +235,17 @@ V1_ONLY_ROUTES: frozenset[str] = frozenset(
         "GET /api/v1/nodes/{instance_id}/jobs/{job_id}/logs",
         "POST /api/v1/nodes/{instance_id}/jobs/{job_id}/stop",
         "DELETE /api/v1/nodes/{instance_id}/jobs/{job_id}",
+        # Environment proxies: the peer's own policy-extra status / install /
+        # install-progress (the pip subprocess runs on the PEER), plus the
+        # forwarded self-restart that makes a just-installed environment
+        # reachable without a shell on the node.
+        "GET /api/v1/nodes/{instance_id}/policy-extra/{policy_type}",
+        "GET /api/v1/nodes/{instance_id}/policy-extra/{policy_type}/install-status",
+        "POST /api/v1/nodes/{instance_id}/policy-extra/{policy_type}/install",
+        "POST /api/v1/nodes/{instance_id}/restart",
+        # Self-restart (the peer half of the proxy above): re-exec in place,
+        # guarded by the busy matrix + the training queue.
+        "POST /api/v1/system/restart",
         # Local training queue (PR #83): the machine's plan, in run order, and
         # the whole-list reorder that goes with it.
         "GET /api/v1/jobs/queue",

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -43,6 +43,7 @@ DOMAINS = frozenset(
         "checkpoint",
         "session",
         "node",
+        "system",
         "internal",
     ]
 )

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -82,6 +82,13 @@ class FakeNetwork:
         # None ⇒ an empty response (the peer's own DELETE answers 204).
         self.stop_results: dict[tuple[str, str], tuple[int, dict | None]] = {}
         self.delete_results: dict[tuple[str, str], tuple[int, dict | None]] = {}
+        # The peer's system group, for the environment proxies: policy-extra
+        # status docs keyed (base url, policy type), install/restart answers
+        # programmed like the stop/delete forwards above.
+        self.policy_extras: dict[tuple[str, str], dict] = {}
+        self.extra_statuses: dict[tuple[str, str], dict] = {}
+        self.extra_install_results: dict[tuple[str, str], tuple[int, dict | None]] = {}
+        self.restart_results: dict[str, tuple[int, dict | None]] = {}
         self.down: set[str] = set()
         self.probes: dict[str, int] = {}
         # Every request that reached the transport, for asserting what the
@@ -110,6 +117,25 @@ class FakeNetwork:
                 if base not in self.peers:
                     return httpx.Response(404, json={"detail": "Not Found"})
                 return httpx.Response(200, json=self.peers[base])
+            # The peer's system group: policy-extra + self-restart (the
+            # environment proxies).
+            if path == "/api/v1/system/restart":
+                assert request.method == "POST", f"restart must be POSTed, got {request.method}"
+                status, body = self.restart_results.get(base, (404, {"detail": "Not Found"}))
+                return httpx.Response(status) if body is None else httpx.Response(status, json=body)
+            extra = re.fullmatch(r"/api/v1/system/policy-extra/([^/]+)(?:/(install|install-status))?", path)
+            if extra:
+                key = (base, extra.group(1))
+                not_found = {"detail": "Not Found"}
+                if extra.group(2) == "install":
+                    assert request.method == "POST"
+                    status, body = self.extra_install_results.get(key, (404, not_found))
+                    return httpx.Response(status) if body is None else httpx.Response(status, json=body)
+                assert request.method == "GET"
+                docs = self.extra_statuses if extra.group(2) == "install-status" else self.policy_extras
+                if key not in docs:
+                    return httpx.Response(404, json=not_found)
+                return httpx.Response(200, json=docs[key])
             # The peer's own per-job surface: /api/v1/jobs/{id}[/logs|/stop].
             match = re.fullmatch(r"/api/v1/jobs/([^/]+)(?:/(logs|stop))?", path)
             assert match, f"unexpected probe path: {request.url}"
@@ -1218,6 +1244,139 @@ def test_node_job_delete_dead_peer_502(client, api_registry, network):
     client.post("/api/v1/nodes", json={"url": PEER_A_URL})
     network.down.add(PEER_A_URL)
     resp = client.delete(f"/api/v1/nodes/{PEER_A_ID}/jobs/job-1")
+    assert resp.status_code == 502
+    assert resp.json()["code"] == "node.unreachable"
+
+
+def _extra_doc(available: bool = False) -> dict:
+    """A PolicyExtraStatus as the peer's own GET serves it — built from the
+    real handler's shape, because the peer runs this same code."""
+    return {
+        "policy_type": "smolvla",
+        "needs_extra": True,
+        "available": available,
+        "package": "transformers",
+        "install_target": "lerobot[smolvla]",
+        "install_hint": "pip install 'lerobot[smolvla]'",
+    }
+
+
+def test_node_policy_extra_proxies_the_peers_answer(client, api_registry, network):
+    """The proxy answers with the PEER's environment, not the local one — the
+    offloaded run imports from the peer's site-packages."""
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.policy_extras[(PEER_A_URL, "smolvla")] = _extra_doc(available=False)
+    resp = client.get(f"/api/v1/nodes/{PEER_A_ID}/policy-extra/smolvla")
+    assert resp.status_code == 200
+    assert resp.json()["needs_extra"] is True
+    assert resp.json()["available"] is False
+    assert resp.json()["install_target"] == "lerobot[smolvla]"
+    forwarded = [(m, u) for m, u in network.requests if "policy-extra" in u]
+    assert forwarded == [("GET", f"{PEER_A_URL}/api/v1/system/policy-extra/smolvla")]
+
+
+def test_node_policy_extra_unknown_node_404(client, api_registry):
+    resp = client.get("/api/v1/nodes/deadbeef/policy-extra/smolvla")
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "node.not_found"
+
+
+def test_node_policy_extra_dead_peer_502(client, api_registry, network):
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.down.add(PEER_A_URL)
+    resp = client.get(f"/api/v1/nodes/{PEER_A_ID}/policy-extra/smolvla")
+    assert resp.status_code == 502
+    assert resp.json()["code"] == "node.unreachable"
+
+
+def test_node_policy_extra_install_forwards_post(client, api_registry, network):
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.extra_install_results[(PEER_A_URL, "smolvla")] = (
+        200,
+        {"started": True, "message": "Install started"},
+    )
+    resp = client.post(f"/api/v1/nodes/{PEER_A_ID}/policy-extra/smolvla/install")
+    assert resp.status_code == 200
+    assert resp.json() == {"started": True, "message": "Install started"}
+    forwarded = [(m, u) for m, u in network.requests if u.endswith("/install")]
+    assert forwarded == [("POST", f"{PEER_A_URL}/api/v1/system/policy-extra/smolvla/install")]
+
+
+def test_node_policy_extra_install_peer_refusal_passes_through(client, api_registry, network):
+    """A peer that answered with an error keeps ITS status and body — same
+    mutation stance as the forwarded stop/delete."""
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.extra_install_results[(PEER_A_URL, "smolvla")] = (
+        500,
+        {"detail": "pip exploded"},
+    )
+    resp = client.post(f"/api/v1/nodes/{PEER_A_ID}/policy-extra/smolvla/install")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "pip exploded"
+
+
+def test_node_policy_extra_install_dead_peer_502(client, api_registry, network):
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.down.add(PEER_A_URL)
+    resp = client.post(f"/api/v1/nodes/{PEER_A_ID}/policy-extra/smolvla/install")
+    assert resp.status_code == 502
+    assert resp.json()["code"] == "node.unreachable"
+
+
+def test_node_policy_extra_status_proxies_progress(client, api_registry, network):
+    """The install-status proxy is incremental like the log-tail proxy: the
+    peer drains pending pip lines per call, whoever made it."""
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.extra_statuses[(PEER_A_URL, "smolvla")] = {
+        "state": "installing",
+        "error": None,
+        "logs": [{"timestamp": 1.0, "message": "Collecting transformers"}],
+    }
+    resp = client.get(f"/api/v1/nodes/{PEER_A_ID}/policy-extra/smolvla/install-status")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "installing"
+    assert resp.json()["logs"][0]["message"] == "Collecting transformers"
+
+
+def test_node_restart_forwards_and_returns_the_peers_answer(client, api_registry, network):
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.restart_results[PEER_A_URL] = (
+        200,
+        {"restarting": True, "message": "Restarting — the server will be back in a few seconds."},
+    )
+    resp = client.post(f"/api/v1/nodes/{PEER_A_ID}/restart")
+    assert resp.status_code == 200
+    assert resp.json()["restarting"] is True
+    forwarded = [(m, u) for m, u in network.requests if u.endswith("/system/restart")]
+    assert forwarded == [("POST", f"{PEER_A_URL}/api/v1/system/restart")]
+
+
+def test_node_restart_peer_refusal_passes_through(client, api_registry, network):
+    """The peer's own busy guard travels back whole: a node mid-training says
+    WHY it refused, with its own status and code."""
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.restart_results[PEER_A_URL] = (
+        409,
+        {"detail": "Cannot restart while a local training run is active.", "code": "robot.busy.training"},
+    )
+    resp = client.post(f"/api/v1/nodes/{PEER_A_ID}/restart")
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "robot.busy.training"
+
+
+def test_node_restart_old_peer_404_passes_through(client, api_registry, network):
+    """A peer too old to have the endpoint answers a plain 404 — that verdict
+    reaches the caller as-is (degradation, not unreachable)."""
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    resp = client.post(f"/api/v1/nodes/{PEER_A_ID}/restart")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Not Found"
+
+
+def test_node_restart_dead_peer_502(client, api_registry, network):
+    client.post("/api/v1/nodes", json={"url": PEER_A_URL})
+    network.down.add(PEER_A_URL)
+    resp = client.post(f"/api/v1/nodes/{PEER_A_ID}/restart")
     assert resp.status_code == 502
     assert resp.json()["code"] == "node.unreachable"
 

--- a/tests/test_utils_system.py
+++ b/tests/test_utils_system.py
@@ -32,10 +32,13 @@ def test_build_install_cmd_contains_pip_and_package() -> None:
 def test_build_install_cmd_uses_current_python_when_no_uv(monkeypatch) -> None:
     import shutil
 
+    from makermodslab.utils import system
     from makermodslab.utils.system import _build_install_cmd
 
-    # If uv is not on PATH, command must use sys.executable.
+    # If uv is not on PATH (nor at any standard install location), the
+    # command must use sys.executable.
     monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(system, "_UV_FALLBACK_PATHS", ())
     cmd = _build_install_cmd("lerobot[training]")
     assert cmd[0] == sys.executable
     assert "pip" in cmd
@@ -266,6 +269,163 @@ def test_policy_extra_route_known_and_core(client) -> None:
     assert smol["install_target"] == "lerobot[smolvla]"
     core = client.get("/system/policy-extra/act").json()
     assert core["needs_extra"] is False
+
+
+# --- self-restart (POST /api/v1/system/restart) --------------------------------
+
+
+def test_build_install_cmd_falls_back_to_known_uv_locations(monkeypatch, tmp_path) -> None:
+    """A headless server started over ssh/nohup gets a PATH without
+    ~/.local/bin — uv must still be found at its standard install target,
+    because a uv venv has no pip to fall back to."""
+    import shutil
+
+    from makermodslab.utils import system
+
+    fake_uv = tmp_path / "uv"
+    fake_uv.write_text("#!/bin/sh\n")
+    fake_uv.chmod(0o755)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(system, "_UV_FALLBACK_PATHS", (str(fake_uv),))
+    cmd = system._build_install_cmd("lerobot[smolvla]")
+    assert cmd[0] == str(fake_uv)
+    assert "--python" in cmd and sys.executable in cmd
+
+
+def test_install_in_progress_reports_the_live_package(monkeypatch) -> None:
+    from makermodslab.utils import system
+
+    assert system.install_in_progress() is None
+    mgr = system.InstallManager("lerobot[smolvla]")
+    mgr.state = "installing"
+    monkeypatch.setitem(system._policy_install_managers, "lerobot[smolvla]", mgr)
+    assert system.install_in_progress() == "lerobot[smolvla]"
+
+
+def test_restart_supported_only_for_entry_point_argv(monkeypatch) -> None:
+    """Only a launch we KNOW re-runs the launcher (argv[0] is one of our entry
+    points) may execv; a dev reload worker or a bare `python -m` must not."""
+    from makermodslab.utils import system
+
+    monkeypatch.setattr(sys, "argv", ["/some/.venv/bin/makermodslab", "--lan"])
+    supported, why = system.restart_supported()
+    assert supported is True and why == ""
+
+    monkeypatch.setattr(sys, "argv", ["/some/.venv/bin/makermodslab-station"])
+    assert system.restart_supported()[0] is True
+
+    monkeypatch.setattr(sys, "argv", ["-c"])  # a multiprocessing spawn worker
+    supported, why = system.restart_supported()
+    assert supported is False
+    assert "entry point" in why
+
+
+def test_restart_supported_posix_only(monkeypatch) -> None:
+    from makermodslab.utils import system
+
+    monkeypatch.setattr(system.os, "name", "nt")
+    monkeypatch.setattr(sys, "argv", ["C:/venv/Scripts/makermodslab"])
+    supported, why = system.restart_supported()
+    assert supported is False
+    assert "platform" in why
+
+
+def test_schedule_restart_execs_same_argv(monkeypatch) -> None:
+    """The re-exec must reproduce this exact process: same interpreter, same
+    argv — that is the whole restart contract."""
+    from makermodslab.utils import system
+
+    monkeypatch.setattr(sys, "argv", ["/venv/bin/makermodslab", "--lan", "--bind", "tailscale0"])
+    calls: list[tuple[str, list[str]]] = []
+    thread = system.schedule_restart(delay_s=0, execv=lambda exe, argv: calls.append((exe, argv)))
+    thread.join(timeout=5)
+    assert calls == [
+        (sys.executable, [sys.executable, "/venv/bin/makermodslab", "--lan", "--bind", "tailscale0"])
+    ]
+
+
+def test_restart_route_refuses_while_a_feature_holds_the_robot(client, monkeypatch) -> None:
+    """Killing the server mid-flow drops the hardware threads with it, so the
+    refusal carries the holder's own busy discriminant."""
+    from makermodslab import server
+
+    monkeypatch.setattr(server, "held_by", lambda: "teleoperation")
+    resp = client.post("/api/v1/system/restart")
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "robot.busy.teleoperation"
+
+
+def test_restart_route_refuses_while_training_runs(client, monkeypatch) -> None:
+    from makermodslab import server
+
+    monkeypatch.setattr(server, "held_by", lambda: None)
+    monkeypatch.setattr(server, "training_is_active", lambda: "act_so101_run")
+    resp = client.post("/api/v1/system/restart")
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "robot.busy.training"
+
+
+def test_restart_route_refuses_while_an_install_runs(client, monkeypatch) -> None:
+    """Re-exec would orphan the pip subprocess mid-write — refuse until it
+    finishes."""
+    from makermodslab import server
+
+    monkeypatch.setattr(server, "held_by", lambda: None)
+    monkeypatch.setattr(server, "training_is_active", lambda: None)
+    monkeypatch.setattr(server.job_registry, "list_queue", lambda: [])
+    monkeypatch.setattr(server, "install_in_progress", lambda: "lerobot[smolvla]")
+    resp = client.post("/api/v1/system/restart")
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "system.install_in_progress"
+    assert "lerobot[smolvla]" in resp.json()["detail"]
+
+
+def test_restart_route_refuses_with_a_queued_run(client, monkeypatch) -> None:
+    """The loader retires queued records on startup — a restart would silently
+    eat the queue, so it refuses instead."""
+    from makermodslab import server
+
+    monkeypatch.setattr(server, "held_by", lambda: None)
+    monkeypatch.setattr(server, "training_is_active", lambda: None)
+    monkeypatch.setattr(server.job_registry, "list_queue", lambda: [object()])
+    resp = client.post("/api/v1/system/restart")
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "robot.busy.training"
+    assert "queued" in resp.json()["detail"]
+
+
+def test_restart_route_refuses_when_unsupported(client, monkeypatch) -> None:
+    """Under pytest argv[0] is not a launcher entry point, so the REAL
+    restart_supported refuses — no monkeypatching the gate itself."""
+    from makermodslab import server
+
+    monkeypatch.setattr(server, "held_by", lambda: None)
+    monkeypatch.setattr(server, "training_is_active", lambda: None)
+    monkeypatch.setattr(server.job_registry, "list_queue", lambda: [])
+    resp = client.post("/api/v1/system/restart")
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "system.restart_unsupported"
+
+
+def test_restart_route_answers_then_schedules(client, monkeypatch) -> None:
+    from makermodslab import server
+
+    monkeypatch.setattr(server, "held_by", lambda: None)
+    monkeypatch.setattr(server, "training_is_active", lambda: None)
+    monkeypatch.setattr(server.job_registry, "list_queue", lambda: [])
+    monkeypatch.setattr(server, "restart_supported", lambda: (True, ""))
+    scheduled: list[int] = []
+    monkeypatch.setattr(server, "schedule_restart", lambda: scheduled.append(1))
+    resp = client.post("/api/v1/system/restart")
+    assert resp.status_code == 200
+    assert resp.json()["restarting"] is True
+    assert scheduled == [1]
+
+
+def test_restart_route_is_v1_only(client) -> None:
+    """New surface never lands on the frozen flat mount."""
+    resp = client.post("/system/restart")
+    assert resp.status_code in {404, 405}
 
 
 def test_torchcodec_probe_caches_and_reports(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -979,8 +979,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 test = [
@@ -994,10 +996,10 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27" },
     { name = "lerobot", extras = ["core-scripts", "feetech", "training"], git = "https://github.com/huggingface/lerobot.git?rev=v0.6.0" },
+    { name = "makermodslab", extras = ["test"], marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pygrabber", marker = "sys_platform == 'win32'", specifier = ">=0.2" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
@@ -1759,8 +1761,8 @@ name = "pygrabber"
 version = "0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comtypes", marker = "sys_platform != 'linux'" },
-    { name = "numpy", marker = "sys_platform != 'linux'" },
+    { name = "comtypes", marker = "sys_platform == 'win32'" },
+    { name = "numpy", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/24/e7e5efa1d915853f3f34cedf751cbee9d88bee47a41122d495ee95452dad/pygrabber-0.2.tar.gz", hash = "sha256:e584b119d4c9b9a8f339eb34d1fe7fdd16214a2bf5a1876171145caebdb9e413", size = 18487, upload-time = "2023-10-20T07:17:14.97Z" }
 wheels = [


### PR DESCRIPTION
## Why

Offloading a smolvla training to a LAN node died with a buried ImportError on the peer: the Start preflight only checked the **local** environment, and there was no way to put `lerobot[smolvla]` on a node without a shell on it.

## What

**Environment proxies (nodes tag, v1-only, typed):**
- `GET /api/v1/nodes/{id}/policy-extra/{policy_type}` — the peer's own answer: can *its* environment import what the policy needs (the local answer is irrelevant to an offloaded run).
- `POST .../install` + `GET .../install-status` — the pip subprocess runs **on the node**, in the environment its training subprocesses import from; progress logs stream back incrementally like the job-log proxy. The peer's refusals pass through with their status and body, same stance as the stop/delete proxies.

**Remote restart:**
- Peer-side `POST /api/v1/system/restart` re-execs the server process in place (`os.execv` — same PID/argv/env; the listen socket closes on exec and rebinds cleanly), proxied by `POST /api/v1/nodes/{id}/restart`.
- Guarded, all coded 409s: a live robot flow (`robot.busy.<feature>`), a running **or queued** training run (`robot.busy.training` — the loader retires both on startup), an in-flight pip install (`system.install_in_progress` — re-exec would orphan it mid-write), and a process that can't safely re-exec (`system.restart_unsupported`: dev reload worker, non-entry-point argv, Windows). New `system` error domain, added to the taxonomy test first.

**A real bug this surfaced, fixed here:** a headless server started over ssh/nohup has no `~/.local/bin` on PATH, so `_build_install_cmd` couldn't find uv and fell back to `python -m pip` — which doesn't exist in a uv venv, so **every** extra install on a remote node failed with "pip exited with code 1". uv is now looked up at its standard install locations too (same disease and cure as the macOS tailscale CLI lookup in node_sources).

**Frontend:** the Start preflight now asks the *node* when Compute is a LAN node and opens the install dialog in a node variant (named after the node, installing through the proxy with live logs); NodeDetailPanel gains a two-step arm/confirm **Restart node** button that disarms after 5s and recovers when the workload poll answers again. Strings in en + zh-CN.

## Contract

Five new `V1_ONLY_ROUTES` entries, all with response models; `system.restart_unsupported` / `system.install_in_progress` added grammar-first in tests/test_api_errors.py; openapi.json regenerated.

## Verified

- 2060 backend tests pass (new: proxy tests in test_nodes.py against the MockTransport fake network incl. peer-refusal passthrough and old-peer 404 degradation; restart guard/route/exec tests in test_utils_system.py with injected execv). ruff clean; both tsc projects clean; vitest and eslint at their pre-existing baselines; build passes.
- **End-to-end over a real tailnet node** (gavin-linux, RTX 5070 Ti): install proxy reported `transformers` missing → install ran on the node (uv logs streamed back) → availability flipped true; restart mid-install refused with `system.install_in_progress` through the proxy; restart while idle re-exec'd (log shows the re-exec line + second uvicorn boot) and came back on the same instance id. UI flow driven with Playwright: node selected, restart armed/confirmed, status line shown and cleared on recovery.

## Known adjacent issue (not addressed here)

`makermodslab --stop` cannot stop a *prod-mode* server: `_identity_reason` matches "makermodslab.server" in cmdlines, which only dev/uvicorn processes carry. Pre-existing; worth its own small fix.