### PR TITLE
Verify inference camera bindings before a run

### DIFF
--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -43,11 +43,11 @@ cv2 walks (video + muxed devices, uniqueID-sorted — mirrors OpenCV's
 cap_avfoundation_mac.mm). A device attached after startup is invisible to
 in-process AVFoundation entirely — and, worse, a camera replugged into the
 SAME port comes back with the same uniqueID (it is derived from the port), so
-it stays *present* in the stale list as a dead device object that opens "successfully" and then never produces a frame
-(silently blank previews, reads that can block forever). Resolution returns
-None only for the verifiably-absent case; callers must fail loudly (telling
-the user to restart MakerMods Lab) rather than open whatever now sits at the
-stale index.
+it stays *present* in the stale list as a dead device object that opens
+"successfully" and then never produces a frame (silently blank previews,
+reads that can block forever). Resolution returns None only for the
+verifiably-absent case; callers must fail loudly (telling the user to restart
+MakerMods Lab) rather than open whatever now sits at the stale index.
 
 Both failure modes disappear while :func:`pump_avfoundation_runloop` runs:
 AVFoundation queues its device-cache updates on the main dispatch queue,

--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -177,10 +177,30 @@ def list_cameras_in_process() -> list[dict] | None:
 # uniqueID (cap_avfoundation_mac.mm), so the returned index matches what
 # cv2.VideoCapture will open.
 _AVF_ENUM_SCRIPT = """
-import json, objc
+import json, sys, objc
 from Foundation import NSBundle
+
+
+def fail(reason):
+    # The child is the ONLY place that can tell "could not ask" from "asked and
+    # saw nothing", so every could-not-ask path funnels through here rather than
+    # falling through to an empty device list. The parent's [] is acted on as a
+    # fact about the machine (rollout refuses a start on it), so a failure that
+    # printed [] would 400 every inference run and send the user to re-select
+    # cameras that never moved. Signalled twice on purpose, since neither
+    # channel is guaranteed to be read: a JSON null on stdout, which the parent
+    # maps to None, and a non-zero exit, which trips subprocess.run(check=True)
+    # on its own even if stdout were lost or truncated.
+    sys.stderr.write(reason + "\\n")
+    print(json.dumps(None))
+    sys.exit(1)
+
+
 bundle = NSBundle.bundleWithPath_("/System/Library/Frameworks/AVFoundation.framework")
-bundle.load()
+if not bundle.load():
+    # Nothing below can work with the framework unloaded: no device-type
+    # constant resolves and the discovery session reports an empty device set.
+    fail("AVFoundation framework did not load")
 types = []
 for name in (
     "AVCaptureDeviceTypeBuiltInWideAngleCamera",
@@ -196,10 +216,27 @@ for name in (
         continue
     if loaded.get(name) is not None:
         types.append(loaded[name])
+if not types:
+    # Never run a discovery session with an empty type list: it can only match
+    # nothing, and that nothing would be a lie. Individual names are expected to
+    # miss (they are version-gated); all of them missing means the lookup is
+    # broken -- a macOS release renaming them, say.
+    fail("No AVFoundation camera device-type constants resolved (renamed by macOS?)")
 cls = objc.lookUpClass("AVCaptureDeviceDiscoverySession")
 devs = []
+answered = False
 for mt in ("vide", "muxx"):
-    devs.extend(cls.discoverySessionWithDeviceTypes_mediaType_position_(types, mt, 0).devices() or [])
+    found = cls.discoverySessionWithDeviceTypes_mediaType_position_(types, mt, 0).devices()
+    # nil (a query that did not answer) is tracked apart from an empty array (a
+    # query that answered "none"); flattening both with `or []` is what would
+    # let a failed query read as an empty machine. One query answering is
+    # enough to trust the result -- the muxed query going nil is unremarkable.
+    if found is None:
+        continue
+    answered = True
+    devs.extend(found)
+if not answered:
+    fail("AVFoundation discovery answered nothing")
 devs.sort(key=lambda d: d.uniqueID())
 print(json.dumps([
     {"index": i, "name": str(d.localizedName()), "unique_id": str(d.uniqueID())}
@@ -229,11 +266,19 @@ def list_cameras_in_subprocess() -> list[dict] | None:
     wrong physical device.
 
     None and ``[]`` are **different answers**, exactly as in
-    :func:`list_cameras_in_process`:
+    :func:`list_cameras_in_process` — and that parity is the child's job, not
+    this function's: nothing here can see WHY the script printed what it
+    printed, so the script itself distinguishes the two and only ever prints
+    ``[]`` for a machine it really did enumerate (see :data:`_AVF_ENUM_SCRIPT`,
+    whose ``fail()`` guards the same three could-not-ask steps
+    :func:`list_cameras_in_process` guards, with the same ``answered``-flag
+    reasoning).
 
     - None — the enumeration could not be performed (non-macOS, the subprocess
-      failing to run, unparseable output). Nothing is known about the device
-      set, so callers must fall back to trusting the index they were given.
+      failing to run, unparseable output, or the script reporting a failure to
+      ask: AVFoundation not loading, no device-type constant resolving, no
+      discovery query answering). Nothing is known about the device set, so
+      callers must fall back to trusting the index they were given.
     - ``[]`` — the enumeration ran and found zero cameras; a requested device
       is then definitively absent.
 
@@ -250,14 +295,31 @@ def list_cameras_in_subprocess() -> list[dict] | None:
             timeout=10,
             check=True,
         )
+    except subprocess.CalledProcessError as e:
+        # The script's own could-not-ask signal (fail() exits non-zero after
+        # naming the reason on stderr). Surfaced with that reason, because
+        # "AVFoundation did not load" and "the constants were renamed" are the
+        # difference between a transient and a needs-a-code-change failure.
+        logger.warning(
+            "AVFoundation enumeration could not be performed: %s",
+            (e.stderr or "").strip() or e,
+        )
+        return None
     except (subprocess.SubprocessError, OSError) as e:
         logger.warning("AVFoundation enumeration subprocess failed: %s", e)
         return None
     try:
-        return json.loads(result.stdout)
+        cameras = json.loads(result.stdout)
     except json.JSONDecodeError as e:
         logger.warning("AVFoundation enumeration returned invalid JSON: %s", e)
         return None
+    if not isinstance(cameras, list):
+        # The script's other failure channel: a JSON null. Belt and braces with
+        # the exit code above — a null that arrived without one still means the
+        # child could not ask, and only a real list may be trusted as [].
+        logger.warning("AVFoundation enumeration reported no answer: %r", cameras)
+        return None
+    return cameras
 
 
 def resolve_in_enumeration(

--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -176,7 +176,13 @@ def list_cameras_in_process() -> list[dict] | None:
 # Mirrors OpenCV's macOS enumeration: video + muxed devices sorted by
 # uniqueID (cap_avfoundation_mac.mm), so the returned index matches what
 # cv2.VideoCapture will open.
-_AVF_ENUM_SCRIPT = """
+#
+# `__DEVICE_TYPE_NAMES__` is substituted (not f-formatted — the script is full
+# of braces) with a repr of _AVF_DEVICE_TYPE_NAMES, so the two enumerations
+# cannot drift: a device type added to only one of them would put the parent's
+# index space and the child's out of step, which is the exact desynchronisation
+# this module exists to prevent.
+_AVF_ENUM_SCRIPT_TEMPLATE = """
 import json, sys, objc
 from Foundation import NSBundle
 
@@ -202,13 +208,7 @@ if not bundle.load():
     # constant resolves and the discovery session reports an empty device set.
     fail("AVFoundation framework did not load")
 types = []
-for name in (
-    "AVCaptureDeviceTypeBuiltInWideAngleCamera",
-    "AVCaptureDeviceTypeExternalUnknown",   # macOS < 14
-    "AVCaptureDeviceTypeExternal",          # macOS >= 14
-    "AVCaptureDeviceTypeContinuityCamera",  # macOS >= 14
-    "AVCaptureDeviceTypeDeskViewCamera",    # macOS >= 13
-):
+for name in __DEVICE_TYPE_NAMES__:
     loaded = {}
     try:
         objc.loadBundleVariables(bundle, loaded, [(name, b"@")])
@@ -243,6 +243,8 @@ print(json.dumps([
     for i, d in enumerate(devs)
 ]))
 """
+
+_AVF_ENUM_SCRIPT = _AVF_ENUM_SCRIPT_TEMPLATE.replace("__DEVICE_TYPE_NAMES__", repr(_AVF_DEVICE_TYPE_NAMES))
 
 
 def list_cameras_in_subprocess() -> list[dict] | None:

--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -11,27 +11,39 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Camera identity → cv2 index translation for THIS process (macOS).
+"""Camera identity → cv2 index translation, in both of macOS's index spaces.
 
 ``cv2.VideoCapture(index)`` resolves the index against AVFoundation's
 *in-process* device list, which is snapshotted the first time this process
 touches AVFoundation and never refreshes — device-connection notifications
 are delivered on a thread that needs an active NSRunLoop, which uvicorn
 doesn't run. ``/available-cameras`` therefore enumerates in a *fresh
-subprocess* (see server._avfoundation_cameras_in_cv2_order), but that yields
-indices in the fresh device order, which diverges from this process's order
-whenever cameras were plugged/unplugged after startup. Opening by such an
-index then silently hits the wrong physical device — e.g. the built-in
-webcam instead of a robot camera, poisoning previews AND recordings.
+subprocess* (:func:`list_cameras_in_subprocess`), but that yields indices in
+the fresh device order, which diverges from this process's order whenever
+cameras were plugged/unplugged after startup. Opening by such an index then
+silently hits the wrong physical device — e.g. the built-in webcam instead of
+a robot camera, poisoning previews AND recordings. Which enumeration is
+correct depends on WHO opens the camera: this process (previews →
+:func:`identify_cv2_index`) or a freshly spawned child (`lerobot-rollout` →
+:func:`list_cameras_in_subprocess`).
 
-The stable link between the two index spaces is AVFoundation's ``uniqueID``.
+What links the two index spaces is AVFoundation's ``uniqueID`` — a better
+handle than a bare index, but read what it actually is before trusting it.
+Measured on this rig it is the USB **locationID** plus a per-model constant,
+so it names a **(model, port) pair, not a physical unit**: move a camera to
+another port and its uniqueID changes; plug a different camera of the same
+model into that port and it inherits the old one. It is not a serial number,
+and it does not follow the hardware. So it is exactly strong enough to catch
+"the indices renumbered underneath us" and NOT strong enough to prove the
+device in front of the lens is the one the user chose.
+
 :func:`resolve_cv2_index` maps a camera's uniqueID to the index cv2 will
 actually open *in this process*, by walking the same in-process device list
 cv2 walks (video + muxed devices, uniqueID-sorted — mirrors OpenCV's
 cap_avfoundation_mac.mm). A device attached after startup is invisible to
 in-process AVFoundation entirely — and, worse, a camera replugged into the
-SAME port keeps its uniqueID, so it stays *present* in the stale list as a
-dead device object that opens "successfully" and then never produces a frame
+SAME port comes back with the same uniqueID (it is derived from the port), so
+it stays *present* in the stale list as a dead device object that opens "successfully" and then never produces a frame
 (silently blank previews, reads that can block forever). Resolution returns
 None only for the verifiably-absent case; callers must fail loudly (telling
 the user to restart MakerMods Lab) rather than open whatever now sits at the
@@ -54,8 +66,11 @@ therefore use :func:`identify_cv2_index`, which returns the index to open
 """
 
 import asyncio
+import json
 import logging
 import platform
+import subprocess
+import sys
 import threading
 
 logger = logging.getLogger(__name__)
@@ -154,6 +169,94 @@ def list_cameras_in_process() -> list[dict] | None:
         ]
     except Exception as e:
         logger.warning("In-process AVFoundation enumeration failed: %s", e)
+        return None
+
+
+# Runs in a fresh Python — see list_cameras_in_subprocess for why.
+# Mirrors OpenCV's macOS enumeration: video + muxed devices sorted by
+# uniqueID (cap_avfoundation_mac.mm), so the returned index matches what
+# cv2.VideoCapture will open.
+_AVF_ENUM_SCRIPT = """
+import json, objc
+from Foundation import NSBundle
+bundle = NSBundle.bundleWithPath_("/System/Library/Frameworks/AVFoundation.framework")
+bundle.load()
+types = []
+for name in (
+    "AVCaptureDeviceTypeBuiltInWideAngleCamera",
+    "AVCaptureDeviceTypeExternalUnknown",   # macOS < 14
+    "AVCaptureDeviceTypeExternal",          # macOS >= 14
+    "AVCaptureDeviceTypeContinuityCamera",  # macOS >= 14
+    "AVCaptureDeviceTypeDeskViewCamera",    # macOS >= 13
+):
+    loaded = {}
+    try:
+        objc.loadBundleVariables(bundle, loaded, [(name, b"@")])
+    except objc.error:
+        continue
+    if loaded.get(name) is not None:
+        types.append(loaded[name])
+cls = objc.lookUpClass("AVCaptureDeviceDiscoverySession")
+devs = []
+for mt in ("vide", "muxx"):
+    devs.extend(cls.discoverySessionWithDeviceTypes_mediaType_position_(types, mt, 0).devices() or [])
+devs.sort(key=lambda d: d.uniqueID())
+print(json.dumps([
+    {"index": i, "name": str(d.localizedName()), "unique_id": str(d.uniqueID())}
+    for i, d in enumerate(devs)
+]))
+"""
+
+
+def list_cameras_in_subprocess() -> list[dict] | None:
+    """A FRESHLY spawned process's camera list, in cv2 open order (macOS).
+
+    The other index space from :func:`list_cameras_in_process`, and the two
+    diverge the moment a camera is plugged or unplugged. AVFoundation's
+    in-process device cache doesn't refresh on USB hotplug — both the
+    deprecated ``+devicesWithMediaType:`` and a long-lived
+    ``AVCaptureDeviceDiscoverySession`` go stale, because device-connection
+    notifications are delivered via ``NSNotificationCenter`` on a thread that
+    needs an active ``NSRunLoop``, which uvicorn workers don't run. A fresh
+    subprocess re-initializes AVFoundation, which reads IOKit's live device
+    state at startup.
+
+    This is therefore the ordering a NEWLY SPAWNED CHILD will index against:
+    ``/available-cameras`` (so the list the user picks from is live), and any
+    camera a child process opens — notably the ``lerobot-rollout`` subprocess
+    inference spawns. Anything opened *inside the server process* must use
+    :func:`identify_cv2_index` instead; mixing the two silently opens the
+    wrong physical device.
+
+    None and ``[]`` are **different answers**, exactly as in
+    :func:`list_cameras_in_process`:
+
+    - None — the enumeration could not be performed (non-macOS, the subprocess
+      failing to run, unparseable output). Nothing is known about the device
+      set, so callers must fall back to trusting the index they were given.
+    - ``[]`` — the enumeration ran and found zero cameras; a requested device
+      is then definitively absent.
+
+    Collapsing the two would turn a PyObjC hiccup into "no cameras attached",
+    which for the verification caller means refusing every start.
+    """
+    if platform.system() != "Darwin":
+        return None
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", _AVF_ENUM_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.warning("AVFoundation enumeration subprocess failed: %s", e)
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        logger.warning("AVFoundation enumeration returned invalid JSON: %s", e)
         return None
 
 

--- a/makermodslab/camera_identity.py
+++ b/makermodslab/camera_identity.py
@@ -277,7 +277,7 @@ def list_cameras_in_subprocess() -> list[dict] | None:
     reasoning).
 
     - None — the enumeration could not be performed (non-macOS, the subprocess
-      failing to run, unparseable output, or the script reporting a failure to
+      failing to run, unparsable output, or the script reporting a failure to
       ask: AVFoundation not loading, no device-type constant resolving, no
       discovery query answering). Nothing is known about the device set, so
       callers must fall back to trusting the index they were given.

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -1218,13 +1218,18 @@ def _verify_camera_identities(cameras: dict[str, dict[str, Any]], bindings: dict
 
     A disagreement RAISES rather than re-anchoring to wherever the uniqueID now
     sits. Silently correcting would open a device the user never chose, in a
-    flow that then drives a robot arm; refusing sends them back to the camera
-    picker, which is one click and unambiguous. Verification is skipped — the
-    run proceeds exactly as it did before — whenever there is nothing to check
-    against: no `unique_id` in the record (records written before identity
-    existed, and every record on a non-macOS host), a non-int index (a device
-    path, which is not a position in this enumeration), or an enumeration that
-    could not be performed.
+    flow that then drives a robot arm; refusing hands the choice back to the
+    person who made it. The two ways a binding can break need DIFFERENT
+    instructions, so the refusal separates them: a camera whose uniqueID is not
+    in the enumeration at all is unplugged and cannot be picked in a UI that
+    only lists attached devices (reconnect it, or drop it from the record),
+    while one sitting at another index is present and merely renumbered (the
+    message says where it is now, and to re-save this robot's cameras).
+    Verification is skipped — the run proceeds exactly as it did before —
+    whenever there is nothing to check against: no `unique_id` in the record
+    (records written before identity existed, and every record on a non-macOS
+    host), a non-int index (a device path, which is not a position in this
+    enumeration), or an enumeration that could not be performed.
     """
     # Only macOS records carry a uniqueID, so a fully unverifiable camera set
     # must not pay for a subprocess spawn on every start.
@@ -1247,37 +1252,70 @@ def _verify_camera_identities(cameras: dict[str, dict[str, Any]], bindings: dict
         logger.info("Camera enumeration unavailable — starting without verifying camera identities")
         return
     by_index = {cam.get("index"): cam.get("unique_id") for cam in attached}
-    mismatched = []
+    by_unique_id = {cam.get("unique_id"): cam.get("index") for cam in attached}
+    # Two genuinely different failures, and they need different instructions:
+    # a camera that is NOT ATTACHED cannot be re-selected (it is not in the
+    # picker), and a camera that merely RENUMBERED is still there — the
+    # enumeration says exactly where. Telling a user to re-select a device that
+    # is not connected is a dead end, so they are split here rather than in the
+    # message.
+    absent: list[tuple[str, str, Any]] = []
+    moved: list[tuple[str, str, Any, Any]] = []
     for slot, camera in verifiable.items():
         index = camera["camera_index"]
-        if by_index.get(index) == camera["unique_id"]:
+        unique_id = camera["unique_id"]
+        if by_index.get(index) == unique_id:
             continue
         # The record's own label is what the user chose in the camera picker;
         # the policy slot ("observation.images.front") is checkpoint jargon they
         # never typed. Name the label, fall back to the slot only if the request
         # somehow carries no binding for it.
         label = bindings.get(slot) or slot
-        mismatched.append((label, camera["unique_id"], index))
-    if not mismatched:
+        if unique_id in by_unique_id:
+            moved.append((label, unique_id, index, by_unique_id[unique_id]))
+        else:
+            absent.append((label, unique_id, index))
+    if not absent and not moved:
         return
     logger.warning(
-        "Refusing inference: camera indices no longer match the robot record (%s); attached: %s",
-        ", ".join(f"{label} {uid} expected at index {index}" for label, uid, index in mismatched),
+        "Refusing inference: camera indices no longer match the robot record "
+        "(not connected: %s; moved: %s); attached: %s",
+        ", ".join(f"{label} {uid} expected at index {index}" for label, uid, index in absent) or "none",
+        ", ".join(
+            f"{label} {uid} expected at index {index}, now at index {now}" for label, uid, index, now in moved
+        )
+        or "none",
         attached,
     )
-    named = "; ".join(f"'{label}' (device {uid})" for label, uid, _ in mismatched)
     # Deliberately never says "restart": the index is stale on disk, so a
-    # restart changes nothing and sends the user round a loop. Re-selecting the
-    # camera is the only thing that rewrites the record — and it must be the
-    # USER doing it, since only they know which physical camera they meant.
-    raise CameraResolutionError(
-        f"{'These cameras are' if len(mismatched) > 1 else 'This camera is'} no longer at the "
-        f"position saved for this robot, so inference would open the wrong device: {named}. "
-        "USB camera numbering shifts whenever cameras are plugged in or removed. "
-        "Open Robot settings and re-select "
-        f"{'these cameras' if len(mismatched) > 1 else 'this camera'} in this robot's camera "
-        "configuration, then start again."
-    )
+    # restart changes nothing and sends the user round a loop. Only the record
+    # changing fixes this, and it must be the USER doing it — they are the
+    # only one who knows which physical camera they meant.
+    parts = []
+    if absent:
+        named = "; ".join(f"'{label}' (device {uid})" for label, uid, _ in absent)
+        parts.append(
+            f"{'These cameras are' if len(absent) > 1 else 'This camera is'} not connected, so "
+            f"inference cannot open {'them' if len(absent) > 1 else 'it'}: {named}. Reconnect "
+            f"{'them' if len(absent) > 1 else 'it'}, or remove "
+            f"{'them' if len(absent) > 1 else 'it'} from this robot's cameras, then start again."
+        )
+    if moved:
+        # Say where the camera actually IS. Without it the user is told their
+        # camera moved and left to guess where to, which is the one fact the
+        # enumeration already handed us.
+        named = "; ".join(
+            f"'{label}' (device {uid}) was saved at position {index} but is now at position {now}"
+            for label, uid, index, now in moved
+        )
+        parts.append(
+            f"{'These cameras have' if len(moved) > 1 else 'This camera has'} moved since this "
+            f"robot's cameras were saved, so inference would open the wrong device: {named}. "
+            "USB camera numbering shifts whenever cameras are plugged in or removed. "
+            "Open this robot's settings and save its camera configuration to update the saved "
+            f"position{'s' if len(moved) > 1 else ''}, then start again."
+        )
+    raise CameraResolutionError(" ".join(parts))
 
 
 def _session_cameras(request: InferenceRequest) -> dict[str, dict[str, Any]]:
@@ -2329,6 +2367,12 @@ def handle_next_episode() -> dict[str, Any]:
         # and the frontend's past-duration safety net both measure the EPISODE,
         # not the (much longer) session. On the live-runner path the setup time
         # is now ~0, which is the win.
+        # Everything cleared or restamped below has to be restorable: the
+        # respawn path can still refuse (a camera moved during the reset), and
+        # that refusal leaves the session parked exactly where it was.
+        prev_started_at = _inference_started_at
+        prev_rollout_started_at = _inference_rollout_started_at
+        prev_error, prev_hint, prev_runner_error = ev.error, ev.hint, ev.runner_error
         _inference_started_at = time.time()
         _inference_rollout_started_at = None
         # Clear the previous episode's crash banner — the user chose to continue.
@@ -2379,6 +2423,18 @@ def handle_next_episode() -> dict[str, Any]:
             if _eval_session is ev and inference_active:
                 ev.episode_pending = False
                 _inference_meta["phase"] = PHASE_RESETTING
+                # The clocks were restamped to "now" for an episode that never
+                # began; left that way the reset dialog's elapsed time restarts
+                # from zero and lies about how long the user has been parked.
+                _inference_started_at = prev_started_at
+                _inference_rollout_started_at = prev_rollout_started_at
+                # This path is only reached because the runner CRASHED, so the
+                # banner cleared a moment ago is the only explanation of why the
+                # user is being asked to continue at all. Wiping it leaves a
+                # transient toast as the sole account of the crash.
+                ev.error = prev_error
+                ev.hint = prev_hint
+                ev.runner_error = prev_runner_error
         return {"success": False, "status_code": 400, "message": str(exc)}
 
     try:

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -59,6 +59,7 @@ from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 from .api_errors import ErrorCode
 from .arm_capabilities import uses_feetech_bus
 from .arm_identity import ArmIdentityError, ArmSlot, verify_devices
+from .camera_identity import list_cameras_in_subprocess
 from .camera_preview import camera_preview_manager
 from .eval_protocol import (
     CMD_EPISODE,
@@ -1196,6 +1197,89 @@ def _build_eval_runner_cmd(request: InferenceRequest, policy_path: str, robot_ar
     ]
 
 
+def _verify_camera_identities(cameras: dict[str, dict[str, Any]], bindings: dict[str, str]) -> None:
+    """Refuse the run if a record's stored index no longer holds its camera.
+
+    `camera_index` is a POSITION in an enumeration, not a device address: cv2's
+    macOS indices are the AVFoundation device list sorted by uniqueID, so
+    attaching, removing or replugging ANY camera renumbers the others. The
+    record keeps the index the user picked, so after a device-set change it can
+    address a different physical camera than the label next to it says — and
+    nothing downstream notices. lerobot opens the index it is handed, the frames
+    arrive, the episode runs; the policy simply gets a view it was never trained
+    on and performs worse for no visible reason. That silence is the bug.
+
+    Verified against a FRESH-SUBPROCESS enumeration, which is the index space
+    that matters here: `lerobot-rollout` is itself a fresh subprocess, so it
+    indexes against live IOKit state. This process's own AVFoundation list
+    (camera_identity.identify_cv2_index) is the right answer for previews the
+    SERVER opens and the wrong one for the child — mixing the two would confirm
+    the binding against an ordering nobody is going to use.
+
+    A disagreement RAISES rather than re-anchoring to wherever the uniqueID now
+    sits. Silently correcting would open a device the user never chose, in a
+    flow that then drives a robot arm; refusing sends them back to the camera
+    picker, which is one click and unambiguous. Verification is skipped — the
+    run proceeds exactly as it did before — whenever there is nothing to check
+    against: no `unique_id` in the record (records written before identity
+    existed, and every record on a non-macOS host), a non-int index (a device
+    path, which is not a position in this enumeration), or an enumeration that
+    could not be performed.
+    """
+    # Only macOS records carry a uniqueID, so a fully unverifiable camera set
+    # must not pay for a subprocess spawn on every start.
+    verifiable = {
+        slot: camera
+        for slot, camera in cameras.items()
+        if camera.get("unique_id")
+        and isinstance(camera.get("camera_index"), int)
+        and not isinstance(camera.get("camera_index"), bool)
+    }
+    if not verifiable:
+        return
+    attached = list_cameras_in_subprocess()
+    if attached is None:
+        # "Could not ask" is NOT "nothing is attached". Treating a PyObjC or
+        # subprocess failure as an empty device set would refuse every start on
+        # this machine, so an unavailable enumeration falls back to trusting the
+        # record — the pre-existing behaviour. An enumeration that DID run and
+        # returned [] is a fact about the machine and does refuse below.
+        logger.info("Camera enumeration unavailable — starting without verifying camera identities")
+        return
+    by_index = {cam.get("index"): cam.get("unique_id") for cam in attached}
+    mismatched = []
+    for slot, camera in verifiable.items():
+        index = camera["camera_index"]
+        if by_index.get(index) == camera["unique_id"]:
+            continue
+        # The record's own label is what the user chose in the camera picker;
+        # the policy slot ("observation.images.front") is checkpoint jargon they
+        # never typed. Name the label, fall back to the slot only if the request
+        # somehow carries no binding for it.
+        label = bindings.get(slot) or slot
+        mismatched.append((label, camera["unique_id"], index))
+    if not mismatched:
+        return
+    logger.warning(
+        "Refusing inference: camera indices no longer match the robot record (%s); attached: %s",
+        ", ".join(f"{label} {uid} expected at index {index}" for label, uid, index in mismatched),
+        attached,
+    )
+    named = "; ".join(f"'{label}' (device {uid})" for label, uid, _ in mismatched)
+    # Deliberately never says "restart": the index is stale on disk, so a
+    # restart changes nothing and sends the user round a loop. Re-selecting the
+    # camera is the only thing that rewrites the record — and it must be the
+    # USER doing it, since only they know which physical camera they meant.
+    raise CameraResolutionError(
+        f"{'These cameras are' if len(mismatched) > 1 else 'This camera is'} no longer at the "
+        f"position saved for this robot, so inference would open the wrong device: {named}. "
+        "USB camera numbering shifts whenever cameras are plugged in or removed. "
+        "Open Robot settings and re-select "
+        f"{'these cameras' if len(mismatched) > 1 else 'this camera'} in this robot's camera "
+        "configuration, then start again."
+    )
+
+
 def _session_cameras(request: InferenceRequest) -> dict[str, dict[str, Any]]:
     """This run's cameras, keyed by the policy-expected name.
 
@@ -1203,13 +1287,18 @@ def _session_cameras(request: InferenceRequest) -> dict[str, dict[str, Any]]:
     every time they're needed rather than carried on the request: the record is
     the only place they live, and the lookup is one small JSON read. Capture
     resolution is overlaid from the checkpoint (see PolicyCameraDims /
-    bind_robot_cameras). Raises CameraResolutionError, which
-    handle_start_inference turns into a 400 before the session starts."""
-    return bind_robot_cameras(
+    bind_robot_cameras). The bound cameras are then verified to still BE the
+    cameras the record names (see _verify_camera_identities) — a stored index
+    can silently address a different device after any USB change. Raises
+    CameraResolutionError, which handle_start_inference turns into a 400 before
+    the session starts, so a wrong-camera run never energises an arm."""
+    cameras = bind_robot_cameras(
         request.robot_name,
         request.camera_bindings,
         dims={name: dims.model_dump() for name, dims in request.camera_dims.items()},
     )
+    _verify_camera_identities(cameras, request.camera_bindings)
+    return cameras
 
 
 # lerobot `--robot.type` per arm type, single and bimanual. These are draccus

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -1285,13 +1285,24 @@ def _session_cameras(request: InferenceRequest) -> dict[str, dict[str, Any]]:
 
     Camera identity and transport settings are resolved from the robot record
     every time they're needed rather than carried on the request: the record is
-    the only place they live, and the lookup is one small JSON read. Capture
-    resolution is overlaid from the checkpoint (see PolicyCameraDims /
-    bind_robot_cameras). The bound cameras are then verified to still BE the
-    cameras the record names (see _verify_camera_identities) — a stored index
-    can silently address a different device after any USB change. Raises
-    CameraResolutionError, which handle_start_inference turns into a 400 before
-    the session starts, so a wrong-camera run never energises an arm."""
+    the only place they live, and re-reading it is what lets a record the user
+    fixes mid-session take effect. Capture resolution is overlaid from the
+    checkpoint (see PolicyCameraDims / bind_robot_cameras). The bound cameras
+    are then verified to still BE the cameras the record names (see
+    _verify_camera_identities) — a stored index can silently address a
+    different device after any USB change. Raises CameraResolutionError, which
+    handle_start_inference turns into a 400 before the session starts, so a
+    wrong-camera run never energises an arm.
+
+    NOT cheap, despite reading like a config lookup: whenever there are
+    bindings, verification spawns a fresh Python that imports PyObjC and runs
+    an AVFoundation discovery session (10s timeout) — see
+    list_cameras_in_subprocess for why a child is the only honest answer. That
+    is paid at least twice per start (the request-thread reject, then again in
+    _prepare_robot after the download) plus once per eval respawn. The
+    duplication is deliberate — the whole point is that the device set can
+    change between those calls — so treat this as an I/O call and keep it off
+    any path that must not block, not as something to sprinkle freely."""
     cameras = bind_robot_cameras(
         request.robot_name,
         request.camera_bindings,
@@ -2029,10 +2040,15 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
             "message": f"Unrecognised policy ref: {request.policy_ref!r}",
         }
 
-    # Resolve the camera bindings against the robot record now (one small JSON
-    # read, no hardware). A binding that names a camera the record doesn't have
-    # must 4xx in the panel; deferring it to the startup worker would surface
-    # the same mistake as a mid-startup failure after the model download.
+    # Resolve the camera bindings against the robot record now. A binding that
+    # names a camera the record doesn't have — or a stored index that no longer
+    # holds it — must 4xx in the panel; deferring it to the startup worker
+    # would surface the same mistake as a mid-startup failure after the model
+    # download. Not free on the request thread: with bindings present this
+    # spawns an enumeration child (see _session_cameras) that can take up to
+    # its 10s timeout. Worth it here — no arm is touched and no bus is opened,
+    # and the alternative is the user watching a multi-minute download only to
+    # be told the camera is wrong.
     try:
         _session_cameras(request)
     except CameraResolutionError as exc:

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -1197,6 +1197,50 @@ def _build_eval_runner_cmd(request: InferenceRequest, policy_path: str, robot_ar
     ]
 
 
+def _camera_mismatch_message(
+    absent: list[tuple[str, str, Any]], moved: list[tuple[str, str, Any, Any]]
+) -> str:
+    """The user-facing refusal for cameras that no longer sit where the record says.
+
+    Takes the two classifications `_verify_camera_identities` made — `absent`
+    is (label, uniqueID, saved index), `moved` is that plus the index the
+    camera is at now — and renders one paragraph per non-empty group, in that
+    order, so a bench rearrangement that did both gets both instructions
+    rather than whichever one happened to win.
+
+    Deliberately never says "restart": the index is stale on disk, so a restart
+    changes nothing and sends the user round a loop. Only the record changing
+    fixes this, and it must be the USER doing it — they are the only one who
+    knows which physical camera they meant.
+    """
+    parts = []
+    if absent:
+        named = "; ".join(f"'{label}' (device {uid})" for label, uid, _ in absent)
+        parts.append(
+            f"{'These cameras are' if len(absent) > 1 else 'This camera is'} not connected, so "
+            f"inference cannot open {'them' if len(absent) > 1 else 'it'}: {named}. Reconnect "
+            f"{'them' if len(absent) > 1 else 'it'} and start again, or remove "
+            f"{'them' if len(absent) > 1 else 'it'} from this robot's cameras and rebind the "
+            f"policy {'cameras' if len(absent) > 1 else 'camera'} before starting."
+        )
+    if moved:
+        # Say where the camera actually IS. Without it the user is told their
+        # camera moved and left to guess where to, which is the one fact the
+        # enumeration already handed us.
+        named = "; ".join(
+            f"'{label}' (device {uid}) was saved at position {index} but is now at position {now}"
+            for label, uid, index, now in moved
+        )
+        parts.append(
+            f"{'These cameras have' if len(moved) > 1 else 'This camera has'} moved since this "
+            f"robot's cameras were saved, so inference would open the wrong device: {named}. "
+            "USB camera numbering shifts whenever cameras are plugged in or removed. "
+            "Open this robot's settings and save its camera configuration to update the saved "
+            f"position{'s' if len(moved) > 1 else ''}, then start again."
+        )
+    return " ".join(parts)
+
+
 def _verify_camera_identities(cameras: dict[str, dict[str, Any]], bindings: dict[str, str]) -> None:
     """Refuse the run if a record's stored index no longer holds its camera.
 
@@ -1222,9 +1266,10 @@ def _verify_camera_identities(cameras: dict[str, dict[str, Any]], bindings: dict
     person who made it. The two ways a binding can break need DIFFERENT
     instructions, so the refusal separates them: a camera whose uniqueID is not
     in the enumeration at all is unplugged and cannot be picked in a UI that
-    only lists attached devices (reconnect it, or drop it from the record),
-    while one sitting at another index is present and merely renumbered (the
-    message says where it is now, and to re-save this robot's cameras).
+    only lists attached devices, while one sitting at another index is present
+    and merely renumbered. What each case is told to do is
+    _camera_mismatch_message's job; this function only decides which case a
+    camera is in.
     Verification is skipped — the run proceeds exactly as it did before —
     whenever there is nothing to check against: no `unique_id` in the record
     (records written before identity existed, and every record on a non-macOS
@@ -1287,36 +1332,7 @@ def _verify_camera_identities(cameras: dict[str, dict[str, Any]], bindings: dict
         or "none",
         attached,
     )
-    # Deliberately never says "restart": the index is stale on disk, so a
-    # restart changes nothing and sends the user round a loop. Only the record
-    # changing fixes this, and it must be the USER doing it — they are the
-    # only one who knows which physical camera they meant.
-    parts = []
-    if absent:
-        named = "; ".join(f"'{label}' (device {uid})" for label, uid, _ in absent)
-        parts.append(
-            f"{'These cameras are' if len(absent) > 1 else 'This camera is'} not connected, so "
-            f"inference cannot open {'them' if len(absent) > 1 else 'it'}: {named}. Reconnect "
-            f"{'them' if len(absent) > 1 else 'it'} and start again, or remove "
-            f"{'them' if len(absent) > 1 else 'it'} from this robot's cameras and rebind the "
-            f"policy {'cameras' if len(absent) > 1 else 'camera'} before starting."
-        )
-    if moved:
-        # Say where the camera actually IS. Without it the user is told their
-        # camera moved and left to guess where to, which is the one fact the
-        # enumeration already handed us.
-        named = "; ".join(
-            f"'{label}' (device {uid}) was saved at position {index} but is now at position {now}"
-            for label, uid, index, now in moved
-        )
-        parts.append(
-            f"{'These cameras have' if len(moved) > 1 else 'This camera has'} moved since this "
-            f"robot's cameras were saved, so inference would open the wrong device: {named}. "
-            "USB camera numbering shifts whenever cameras are plugged in or removed. "
-            "Open this robot's settings and save its camera configuration to update the saved "
-            f"position{'s' if len(moved) > 1 else ''}, then start again."
-        )
-    raise CameraResolutionError(" ".join(parts))
+    raise CameraResolutionError(_camera_mismatch_message(absent, moved))
 
 
 def _session_cameras(request: InferenceRequest) -> dict[str, dict[str, Any]]:

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -1297,8 +1297,9 @@ def _verify_camera_identities(cameras: dict[str, dict[str, Any]], bindings: dict
         parts.append(
             f"{'These cameras are' if len(absent) > 1 else 'This camera is'} not connected, so "
             f"inference cannot open {'them' if len(absent) > 1 else 'it'}: {named}. Reconnect "
-            f"{'them' if len(absent) > 1 else 'it'}, or remove "
-            f"{'them' if len(absent) > 1 else 'it'} from this robot's cameras, then start again."
+            f"{'them' if len(absent) > 1 else 'it'} and start again, or remove "
+            f"{'them' if len(absent) > 1 else 'it'} from this robot's cameras and rebind the "
+            f"policy {'cameras' if len(absent) > 1 else 'camera'} before starting."
         )
     if moved:
         # Say where the camera actually IS. Without it the user is told their

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -1322,25 +1322,36 @@ def _robot_cli_type(request: InferenceRequest) -> str:
     return _ROBOT_CLI_TYPES[(normalize_arm_type(request.arm_type), request.mode == "bimanual")]
 
 
-def _single_robot_args(request: InferenceRequest, follower_id: str) -> list[str]:
+def _single_robot_args(
+    request: InferenceRequest, follower_id: str, cameras: dict[str, dict[str, Any]]
+) -> list[str]:
     """`--robot.*` args for a single follower (SO-101 or Maker).
 
     Both follower types take the same three flags: `port` is the Feetech
     USB-serial device for an SO-101 and the CAN adapter's serial port for a
     Maker arm (slcan, the only transport that works on macOS), so the shape is
-    identical and only the type key differs."""
+    identical and only the type key differs.
+
+    `cameras` is handed in rather than resolved here: resolving it also VERIFIES
+    it (see _session_cameras), and that check must happen before the caller
+    touches the arm — not while formatting argv, which is the last thing
+    _prepare_robot does."""
     args = [
         f"--robot.type={_robot_cli_type(request)}",
         f"--robot.port={request.follower_port}",
         f"--robot.id={follower_id}",
     ]
-    cameras = _session_cameras(request)
     if cameras:
         args.append(f"--robot.cameras={_format_cameras_arg(cameras)}")
     return args
 
 
-def _bimanual_robot_args(request: InferenceRequest, base: str, follower_staging: str) -> list[str]:
+def _bimanual_robot_args(
+    request: InferenceRequest,
+    base: str,
+    follower_staging: str,
+    cameras: dict[str, dict[str, Any]],
+) -> list[str]:
     """`--robot.*` args for a bimanual follower (BiSO or BiMaker).
 
     Both bimanual follower configs have the same shape — two sub-arms sharing
@@ -1351,7 +1362,9 @@ def _bimanual_robot_args(request: InferenceRequest, base: str, follower_staging:
     (left_arm_config / right_arm_config) sharing ONE calibration_dir + base id,
     loading each sub-arm's calibration as "<base>_left.json"/"<base>_right.json".
     `follower_staging` is the per-session dir the two library calibrations were
-    staged into under that convention (see stage_bimanual_follower_calibrations).
+    staged into under that convention (see stage_bimanual_follower_calibrations);
+    `cameras` is pre-resolved and pre-verified by the caller, for the reason
+    given on _single_robot_args.
     Cameras
     go on the LEFT arm (BiSO re-exposes them prefixed "left_*"); the right arm is
     camera-free, matching the record/teleop bimanual shape."""
@@ -1362,10 +1375,36 @@ def _bimanual_robot_args(request: InferenceRequest, base: str, follower_staging:
         f"--robot.left_arm_config.port={request.follower_port}",
         f"--robot.right_arm_config.port={request.right_follower_port}",
     ]
-    cameras = _session_cameras(request)
     if cameras:
         args.append(f"--robot.left_arm_config.cameras={_format_cameras_arg(cameras)}")
     return args
+
+
+def _reverified_robot_args(request: InferenceRequest, robot_args: list[str]) -> list[str]:
+    """Cached `--robot.*` args, re-checked against the CURRENT device set.
+
+    For the eval respawn only. Between episodes the user is explicitly invited
+    to take their time rearranging the bench, and a camera unplugged (or a new
+    one added) there renumbers every AVFoundation index — the cached args carry
+    the index the record held at session start, and a FRESHLY spawned runner
+    resolves it against the new order, so it would open a different physical
+    camera for every remaining episode with nothing anywhere saying so. The
+    live-runner path needs none of this: that child already holds the verified
+    devices open, and a handle cannot renumber underneath itself.
+
+    Raises CameraResolutionError (the caller turns it into a refusal that leaves
+    the session parked in its reset). The camera args are rebuilt from the same
+    re-read record the check ran against, so a record the user fixed mid-session
+    takes effect instead of relaunching against the stale index that just
+    passed. Everything else — ports, ids, the staged calibration dir — is reused
+    verbatim: those came from preflights we deliberately do not re-run.
+    """
+    cameras = _session_cameras(request)
+    flag = "--robot.left_arm_config.cameras=" if request.mode == "bimanual" else "--robot.cameras="
+    rebuilt = [arg for arg in robot_args if not arg.startswith(flag)]
+    if cameras:
+        rebuilt.append(f"{flag}{_format_cameras_arg(cameras)}")
+    return rebuilt
 
 
 def _prepare_robot(request: InferenceRequest) -> tuple[list[str], list[str]]:
@@ -1376,8 +1415,19 @@ def _prepare_robot(request: InferenceRequest) -> tuple[list[str], list[str]]:
     follower serial bus (read-only identity check + RAM torque-limit priming).
     It runs in the background startup worker AFTER the model download, so a stop
     pressed during the (long) download never reaches here — no bus is opened and
-    no register is written. Raises ArmIdentityError on a hard arm mismatch;
-    returns (robot_args, warn-but-allow messages)."""
+    no register is written. Raises ArmIdentityError on a hard arm mismatch, or
+    CameraResolutionError before anything is touched at all; returns
+    (robot_args, warn-but-allow messages)."""
+    # Cameras FIRST, and not merely because the args need them. Resolving them
+    # verifies that each stored index still holds the camera the record names
+    # (_session_cameras -> _verify_camera_identities), and that check is only
+    # worth anything while the arm is still untouched: the request-thread check
+    # ran before the model download, which can be minutes long and is exactly
+    # when a user reseats a camera. Building the args last — after the
+    # preflights had read the identity EEPROM and rewritten the torque and
+    # velocity registers — meant the refusal arrived with the bus already
+    # opened and the arm already reconfigured for a run that will not happen.
+    cameras = _session_cameras(request)
     is_bimanual = request.mode == "bimanual"
     if is_bimanual:
         # BiSO loads each sub-arm's calibration as "<base>_left/right.json"
@@ -1421,7 +1471,7 @@ def _prepare_robot(request: InferenceRequest) -> tuple[list[str], list[str]]:
             identity_warnings += _preflight_motor_registers(request.follower_port, left_id)
             identity_warnings += _preflight_motor_registers(request.right_follower_port, right_id)
 
-        return _bimanual_robot_args(request, base, follower_staging), identity_warnings
+        return _bimanual_robot_args(request, base, follower_staging, cameras), identity_warnings
 
     # `setup_follower_calibration_file` returns the basename without the
     # .json extension. We need that stripped form for `--robot.id`,
@@ -1437,7 +1487,7 @@ def _prepare_robot(request: InferenceRequest) -> tuple[list[str], list[str]]:
         # writes homing_offset=0 for every joint, so the EEPROM fingerprint has
         # nothing to compare and the torque-limit register does not exist.
         logger.info("CAN arm: skipping the Feetech identity + register preflights")
-        return _single_robot_args(request, follower_id), identity_warnings
+        return _single_robot_args(request, follower_id, cameras), identity_warnings
 
     if request.skip_identity_check:
         logger.warning("Arm identity check SKIPPED by request (skip_identity_check=true)")
@@ -1448,7 +1498,7 @@ def _prepare_robot(request: InferenceRequest) -> tuple[list[str], list[str]]:
     # when the arm was never power-cycled.
     identity_warnings += _preflight_motor_registers(request.follower_port, follower_id)
 
-    return _single_robot_args(request, follower_id), identity_warnings
+    return _single_robot_args(request, follower_id, cameras), identity_warnings
 
 
 def _fail_startup(error: str) -> None:
@@ -1695,6 +1745,15 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
     except ArmIdentityError as exc:
         # The connected arm doesn't match its assigned calibration; the message
         # is already user-facing.
+        _fail_startup(str(exc))
+        return
+    except CameraResolutionError as exc:
+        # A camera moved between the request-thread check and here (the model
+        # download is the window). Same deal as ArmIdentityError: the message
+        # already tells the user exactly what to do — re-select the camera in
+        # Robot settings — and a "Failed to start inference:" prefix would read
+        # as an internal crash and bury the one instruction that helps.
+        logger.warning("Refusing inference after the camera check: %s", exc)
         _fail_startup(str(exc))
         return
     except Exception as exc:
@@ -2285,6 +2344,27 @@ def handle_next_episode() -> dict[str, Any]:
     # The runner died during the previous episode (or during the reset). Respawn
     # it — one policy load — and let the READY handler issue the episode, the
     # same way the session's first episode is issued.
+    #
+    # A respawn re-opens the cameras BY INDEX against whatever AVFoundation
+    # ordering exists now, so the session-start verification does not carry: the
+    # reset the user just spent rearranging the bench in is precisely when a
+    # camera gets unplugged or added. Re-check before spawning, outside the lock
+    # (it reads the record and spawns an enumeration child).
+    try:
+        robot_args = _reverified_robot_args(request, robot_args)
+    except CameraResolutionError as exc:
+        logger.warning("Refusing the next eval episode: %s", exc)
+        with _state_lock:
+            # Roll back the "we are starting" bookkeeping done under the lock
+            # above so the session stays parked in its reset: the tally and the
+            # runner-less state are intact, and Continue works again the moment
+            # the user re-selects the camera (or reattaches it). Failing the
+            # whole session here would throw away the episodes already scored.
+            if _eval_session is ev and inference_active:
+                ev.episode_pending = False
+                _inference_meta["phase"] = PHASE_RESETTING
+        return {"success": False, "status_code": 400, "message": str(exc)}
+
     try:
         proc, log_handle, log_path = _launch_eval_runner(request, policy_path, robot_args)
     except Exception as exc:

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -22,8 +22,6 @@ import logging
 import os
 import queue
 import re
-import subprocess
-import sys
 import threading
 import time
 import zipfile
@@ -67,7 +65,11 @@ from .auto_calibrate import (
     auto_calibration_manager,
 )
 from .calibrate import CalibrationRequest, calibration_manager
-from .camera_identity import identify_cv2_index, pump_avfoundation_runloop
+from .camera_identity import (
+    identify_cv2_index,
+    list_cameras_in_subprocess,
+    pump_avfoundation_runloop,
+)
 from .camera_preview import CameraOpenError, camera_preview_manager
 from .can_recovery import ReleaseCanTorqueRequest, handle_release_can_torque
 from .identify import identify_arm_by_motion
@@ -3564,72 +3566,6 @@ async def supply_voltage(port: str = ""):
     return await read_supply_voltage(port)
 
 
-# Runs in a fresh Python — see _avfoundation_cameras_in_cv2_order for why.
-# Mirrors OpenCV's macOS enumeration: video + muxed devices sorted by
-# uniqueID (cap_avfoundation_mac.mm), so the returned index matches what
-# cv2.VideoCapture will open.
-_AVF_ENUM_SCRIPT = """
-import json, objc
-from Foundation import NSBundle
-bundle = NSBundle.bundleWithPath_("/System/Library/Frameworks/AVFoundation.framework")
-bundle.load()
-types = []
-for name in (
-    "AVCaptureDeviceTypeBuiltInWideAngleCamera",
-    "AVCaptureDeviceTypeExternalUnknown",   # macOS < 14
-    "AVCaptureDeviceTypeExternal",          # macOS >= 14
-    "AVCaptureDeviceTypeContinuityCamera",  # macOS >= 14
-    "AVCaptureDeviceTypeDeskViewCamera",    # macOS >= 13
-):
-    loaded = {}
-    try:
-        objc.loadBundleVariables(bundle, loaded, [(name, b"@")])
-    except objc.error:
-        continue
-    if loaded.get(name) is not None:
-        types.append(loaded[name])
-cls = objc.lookUpClass("AVCaptureDeviceDiscoverySession")
-devs = []
-for mt in ("vide", "muxx"):
-    devs.extend(cls.discoverySessionWithDeviceTypes_mediaType_position_(types, mt, 0).devices() or [])
-devs.sort(key=lambda d: d.uniqueID())
-print(json.dumps([
-    {"index": i, "name": str(d.localizedName()), "unique_id": str(d.uniqueID())}
-    for i, d in enumerate(devs)
-]))
-"""
-
-
-def _avfoundation_cameras_in_cv2_order() -> list[dict[str, Any]]:
-    """Enumerate macOS cameras in a fresh Python subprocess.
-
-    AVFoundation's in-process device cache doesn't refresh on USB
-    hotplug. Both the deprecated ``+devicesWithMediaType:`` and a
-    long-lived ``AVCaptureDeviceDiscoverySession`` go stale, because
-    device-connection notifications are delivered via
-    ``NSNotificationCenter`` on a thread that needs an active
-    ``NSRunLoop`` — uvicorn workers don't run one. A fresh subprocess
-    re-initializes AVFoundation, which reads IOKit's live device state
-    at startup.
-    """
-    try:
-        result = subprocess.run(
-            [sys.executable, "-c", _AVF_ENUM_SCRIPT],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=True,
-        )
-    except (subprocess.SubprocessError, OSError) as e:
-        logger.warning("AVFoundation enumeration subprocess failed: %s", e)
-        return []
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError as e:
-        logger.warning("AVFoundation enumeration returned invalid JSON: %s", e)
-        return []
-
-
 def _generic_cv2_cameras(backend) -> list[dict[str, Any]]:
     """Last-resort enumeration: probe cv2 indices with placeholder names."""
     import cv2
@@ -3755,7 +3691,10 @@ def get_available_cameras():
         system = platform.system()
 
         if system == "Darwin":
-            cameras = _avfoundation_cameras_in_cv2_order()
+            # None (enumeration unavailable) and [] (no cameras) are the same
+            # answer to this endpoint: an empty list. Only the callers that
+            # REFUSE on an empty enumeration need to tell them apart.
+            cameras = list_cameras_in_subprocess() or []
             for cam in cameras:
                 cam["available"] = True
             return {"status": "success", "cameras": cameras}

--- a/makermodslab/utils/config.py
+++ b/makermodslab/utils/config.py
@@ -817,6 +817,20 @@ def bind_robot_cameras(
     name pairing; the camera's IDENTITY and transport settings (index,
     unique_id, fps, fourcc, backend) come from the record.
 
+    Neither of those identity fields is an address the OS honours. `camera_index`
+    is a POSITION in a USB/AVFoundation enumeration that renumbers whenever the
+    device set changes, so it can end up addressing a different physical camera
+    than the label beside it names — and the session would open it without a
+    murmur. `unique_id` (AVFoundation's uniqueID) is the better of the two but
+    is still only a (model, port) pair — it is derived from the USB locationID,
+    so it changes when a camera moves ports and is inherited by an identical
+    model plugged into the same one; it is not a serial. What it IS good for is
+    detecting the renumbering: `rollout._verify_camera_identities` checks the
+    stored index still holds the stored uniqueID before a run and refuses
+    otherwise. This function itself does no such check — it reads the record as
+    written, and every caller that opens a camera on the strength of it should
+    consider whether it needs that verification too.
+
     CAPTURE RESOLUTION is the one exception, supplied by `dims`
     ({policy camera name: {"width": w, "height": h}}, from the checkpoint's
     image_features). lerobot's standard rollout pipeline does NOT resize frames

--- a/tests/test_camera_identity.py
+++ b/tests/test_camera_identity.py
@@ -657,3 +657,36 @@ def test_real_script_trusts_one_answering_query(run_real_enum_script) -> None:
         FAKE_DEVICES_vide='[{"name": "Front", "unique_id": "uid-A"}]',
         FAKE_DEVICES_muxx="null",
     ) == [{"index": 0, "name": "Front", "unique_id": "uid-A"}]
+
+
+# ---------------------------------------------------------------------------
+# The two enumerations must ask for the SAME device types
+#
+# The parent's in-process list and the child's fresh list are only comparable
+# while they enumerate the same universe of devices. A device type present in
+# one and not the other shifts every index after it in exactly one of the two
+# index spaces — which is the silent renumbering this whole module exists to
+# catch, reintroduced inside the detector. The script therefore interpolates
+# _AVF_DEVICE_TYPE_NAMES rather than repeating it, and these pin that.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("type_name", camera_identity._AVF_DEVICE_TYPE_NAMES)
+def test_real_script_asks_for_every_shared_device_type_constant(run_real_enum_script, type_name: str) -> None:
+    """Driven through the real script: the fake only resolves a constant the
+    script actually asks for, so a name missing from the child's list leaves it
+    with an empty type list, which `fail()` turns into None."""
+    assert run_real_enum_script(
+        FAKE_TYPES=type_name,
+        FAKE_DEVICES_vide='[{"name": "Front", "unique_id": "uid-A"}]',
+    ) == [{"index": 0, "name": "Front", "unique_id": "uid-A"}]
+
+
+def test_enum_script_names_no_device_type_the_shared_constant_lacks() -> None:
+    """The other direction: an extra type in the CHILD only would renumber the
+    child's indices, so the record would verify against an ordering the parent
+    never sees."""
+    import re
+
+    named = set(re.findall(r"AVCaptureDeviceType\w+", camera_identity._AVF_ENUM_SCRIPT))
+    assert named == set(camera_identity._AVF_DEVICE_TYPE_NAMES)

--- a/tests/test_camera_identity.py
+++ b/tests/test_camera_identity.py
@@ -333,3 +333,92 @@ def test_a_missing_version_gated_constant_is_not_a_failure(fake_avfoundation) ->
 def test_non_macos_has_no_in_process_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(camera_identity.platform, "system", lambda: "Linux")
     assert list_cameras_in_process() is None
+
+
+# ---------------------------------------------------------------------------
+# list_cameras_in_subprocess — the OTHER index space
+#
+# A fresh subprocess re-reads IOKit's live device state, so this is the
+# ordering a newly spawned child (a preview probe, `lerobot-rollout`) will
+# index against. It is NOT this process's ordering, which went stale at the
+# first AVFoundation touch. The subprocess is always faked here: really
+# spawning one would depend on the host's cameras and on camera permission.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+
+@pytest.fixture
+def fake_enum_subprocess(monkeypatch: pytest.MonkeyPatch):
+    """Patch the enumeration subprocess; returns a setter taking either the
+    stdout string to hand back or an exception instance to raise."""
+
+    def _set(outcome) -> None:
+        def _run(*args, **kwargs):
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return _FakeCompleted(outcome)
+
+        monkeypatch.setattr(camera_identity.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(camera_identity.subprocess, "run", _run)
+
+    return _set
+
+
+def test_subprocess_enumeration_returns_the_parsed_device_list(fake_enum_subprocess) -> None:
+    from makermodslab.camera_identity import list_cameras_in_subprocess
+
+    fake_enum_subprocess(
+        '[{"index": 0, "name": "Cam A", "unique_id": "uid-A"},'
+        ' {"index": 1, "name": "Cam B", "unique_id": "uid-B"}]'
+    )
+    assert list_cameras_in_subprocess() == [
+        {"index": 0, "name": "Cam A", "unique_id": "uid-A"},
+        {"index": 1, "name": "Cam B", "unique_id": "uid-B"},
+    ]
+
+
+def test_subprocess_enumeration_reports_an_empty_machine_as_an_empty_list(
+    fake_enum_subprocess,
+) -> None:
+    """An answered enumeration finding nothing is a fact about the machine, and
+    callers act on it (refusing a start). It must not read as a failure."""
+    from makermodslab.camera_identity import list_cameras_in_subprocess
+
+    fake_enum_subprocess("[]")
+    assert list_cameras_in_subprocess() == []
+
+
+def test_subprocess_enumeration_failure_is_none_not_empty(fake_enum_subprocess) -> None:
+    """A subprocess that never ran knows nothing about the device set. Reporting
+    [] would make every caller conclude "no cameras attached"."""
+    import subprocess as _subprocess
+
+    from makermodslab.camera_identity import list_cameras_in_subprocess
+
+    fake_enum_subprocess(_subprocess.SubprocessError("boom"))
+    assert list_cameras_in_subprocess() is None
+
+
+def test_subprocess_enumeration_invalid_json_is_none(fake_enum_subprocess) -> None:
+    from makermodslab.camera_identity import list_cameras_in_subprocess
+
+    fake_enum_subprocess("not json at all")
+    assert list_cameras_in_subprocess() is None
+
+
+def test_subprocess_enumeration_is_none_off_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The script is PyObjC/AVFoundation-only. Elsewhere there is no answer to
+    give — and, again, "no answer" is not "no cameras"."""
+    from makermodslab.camera_identity import list_cameras_in_subprocess
+
+    monkeypatch.setattr(camera_identity.platform, "system", lambda: "Linux")
+    called = []
+    monkeypatch.setattr(
+        camera_identity.subprocess, "run", lambda *a, **k: called.append(a) or _FakeCompleted("[]")
+    )
+    assert list_cameras_in_subprocess() is None
+    assert called == []

--- a/tests/test_camera_identity.py
+++ b/tests/test_camera_identity.py
@@ -20,6 +20,7 @@ external cameras needs camera permission.
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 
@@ -410,6 +411,33 @@ def test_subprocess_enumeration_invalid_json_is_none(fake_enum_subprocess) -> No
     assert list_cameras_in_subprocess() is None
 
 
+def test_subprocess_enumeration_treats_a_json_null_as_no_answer(
+    fake_enum_subprocess, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The child signals could-not-ask twice — a JSON null AND a non-zero exit
+    — because neither channel is guaranteed to survive. Only the exit code is
+    load-bearing today (check=True raises before stdout is looked at), so this
+    covers the null on its own: the day someone drops the `sys.exit(1)`, the
+    null is all that stands between a failed enumeration and a parent that
+    concludes "no cameras attached" and refuses every start."""
+    from makermodslab.camera_identity import list_cameras_in_subprocess
+
+    fake_enum_subprocess("null")
+    with caplog.at_level(logging.WARNING, logger="makermodslab.camera_identity"):
+        assert list_cameras_in_subprocess() is None
+    assert "reported no answer" in caplog.text
+
+
+def test_subprocess_enumeration_rejects_json_that_is_not_a_list(fake_enum_subprocess) -> None:
+    """Only a real list may be trusted as a device set: `[]` is acted on as a
+    fact about the machine, so anything that is not a list has to be no answer
+    rather than something a caller iterates."""
+    from makermodslab.camera_identity import list_cameras_in_subprocess
+
+    fake_enum_subprocess('{"index": 0, "name": "Cam A", "unique_id": "uid-A"}')
+    assert list_cameras_in_subprocess() is None
+
+
 def test_subprocess_enumeration_is_none_off_macos(monkeypatch: pytest.MonkeyPatch) -> None:
     """The script is PyObjC/AVFoundation-only. Elsewhere there is no answer to
     give — and, again, "no answer" is not "no cameras"."""
@@ -535,6 +563,25 @@ def run_real_enum_script(tmp_path, monkeypatch: pytest.MonkeyPatch):
     return _set
 
 
+def _enum_failure_reason(caplog: pytest.LogCaptureFixture) -> str | None:
+    """The child's could-not-ask reason as it reached the parent's log.
+
+    Only the CalledProcessError branch relays it: `fail()` names the reason on
+    stderr and exits 1, and `check=True` turns that into an exception carrying
+    the stderr. Fall through to the generic subprocess-failed branch instead and
+    the reason is gone — replaced by a "returned non-zero exit status 1" whose
+    text happens to quote the whole argv (the enum script's own source, reason
+    strings and all), which is why this matches the prefix rather than searching
+    caplog for the words.
+    """
+    prefix = "AVFoundation enumeration could not be performed: "
+    for record in caplog.records:
+        message = record.getMessage()
+        if message.startswith(prefix):
+            return message[len(prefix) :]
+    return None
+
+
 def test_real_script_reports_a_genuinely_empty_machine_as_an_empty_list(run_real_enum_script) -> None:
     """The control: an ask that succeeded and saw nothing still returns [], so
     the failure signalling below cannot be blamed for over-triggering."""
@@ -553,33 +600,53 @@ def test_real_script_returns_the_devices_it_saw(run_real_enum_script) -> None:
 
 
 def test_real_script_signals_failure_when_no_device_type_constant_resolves(
-    run_real_enum_script,
+    run_real_enum_script, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A macOS point release renaming the AVCaptureDeviceType constants leaves
     the script with an empty type list, which can only ever match nothing. That
     nothing must not reach the parent as [] — `_verify_camera_identities` would
     then declare every bound camera missing and 400 every start, telling the
     user to re-select cameras that are sitting right there."""
-    assert run_real_enum_script(FAKE_TYPES="") is None
+    with caplog.at_level(logging.WARNING, logger="makermodslab.camera_identity"):
+        assert run_real_enum_script(FAKE_TYPES="") is None
+    # The child's own reason has to survive the process boundary and land in the
+    # log. All three failures return the same None, so the stderr text is the
+    # ONLY thing that separates "renamed by a macOS release" (needs a code
+    # change) from the transient ones — see the reasons asserted below. Matched
+    # WITH the "could not be performed" prefix on purpose: that prefix is what
+    # marks the child's own could-not-ask signal, and the generic
+    # subprocess-failed branch quotes the whole argv, script source included,
+    # so every reason string appears in its message too.
+    assert _enum_failure_reason(caplog) == (
+        "No AVFoundation camera device-type constants resolved (renamed by macOS?)"
+    )
 
 
-def test_real_script_signals_failure_when_the_framework_does_not_load(run_real_enum_script) -> None:
+def test_real_script_signals_failure_when_the_framework_does_not_load(
+    run_real_enum_script, caplog: pytest.LogCaptureFixture
+) -> None:
     """Without AVFoundation loaded no constant resolves and no device can be
     found — a failure to ask, not an empty machine."""
-    assert run_real_enum_script(FAKE_BUNDLE_LOAD="0", FAKE_TYPES="AVCaptureDeviceTypeExternal") is None
+    with caplog.at_level(logging.WARNING, logger="makermodslab.camera_identity"):
+        assert run_real_enum_script(FAKE_BUNDLE_LOAD="0", FAKE_TYPES="AVCaptureDeviceTypeExternal") is None
+    assert _enum_failure_reason(caplog) == "AVFoundation framework did not load"
 
 
-def test_real_script_signals_failure_when_no_discovery_query_answered(run_real_enum_script) -> None:
+def test_real_script_signals_failure_when_no_discovery_query_answered(
+    run_real_enum_script, caplog: pytest.LogCaptureFixture
+) -> None:
     """`devices()` returning nil is a query that did not answer. Flattening it
     with `or []` is exactly what turns a failed query into an empty machine."""
-    assert (
-        run_real_enum_script(
-            FAKE_TYPES="AVCaptureDeviceTypeExternal",
-            FAKE_DEVICES_vide="null",
-            FAKE_DEVICES_muxx="null",
+    with caplog.at_level(logging.WARNING, logger="makermodslab.camera_identity"):
+        assert (
+            run_real_enum_script(
+                FAKE_TYPES="AVCaptureDeviceTypeExternal",
+                FAKE_DEVICES_vide="null",
+                FAKE_DEVICES_muxx="null",
+            )
+            is None
         )
-        is None
-    )
+    assert _enum_failure_reason(caplog) == "AVFoundation discovery answered nothing"
 
 
 def test_real_script_trusts_one_answering_query(run_real_enum_script) -> None:

--- a/tests/test_camera_identity.py
+++ b/tests/test_camera_identity.py
@@ -422,3 +422,171 @@ def test_subprocess_enumeration_is_none_off_macos(monkeypatch: pytest.MonkeyPatc
     )
     assert list_cameras_in_subprocess() is None
     assert called == []
+
+
+# ---------------------------------------------------------------------------
+# The enumeration SCRIPT itself, executed for real
+#
+# Every test above fakes `subprocess.run`, so none of them ever runs the script
+# body — and the whole None-vs-[] contract lives inside that body. The child is
+# the only thing that can tell "could not ask" from "asked, saw nothing", so a
+# child that prints `[]` when the ask failed makes the parent's careful
+# distinction cosmetic: `_verify_camera_identities` would read a PyObjC/TCC
+# failure as a bare machine and refuse every inference start.
+#
+# These tests therefore spawn the REAL script with fake `objc`/`Foundation`
+# modules shadowing PyObjC on PYTHONPATH, so each failure mode can be induced
+# on any host (and without camera permission) while the code under test is the
+# shipped script, character for character.
+# ---------------------------------------------------------------------------
+
+_FAKE_OBJC = '''
+import json, os
+
+class error(Exception):
+    """Stands in for objc.error, which the script catches per-constant."""
+
+def loadBundleVariables(bundle, into, names):
+    wanted = [n for n in os.environ.get("FAKE_TYPES", "").split(",") if n]
+    for name, _enc in names:
+        if name in wanted:
+            into[name] = "avf-type:" + name
+
+class _Device:
+    def __init__(self, raw):
+        self._raw = raw
+
+    def uniqueID(self):
+        return self._raw["unique_id"]
+
+    def localizedName(self):
+        return self._raw["name"]
+
+class _Session:
+    def __init__(self, types, media_type):
+        self._types = types
+        self._media_type = media_type
+
+    def devices(self):
+        # No device types means a query that can only match nothing — which is
+        # what real AVFoundation returns, not an error. Modelling it faithfully
+        # is the point: the script cannot be allowed to pass that off as an
+        # empty machine.
+        if not self._types:
+            return []
+        # Muxed devices are a separate (usually empty) query; only the video
+        # query is scripted, so a `null` here models exactly one query failing
+        # to answer while the other answers honestly.
+        raw = os.environ.get("FAKE_DEVICES_" + self._media_type, "[]")
+        if raw == "null":
+            return None
+        return [_Device(d) for d in json.loads(raw)]
+
+class _DiscoverySession:
+    @staticmethod
+    def discoverySessionWithDeviceTypes_mediaType_position_(types, media_type, position):
+        return _Session(types, media_type)
+
+def lookUpClass(name):
+    return _DiscoverySession
+'''
+
+_FAKE_FOUNDATION = """
+import os
+
+class _Bundle:
+    def load(self):
+        return os.environ.get("FAKE_BUNDLE_LOAD", "1") == "1"
+
+class NSBundle:
+    @staticmethod
+    def bundleWithPath_(path):
+        return _Bundle()
+"""
+
+
+@pytest.fixture
+def run_real_enum_script(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Run `list_cameras_in_subprocess` for real against a fake AVFoundation.
+
+    Only PyObjC is faked (via PYTHONPATH shadowing); the script body, the spawn
+    and the parent's parsing are all the shipped code."""
+    import os
+    import subprocess as _subprocess
+
+    (tmp_path / "objc.py").write_text(_FAKE_OBJC)
+    (tmp_path / "Foundation.py").write_text(_FAKE_FOUNDATION)
+
+    def _set(**env) -> list[dict] | None:
+        real_run = _subprocess.run
+
+        def _run(cmd, **kwargs):
+            kwargs["env"] = {
+                **os.environ,
+                "PYTHONPATH": str(tmp_path),
+                **{k: str(v) for k, v in env.items()},
+            }
+            return real_run(cmd, **kwargs)
+
+        monkeypatch.setattr(camera_identity.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(camera_identity.subprocess, "run", _run)
+        return camera_identity.list_cameras_in_subprocess()
+
+    return _set
+
+
+def test_real_script_reports_a_genuinely_empty_machine_as_an_empty_list(run_real_enum_script) -> None:
+    """The control: an ask that succeeded and saw nothing still returns [], so
+    the failure signalling below cannot be blamed for over-triggering."""
+    assert run_real_enum_script(FAKE_TYPES="AVCaptureDeviceTypeExternal") == []
+
+
+def test_real_script_returns_the_devices_it_saw(run_real_enum_script) -> None:
+    assert run_real_enum_script(
+        FAKE_TYPES="AVCaptureDeviceTypeExternal",
+        FAKE_DEVICES_vide='[{"name": "Wrist", "unique_id": "uid-B"},'
+        ' {"name": "Front", "unique_id": "uid-A"}]',
+    ) == [
+        {"index": 0, "name": "Front", "unique_id": "uid-A"},
+        {"index": 1, "name": "Wrist", "unique_id": "uid-B"},
+    ]
+
+
+def test_real_script_signals_failure_when_no_device_type_constant_resolves(
+    run_real_enum_script,
+) -> None:
+    """A macOS point release renaming the AVCaptureDeviceType constants leaves
+    the script with an empty type list, which can only ever match nothing. That
+    nothing must not reach the parent as [] — `_verify_camera_identities` would
+    then declare every bound camera missing and 400 every start, telling the
+    user to re-select cameras that are sitting right there."""
+    assert run_real_enum_script(FAKE_TYPES="") is None
+
+
+def test_real_script_signals_failure_when_the_framework_does_not_load(run_real_enum_script) -> None:
+    """Without AVFoundation loaded no constant resolves and no device can be
+    found — a failure to ask, not an empty machine."""
+    assert run_real_enum_script(FAKE_BUNDLE_LOAD="0", FAKE_TYPES="AVCaptureDeviceTypeExternal") is None
+
+
+def test_real_script_signals_failure_when_no_discovery_query_answered(run_real_enum_script) -> None:
+    """`devices()` returning nil is a query that did not answer. Flattening it
+    with `or []` is exactly what turns a failed query into an empty machine."""
+    assert (
+        run_real_enum_script(
+            FAKE_TYPES="AVCaptureDeviceTypeExternal",
+            FAKE_DEVICES_vide="null",
+            FAKE_DEVICES_muxx="null",
+        )
+        is None
+    )
+
+
+def test_real_script_trusts_one_answering_query(run_real_enum_script) -> None:
+    """Mirrors list_cameras_in_process's `answered` flag: the muxed query going
+    nil is normal, and one query answering is enough to trust the result."""
+    assert run_real_enum_script(
+        FAKE_TYPES="AVCaptureDeviceTypeExternal",
+        FAKE_DEVICES_vide='[{"name": "Front", "unique_id": "uid-A"}]',
+        FAKE_DEVICES_muxx="null",
+    ) == [{"index": 0, "name": "Front", "unique_id": "uid-A"}]

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -3291,6 +3291,22 @@ def _fake_enumeration(monkeypatch: pytest.MonkeyPatch, cameras: list[dict] | Non
     monkeypatch.setattr(rollout, "list_cameras_in_subprocess", lambda: cameras)
 
 
+def _forbid_enumeration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the enumeration EXPLODE if it is spawned at all.
+
+    Patching it to return a list cannot tell "skipped verification" from
+    "verified and happened to agree", so every skip case traps the spawn
+    instead. The skip is the feature's cost guarantee: a record with nothing to
+    verify (no uniqueID, a non-int index) must not pay for a PyObjC subprocess
+    on every single start."""
+    from makermodslab import rollout
+
+    def _boom():
+        raise AssertionError("spawned a camera enumeration for an unverifiable camera set")
+
+    monkeypatch.setattr(rollout, "list_cameras_in_subprocess", _boom)
+
+
 def _cam_request(robot: str, bindings: dict[str, str]):
     from makermodslab.rollout import InferenceRequest
 
@@ -3401,6 +3417,159 @@ def test_session_cameras_names_every_mismatched_camera(
     assert "uid-O" in message
 
 
+def test_session_cameras_refuses_when_the_enumeration_found_no_cameras(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An enumeration that RAN and returned [] is a fact about the machine, not
+    a failure to ask — everything got unplugged. Collapsing it into the
+    "could not enumerate" skip (`if not attached`) would sail past the guard and
+    hand lerobot an index with nothing behind it. Keeping None and [] apart is
+    the entire reason camera_identity maintains the split."""
+    from makermodslab.rollout import _session_cameras
+    from makermodslab.utils.config import CameraResolutionError
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(monkeypatch, [])
+    with pytest.raises(CameraResolutionError) as exc:
+        _session_cameras(_cam_request("solo", {"front": "wrist"}))
+
+    assert "not connected" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# WHAT the refusal tells the user to do
+#
+# Two different failures hide behind "the index no longer matches", and they
+# need opposite instructions. A camera that is UNPLUGGED cannot be re-selected:
+# the picker only lists attached devices, so "re-select it" is a dead end. A
+# camera that merely RENUMBERED is still attached, and the enumeration already
+# knows where it went — so say where, and point at the record that needs
+# re-saving. Neither may say "restart".
+# ---------------------------------------------------------------------------
+
+
+def _refusal(tmp_lerobot_home, monkeypatch, cams, attached, bindings) -> str:
+    from makermodslab.rollout import _session_cameras
+    from makermodslab.utils.config import CameraResolutionError
+
+    _robot_record_with_identified_cams(tmp_lerobot_home, monkeypatch, "solo", cams)
+    _fake_enumeration(monkeypatch, attached)
+    with pytest.raises(CameraResolutionError) as exc:
+        _session_cameras(_cam_request("solo", bindings))
+    return str(exc.value)
+
+
+def test_refusal_for_an_unplugged_camera_says_reconnect_not_re_select(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    message = _refusal(
+        tmp_lerobot_home,
+        monkeypatch,
+        [_identified_cam("wrist", 1, "uid-W")],
+        [{"index": 0, "name": "Front", "unique_id": "uid-F"}],
+        {"front": "wrist"},
+    )
+    assert "This camera is not connected" in message
+    assert "These cameras are" not in message
+    assert "Reconnect it" in message
+    assert "remove it from this robot's cameras" in message
+    # The camera is absent from the picker, so any instruction that starts in
+    # the picker sends the user somewhere that cannot help them.
+    assert "re-select" not in message.lower()
+    assert "restart" not in message.lower()
+
+
+def test_refusal_for_a_moved_camera_says_where_it_actually_is_now(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The enumeration is in hand, so the new position is knowable — without it
+    the user is told their camera moved and left to guess where to."""
+    message = _refusal(
+        tmp_lerobot_home,
+        monkeypatch,
+        [_identified_cam("wrist", 1, "uid-W")],
+        [
+            {"index": 0, "name": "Front", "unique_id": "uid-F"},
+            {"index": 1, "name": "Other", "unique_id": "uid-X"},
+            {"index": 3, "name": "Wrist", "unique_id": "uid-W"},
+        ],
+        {"front": "wrist"},
+    )
+    assert "This camera has moved" in message
+    assert "These cameras have" not in message
+    assert "was saved at position 1 but is now at position 3" in message
+    assert "save its camera configuration" in message
+    # Still attached, so it is emphatically NOT the unplugged wording.
+    assert "not connected" not in message
+    assert "restart" not in message.lower()
+
+
+def test_refusal_pluralises_when_several_cameras_moved(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    message = _refusal(
+        tmp_lerobot_home,
+        monkeypatch,
+        [_identified_cam("wrist", 1, "uid-W"), _identified_cam("overhead", 2, "uid-O")],
+        [
+            {"index": 1, "name": "Other", "unique_id": "uid-X"},
+            {"index": 3, "name": "Wrist", "unique_id": "uid-W"},
+            {"index": 4, "name": "Over", "unique_id": "uid-O"},
+        ],
+        {"cam_a": "wrist", "cam_b": "overhead"},
+    )
+    assert "These cameras have moved" in message
+    assert "This camera has" not in message
+    assert "update the saved positions" in message
+    assert "'wrist' (device uid-W) was saved at position 1 but is now at position 3" in message
+    assert "'overhead' (device uid-O) was saved at position 2 but is now at position 4" in message
+
+
+def test_refusal_pluralises_when_several_cameras_are_unplugged(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    message = _refusal(
+        tmp_lerobot_home,
+        monkeypatch,
+        [_identified_cam("wrist", 1, "uid-W"), _identified_cam("overhead", 2, "uid-O")],
+        [{"index": 0, "name": "Front", "unique_id": "uid-F"}],
+        {"cam_a": "wrist", "cam_b": "overhead"},
+    )
+    assert "These cameras are not connected" in message
+    assert "This camera is" not in message
+    assert "Reconnect them" in message
+    assert "'wrist' (device uid-W)" in message
+    assert "'overhead' (device uid-O)" in message
+
+
+def test_refusal_keeps_the_two_cases_apart_when_both_happen(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bench rearrangement typically does both at once: unplugging one camera
+    renumbers the rest. Lumping them under either instruction leaves one of the
+    two cameras with advice that cannot work."""
+    message = _refusal(
+        tmp_lerobot_home,
+        monkeypatch,
+        [_identified_cam("wrist", 1, "uid-W"), _identified_cam("overhead", 2, "uid-O")],
+        [
+            {"index": 0, "name": "Front", "unique_id": "uid-F"},
+            {"index": 1, "name": "Other", "unique_id": "uid-X"},
+            {"index": 3, "name": "Over", "unique_id": "uid-O"},
+        ],
+        {"cam_a": "wrist", "cam_b": "overhead"},
+    )
+    # The absent one gets "reconnect", the present one gets its new position —
+    # each named exactly once, in the sentence that applies to it.
+    assert "This camera is not connected, so inference cannot open it: 'wrist' (device uid-W)." in message
+    assert "'overhead' (device uid-O) was saved at position 2 but is now at position 3" in message
+    assert "This camera has moved" in message
+    assert "'wrist'" not in message.split("This camera has moved")[1]
+    assert "restart" not in message.lower()
+
+
 def test_session_cameras_skips_verification_without_a_unique_id(
     tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3411,7 +3580,7 @@ def test_session_cameras_skips_verification_without_a_unique_id(
     _robot_record_with_identified_cams(
         tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, None)]
     )
-    _fake_enumeration(monkeypatch, [{"index": 0, "name": "Front", "unique_id": "uid-F"}])
+    _forbid_enumeration(monkeypatch)
     assert _session_cameras(_cam_request("solo", {"front": "wrist"}))["front"]["camera_index"] == 1
 
 
@@ -3439,10 +3608,26 @@ def test_session_cameras_skips_verification_for_a_non_int_index(
     cam = _identified_cam("wrist", 1, "uid-W")
     cam["camera_index"] = "/dev/video0"
     _robot_record_with_identified_cams(tmp_lerobot_home, monkeypatch, "solo", [cam])
-    _fake_enumeration(monkeypatch, [{"index": 0, "name": "Front", "unique_id": "uid-F"}])
+    _forbid_enumeration(monkeypatch)
     assert (
         _session_cameras(_cam_request("solo", {"front": "wrist"}))["front"]["camera_index"] == "/dev/video0"
     )
+
+
+def test_session_cameras_skips_verification_for_a_bool_index(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`True` passes `isinstance(x, int)` in Python, and would then be compared
+    against enumerated index 1 — a record with a junk boolean index would be
+    "verified" against an unrelated camera and refuse a start that has nothing
+    wrong with it. A bool is not a position, so there is nothing to check."""
+    from makermodslab.rollout import _session_cameras
+
+    cam = _identified_cam("wrist", 1, "uid-W")
+    cam["camera_index"] = True
+    _robot_record_with_identified_cams(tmp_lerobot_home, monkeypatch, "solo", [cam])
+    _forbid_enumeration(monkeypatch)
+    assert _session_cameras(_cam_request("solo", {"front": "wrist"}))["front"]["camera_index"] is True
 
 
 def test_session_cameras_does_not_enumerate_without_bindings(
@@ -3625,6 +3810,14 @@ def test_next_episode_respawn_refuses_when_a_camera_moved(
     session.request = _cam_request("solo", {"front": "wrist"})
     # Two episodes already scored — the thing the rollback is protecting.
     session.results = ["success", "failure"]
+    # This path is ONLY reached with a dead runner, so there is always a crash
+    # banner sitting on the dialog explaining why Continue is being offered.
+    session.error = "The rollout process exited with code 1"
+    session.hint = "The policy could not be loaded"
+    session.runner_error = "RuntimeError: boom"
+    # The previous episode's rollout stamp is still standing; nothing has
+    # started, so nothing should restamp it.
+    monkeypatch.setattr(rollout, "_inference_rollout_started_at", 1005.0)
     monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
     monkeypatch.setattr(
         rollout,
@@ -3649,6 +3842,18 @@ def test_next_episode_respawn_refuses_when_a_camera_moved(
     assert rollout._inference_meta["phase"] == rollout.PHASE_RESETTING
     assert session.results == results_before
     assert session.episodes_total == 3
+    # The clocks were restamped to "now" for an episode that never began. Left
+    # that way the reset dialog's elapsed time restarts from zero, so it reports
+    # the age of a refusal instead of how long the user has been parked.
+    assert rollout._inference_started_at == 1000.0
+    assert rollout._inference_rollout_started_at == 1005.0
+    # And the crash banner was cleared a moment earlier on the assumption the
+    # episode was about to run. Wiping it leaves a transient toast as the only
+    # account of why the runner is gone — on the one path that is guaranteed to
+    # have crashed.
+    assert session.error == "The rollout process exited with code 1"
+    assert session.hint == "The policy could not be loaded"
+    assert session.runner_error == "RuntimeError: boom"
 
 
 def test_next_episode_respawn_proceeds_when_the_cameras_still_match(

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -851,9 +851,10 @@ def _bimanual_request():
 
 
 def test_single_robot_args_uses_so101_follower_type() -> None:
-    from makermodslab.rollout import _single_robot_args
+    from makermodslab.rollout import _session_cameras, _single_robot_args
 
-    args = _single_robot_args(_stub_request(), "robot_a")
+    req = _stub_request()
+    args = _single_robot_args(req, "robot_a", _session_cameras(req))
     assert "--robot.type=so101_follower" in args
     assert "--robot.port=/dev/ttyUSB0" in args
     assert "--robot.id=robot_a" in args
@@ -866,7 +867,7 @@ def test_single_robot_args_appends_bound_record_cameras(
 ) -> None:
     """The binding names a RECORD camera ("wrist"); the CLI arg is keyed by the
     POLICY-expected name ("front") and carries the record's own settings."""
-    from makermodslab.rollout import InferenceRequest, _single_robot_args
+    from makermodslab.rollout import InferenceRequest, _session_cameras, _single_robot_args
 
     _robot_record_with_cam(tmp_lerobot_home, monkeypatch, "solo")
     req = InferenceRequest(
@@ -876,7 +877,7 @@ def test_single_robot_args_appends_bound_record_cameras(
         robot_name="solo",
         camera_bindings={"front": "wrist"},
     )
-    args = _single_robot_args(req, "robot_a")
+    args = _single_robot_args(req, "robot_a", _session_cameras(req))
     cam_arg = next(a for a in args if a.startswith("--robot.cameras="))
     assert "front:" in cam_arg
     assert "wrist" not in cam_arg
@@ -895,7 +896,7 @@ def test_single_robot_args_captures_at_the_checkpoints_resolution(
     """The rollout pipeline doesn't resize frames to the policy's input shape,
     so `camera_dims` (from the checkpoint) must win over the record's own
     configured size — while identity still comes from the record."""
-    from makermodslab.rollout import InferenceRequest, _single_robot_args
+    from makermodslab.rollout import InferenceRequest, _session_cameras, _single_robot_args
 
     _robot_record_with_cam(tmp_lerobot_home, monkeypatch, "solo")
     req = InferenceRequest(
@@ -906,7 +907,8 @@ def test_single_robot_args_captures_at_the_checkpoints_resolution(
         camera_bindings={"front": "wrist"},
         camera_dims={"front": {"width": 320, "height": 240}},
     )
-    cam_arg = next(a for a in _single_robot_args(req, "robot_a") if a.startswith("--robot.cameras="))
+    args = _single_robot_args(req, "robot_a", _session_cameras(req))
+    cam_arg = next(a for a in args if a.startswith("--robot.cameras="))
 
     assert "width: 320" in cam_arg
     assert "height: 240" in cam_arg
@@ -915,9 +917,10 @@ def test_single_robot_args_captures_at_the_checkpoints_resolution(
 
 
 def test_bimanual_robot_args_uses_bi_so_follower_with_both_ports() -> None:
-    from makermodslab.rollout import _bimanual_robot_args
+    from makermodslab.rollout import _bimanual_robot_args, _session_cameras
 
-    args = _bimanual_robot_args(_bimanual_request(), "dual_arm", "/staging/follower")
+    req = _bimanual_request()
+    args = _bimanual_robot_args(req, "dual_arm", "/staging/follower", _session_cameras(req))
     assert "--robot.type=bi_so_follower" in args
     assert "--robot.id=dual_arm" in args
     assert "--robot.calibration_dir=/staging/follower" in args
@@ -928,7 +931,7 @@ def test_bimanual_robot_args_uses_bi_so_follower_with_both_ports() -> None:
 def test_bimanual_robot_args_puts_cameras_on_left_arm_only(
     tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from makermodslab.rollout import InferenceRequest, _bimanual_robot_args
+    from makermodslab.rollout import InferenceRequest, _bimanual_robot_args, _session_cameras
 
     _robot_record_with_cam(tmp_lerobot_home, monkeypatch, "dual_arm")
     req = InferenceRequest(
@@ -941,7 +944,7 @@ def test_bimanual_robot_args_puts_cameras_on_left_arm_only(
         robot_name="dual_arm",
         camera_bindings={"front": "wrist"},
     )
-    args = _bimanual_robot_args(req, "dual_arm", "/staging/follower")
+    args = _bimanual_robot_args(req, "dual_arm", "/staging/follower", _session_cameras(req))
     assert any(a.startswith("--robot.left_arm_config.cameras=") for a in args)
     assert not any(a.startswith("--robot.right_arm_config.cameras=") for a in args)
 
@@ -3473,3 +3476,194 @@ def test_handle_start_inference_refuses_a_camera_that_moved(
     assert "wrist" in result["message"]
     assert "restart" not in result["message"].lower()
     assert rollout.inference_active is False
+
+
+# ---------------------------------------------------------------------------
+# WHEN the camera check fires relative to the hardware
+#
+# The request-thread check is a fast reject for a stale record; it is NOT the
+# guarantee. Minutes can pass between it and the run (a Hub download), and a
+# camera reseated in that window is exactly the case the guard exists for. So
+# the check inside `_prepare_robot` has to come before the preflights, which
+# open the follower bus and write torque/velocity registers — a refusal that
+# lands after those has already claimed and rewritten the arm.
+# ---------------------------------------------------------------------------
+
+
+def _trap_preflights(monkeypatch, rollout) -> list[str]:
+    """Make both hardware-touching preflights record (and forbid) themselves."""
+    touched: list[str] = []
+
+    def _identity(port, follower_id, config_name=None):
+        touched.append(f"identity:{port}")
+        return []
+
+    def _registers(port, follower_id):
+        touched.append(f"registers:{port}")
+        return []
+
+    monkeypatch.setattr(rollout, "_preflight_arm_identity", _identity)
+    monkeypatch.setattr(rollout, "_preflight_motor_registers", _registers)
+    monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda cfg, arm: "robot_a")
+    return touched
+
+
+def test_prepare_robot_verifies_cameras_before_opening_the_bus(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A camera that moved during the download must be caught with the arm
+    untouched: no identity read, and above all no torque-limit write."""
+    from makermodslab import rollout
+    from makermodslab.utils.config import CameraResolutionError
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(monkeypatch, [{"index": 1, "name": "Other", "unique_id": "uid-X"}])
+    touched = _trap_preflights(monkeypatch, rollout)
+
+    with pytest.raises(CameraResolutionError):
+        rollout._prepare_robot(_cam_request("solo", {"front": "wrist"}))
+
+    assert touched == [], f"the bus was opened before the camera check: {touched}"
+
+
+def test_prepare_robot_bimanual_verifies_cameras_before_opening_either_bus(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two buses, twice the exposure — and the bimanual path builds its camera
+    args last of all, so it is the one most likely to regress."""
+    from makermodslab import rollout
+    from makermodslab.rollout import InferenceRequest
+    from makermodslab.utils.config import CameraResolutionError
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "dual_arm", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(monkeypatch, [{"index": 1, "name": "Other", "unique_id": "uid-X"}])
+    touched = _trap_preflights(monkeypatch, rollout)
+    monkeypatch.setattr(
+        rollout, "stage_bimanual_follower_calibrations", lambda *a, **k: ("/staging/follower", None)
+    )
+
+    req = InferenceRequest(
+        follower_port="/dev/left",
+        follower_config="left_cal",
+        policy_ref="user/repo@checkpoints/000050",
+        mode="bimanual",
+        right_follower_port="/dev/right",
+        right_follower_config="right_cal",
+        robot_name="dual_arm",
+        camera_bindings={"front": "wrist"},
+    )
+    with pytest.raises(CameraResolutionError):
+        rollout._prepare_robot(req)
+
+    assert touched == [], f"a bus was opened before the camera check: {touched}"
+
+
+def test_startup_worker_reports_a_moved_camera_in_its_own_words(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`CameraResolutionError` carries finished, actionable prose (re-select the
+    camera). Falling through to the generic handler would bury it behind
+    "Failed to start inference:", which reads like a crash the user caused."""
+    import threading
+
+    from makermodslab import rollout
+    from makermodslab.utils.config import CameraResolutionError
+
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(
+        rollout, "_inference_meta", {"phase": rollout.PHASE_STARTING, "policy_ref": "/tmp/model"}
+    )
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: "/tmp/model")
+
+    def _refuse(request):
+        raise CameraResolutionError("This camera is no longer at the position saved for this robot.")
+
+    monkeypatch.setattr(rollout, "_prepare_robot", _refuse)
+    monkeypatch.setattr(
+        rollout.subprocess,
+        "Popen",
+        lambda *a, **k: pytest.fail("no subprocess may spawn after a camera refusal"),
+    )
+
+    rollout._run_inference_startup(
+        rollout.InferenceRequest(
+            follower_port="/dev/f", follower_config="follower_a", policy_ref="/tmp/model"
+        ),
+        threading.Event(),
+    )
+
+    status = rollout.handle_inference_status()
+    assert status["outcome"] == "failed"
+    assert status["error"] == "This camera is no longer at the position saved for this robot."
+
+
+# ---------------------------------------------------------------------------
+# Eval respawn: the bench gets rearranged between episodes
+#
+# The reset is deliberately unrushed, which is precisely when a user reaches
+# behind the rig and moves a camera. On the live-runner path that is harmless —
+# the child is holding the verified devices open, and an index it never re-reads
+# cannot renumber underneath it. A respawn re-opens by index against the NEW
+# AVFoundation order, so it must re-verify or it silently films something else
+# for every remaining episode.
+# ---------------------------------------------------------------------------
+
+
+def test_next_episode_respawn_refuses_when_a_camera_moved(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from makermodslab import rollout
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=None)
+    session.request = _cam_request("solo", {"front": "wrist"})
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(
+        rollout,
+        "_launch_eval_runner",
+        lambda *a, **k: pytest.fail("a runner must not respawn against an unverified camera set"),
+    )
+    _fake_enumeration(monkeypatch, [{"index": 1, "name": "Other", "unique_id": "uid-X"}])
+
+    result = rollout.handle_next_episode()
+
+    assert result["success"] is False
+    assert "wrist" in result["message"]
+
+
+def test_next_episode_respawn_proceeds_when_the_cameras_still_match(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must not tax the ordinary crash-respawn: an unchanged bench
+    continues on the cached args, with no re-download and no second preflight."""
+    from makermodslab import rollout
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=None)
+    session.request = _cam_request("solo", {"front": "wrist"})
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+    _fake_enumeration(monkeypatch, [{"index": 1, "name": "Wrist", "unique_id": "uid-W"}])
+
+    launched = {}
+
+    def _fake_launch(request, policy_path, robot_args):
+        launched["robot_args"] = robot_args
+        proc = _FakeRunner()
+        proc.stdout = _EmptyStdout()
+        return proc, io.StringIO(), Path("/tmp/ep2.log")
+
+    monkeypatch.setattr(rollout, "_launch_eval_runner", _fake_launch)
+    monkeypatch.setattr(rollout, "_handle_runner_exit", lambda proc, rc: None)
+
+    result = rollout.handle_next_episode()
+
+    assert result["success"] is True
+    assert launched["robot_args"][0] == "--robot.type=so101_follower"

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -3238,3 +3238,238 @@ def test_sharded_weights_are_not_accepted(tmp_path) -> None:
     (d / "model.safetensors.index.json").write_text("{}")
 
     assert models._has_loadable_weights(d) is False
+
+
+# ---------------------------------------------------------------------------
+# Camera-identity verification before a rollout
+#
+# `camera_index` is a POSITION in a USB enumeration that renumbers whenever the
+# device set changes, so the record's index can point at a different physical
+# camera than the record names — and the policy then silently gets the wrong
+# view. Before spawning, the stored index is checked against a fresh-subprocess
+# enumeration (the ordering the `lerobot-rollout` CHILD will index against, not
+# this process's stale one) and a disagreement refuses the start.
+# ---------------------------------------------------------------------------
+
+
+def _robot_record_with_identified_cams(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch, name: str, cameras: list[dict]
+) -> None:
+    """Write a robot record whose cameras carry uniqueIDs (macOS records)."""
+    from makermodslab.utils import config as cfg
+
+    robots_dir = tmp_lerobot_home / "robots"
+    robots_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cfg, "ROBOTS_PATH", str(robots_dir))
+    cfg.save_robot_record(name, {"cameras": cameras}, allow_create=True)
+
+
+def _identified_cam(name: str, index: int, unique_id: str | None) -> dict:
+    cam = {
+        "id": f"camera_{name}",
+        "name": name,
+        "type": "opencv",
+        "camera_index": index,
+        "width": 640,
+        "height": 480,
+        "fps": 30,
+    }
+    if unique_id is not None:
+        cam["unique_id"] = unique_id
+    return cam
+
+
+def _fake_enumeration(monkeypatch: pytest.MonkeyPatch, cameras: list[dict] | None) -> None:
+    """Patch the fresh-subprocess enumeration rollout verifies against.
+
+    None means "could not enumerate" — deliberately different from []."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "list_cameras_in_subprocess", lambda: cameras)
+
+
+def _cam_request(robot: str, bindings: dict[str, str]):
+    from makermodslab.rollout import InferenceRequest
+
+    return InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        robot_name=robot,
+        camera_bindings=bindings,
+    )
+
+
+def test_session_cameras_passes_when_the_index_still_holds_the_named_camera(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from makermodslab.rollout import _session_cameras
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(
+        monkeypatch,
+        [
+            {"index": 0, "name": "Front", "unique_id": "uid-F"},
+            {"index": 1, "name": "Wrist", "unique_id": "uid-W"},
+        ],
+    )
+    cameras = _session_cameras(_cam_request("solo", {"front": "wrist"}))
+    # Verification never rewrites: the index the user chose is what is opened.
+    assert cameras["front"]["camera_index"] == 1
+
+
+def test_session_cameras_refuses_when_the_index_holds_a_different_camera(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point: index 1 now holds some other device, so the policy would
+    get a view it was never trained on, with no error anywhere."""
+    from makermodslab.rollout import _session_cameras
+    from makermodslab.utils.config import CameraResolutionError
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(
+        monkeypatch,
+        [
+            {"index": 0, "name": "Front", "unique_id": "uid-F"},
+            {"index": 1, "name": "Some Other Cam", "unique_id": "uid-X"},
+        ],
+    )
+    with pytest.raises(CameraResolutionError) as exc:
+        _session_cameras(_cam_request("solo", {"front": "wrist"}))
+
+    message = str(exc.value)
+    # Names the RECORD label the user recognises, plus the identity it wanted.
+    assert "wrist" in message
+    assert "uid-W" in message
+    # Actionable, and never "restart": a restart cannot fix a renumbered index.
+    assert "restart" not in message.lower()
+    assert "camera" in message.lower()
+
+
+def test_session_cameras_refuses_when_the_camera_is_not_attached_at_all(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An enumeration that ran and found fewer cameras is a fact, not a failure:
+    nothing sits at the stored index, so opening it would hit the wrong device
+    (or nothing)."""
+    from makermodslab.rollout import _session_cameras
+    from makermodslab.utils.config import CameraResolutionError
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(monkeypatch, [{"index": 0, "name": "Front", "unique_id": "uid-F"}])
+    with pytest.raises(CameraResolutionError):
+        _session_cameras(_cam_request("solo", {"front": "wrist"}))
+
+
+def test_session_cameras_names_every_mismatched_camera(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fixing one and being refused again for the next is a miserable loop."""
+    from makermodslab.rollout import _session_cameras
+    from makermodslab.utils.config import CameraResolutionError
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home,
+        monkeypatch,
+        "solo",
+        [_identified_cam("wrist", 1, "uid-W"), _identified_cam("overhead", 2, "uid-O")],
+    )
+    _fake_enumeration(
+        monkeypatch,
+        [
+            {"index": 0, "name": "Front", "unique_id": "uid-F"},
+            {"index": 1, "name": "Other", "unique_id": "uid-X"},
+            {"index": 2, "name": "Another", "unique_id": "uid-Y"},
+        ],
+    )
+    with pytest.raises(CameraResolutionError) as exc:
+        _session_cameras(_cam_request("solo", {"cam_a": "wrist", "cam_b": "overhead"}))
+
+    message = str(exc.value)
+    assert "wrist" in message
+    assert "overhead" in message
+    assert "uid-W" in message
+    assert "uid-O" in message
+
+
+def test_session_cameras_skips_verification_without_a_unique_id(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Older records, and every record on non-macOS, carry no identity. There is
+    nothing to verify against, so behave exactly as before."""
+    from makermodslab.rollout import _session_cameras
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, None)]
+    )
+    _fake_enumeration(monkeypatch, [{"index": 0, "name": "Front", "unique_id": "uid-F"}])
+    assert _session_cameras(_cam_request("solo", {"front": "wrist"}))["front"]["camera_index"] == 1
+
+
+def test_session_cameras_skips_verification_when_enumeration_unavailable(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "Could not enumerate" must not read as "no cameras attached" — that would
+    refuse every start on non-macOS and on any PyObjC/subprocess hiccup."""
+    from makermodslab.rollout import _session_cameras
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(monkeypatch, None)
+    assert _session_cameras(_cam_request("solo", {"front": "wrist"}))["front"]["camera_index"] == 1
+
+
+def test_session_cameras_skips_verification_for_a_non_int_index(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path-valued index (or any non-int) is not a position in this
+    enumeration, so there is nothing to compare it against."""
+    from makermodslab.rollout import _session_cameras
+
+    cam = _identified_cam("wrist", 1, "uid-W")
+    cam["camera_index"] = "/dev/video0"
+    _robot_record_with_identified_cams(tmp_lerobot_home, monkeypatch, "solo", [cam])
+    _fake_enumeration(monkeypatch, [{"index": 0, "name": "Front", "unique_id": "uid-F"}])
+    assert (
+        _session_cameras(_cam_request("solo", {"front": "wrist"}))["front"]["camera_index"] == "/dev/video0"
+    )
+
+
+def test_session_cameras_does_not_enumerate_without_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A camera-less policy must not pay for (or be refused by) an enumeration."""
+    from makermodslab import rollout
+
+    def _boom():
+        raise AssertionError("enumerated for a camera-less session")
+
+    monkeypatch.setattr(rollout, "list_cameras_in_subprocess", _boom)
+    assert rollout._session_cameras(_stub_request()) == {}
+
+
+def test_handle_start_inference_refuses_a_camera_that_moved(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal must land as a 400 BEFORE the session starts, so nothing
+    energises, and it must not wedge the inference slot."""
+    from makermodslab import rollout
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(monkeypatch, [{"index": 1, "name": "Other", "unique_id": "uid-X"}])
+    result = rollout.handle_start_inference(_cam_request("solo", {"front": "wrist"}))
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "wrist" in result["message"]
+    assert "restart" not in result["message"].lower()
+    assert rollout.inference_active is False

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -3623,6 +3623,8 @@ def test_next_episode_respawn_refuses_when_a_camera_moved(
     )
     session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=None)
     session.request = _cam_request("solo", {"front": "wrist"})
+    # Two episodes already scored — the thing the rollback is protecting.
+    session.results = ["success", "failure"]
     monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
     monkeypatch.setattr(
         rollout,
@@ -3631,10 +3633,22 @@ def test_next_episode_respawn_refuses_when_a_camera_moved(
     )
     _fake_enumeration(monkeypatch, [{"index": 1, "name": "Other", "unique_id": "uid-X"}])
 
+    results_before = list(session.results)
     result = rollout.handle_next_episode()
 
     assert result["success"] is False
+    assert result["status_code"] == 400
     assert "wrist" in result["message"]
+    # The refusal must ROLL BACK the "we are starting" bookkeeping the lock
+    # section already did, not just decline to spawn. Left as-is the session
+    # sits at PHASE_STARTING with an episode pending: the reset dialog never
+    # comes back, so Continue can never be pressed again even once the camera
+    # is re-selected — and the only way out is a stop, which discards every
+    # episode already scored.
+    assert session.episode_pending is False
+    assert rollout._inference_meta["phase"] == rollout.PHASE_RESETTING
+    assert session.results == results_before
+    assert session.episodes_total == 3
 
 
 def test_next_episode_respawn_proceeds_when_the_cameras_still_match(
@@ -3667,3 +3681,223 @@ def test_next_episode_respawn_proceeds_when_the_cameras_still_match(
 
     assert result["success"] is True
     assert launched["robot_args"][0] == "--robot.type=so101_follower"
+    # The re-verified args must still CARRY the cameras: the rebuild strips the
+    # cached flag before re-appending it, so a rebuild that silently drops it
+    # respawns a camera-less runner that drives the arm on no images.
+    cam_args = [a for a in launched["robot_args"] if a.startswith("--robot.cameras=")]
+    assert len(cam_args) == 1, f"no single --robot.cameras= in {launched['robot_args']}"
+    assert "index_or_path: 1" in cam_args[0]
+
+
+# ---------------------------------------------------------------------------
+# The camera args actually reaching argv
+#
+# Verification and argv-building are the same step (_prepare_robot resolves the
+# cameras to verify them, THEN formats them), so a refactor that keeps the check
+# can still drop the flag. A run with no `--robot.cameras=` is the worst of the
+# failure modes this branch exists for: lerobot builds a camera-less robot, the
+# arm drives on a policy that is being fed no images at all, and nothing in the
+# logs says so. Assert the flag lands, on both robot shapes.
+# ---------------------------------------------------------------------------
+
+
+def _bimanual_cam_request(robot: str, bindings: dict[str, str]):
+    from makermodslab.rollout import InferenceRequest
+
+    return InferenceRequest(
+        follower_port="/dev/left",
+        follower_config="left_cal",
+        policy_ref="user/repo@checkpoints/000050",
+        mode="bimanual",
+        right_follower_port="/dev/right",
+        right_follower_config="right_cal",
+        robot_name=robot,
+        camera_bindings=bindings,
+    )
+
+
+def test_prepare_robot_passes_the_record_cameras_into_the_single_arm_args(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The successful return, not just the refusal: the resolved cameras must
+    reach `--robot.cameras=` under the POLICY name, carrying the record's
+    index."""
+    from makermodslab import rollout
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(
+        monkeypatch,
+        [
+            {"index": 0, "name": "Built-in", "unique_id": "uid-B"},
+            {"index": 1, "name": "Wrist", "unique_id": "uid-W"},
+        ],
+    )
+    _trap_preflights(monkeypatch, rollout)
+
+    robot_args, _ = rollout._prepare_robot(_cam_request("solo", {"front": "wrist"}))
+
+    cam_args = [a for a in robot_args if a.startswith("--robot.cameras=")]
+    assert len(cam_args) == 1, f"no single --robot.cameras= in {robot_args}"
+    assert "front: {" in cam_args[0]
+    assert "index_or_path: 1" in cam_args[0]
+
+
+def test_prepare_robot_passes_the_record_cameras_into_the_bimanual_args(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """BiSO takes its cameras on the LEFT sub-arm (it re-exposes them as
+    "left_*"); a bare `--robot.cameras=` is not a flag its config has."""
+    from makermodslab import rollout
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "dual_arm", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    _fake_enumeration(monkeypatch, [{"index": 1, "name": "Wrist", "unique_id": "uid-W"}])
+    _trap_preflights(monkeypatch, rollout)
+    monkeypatch.setattr(
+        rollout, "stage_bimanual_follower_calibrations", lambda *a, **k: ("/staging/follower", None)
+    )
+
+    robot_args, _ = rollout._prepare_robot(_bimanual_cam_request("dual_arm", {"front": "wrist"}))
+
+    cam_args = [a for a in robot_args if a.startswith("--robot.left_arm_config.cameras=")]
+    assert len(cam_args) == 1, f"no single left-arm cameras flag in {robot_args}"
+    assert "front: {" in cam_args[0]
+    assert "index_or_path: 1" in cam_args[0]
+    assert not [a for a in robot_args if a.startswith("--robot.cameras=")]
+
+
+def test_next_episode_respawn_picks_up_a_record_fixed_mid_session(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The headline claim of the rebuild: the refusal tells the user to
+    re-select the camera, which REWRITES the record, and pressing Continue then
+    has to relaunch against the new index. Rebuilding from the same re-read
+    record the check ran against is what makes that work — reusing the cached
+    flag would relaunch on the stale index that just passed the check for a
+    different reason."""
+    from makermodslab import rollout
+
+    # Session start: the record said index 1, and the cached args carry it.
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=None)
+    session.request = _cam_request("solo", {"front": "wrist"})
+    session.robot_args = [
+        "--robot.type=so101_follower",
+        "--robot.cameras={front: {type: opencv, index_or_path: 1, fourcc: MJPG}}",
+    ]
+    # The user re-selected the camera during the reset: it now sits at 2, and
+    # the record was rewritten to say so.
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 2, "uid-W")]
+    )
+    _fake_enumeration(
+        monkeypatch,
+        [
+            {"index": 0, "name": "Built-in", "unique_id": "uid-B"},
+            {"index": 1, "name": "Front", "unique_id": "uid-F"},
+            {"index": 2, "name": "Wrist", "unique_id": "uid-W"},
+        ],
+    )
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+
+    launched = {}
+
+    def _fake_launch(request, policy_path, robot_args):
+        launched["robot_args"] = robot_args
+        proc = _FakeRunner()
+        proc.stdout = _EmptyStdout()
+        return proc, io.StringIO(), Path("/tmp/ep2.log")
+
+    monkeypatch.setattr(rollout, "_launch_eval_runner", _fake_launch)
+    monkeypatch.setattr(rollout, "_handle_runner_exit", lambda proc, rc: None)
+
+    result = rollout.handle_next_episode()
+
+    assert result["success"] is True
+    cam_args = [a for a in launched["robot_args"] if a.startswith("--robot.cameras=")]
+    assert len(cam_args) == 1, f"stale flag not replaced: {launched['robot_args']}"
+    assert "index_or_path: 2" in cam_args[0]
+
+
+def test_next_episode_bimanual_respawn_rebuilds_the_left_arm_camera_flag(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bimanual session's cameras live on `--robot.left_arm_config.cameras=`.
+    Rebuilding under the single-arm name would leave the stale flag in place
+    (nothing matches it to strip) AND append one BiSOFollowerConfig has no field
+    for — draccus rejects unknown args, so the respawn dies at CLI parse; and if
+    it did not, every remaining episode would run on the stale index."""
+    from makermodslab import rollout
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "dual_arm", [_identified_cam("wrist", 2, "uid-W")]
+    )
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=None)
+    session.request = _bimanual_cam_request("dual_arm", {"front": "wrist"})
+    session.robot_args = [
+        "--robot.type=bi_so_follower",
+        "--robot.left_arm_config.cameras={front: {type: opencv, index_or_path: 1, fourcc: MJPG}}",
+    ]
+    _fake_enumeration(
+        monkeypatch,
+        [
+            {"index": 0, "name": "Built-in", "unique_id": "uid-B"},
+            {"index": 1, "name": "Front", "unique_id": "uid-F"},
+            {"index": 2, "name": "Wrist", "unique_id": "uid-W"},
+        ],
+    )
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+
+    launched = {}
+
+    def _fake_launch(request, policy_path, robot_args):
+        launched["robot_args"] = robot_args
+        proc = _FakeRunner()
+        proc.stdout = _EmptyStdout()
+        return proc, io.StringIO(), Path("/tmp/ep2.log")
+
+    monkeypatch.setattr(rollout, "_launch_eval_runner", _fake_launch)
+    monkeypatch.setattr(rollout, "_handle_runner_exit", lambda proc, rc: None)
+
+    result = rollout.handle_next_episode()
+
+    assert result["success"] is True
+    args = launched["robot_args"]
+    cam_args = [a for a in args if a.startswith("--robot.left_arm_config.cameras=")]
+    assert len(cam_args) == 1, f"stale left-arm flag not replaced: {args}"
+    assert "index_or_path: 2" in cam_args[0]
+    assert not [a for a in args if a.startswith("--robot.cameras=")], args
+
+
+def test_next_episode_live_runner_does_not_re_enumerate(
+    tmp_lerobot_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-verification is the RESPAWN's business only. The live runner is
+    already holding the verified devices open — an index it never re-reads
+    cannot renumber underneath it — so enumerating there would buy nothing and
+    cost a subprocess spawn plus, on a bench the user rearranged and will
+    rearrange back, a spurious mid-session 400 against cameras the running child
+    is happily using."""
+    from makermodslab import rollout
+
+    _robot_record_with_identified_cams(
+        tmp_lerobot_home, monkeypatch, "solo", [_identified_cam("wrist", 1, "uid-W")]
+    )
+    proc = _FakeRunner()
+    session = _arm_eval_session(monkeypatch, rollout, episodes=3, running=False, proc=proc)
+    session.request = _cam_request("solo", {"front": "wrist"})
+
+    def _boom():
+        raise AssertionError("the live-runner path enumerated cameras")
+
+    monkeypatch.setattr(rollout, "list_cameras_in_subprocess", _boom)
+
+    result = rollout.handle_next_episode()
+
+    assert result["success"] is True
+    assert rollout.CMD_EPISODE in proc.commands

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1570,3 +1570,20 @@ def test_format_accelerator_survives_a_renamed_hub_field() -> None:
             return "some-future-accelerator"
 
     assert _format_accelerator(_Unknown()) == "some-future-accelerator"
+
+
+def test_available_cameras_reports_a_failed_darwin_enumeration_as_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`list_cameras_in_subprocess` distinguishes None ("could not ask") from []
+    ("asked, nothing attached") for the callers that REFUSE on an empty set.
+    This endpoint is not one of them — it only populates a picker — so it
+    flattens both to []. Iterating the None instead crashes the handler into its
+    error branch, and the camera picker goes blank on a transient PyObjC
+    hiccup."""
+    import platform
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(server_mod, "list_cameras_in_subprocess", lambda: None)
+
+    assert server_mod.get_available_cameras() == {"status": "success", "cameras": []}


### PR DESCRIPTION
## Summary

Inference stored each policy camera by its position in the Mac's camera list which changes frequently under certain conditions.
- Plugging in a camera
- Unplugging a camera
- Switching cameras to another port
- Powered hub power cycling

 These could make the arm run despite using an incorrect camera. Fix now checks every camera binding still points at the right device before a run starts, and refuses with a specific message if it does not. Reuses the unique_id logic instead of the seat number for MacOS as #104 

Verified via real hardware on a Mac Mini

I can't lie however, I rarely actually experienced this problem, this was actually just derived from #104 and its fixes. 
Technically, this can also be applied to recording, but since its rarely experienced, it might just be better off not making another PR for recording or even accepting this PR.
#104 is very often encountered however.

## Commits

1. Verify each camera binding's stored index still holds its stored identity before a run, refusing with a 400 before the arm is claimed.
2. Make the camera enumeration fail loudly instead of returning an empty list, and move verification ahead of the arm-identity and torque steps.
3. Add tests for the camera-verification gaps that mutation testing exposed.
4. Split the refusal message by failure type (camera unplugged vs. moved) and point each at an action the UI actually offers.
5. Reword one string that tripped the `typos` pre-commit hook, and extend the unplugged-camera advice to also rebind the policy camera.
6. Extract the mismatch-message wording into its own function, leaving `_verify_camera_identities` to only verify.

## Sensitive changes

Touches the inference start path, which drives the follower arm. This PR only adds a pre-start refusal and moves the camera check earlier — it does not write servo EEPROM, change torque limits, or touch calibration files. The refusal now runs before the existing arm-identity fingerprint and torque-register writes, so a bad binding fails before any servo is energized rather than after.
