### PR TITLE
fix(frontend): keep vitest's jsdom localStorage real on Node >=25

### DIFF
--- a/frontend/src/contexts/LanguageContext.test.tsx
+++ b/frontend/src/contexts/LanguageContext.test.tsx
@@ -27,6 +27,9 @@ function renderApp() {
 }
 
 afterEach(async () => {
+  // Reset both halves of the language state: i18next's active language and
+  // the persisted choice the next LanguageProvider would boot from.
+  localStorage.clear();
   await act(async () => {
     await i18n.changeLanguage("en");
   });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
+    // Node >=25 enables its experimental Web Storage by default, and without
+    // --localstorage-file the global is a method-less stub. Vitest never
+    // shadows an existing global, so jsdom's real localStorage is skipped and
+    // tests hit the stub. Disabling it here restores jsdom's Storage; the flag
+    // is a no-op on Node 22 (CI), where webstorage is off by default.
+    execArgv: ["--no-experimental-webstorage"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Problem

On Node >= 25, all 5 tests in `src/lib/onboarding/storage.test.ts` fail with `TypeError: localStorage.clear is not a function`, with the repo byte-identical to what passes CI.

Node 25 enables its experimental Web Storage API by default, and without `--localstorage-file` its global `localStorage` is a method-less stub (accessing it only emits a `--localstorage-file was provided without a valid path` warning). Vitest's jsdom environment never shadows a global that already exists on `globalThis`, so jsdom's real `Storage` was skipped and tests got the stub. CI runs Node 22, where webstorage is off by default — hence green there, broken on a Node 25 dev machine. `src/i18n/config.test.ts` already documents this exact shadowing hazard in a comment.

## Fix

- **`frontend/vitest.config.ts`**: pass `execArgv: ["--no-experimental-webstorage"]` to the test worker processes (top-level option; Vitest 4 removed `poolOptions`). Strips Node's stub so jsdom's real `localStorage` lands. No-op on Node 22.
- **`frontend/src/contexts/LanguageContext.test.tsx`**: add `localStorage.clear()` to the `afterEach`. A latent test-isolation bug the first fix unmasked: the language choice persists via `i18n/config.ts`, so once storage actually worked, the zh-CN test leaked into "switches back to English".

## Verification

On Node v25.2.1, from a clean `origin/staging` + this diff: `npx vitest run` 134/134 passing (was 5 failing), `npm run lint` / `npx tsc --noEmit -p tsconfig.app.json` / `npx tsc --noEmit -p tsconfig.node.json` / `npm run build` all at their staging baselines (the 4 lint errors are pre-existing in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5FVMB9UU3PXst3V2FCJSz