### PR TITLE
Stop the 164 daemon threads the test suite leaks at exit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,55 @@ def _reset_hub_listing_caches() -> Iterator[None]:
     _reset_module_caches()
 
 
+@pytest.fixture(autouse=True)
+def _reap_job_registry_threads(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Stop the threads of every JobRegistry a test builds, after the test.
+
+    ~100 tests construct throwaway registries, and each one starts a
+    1s-interval "job-registry-watchdog" daemon thread that nothing stops — a
+    full run used to end with ~160 of them (plus a few runner tail/poll
+    threads) still parked in Event.wait at interpreter exit. Daemon threads
+    are normally frozen harmlessly at shutdown, but a teardown that catches
+    one inside native code aborts the process AFTER a fully green summary
+    (glibc's "FATAL: exception not rethrown", exit 134 — seen on the Linux CI
+    runner), which fails the job with zero failing tests.
+
+    Instances are tracked by wrapping __init__ (registries are created inside
+    test bodies, so no fixture can hand them out), then stopped the way the
+    app's own shutdown hook does: `shutdown()` sets the watchdog's stop event
+    and the thread exits within its 1s wait. Runner threads (job-tail-*,
+    hf-job-*) get their `_stop_event` set directly — deliberately NOT
+    `runner.stop()`, which for a tailing runner SIGTERMs a real process
+    group. The module-level `job_registry` singleton (created at import, one
+    thread, mirrors production's lifetime) is left alone.
+    """
+    import makermodslab.jobs as _jobs
+
+    created: list = []
+    real_init = _jobs.JobRegistry.__init__
+
+    def _tracking_init(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        real_init(self, *args, **kwargs)
+        created.append(self)
+
+    monkeypatch.setattr(_jobs.JobRegistry, "__init__", _tracking_init)
+    yield
+    for reg in created:
+        try:
+            reg.shutdown()
+            for runner in list(getattr(reg, "_runners", {}).values()):
+                stop_event = getattr(runner, "_stop_event", None)
+                if stop_event is not None:
+                    stop_event.set()
+        except Exception:
+            # Teardown must never fail a test that already passed.
+            pass
+    for reg in created:
+        thread = getattr(reg, "_watchdog_thread", None)
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=2.0)
+
+
 @pytest.fixture
 def mock_lerobot_record(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Patch `lerobot.record.record` so no real recording loop runs.


### PR DESCRIPTION
## Why

The Tests job on `fix/incomplete-hub-upload` failed with exit 134 **after a fully green summary** (`2202 passed, 2 skipped` → `FATAL: exception not rethrown` → core dump). That glibc abort happens when interpreter teardown catches a daemon thread inside native code — and an at-exit thread dump showed the suite ends with **164 non-main daemon threads still alive**, on `staging` and feature branches alike. Any branch can trip this; the PR that hit it merely lost the timing lottery.

## What leaks

Each of the ~100 tests that builds a throwaway `JobRegistry` starts a 1s-interval `job-registry-watchdog` daemon thread that nothing stops (~160 of the 164), plus a few `job-tail-*` / `hf-job-*` runner threads from reattach tests.

## Fix

One autouse conftest fixture tracks every `JobRegistry` constructed during a test (by wrapping `__init__` — registries are created inside test bodies, so no fixture can hand them out) and stops it afterwards the way the app's own shutdown hook does (`shutdown()` sets the watchdog's stop event; join with a 2 s cap). Runner threads get their `_stop_event` set directly — deliberately **not** `runner.stop()`, which for a tailing runner SIGTERMs a real process group. The import-time `job_registry` singleton is left alone: one thread, matching production's lifetime.

## Result

- `0` non-main threads alive at exit (was 164)
- 2183 passed, unchanged
- warnings drop ~1000 → ~18: most were stray watchdog ticks serializing `MagicMock` records after their test had ended (the `PydanticSerializationUnexpectedValue` spam in every CI log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDc45qRdaBnfi6sS96gWeG