### PR TITLE
Fix false "Camera Already Added" rejection from a stale saved camera index

### DIFF
--- a/frontend/src/components/recording/CameraConfiguration.test.tsx
+++ b/frontend/src/components/recording/CameraConfiguration.test.tsx
@@ -1,0 +1,339 @@
+import React, { useEffect, useState } from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import CameraConfiguration, { CameraConfig } from "./CameraConfiguration";
+import type { AvailableCamera } from "@/hooks/useAvailableCameras";
+
+// The live enumeration this machine actually reports: two identically-named
+// USB cameras, ordered by AVFoundation uniqueID.
+//   index 0 -> 0x11300002c7f4a60   ("top" in the saved records)
+//   index 1 -> 0x1322002c7f4a60    ("front")
+const MAC_CAMERAS: AvailableCamera[] = [
+  {
+    index: 0,
+    name: "KD-USB Cameras",
+    deviceId: "browser-device-id-for-top",
+    available: true,
+    uniqueId: "0x11300002c7f4a60",
+  },
+  {
+    index: 1,
+    name: "KD-USB Cameras",
+    deviceId: "browser-device-id-for-front",
+    available: true,
+    uniqueId: "0x1322002c7f4a60",
+  },
+];
+
+// Off macOS the backend reports no uniqueID at all (camera_identity returns
+// None when platform.system() != "Darwin"), so the frontend has nothing but
+// the index to go on. Same two cameras, stripped of the mac-only identity.
+const LINUX_CAMERAS: AvailableCamera[] = MAC_CAMERAS.map(
+  ({ uniqueId: _uniqueId, ...cam }) => cam,
+);
+
+// One camera on the record — "front" — carrying a camera_index that is STALE:
+// it was written when a third camera was plugged in and front sat at index 0.
+const SAVED_FRONT: CameraConfig = {
+  id: "camera_repro_0001",
+  name: "front",
+  type: "opencv",
+  camera_index: 0,
+  device_id: "stale-browser-device-id",
+  unique_id: "0x1322002c7f4a60",
+  width: 640,
+  height: 480,
+  fps: 30,
+};
+
+const toastSpy = vi.fn();
+let liveCameras: AvailableCamera[] = MAC_CAMERAS;
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+vi.mock("@/hooks/useAvailableCameras", () => ({
+  useAvailableCameras: () => ({
+    cameras: liveCameras,
+    isLoading: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+// The preview tile opens a real MJPEG stream against the API; irrelevant here.
+vi.mock("@/components/BackendCameraStream", () => ({
+  default: () => <div data-testid="camera-stream" />,
+}));
+
+beforeAll(() => {
+  // Radix Select drives its popup through Pointer Events APIs jsdom lacks.
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+beforeEach(() => {
+  toastSpy.mockClear();
+  liveCameras = MAC_CAMERAS;
+});
+
+/**
+ * Mirrors RobotConfigDialog: the saved record is fetched, so `cameras` lands
+ * one tick AFTER the camera enumeration has already settled. `seedFirst`
+ * flips that order — before the fix, the order alone decided the outcome.
+ */
+const Harness: React.FC<{
+  seedFirst?: boolean;
+  saved?: CameraConfig;
+  onChange?: (cameras: CameraConfig[]) => void;
+  /** Drives the record explicitly, to land it mid-interaction on rerender. */
+  seed?: CameraConfig[];
+}> = ({ seedFirst = false, saved = SAVED_FRONT, onChange, seed }) => {
+  const [cameras, setCameras] = useState<CameraConfig[]>(
+    seed ?? (seedFirst ? [saved] : []),
+  );
+  useEffect(() => {
+    if (seed) setCameras(seed);
+    else if (!seedFirst) setCameras([saved]);
+  }, [seedFirst, saved, seed]);
+  return (
+    <CameraConfiguration
+      cameras={cameras}
+      onCamerasChange={(next) => {
+        onChange?.(next);
+        setCameras(next);
+      }}
+    />
+  );
+};
+
+const openDropdown = async () => {
+  const trigger = screen.getAllByRole("combobox")[0];
+  fireEvent.keyDown(trigger, { key: "Enter" });
+  await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(2));
+  return screen.getAllByRole("option");
+};
+
+/** Picks a name from the preset select that appears once a camera is chosen. */
+const chooseName = async (name: string) => {
+  const triggers = await waitFor(() => {
+    const found = screen.getAllByRole("combobox");
+    expect(found.length).toBeGreaterThan(1);
+    return found;
+  });
+  fireEvent.keyDown(triggers[triggers.length - 1], { key: "Enter" });
+  fireEvent.click(await screen.findByRole("option", { name }));
+};
+
+/** Selects the dropdown row at `optionIndex`, names it, and clicks Add. */
+const addCameraAt = async (optionIndex: number, name: string) => {
+  const options = await openDropdown();
+  fireEvent.click(options[optionIndex]);
+  await chooseName(name);
+  fireEvent.click(screen.getByRole("button", { name: /add camera/i }));
+};
+
+describe("CameraConfiguration — 'Camera Already Added' false positive", () => {
+  // The regression. A stale camera_index used to alias a DIFFERENT physical
+  // camera: index 0 was greyed out (it matched front's stale index) while the
+  // only selectable row was front itself, which Add then refused by unique_id.
+  it("adds the second camera when the record's saved index is stale", async () => {
+    render(<Harness />);
+    await screen.findByText("front");
+
+    const options = await openDropdown();
+    // Identity decides: index 0 is a different camera and stays available;
+    // index 1 IS front and is the row correctly greyed out.
+    expect(options[0]).not.toHaveAttribute("aria-disabled", "true");
+    expect(options[1]).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(options[0]);
+    await chooseName("top");
+    fireEvent.click(screen.getByRole("button", { name: /add camera/i }));
+
+    expect(toastSpy).toHaveBeenCalledTimes(1);
+    expect(toastSpy.mock.calls[0][0]).toMatchObject({ title: "Camera Added" });
+    await screen.findByText("top");
+  });
+
+  it("behaves identically when the record arrives before the enumeration", async () => {
+    render(<Harness seedFirst />);
+    await screen.findByText("front");
+
+    await addCameraAt(0, "top");
+
+    expect(toastSpy).toHaveBeenCalledTimes(1);
+    expect(toastSpy.mock.calls[0][0]).toMatchObject({ title: "Camera Added" });
+    await screen.findByText("top");
+  });
+
+  it("re-anchors a stale index onto the camera's unique_id", async () => {
+    const seen: CameraConfig[][] = [];
+    render(<Harness onChange={(next) => seen.push(next)} />);
+    await screen.findByText("front");
+
+    // front is live at index 1; the record said 0. Without the re-anchor the
+    // recorder would open index 0 — a different physical camera.
+    await waitFor(() => {
+      const latest = seen[seen.length - 1];
+      expect(latest?.[0]).toMatchObject({
+        name: "front",
+        camera_index: 1,
+        unique_id: "0x1322002c7f4a60",
+      });
+    });
+  });
+
+  // Both weaker ids decay (a browser deviceId rotates; unique_id tracks the USB
+  // port), and a record can only heal while something still matches. If the
+  // match refreshed the index alone, the stale id would poison every later
+  // comparison for the life of the record.
+  it("heals the stale ids, not just the index, on a confirmed match", async () => {
+    const seen: CameraConfig[][] = [];
+    render(<Harness onChange={(next) => seen.push(next)} />);
+    await screen.findByText("front");
+
+    await waitFor(() => {
+      expect(seen[seen.length - 1]?.[0]).toMatchObject({
+        camera_index: 1,
+        unique_id: "0x1322002c7f4a60",
+        // was "stale-browser-device-id" on the record
+        device_id: "browser-device-id-for-front",
+      });
+    });
+  });
+
+  // The effect writes through onCamerasChange, which feeds back into `cameras`,
+  // which is one of its own deps. The `changed` guard is what stops that being
+  // a render loop — this pins that it settles rather than merely converging
+  // fast enough not to be noticed.
+  it("settles: the re-anchor writes back exactly once", async () => {
+    const seen: CameraConfig[][] = [];
+    render(<Harness onChange={(next) => seen.push(next)} />);
+    await screen.findByText("front");
+    await waitFor(() => expect(seen.length).toBe(1));
+
+    // Give any further passes a chance to fire before declaring it settled.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(seen).toHaveLength(1);
+  });
+
+  // The unique_id on disk is not forever: these cameras re-enumerate with a
+  // different AVFoundation uniqueID across sessions (0x1323… became 0x1322…),
+  // so re-anchoring can legitimately find no match and the index stays stale.
+  // Identity must still win over that stale position.
+  it("does not alias a stale index onto a camera whose unique_id is gone", async () => {
+    const vanished = { ...SAVED_FRONT, unique_id: "0x1323002c7f4a60" };
+    render(<Harness saved={vanished} />);
+    await screen.findByText("front");
+
+    // Nothing live matches, so camera_index is still 0 — but index 0 is a
+    // different camera by unique_id, so it must remain addable.
+    await addCameraAt(0, "top");
+
+    expect(toastSpy).toHaveBeenCalledTimes(1);
+    expect(toastSpy.mock.calls[0][0]).toMatchObject({ title: "Camera Added" });
+  });
+
+  it("still greys out the camera already on the record", async () => {
+    render(<Harness />);
+    await screen.findByText("front");
+
+    // Re-adding front (live index 1, already on the record) is a real
+    // duplicate, and the picker refuses to offer it.
+    const options = await openDropdown();
+    expect(options[1]).toHaveAttribute("aria-disabled", "true");
+  });
+
+  // The picker and Add now share one predicate, so Add's guard is unreachable
+  // through a greyed row — but it is still load-bearing for the race that made
+  // the two disagree in the first place: the user picks while the record is
+  // still loading, and the record arrives holding that very camera.
+  it("refuses on Add when the record loads after the pick", async () => {
+    const { rerender } = render(<Harness seed={[]} />);
+
+    const options = await openDropdown();
+    expect(options[1]).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(options[1]);
+    await chooseName("top");
+
+    // The fetch lands now, and it already contains the camera just picked.
+    rerender(<Harness seed={[SAVED_FRONT]} />);
+    await screen.findByText("front");
+
+    fireEvent.click(screen.getByRole("button", { name: /add camera/i }));
+
+    expect(toastSpy).toHaveBeenCalledTimes(1);
+    expect(toastSpy.mock.calls[0][0]).toMatchObject({
+      title: "Camera Already Added",
+      variant: "destructive",
+    });
+  });
+});
+
+describe("CameraConfiguration — platforms without a stable device id", () => {
+  // Linux/Windows report no uniqueID, so the index is the only identity there.
+  // The tiers must degrade to exactly the old index behaviour, with no
+  // platform check anywhere in the component.
+  beforeEach(() => {
+    liveCameras = LINUX_CAMERAS;
+  });
+
+  // A rotated device_id must never RULE A CAMERA OUT. The browser handle is
+  // populated on every platform and rotates when site data is cleared, so if a
+  // mismatch there decided "different camera", the same physical device could
+  // be added twice under two names — the mirror image of the bug being fixed.
+  it("still refuses a duplicate when the saved device_id has rotated", async () => {
+    const rotated: CameraConfig = {
+      ...SAVED_FRONT,
+      unique_id: undefined,
+      device_id: "device-id-from-before-site-data-was-cleared",
+      camera_index: 0,
+    };
+    render(<Harness saved={rotated} />);
+    await screen.findByText("front");
+
+    // Nothing identifies it any more, so the index is the only signal left —
+    // and it must still be consulted.
+    const options = await openDropdown();
+    expect(options[0]).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("falls back to the index when neither side has a unique id", async () => {
+    const noIdentity: CameraConfig = {
+      ...SAVED_FRONT,
+      unique_id: undefined,
+      device_id: "browser-device-id-for-front",
+      camera_index: 1,
+    };
+    render(<Harness saved={noIdentity} />);
+    await screen.findByText("front");
+
+    const options = await openDropdown();
+    expect(options[0]).not.toHaveAttribute("aria-disabled", "true");
+    expect(options[1]).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(options[0]);
+    await chooseName("top");
+    fireEvent.click(screen.getByRole("button", { name: /add camera/i }));
+
+    expect(toastSpy).toHaveBeenCalledTimes(1);
+    expect(toastSpy.mock.calls[0][0]).toMatchObject({ title: "Camera Added" });
+  });
+
+  it("refuses a genuine duplicate by index alone", async () => {
+    const noIdentity: CameraConfig = {
+      ...SAVED_FRONT,
+      unique_id: undefined,
+      device_id: "browser-device-id-for-top",
+      camera_index: 0,
+    };
+    render(<Harness saved={noIdentity} />);
+    await screen.findByText("front");
+
+    const options = await openDropdown();
+    expect(options[0]).toHaveAttribute("aria-disabled", "true");
+  });
+});

--- a/frontend/src/components/recording/CameraConfiguration.tsx
+++ b/frontend/src/components/recording/CameraConfiguration.tsx
@@ -18,9 +18,13 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { useToast } from "@/hooks/use-toast";
-import { useAvailableCameras } from "@/hooks/useAvailableCameras";
+import { useAvailableCameras, type AvailableCamera } from "@/hooks/useAvailableCameras";
 import BackendCameraStream from "@/components/BackendCameraStream";
-import { isCameraConnected, resolveCameraIndex } from "@/lib/cameraResolve";
+import {
+  isCameraConnected,
+  isSameCamera,
+  resolveCameraIndex,
+} from "@/lib/cameraResolve";
 import { useEyebrowClass } from "@/hooks/useEyebrowClass";
 
 // Sentinels distinguish "leave unset" (auto-detect / platform default) from an
@@ -59,9 +63,22 @@ export interface CameraConfig {
   type: string;
   camera_index?: number; // cv2 index — what the recorder opens
   device_id: string; // Browser deviceId matched to the cv2 index by AVFoundation localizedName
-  // Stable OS device identity (AVFoundation uniqueID). The authoritative link
-  // to the physical camera: cv2 indices shift on replug and device names can
-  // collide (two "KD-USB Cameras"), but this survives both.
+  // OS device identity (AVFoundation uniqueID). The best link to the physical
+  // camera we have — cv2 indices shift on replug and device names collide (two
+  // "KD-USB Cameras") — but NOT a device serial, and it does NOT survive a
+  // replug into a different port.
+  //
+  // Measured on the SO-101 rig (2026-09-01): the id is the USB **locationID**
+  // with a per-model constant appended, so it encodes (model, topology
+  // position), not the unit. locationID 0x132200 -> "0x1322002c7f4a60";
+  // 0x1130000 -> "0x11300002c7f4a60". Move a camera to another port, or let a
+  // bus-powered hub enumerate its ports in a different order across a power
+  // cycle, and the id changes for the same physical device.
+  //
+  // A USB serial would be the stable anchor, but these cameras don't have one:
+  // all three report `USB Serial Number = "KD-USB Cameras"`, so keying on it
+  // would collide every unit into a single identity. Don't "fix" this by
+  // switching to serials without re-checking the hardware.
   unique_id?: string;
   width: number;
   height: number;
@@ -118,16 +135,22 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
 
   // cv2's AVFoundation order is uniqueID-sorted, so plugging/unplugging a
   // device between sessions shifts indices. Refresh each seeded camera's
-  // camera_index by unique_id (exact physical identity) when the record has
-  // one, falling back to the browser device_id for older records — otherwise
-  // the recorder opens the wrong physical device and the dropdown's "already
-  // added" check guards a stale index.
+  // camera_index by unique_id when the record has one, falling back to the
+  // browser device_id for older records — otherwise the recorder opens the
+  // wrong physical device and the "already added" checks guard a stale index.
   //
   // device_id alone is a COIN FLIP when two cameras share a name (twin
   // "KD-USB Cameras"): the deviceId↔index pairing is decided by
   // enumerateDevices() order, which is unrelated to the uniqueID sort and not
   // stable across refreshes. Anchoring on unique_id is what stops this effect
   // from silently rewriting the recorder's index to the other camera.
+  //
+  // Whatever matched, ALL THREE identifiers are written back, not just the
+  // index. Both weaker ids decay — a browser deviceId rotates when site data is
+  // cleared, and unique_id tracks the USB port (see CameraConfig.unique_id) —
+  // and a record only heals while something still matches. Refreshing them at
+  // the moment of a confirmed match is the one chance to do it; leaving a
+  // stale id behind poisons every later comparison for the life of the record.
   useEffect(() => {
     if (availableCameras.length === 0 || cameras.length === 0) return;
     let changed = false;
@@ -139,18 +162,38 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
         (cam.device_id
           ? availableCameras.find((m) => m.deviceId === cam.device_id)
           : undefined);
-      if (match && match.index !== cam.camera_index) {
+      if (!match) return cam;
+      // Only write ids the enumeration actually reported: off macOS uniqueId is
+      // absent, and deviceId is "" when no browser device matched the label.
+      // Clobbering a good saved id with an empty one would lose the anchor.
+      const healed = {
+        ...cam,
+        camera_index: match.index,
+        ...(match.uniqueId ? { unique_id: match.uniqueId } : {}),
+        ...(match.deviceId ? { device_id: match.deviceId } : {}),
+      };
+      if (
+        healed.camera_index !== cam.camera_index ||
+        healed.unique_id !== cam.unique_id ||
+        healed.device_id !== cam.device_id
+      ) {
         changed = true;
-        return { ...cam, camera_index: match.index };
+        return healed;
       }
       return cam;
     });
     if (changed) onCamerasChange(refreshed);
-    // We deliberately don't depend on `cameras`/`onCamerasChange` to avoid
-    // re-running every keystroke in the camera-name input — re-syncing only
-    // when the available-cameras list itself changes is sufficient.
+    // `cameras` IS a dependency: the saved record is fetched, so it usually
+    // lands a tick AFTER the enumeration has settled. Keying only on
+    // `availableCameras` meant the effect had already run (and bailed on the
+    // empty record) by the time the cameras arrived, and never re-ran — so the
+    // dialog spent its whole life comparing against indices stale from disk.
+    // Re-running is safe and converges: the body is a no-op unless an index
+    // actually differs, so the state update it triggers settles on the next
+    // pass. `onCamerasChange` stays out — callers pass an inline lambda, and
+    // depending on it would re-fire this effect on every parent render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [availableCameras]);
+  }, [availableCameras, cameras]);
 
   const addCamera = () => {
     if (!selectedCameraIndex || !cameraName.trim()) {
@@ -178,16 +221,7 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
       return;
     }
 
-    // Block duplicates by unique_id, cv2 index, or browser deviceId — a stale
-    // camera_index in a seeded camera can otherwise let the same physical
-    // device sneak in under a different index. unique_id is checked first
-    // because it's the only one that can't alias between twin cameras.
-    const isDuplicate = cameras.some(
-      (cam) =>
-        (selectedCamera.uniqueId && cam.unique_id === selectedCamera.uniqueId) ||
-        cam.camera_index === selectedCamera.index ||
-        (selectedCamera.deviceId && cam.device_id === selectedCamera.deviceId),
-    );
+    const isDuplicate = cameras.some((cam) => isSameCamera(cam, selectedCamera));
     if (isDuplicate) {
       toast({
         title: t("recording.cameras.toast.duplicateTitle"),
@@ -325,10 +359,11 @@ const CameraConfiguration: React.FC<CameraConfigurationProps> = ({
             </SelectTrigger>
             <SelectContent className="bg-popover border-border">
               {availableCameras.map((camera) => {
-                const alreadyAdded = cameras.some(
-                  (cam) =>
-                    cam.camera_index === camera.index ||
-                    (camera.deviceId && cam.device_id === camera.deviceId),
+                // Exactly the predicate Add enforces. These used to differ —
+                // the dropdown omitted the unique_id clause — so a row could
+                // pass the picker and then be refused by the Add button.
+                const alreadyAdded = cameras.some((cam) =>
+                  isSameCamera(cam, camera),
                 );
                 return (
                   <SelectItem

--- a/frontend/src/hooks/useAvailableCameras.ts
+++ b/frontend/src/hooks/useAvailableCameras.ts
@@ -6,8 +6,11 @@ export interface AvailableCamera {
   name: string;
   deviceId: string;
   available: boolean;
-  /** Stable OS-level device identity (AVFoundation uniqueID on macOS).
-   * Unlike the cv2 index, it survives replugs and identically-named devices. */
+  /** OS-level device identity (AVFoundation uniqueID on macOS; absent
+   * elsewhere). Better than the cv2 index — it does not shift when some other
+   * device comes or goes, and it tells identically-named devices apart — but
+   * it is NOT a serial: it encodes the USB port, so the same camera replugged
+   * elsewhere reports a different one. See CameraConfig.unique_id. */
   uniqueId?: string;
 }
 

--- a/frontend/src/lib/cameraResolve.ts
+++ b/frontend/src/lib/cameraResolve.ts
@@ -4,8 +4,14 @@ import type { CameraConfig } from "@/components/recording/CameraConfiguration";
 // A stored camera_index is only a position in cv2's device list — it silently
 // rebinds to a different physical camera when devices come and go (a robot cam
 // unplugging can leave its index pointing at the laptop's built-in camera).
-// These helpers re-anchor a configured camera to its stable unique_id against
-// a fresh /available-cameras enumeration before the index is trusted.
+// These helpers re-anchor a configured camera to its unique_id against a fresh
+// /available-cameras enumeration before the index is trusted.
+//
+// unique_id is the best anchor available, NOT a stable one: on macOS it is the
+// USB locationID plus a per-model constant, so it tracks (model, port), not the
+// unit — see the note on CameraConfig.unique_id. A camera moved to another port
+// reads as absent here, which is the safe direction (we refuse to trust an
+// index we can't confirm) but is not the same as "this device is unplugged".
 //
 // Verification is only possible when the record stores a unique_id AND the
 // enumeration reports uniqueIds (macOS). Otherwise fall back to legacy
@@ -13,6 +19,49 @@ import type { CameraConfig } from "@/components/recording/CameraConfiguration";
 
 const canVerify = (cam: CameraConfig, available: AvailableCamera[]) =>
   Boolean(cam.unique_id) && available.some((m) => m.uniqueId);
+
+/**
+ * Is `candidate` (a row of a live enumeration) the camera `saved` (a camera
+ * already on a record) refers to?
+ *
+ * Identity, never position. `camera_index` is a POSITION in an enumeration the
+ * backend re-sorts whenever the device set changes, so a saved index that has
+ * gone stale matches whichever camera occupies that slot now — a different
+ * physical device. That aliasing is what rejected a camera a record didn't hold
+ * ("Camera Already Added" with one camera configured) and greyed out the row
+ * the user actually wanted.
+ *
+ * Matching an id CONFIRMS; only a unique_id pair may DENY. That asymmetry is
+ * the whole design. A unique_id mismatch is the one signal strong enough to
+ * rule a camera out and stop the stale index having a say. It is strong, not
+ * airtight — a camera moved to another port also mismatches (see
+ * CameraConfig.unique_id), so the verdict there is "treat as different", which
+ * leaves the stale row on the record for the user to delete rather than
+ * stranding them with a record they cannot re-bind.
+ *
+ * Every other signal is one-directional. A `device_id` equality really is the
+ * same device, but a mismatch proves nothing: the browser handle is per-origin
+ * and rotates (site data cleared, a different origin), and its pairing to an
+ * index is a COIN FLIP for twin identically-named cameras. Letting a mismatch
+ * there decide would hand back the opposite bug — the same camera added twice
+ * under two names.
+ *
+ * No platform check, on purpose. macOS supplies an AVFoundation uniqueID and
+ * settles on the first rule; off Darwin camera_identity returns None, so no
+ * unique_id pair exists, nothing can deny, and the index decides exactly as it
+ * always has. Note `device_id` is NOT mac-only — the browser enumeration fills
+ * it everywhere — which is why it must never be what rules a camera out.
+ */
+export function isSameCamera(
+  saved: Pick<CameraConfig, "camera_index" | "device_id" | "unique_id">,
+  candidate: Pick<AvailableCamera, "index" | "deviceId" | "uniqueId">,
+): boolean {
+  if (saved.unique_id && candidate.uniqueId)
+    return saved.unique_id === candidate.uniqueId;
+  // Confirms only — never falls through to a "not a duplicate" verdict.
+  if (saved.device_id && saved.device_id === candidate.deviceId) return true;
+  return saved.camera_index === candidate.index;
+}
 
 /** True when `cam` is verifiably attached, or when we can't verify. */
 export function isCameraConnected(

--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -24,7 +24,13 @@ whenever cameras were plugged/unplugged after startup. Opening by such an
 index then silently hits the wrong physical device — e.g. the built-in
 webcam instead of a robot camera, poisoning previews AND recordings.
 
-The stable link between the two index spaces is AVFoundation's ``uniqueID``.
+The link between the two index spaces is AVFoundation's ``uniqueID``. It is
+stable against *reordering* — that is what makes it usable here — but it is
+not a device serial: measured on the SO-101 rig it is the USB ``locationID``
+with a per-model constant appended (locationID ``0x132200`` -> uniqueID
+``0x1322002c7f4a60``), so it identifies (model, port), not the unit. That is
+exactly why the same-port replug below keeps its id, and why moving a camera
+to another port changes it.
 :func:`resolve_cv2_index` maps a camera's uniqueID to the index cv2 will
 actually open *in this process*, by walking the same in-process device list
 cv2 walks (video + muxed devices, uniqueID-sorted — mirrors OpenCV's


### PR DESCRIPTION
## Summary

Adding a second camera to a robot that already has one sometimes failed with "Camera Already Added" when only one camera was configured. Only reproduced on MacOS.

The camera dropdown matches cameras by their position in a list that the backend re-sorts on every plug/unplug; it now matches by device identity, so a stale saved position can no longer trigger a false duplicate.

## Screenshot

![Camera Already Added shown with a single camera configured](https://raw.githubusercontent.com/makermods-robotics/makermodslab/assets/pr-104-screenshots/cam-dupe-false-positive.png)

## Fix

- This really only happens because cameras don't have a serial numbers, so MacOS really identifies this just by the port it's plugged into: the "seat" its in
- So, if there were 3 cams added, and the very first cam is unplugged, the last 2 cams would shift down, changing "seats" silently.
- So, if you already added camera 2, then it shifts, you wouldn't be able to add camera 3, because its now in the seat 2 position
- This fix makes it so that it doesn't use the "seat" to identify cameras, but by its unique_id
- So, now it matches cameras by identity, not position.

## Commits

1. Fix false "Camera Already Added" from a stale saved index — match cameras by identity, unify the picker and Add checks, heal stale saved ids when a record loads, and add regression tests for the false positive and the platforms without a stable device id.

## Sensitive changes

None. Frontend camera-selection logic and a Python docstring only — no servo, torque, calibration, or hardware-control code is touched.
