### PR TITLE
feat(studio): run-form opener, single-popover pickers, stretched libraries

### DIFF
--- a/frontend/src/components/jobs/JobsLibrary.tsx
+++ b/frontend/src/components/jobs/JobsLibrary.tsx
@@ -4,7 +4,7 @@ import { RefreshCw } from "lucide-react";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import LibraryToolbar from "@/components/library/LibraryToolbar";
 import LibraryHeader from "@/components/library/LibraryHeader";
-import { GRID_H } from "@/components/library/CappedGrid";
+import { GRID_MIN_H } from "@/components/library/CappedGrid";
 import { SLIDE } from "@/components/studio/panel/primitives";
 import { useApi } from "@/contexts/ApiContext";
 import { useStudio } from "@/contexts/StudioContext";
@@ -384,7 +384,14 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
           : null;
 
   return (
-    <Collapsible open={open} onOpenChange={onOpenChange} className="space-y-3">
+    // flex-1 + min-h-0 down the whole chain (see LibrarySection): the library
+    // fills the column's spare height and its bottom edge sits at the foot,
+    // instead of the slack pooling above the section's rule.
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className="flex min-h-0 flex-1 flex-col space-y-3"
+    >
       <LibraryHeader
         title={t("jobs.jobsLibrary.title")}
         count={activeCount}
@@ -404,8 +411,8 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
         }
       />
 
-      <CollapsibleContent className={SLIDE}>
-        <div className="space-y-3">
+      <CollapsibleContent className={cn(SLIDE, "flex min-h-0 flex-1 flex-col")}>
+        <div className="flex min-h-0 flex-1 flex-col space-y-3">
           {isEmpty ? null : (
             <LibraryToolbar
               query={search}
@@ -459,16 +466,24 @@ const JobsLibrary: React.FC<JobsLibraryProps> = ({ open, onOpenChange }) => {
               remote runs share one list, newest-first inside their launched-by
               group; each row's Local/Cloud/node chip says where it runs.
 
-              The block is held at the libraries' one reserved height (GRID_H —
-              the same measurement the dataset and model grids floor themselves
-              at). That reservation is what puts the three studio panels'
-              `mt-auto` action rows on one visual row, and this library lost it
-              when its card grid became a dropdown: the Train panel's Start
-              button then rose and fell with whether a run was selected and how
-              tall its card was. Held in BOTH directions, so an empty selection
-              reserves the same height a tall card does — the card scrolls
-              inside the box rather than growing it. */}
-          <div className={cn(GRID_H, "flex flex-col gap-2 overflow-hidden")}>
+              The block floors at the libraries' one reserved height (GRID_MIN_H
+              — the same measurement the dataset and model grids floor
+              themselves at) and then grows into whatever the section has
+              spare, so its bottom edge lands at the column foot like the other
+              two libraries' footers, and a tall detail card can't push it
+              there: the card scrolls inside the box rather than growing it.
+
+              A FLOOR, not a fixed height, is what changed — the block used to
+              be exactly GRID_H so it couldn't move the `mt-auto` action rows
+              the three panels hung off. Those are gone; the panels top-pack and
+              the libraries stretch instead. (min-h-0 belongs on the WRAPPERS
+              above, never here — it would cancel this floor.) */}
+          <div
+            className={cn(
+              GRID_MIN_H,
+              "flex flex-1 flex-col gap-2 overflow-hidden",
+            )}
+          >
             {isEmpty ? (
               // Inside the reserved block, not instead of it: the height is
               // what keeps the three studio panels' action rows on one row, so

--- a/frontend/src/components/jobs/ModelsLibrary.tsx
+++ b/frontend/src/components/jobs/ModelsLibrary.tsx
@@ -45,6 +45,12 @@ interface ModelsLibraryProps {
   /** Select this model (job record + optional checkpoint step) as the skill
    * to deploy — wired to the Deploy panel's picker state. */
   onPick: (job: JobRecord, step: number | null) => void;
+  /** Controlled disclosure, so the Deploy panel can fold this shelf down to
+   * its header while its run form is open — the same wiring JobsLibrary takes
+   * from Train and Collect's dataset library takes from Collect. Optional:
+   * left out, the library owns its own open state and starts expanded. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 /**
@@ -55,7 +61,11 @@ interface ModelsLibraryProps {
  * entry point is always visible. Card Run actions select the model in the
  * Deploy panel instead of opening the legacy modal.
  */
-const ModelsLibrary: React.FC<ModelsLibraryProps> = ({ onPick }) => {
+const ModelsLibrary: React.FC<ModelsLibraryProps> = ({
+  onPick,
+  open: openProp,
+  onOpenChange,
+}) => {
   const { t } = useTranslation();
   const { openStudio } = useStudio();
   const { jobs, untrackedHubModels, refresh, stop, remove } = useJobsData();
@@ -68,7 +78,10 @@ const ModelsLibrary: React.FC<ModelsLibraryProps> = ({ onPick }) => {
   // untracked Hub repo resolves to a pseudo-job exactly as everywhere else.
   const { importSource } = useInferenceLaunch();
 
-  const [libraryOpen, setLibraryOpen] = useState(true);
+  // Uncontrolled fallback: only used when the caller passes neither prop.
+  const [ownOpen, setOwnOpen] = useState(true);
+  const libraryOpen = openProp ?? ownOpen;
+  const setLibraryOpen = onOpenChange ?? setOwnOpen;
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<ModelsFilter>("all");
@@ -158,7 +171,10 @@ const ModelsLibrary: React.FC<ModelsLibraryProps> = ({ onPick }) => {
     <Collapsible
       open={libraryOpen}
       onOpenChange={setLibraryOpen}
-      className="space-y-3"
+      // flex-1 + min-h-0 down the whole chain (see LibrarySection): the
+      // library fills the column's spare height and its footer sits at the
+      // foot, instead of the slack pooling above the section's rule.
+      className="flex min-h-0 flex-1 flex-col space-y-3"
     >
       <LibraryHeader
         title={t("jobs.modelsLibrary.title")}
@@ -177,7 +193,7 @@ const ModelsLibrary: React.FC<ModelsLibraryProps> = ({ onPick }) => {
         }
       />
 
-      <CollapsibleContent className={SLIDE}>
+      <CollapsibleContent className={cn(SLIDE, "flex min-h-0 flex-1 flex-col")}>
         {count === 0 ? (
           <div
             className={cn(
@@ -188,7 +204,7 @@ const ModelsLibrary: React.FC<ModelsLibraryProps> = ({ onPick }) => {
             {t("jobs.modelsLibrary.empty")}
           </div>
         ) : (
-          <div className="space-y-3">
+          <div className="flex min-h-0 flex-1 flex-col space-y-3">
             <LibraryToolbar
               query={search}
               onQueryChange={setSearch}

--- a/frontend/src/components/landing/DatasetPicker.tsx
+++ b/frontend/src/components/landing/DatasetPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Trash2 } from "lucide-react";
+import { Trans, useTranslation } from "react-i18next";
+import { Plus, Trash2 } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/command";
 import { DatasetItem } from "@/lib/replayApi";
 import { sortDatasets } from "@/lib/sortDatasets";
+import { HUB_REPO_ID_RE } from "@/lib/repoId";
 import { useHfAuth } from "@/contexts/HfAuthContext";
 
 interface DatasetPickerProps {
@@ -32,14 +33,26 @@ interface DatasetPickerProps {
    * second search input would just duplicate it. The list still shows every
    * dataset, unfiltered. */
   hideSearch?: boolean;
+  /** Offer a typed, well-formed `org/name` that ISN'T in the listing as a
+   * public Hub dataset — one extra row, "Use org/name from the Hub".
+   *
+   * Opt-in, because it is a capability and not a decoration: the caller has to
+   * be somewhere that can act on an arbitrary public repo (Train fetches it on
+   * demand and pins it). Left out, the picker only selects what it lists, as
+   * it always has. */
+  onPickHubId?: (repoId: string) => void;
   children: React.ReactNode;
 }
 
 /**
  * Search-only dataset selector. The input filters the existing Local /
- * Hugging Face lists — it no longer creates new names or pins typed `org/name`
- * Hub ids. Those capabilities now live in the "Add dataset" menu on the Landing
- * page (Record / Add from Hugging Face / Import from disk).
+ * Hugging Face lists — it does not create new names, and creation lives in the
+ * "Add dataset" menu on the Landing page (Record / Add from Hugging Face /
+ * Import from disk).
+ *
+ * The one thing it can do beyond selecting what it lists is opt-in: pass
+ * `onPickHubId` and a typed, unlisted `org/name` is offered as a public Hub
+ * dataset (see below). Train uses it; nothing else does.
  */
 const DatasetPicker: React.FC<DatasetPickerProps> = ({
   datasets,
@@ -47,6 +60,7 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
   onPickExisting,
   onDeleteItem,
   hideSearch = false,
+  onPickHubId,
   children,
 }) => {
   const { t } = useTranslation();
@@ -75,6 +89,18 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
       ),
     [datasets, username],
   );
+
+  // A well-formed `org/name` the listing doesn't have, offered as a public Hub
+  // dataset — the affordance that ANY public dataset is usable, not just the
+  // user's own. (Lived in Train's own results list until its typed search was
+  // folded into this popover.)
+  const trimmedQuery = query.trim();
+  const hubCandidate = useMemo(() => {
+    if (!onPickHubId || !HUB_REPO_ID_RE.test(trimmedQuery)) return null;
+    const q = trimmedQuery.toLowerCase();
+    if (datasets.some((d) => d.repo_id.toLowerCase() === q)) return null;
+    return trimmedQuery;
+  }, [onPickHubId, datasets, trimmedQuery]);
 
   const reset = () => {
     setQuery("");
@@ -166,6 +192,39 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
             {localDatasets.length > 0 && (
               <CommandGroup heading={t("landing.picker.local")}>
                 {localDatasets.map(renderItem)}
+              </CommandGroup>
+            )}
+            {hubCandidate && (
+              // Last, under whatever the query did match: reaching for a repo
+              // by its full id is the rarer intent, and cmdk keeps this row
+              // visible because its value IS the query.
+              <CommandGroup>
+                <CommandItem
+                  value={hubCandidate}
+                  onSelect={() => {
+                    onPickHubId?.(hubCandidate);
+                    reset();
+                  }}
+                  className="items-start"
+                >
+                  <Plus className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate">
+                      {/* The typed repo id is DATA — one <0> slot, not a
+                          sentence stitched around it. (Same two strings the
+                          Train panel rendered before its typed search folded
+                          into this popover.) */}
+                      <Trans
+                        i18nKey="landing.datasetPicker.useHub"
+                        values={{ repoId: hubCandidate }}
+                        components={[<span key="0" className="font-mono" />]}
+                      />
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      {t("landing.datasetPicker.useHubHint")}
+                    </span>
+                  </span>
+                </CommandItem>
               </CommandGroup>
             )}
           </CommandList>

--- a/frontend/src/components/landing/DatasetPicker.tsx
+++ b/frontend/src/components/landing/DatasetPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Plus, Trash2 } from "lucide-react";
 import {
@@ -14,9 +14,10 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { DatasetItem } from "@/lib/replayApi";
+import { DatasetItem, getDatasetInfo } from "@/lib/replayApi";
 import { sortDatasets } from "@/lib/sortDatasets";
 import { HUB_REPO_ID_RE } from "@/lib/repoId";
+import { useApi } from "@/contexts/ApiContext";
 import { useHfAuth } from "@/contexts/HfAuthContext";
 
 interface DatasetPickerProps {
@@ -43,6 +44,127 @@ interface DatasetPickerProps {
   onPickHubId?: (repoId: string) => void;
   children: React.ReactNode;
 }
+
+/**
+ * One picker row: the repo id plus the markers the Train panel's retired
+ * results list carried — an abbreviated episode count, a "weighted" marker for
+ * a weighted merge, and a source marker — then the Hub-status chips and the
+ * per-row trash affordance the popover already had.
+ *
+ * Its own component because the episode count is fetched per row (the
+ * `/datasets` listing has no count) and hooks cannot live in a `.map`
+ * callback. Skips the network for Hub-only rows — that would be a remote
+ * meta.json read purely for a badge — so counts are shown "where available",
+ * exactly as the retired row did it. The `weighted` and source markers cost
+ * nothing (both are on the listing) and are always shown.
+ */
+const DatasetPickerRow: React.FC<{
+  item: DatasetItem;
+  /** Whether to fetch the episode count for this row — see the fetch site. */
+  shouldFetchDetails: boolean;
+  onPick: (item: DatasetItem) => void;
+  onDelete?: (item: DatasetItem) => void;
+}> = ({ item, shouldFetchDetails, onPick, onDelete }) => {
+  const { t } = useTranslation();
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const [episodes, setEpisodes] = useState<number | null>(null);
+
+  useEffect(() => {
+    // Only while a query narrows the list — the retired results row mounted
+    // ONLY for typed matches, and this reproduces that fetch profile: a
+    // per-row /datasets/info walks the whole dataset directory for size_bytes,
+    // so fetching one per row on the browse-everything open would be a full
+    // tree walk per local dataset. A `total_episodes` field on the /datasets
+    // listing is the proper fix and would retire this fetch entirely.
+    if (!shouldFetchDetails) return;
+    if (item.source === "hub") return; // avoid a remote fetch just for a count
+    let cancelled = false;
+    getDatasetInfo(baseUrl, fetchWithHeaders, item.repo_id)
+      .then((info) => {
+        if (!cancelled) setEpisodes(info.total_episodes);
+      })
+      .catch(() => {
+        /* count is optional — leave it blank */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    shouldFetchDetails,
+    item.repo_id,
+    item.source,
+    baseUrl,
+    fetchWithHeaders,
+  ]);
+
+  return (
+    <CommandItem
+      value={item.repo_id}
+      onSelect={() => onPick(item)}
+      className="group items-start aria-selected:bg-accent"
+    >
+      <span className="min-w-0 flex-1 break-all">{item.repo_id}</span>
+      {episodes != null && (
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {t("landing.datasetPicker.row.episodes", { episodes })}
+        </span>
+      )}
+      {/* A weighted merge and its unweighted sibling are otherwise
+          indistinguishable here, and picking the wrong one silently trains the
+          wrong mix. `=== true` on purpose: the flag is absent (unknown), not
+          false, for Hub-only rows. */}
+      {item.weighted === true && (
+        <span
+          className="shrink-0 font-mono text-xs text-info"
+          title={t("landing.datasetPicker.row.weightedTitle")}
+        >
+          {t("landing.datasetPicker.row.weighted")}
+        </span>
+      )}
+      {item.source === "both" && (
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {t("landing.picker.localAndHub")}
+        </span>
+      )}
+      {item.source === "hub" && (
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {t("landing.datasetPicker.row.hub")}
+        </span>
+      )}
+      {item.private && (
+        <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">
+          {t("landing.picker.private")}
+        </span>
+      )}
+      {onDelete && (
+        <button
+          type="button"
+          aria-label={t("landing.datasetPicker.deleteAria", {
+            repoId: item.repo_id,
+          })}
+          title={t("landing.picker.deleteTitle")}
+          // cmdk/Radix act on pointerdown AND the click would bubble to the
+          // CommandItem's onSelect — guard both so the trash never also
+          // selects the row or closes the popover on its own.
+          onPointerDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onDelete(item);
+          }}
+          // Hover-revealed on pointer devices (with keyboard-focus fallback),
+          // always visible on touch (no hover to reveal it with).
+          className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-destructive focus:opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </CommandItem>
+  );
+};
 
 /**
  * Search-only dataset selector. The input filters the existing Local /
@@ -113,52 +235,22 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
   };
 
   const renderItem = (d: DatasetItem) => (
-    <CommandItem
+    <DatasetPickerRow
       key={d.repo_id}
-      value={d.repo_id}
-      onSelect={() => handlePick(d)}
-      className="group items-start aria-selected:bg-accent"
-    >
-      <span className="min-w-0 flex-1 break-all">{d.repo_id}</span>
-      {d.source === "both" && (
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {t("landing.picker.localAndHub")}
-        </span>
-      )}
-      {d.private && (
-        <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">
-          {t("landing.picker.private")}
-        </span>
-      )}
-      {onDeleteItem && (
-        <button
-          type="button"
-          aria-label={t("landing.datasetPicker.deleteAria", {
-            repoId: d.repo_id,
-          })}
-          title={t("landing.picker.deleteTitle")}
-          // cmdk/Radix act on pointerdown AND the click would bubble to the
-          // CommandItem's onSelect — guard both so the trash never also
-          // selects the row or closes the popover on its own.
-          onPointerDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onDeleteItem(d);
-            // Close the picker so the Landing-scoped confirm dialog is visible.
-            reset();
-          }}
-          // Hover-revealed on pointer devices (with keyboard-focus fallback),
-          // always visible on touch (no hover to reveal it with).
-          className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-destructive focus:opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
-      )}
-    </CommandItem>
+      item={d}
+      shouldFetchDetails={trimmedQuery.length > 0}
+      onPick={handlePick}
+      onDelete={
+        onDeleteItem
+          ? (item) => {
+              onDeleteItem(item);
+              // Close the picker so the Landing-scoped confirm dialog is
+              // visible.
+              reset();
+            }
+          : undefined
+      }
+    />
   );
 
   return (

--- a/frontend/src/components/landing/ModelPicker.tsx
+++ b/frontend/src/components/landing/ModelPicker.tsx
@@ -18,11 +18,19 @@ import { ModelItem } from "@/lib/modelsApi";
 import { sortByNamespaceFirst } from "@/lib/sortByNamespaceFirst";
 import { policyTypeShortLabel } from "@/components/training/types";
 import { useHfAuth } from "@/contexts/HfAuthContext";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { isCaselessScript } from "@/i18n/config";
+import { cn } from "@/lib/utils";
+
+/** A picker row. `state` is the terminal state of the run behind the model,
+ * which /skills reports (SkillItem) and the wider /models listing does not —
+ * optional here so both listings can be passed. */
+type PickerModel = ModelItem & { state?: string | null };
 
 interface ModelPickerProps {
-  models: ModelItem[];
+  models: PickerModel[];
   loading: boolean;
-  onPickExisting: (item: ModelItem) => void;
+  onPickExisting: (item: PickerModel) => void;
   /** Per-row trash affordance. Invoked with the row's item; the parent routes
    * it through the shared delete confirm dialog (resolveDeleteAction decides
    * the semantics: local delete / local-copy removal / unpin / hide). The
@@ -38,7 +46,10 @@ const modelKey = (m: ModelItem): string => m.hf_repo_id ?? m.id ?? "";
 /** Namespace-first alphabetical ordering via the shared sortByNamespaceFirst
  * (the same helper sortDatasets wraps). Sorts on the display label so the
  * ordering matches what's shown. */
-const sortModels = (items: ModelItem[], username: string | null): ModelItem[] =>
+const sortModels = (
+  items: PickerModel[],
+  username: string | null,
+): PickerModel[] =>
   sortByNamespaceFirst(items, username, modelKey, (m) => m.name || modelKey(m));
 
 /**
@@ -56,6 +67,7 @@ const ModelPicker: React.FC<ModelPickerProps> = ({
   children,
 }) => {
   const { t } = useTranslation();
+  const { language } = useLanguage();
   const [open, setOpen] = useState(false);
 
   const { auth } = useHfAuth();
@@ -76,12 +88,12 @@ const ModelPicker: React.FC<ModelPickerProps> = ({
     [models, username],
   );
 
-  const handlePick = (item: ModelItem) => {
+  const handlePick = (item: PickerModel) => {
     onPickExisting(item);
     setOpen(false);
   };
 
-  const renderItem = (m: ModelItem) => (
+  const renderItem = (m: PickerModel) => (
     <CommandItem
       key={m.id || m.hf_repo_id || m.name}
       // cmdk filters/matches on `value`; include the name so a search over the
@@ -107,6 +119,22 @@ const ModelPicker: React.FC<ModelPickerProps> = ({
       {m.private && (
         <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">
           {t("landing.picker.private")}
+        </span>
+      )}
+      {/* A failed run that saved weights IS runnable, and the Train panel's
+          card has always run one. It is offered here rather than silently
+          withheld — but it says so, because a non-zero exit is a fact about
+          the run the user should weigh before deploying it.
+          `uppercase` is a no-op on Chinese but the tracking is not — drop both
+          together on a caseless script. */}
+      {m.state === "failed" && (
+        <span
+          className={cn(
+            "shrink-0 text-[10px] text-amber-600 dark:text-amber-500",
+            isCaselessScript(language) ? "" : "uppercase tracking-wide",
+          )}
+        >
+          {t("landing.modelPicker.failedBadge")}
         </span>
       )}
       {onDeleteItem && (

--- a/frontend/src/components/library/CappedGrid.tsx
+++ b/frontend/src/components/library/CappedGrid.tsx
@@ -22,13 +22,13 @@ const WIDE_COLUMN_MIN_PX = 800;
 export const GRID_MIN_H = "min-h-[18.875rem]";
 
 /** The same reservation as a FIXED height, for a library whose content is not
- * a fixed-height card row. A grid can floor its height and stop there — its
- * rows are 16.5rem whatever they hold. Jobs renders a dropdown plus one
- * variable-height detail card, so flooring alone would let a tall card push the
- * Train panel's action row back out of line with its siblings; capping too, and
- * scrolling inside the box, keeps the block one exact height in both
- * directions. Same measurement as GRID_MIN_H — change them together (and keep
- * both literal: Tailwind only generates classes it can see). */
+ * a fixed-height card row. Jobs renders a dropdown plus one variable-height
+ * detail card, so flooring alone would let a tall card resize the block under
+ * the Train panel's action row; capping too, and scrolling inside the box,
+ * keeps the block one exact height in both directions. The
+ * card grids do the same thing one level down (see the row viewport below).
+ * Same measurement as GRID_MIN_H — change them together (and keep both
+ * literal: Tailwind only generates classes it can see). */
 export const GRID_H = "h-[18.875rem]";
 /** Just the 16.5rem card row, without the footer slot. An empty/no-match state
  * that renders its OWN footer row beneath it (jobs' Untracked toggle) must use
@@ -40,9 +40,11 @@ export const GRID_ROW_MIN_H = "min-h-[16.5rem]";
  * The shared library grid, capped at one row. Every studio library (datasets,
  * training jobs, models) renders one row of cards by default — three where the
  * column is wide enough (see WIDE_COLUMN_MIN_PX), two otherwise; anything past
- * that stays hidden behind a "Show all" toggle. The row is always reserved
- * (fixed row height, blank cells when there aren't enough cards) so the three
- * panels' libraries keep one uniform height however large a collection grows.
+ * that stays hidden behind a "Show all" toggle, and reveals by scrolling
+ * inside the reserved row rather than by growing the block. The row is always
+ * reserved (fixed row height, blank cells when there aren't enough cards) so
+ * the three panels' libraries keep one uniform height however large a
+ * collection grows, expanded or not.
  */
 const CappedGrid: React.FC<{
   /** Pre-keyed cards, already sorted newest-first by the caller. */
@@ -106,16 +108,32 @@ const CappedGrid: React.FC<{
   }, [overflow, onOverflowChange]);
   const shown = expanded || overflow <= 0 ? items : items.slice(0, cap);
   return (
-    <div ref={columnRef} className="space-y-2">
+    <div
+      ref={columnRef}
+      className="flex min-h-0 flex-1 flex-col space-y-2"
+    >
+      {/* The reserved row is a scrolling VIEWPORT that FILLS the library, not
+          a content-height block: it takes every pixel the section has spare
+          (flex-1) and never drops below one card row (min-h), so "Show all"
+          scrolls the extra rows inside it instead of growing the block, and
+          the footer below stays put at the foot of the column whatever the
+          card count does. Only for reserveRows grids: a nested one (jobs'
+          Untracked) hugs its content inside a box that is already held. */}
       <div
         className={cn(
-          LIBRARY_GRID,
-          LIBRARY_GRID_COLS[cap],
-          "auto-rows-[16.5rem]",
-          reserveRows && "grid-rows-[16.5rem]",
+          reserveRows && "min-h-[16.5rem] flex-1 overflow-y-auto",
         )}
       >
-        {shown}
+        <div
+          className={cn(
+            LIBRARY_GRID,
+            LIBRARY_GRID_COLS[cap],
+            "auto-rows-[16.5rem]",
+            reserveRows && "grid-rows-[16.5rem]",
+          )}
+        >
+          {shown}
+        </div>
       </div>
       {overflow > 0 ? (
         <button

--- a/frontend/src/components/library/DatasetLibrary.tsx
+++ b/frontend/src/components/library/DatasetLibrary.tsx
@@ -331,7 +331,10 @@ export const DatasetLibraryList: React.FC<{
   }
 
   return (
-    <div className="space-y-3">
+    // flex-1 + min-h-0: this sits between LibrarySection and CappedGrid's
+    // viewport, so it has to hand the section's height down rather than hug
+    // its content (see LibrarySection's note).
+    <div className="flex min-h-0 flex-1 flex-col space-y-3">
       <LibraryToolbar
         query={query}
         onQueryChange={setQuery}

--- a/frontend/src/components/recording/CameraConfiguration.tsx
+++ b/frontend/src/components/recording/CameraConfiguration.tsx
@@ -742,6 +742,12 @@ interface SessionCameraListProps {
   releaseStreamsRef?: React.MutableRefObject<(() => void) | null>;
   /** Shown when the robot has no cameras. */
   emptyLabel?: string;
+  /** Drive the pause from outside instead of through releaseStreamsRef, for a
+   * caller whose "hand the devices over" state is derived rather than an event
+   * (the Run panel pauses while a rollout is submitting or active, and resumes
+   * on its own when it ends — the ref is one-way and would need a remount).
+   * Left undefined, the list keeps its own state and nothing changes. */
+  paused?: boolean;
 }
 
 /**
@@ -766,6 +772,7 @@ export const SessionCameraList: React.FC<SessionCameraListProps> = ({
   cameras,
   releaseStreamsRef,
   emptyLabel,
+  paused,
 }) => {
   const { t } = useTranslation();
   const eyebrow = useEyebrowClass();
@@ -775,8 +782,9 @@ export const SessionCameraList: React.FC<SessionCameraListProps> = ({
   // Same handover as the editable component: pausing unmounts the streams AND
   // stops the enumeration probe, so cv2 can open the devices exclusively.
   const [streamsPaused, setStreamsPaused] = useState(false);
+  const isPaused = paused ?? streamsPaused;
   const { cameras: availableCameras } = useAvailableCameras({
-    enabled: !streamsPaused,
+    enabled: !isPaused,
   });
 
   const releaseAllCameraStreams = useCallback(() => setStreamsPaused(true), []);
@@ -816,7 +824,7 @@ export const SessionCameraList: React.FC<SessionCameraListProps> = ({
                       : undefined
                   }
                   uniqueId={camera.unique_id}
-                  paused={streamsPaused}
+                  paused={isPaused}
                   emptyLabel={t("recording.cameras.disconnectedSettings")}
                 />
                 <div className="space-y-0.5 p-3">

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -311,29 +311,32 @@ const CollectPanel: React.FC = () => {
         </CollapsibleContent>
       </Collapsible>
 
-      {/* Start recording — pinned directly above the dataset library so the
-          panel's primary action sits at the same level as Train's Start and
-          Deploy's Start/Stop. Disabled until the robot is ready and the
-          required parameters are filled in. */}
-      <div className="mt-auto pt-2">
-        <Button
-          onClick={handleStartRecording}
-          disabled={!canStart}
-          className="w-full gap-2"
-        >
-          <span className="h-2.5 w-2.5 rounded-full bg-red-500" />
-          {t("studio.collect.start")}
-        </Button>
-      </div>
+      {/* Start recording — directly under the form, at the panel's normal
+          gap-5 rhythm, same as Train's Start and Deploy's Start/Stop. Nothing
+          in the column is bottom-pinned any more: everything top-packs and the
+          column scrolls when it overflows. Disabled until the robot is ready
+          and the required parameters are filled in. */}
+      <Button
+        onClick={handleStartRecording}
+        disabled={!canStart}
+        className="w-full gap-2"
+      >
+        <span className="h-2.5 w-2.5 rounded-full bg-red-500" />
+        {t("studio.collect.start")}
+      </Button>
 
-      {/* Dataset library — the user's own datasets, pinned to the panel foot
-          like Train's jobs and Deploy's models. The selected-dataset chip
-          lives in the header row, beside Merge. */}
-      <LibrarySection className="mt-0">
+      {/* Dataset library — the user's own datasets. LibrarySection's own
+          stretch now stands (no mt-0 override): the opener and Start row
+          top-pack, the free space falls between them and this, and the library
+          sits at the column foot so its "Show all" footer lines up with Train's
+          and Deploy's. Its body is a fixed-height viewport, so expanding
+          scrolls inside it and the footer never moves. The selected-dataset
+          chip lives in the header row, beside Merge. */}
+      <LibrarySection>
         <Collapsible
           open={libraryOpen}
           onOpenChange={setLibraryOpen}
-          className="space-y-3"
+          className="flex min-h-0 flex-1 flex-col space-y-3"
         >
           <LibraryHeader
             title={t("studio.collect.library.title")}
@@ -388,7 +391,9 @@ const CollectPanel: React.FC = () => {
               </>
             }
           />
-          <CollapsibleContent className={SLIDE}>
+          <CollapsibleContent
+            className={cn(SLIDE, "flex min-h-0 flex-1 flex-col")}
+          >
             <DatasetLibraryList
               datasets={libraryDatasets}
               loading={datasetsLoading}

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -9,10 +9,11 @@ import React, {
 import { Trans, useTranslation } from "react-i18next";
 import {
   AlertTriangle,
-  Download,
+  ChevronsUpDown,
   Loader2,
   Play,
-  VideoOff,
+  // No VideoOff (the rework dropped CameraThumbnail for SessionCameraList) and
+  // no Square (staging's RunVerbs replaced the Start/Stop pair).
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,6 +21,11 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
   Select,
   SelectContent,
@@ -52,25 +58,27 @@ import { deployBlockedReason } from "./deployGuards";
 import DisplayName from "@/components/library/DisplayName";
 import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
 import ModelsLibrary from "@/components/jobs/ModelsLibrary";
-import ImportModelModal from "@/components/jobs/ImportModelModal";
+import ModelPicker from "@/components/landing/ModelPicker";
 import PolicyExtraDialog from "@/components/training/PolicyExtraDialog";
 import {
   AdvancedSection,
-  FormSection,
   LibrarySection,
-  PANEL_ENTRY_CLASS,
-  PanelEntryDot,
+  PanelEntryControl,
   PanelHeader,
   RobotStatus,
+  SLIDE,
   useEyebrowClass,
 } from "@/components/studio/panel/primitives";
-import { useLanguage } from "@/contexts/LanguageContext";
-import { isCaselessScript } from "@/i18n/config";
 import { cn } from "@/lib/utils";
 import { useAvailableCameras } from "@/hooks/useAvailableCameras";
-import BackendCameraStream from "@/components/BackendCameraStream";
-import type { CameraConfig } from "@/components/recording/CameraConfiguration";
-import { isCameraConnected, resolveCameraIndex } from "@/lib/cameraResolve";
+// Collect's read-only camera list, rendered here verbatim: both panels are
+// answering the same question (which of this robot's cameras will be used), so
+// they are the same component rather than two views of one robot record.
+import {
+  SessionCameraList,
+  type CameraConfig,
+} from "@/components/recording/CameraConfiguration";
+import { isCameraConnected } from "@/lib/cameraResolve";
 import MilestoneReveal from "@/components/onboarding/MilestoneReveal";
 import { useOnceFlag } from "@/lib/onboarding/storage";
 
@@ -83,10 +91,14 @@ import { useOnceFlag } from "@/lib/onboarding/storage";
  * JobsSection + the Landing Models panel through `useInferenceLaunch`). To keep
  * those consumers untouched and avoid drift, the checkpoint/policy-config
  * fetch, the bimanual `left_` camera-prefix round-trip, the state_dim 6-vs-12
- * arm-count guard, the camera thumbnails and the start flow are ported VERBATIM
- * from `components/landing/InferenceModal.tsx` (only the palette becomes token
+ * arm-count guard and the start flow are ported VERBATIM from
+ * `components/landing/InferenceModal.tsx` (only the palette becomes token
  * classes). The Hub lazy-import reuses `useInferenceLaunch().importSource` so
  * the husk-repo messaging is identical, not re-implemented.
+ *
+ * Cameras are the one place this panel deliberately left the modal behind: the
+ * ported per-feature binding dropdowns are gone, replaced by Collect's
+ * read-only SessionCameraList plus name-based binding (see `cameraBindings`).
  */
 
 // Mirrors rollout.MAX_EVAL_EPISODES — the server clamps to the same bound, this
@@ -103,46 +115,20 @@ const MAX_COACHING_CORRECTIONS = 100;
 // and would be worse with a third option folded in.
 type RunMode = "single" | "eval" | "coach";
 
+/** Stable empty list, so "no checkpoints for the current skill" never hands
+ * children a fresh array identity on every render. */
+const NO_CHECKPOINTS: JobCheckpoint[] = [];
+
 /** Coefficient of the original ACT paper's exponential weighting (see
  * lerobot's ACTTemporalEnsembler). Offered as the starting point when the user
  * switches temporal ensembling on. */
 const DEFAULT_TEMPORAL_ENSEMBLE_COEFF = 0.01;
 
-/** Small preview for verifying which physical camera a role binds to.
- *
- * Streams from the backend by cv2 index — the live feed at exactly the index
- * the rollout will open, independent of any browser deviceId match. That match
- * was by localizedName, so twin cameras ("KD-USB Cameras" x2) paired
- * arbitrarily and the tiles swapped footage between refreshes.
- * `paused` unmounts the stream so the rollout subprocess can claim the device.
- * (Ported from InferenceModal.) */
-const CameraThumbnail: React.FC<{
-  cameraIndex?: number;
-  uniqueId?: string;
-  paused: boolean;
-}> = ({ cameraIndex, uniqueId, paused }) => {
-  const { t } = useTranslation();
-  if (paused || cameraIndex === undefined) {
-    return (
-      <div className="flex h-24 w-32 flex-col items-center justify-center rounded border border-border bg-muted">
-        <VideoOff className="mb-1 h-5 w-5 text-muted-foreground" />
-        <span className="text-[10px] text-muted-foreground">
-          {paused
-            ? t("studio.deploy.thumbnail.released")
-            : t("studio.deploy.thumbnail.noPreview")}
-        </span>
-      </div>
-    );
-  }
-  // BackendCameraStream owns its own failure/retry UI.
-  return (
-    <BackendCameraStream
-      cameraIndex={cameraIndex}
-      uniqueId={uniqueId}
-      className="h-24 w-32 rounded border border-border bg-muted object-cover"
-    />
-  );
-};
+/** The studio's form-field trigger size — what a bare shadcn <SelectTrigger>
+ * and <Input> already are (h-10, full width, text-sm), spelled out for the one
+ * control that ships a card-sized trigger of its own. `cn` is tailwind-merge,
+ * so these win over the component's defaults rather than fighting them. */
+const FIELD_TRIGGER = "h-10 w-full text-sm";
 
 /**
  * One camera as the panel sees it. The BiSO prefix round-trip lives here so the
@@ -398,8 +384,6 @@ export const RunVerbs: React.FC<{
 
 const DeployPanel: React.FC = () => {
   const { t } = useTranslation();
-  const { language } = useLanguage();
-  const isCJK = isCaselessScript(language);
   const eyebrow = useEyebrowClass();
   const { baseUrl, fetchWithHeaders } = useApi();
   const { toast } = useToast();
@@ -409,7 +393,6 @@ const DeployPanel: React.FC = () => {
   // Reuse the shared lazy-import (husk-repo messaging + idempotent registration)
   // so a Hub skill resolves to a pseudo-job exactly as the Jobs cards do.
   const { importSource } = useInferenceLaunch();
-
   // --- Skill picker state ------------------------------------------------
   // The listing is NOT owned here. It is one app-wide fetch behind the
   // `jobs_changed` push (see ModelsDataContext), so a run that finishes while
@@ -433,10 +416,27 @@ const DeployPanel: React.FC = () => {
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
   const [selectedJob, setSelectedJob] = useState<JobRecord | null>(null);
   const [resolving, setResolving] = useState(false);
-  // Duplicate of ModelsLibrary's "Import skill" entry point, surfaced right
-  // on the skill picker itself so importing doesn't require scrolling down
-  // to the library section below.
-  const [importModalOpen, setImportModalOpen] = useState(false);
+
+  // (No client-side deny-list here any more. The rework derived one from the
+  // job registry's `checkpoint_count` to keep a cloud run that died before its
+  // first checkpoint out of the picker; `/skills` now answers that question
+  // server-side and better — `deployable` means the weights are loadable AND
+  // nothing supersedes the row — so `models` above is already the filtered
+  // set and a second, weaker filter over it would only be drift waiting to
+  // happen.)
+
+  // The run form slides open in place under the panel's entry control, same as
+  // Collect's "Record new dataset" and Train's "Start a new training"; the
+  // skills library folds to its header while it is open (still expandable by
+  // hand). Everything that configures a run lives inside it, the skill picker
+  // first.
+  const [formOpen, setFormOpen] = useState(false);
+  const [libraryOpen, setLibraryOpen] = useState(true);
+
+  const toggleForm = useCallback((open: boolean) => {
+    setFormOpen(open);
+    setLibraryOpen(!open);
+  }, []);
 
   // --- Inference config state (ported from InferenceModal) ---------------
   const [checkpoints, setCheckpoints] = useState<JobCheckpoint[]>([]);
@@ -573,21 +573,11 @@ const DeployPanel: React.FC = () => {
   } | null>(null);
   const [checkingExtra, setCheckingExtra] = useState(false);
 
-  // Per camera DISPLAY name → the NAME of one of the selected robot's cameras.
-  // Keyed by the stripped display name (== requestKey), and sent verbatim as
-  // the request's `camera_bindings`. The binding is a name pairing only: the
-  // server reads which device and how to open it (index, unique_id, fps,
-  // fourcc, backend) out of the robot record, so a run can never open a camera
-  // set the saved robot doesn't have. Capture resolution is the exception —
-  // it's forwarded from the checkpoint as `camera_dims`, because the rollout
-  // doesn't resize frames. Cameras are edited in Robot settings.
-  const [cameraBindings, setCameraBindings] = useState<
-    Record<string, string | null>
-  >({});
   const { cameras: availableCameras } = useAvailableCameras({ enabled: open });
 
-  // Light status poll while the panel is visible so the launch guards (and
-  // the camera previews) know whether a rollout is already running.
+  // Light status poll while the panel is visible so the launch guards know
+  // whether a rollout is already running, and so SessionCameraList keeps its
+  // previews released for as long as that rollout holds the devices.
   const [status, setStatus] = useState<InferenceStatus | null>(null);
 
   // Edge-triggered "consume once": handleStart sets the pending flag, and the
@@ -606,9 +596,6 @@ const DeployPanel: React.FC = () => {
       setDeployMilestonePending(false);
     }
   }, [sessionOpen, deployMilestonePending]);
-
-  // The settings block (robot, checkpoint, run parameters, cameras) collapses
-  // as one so a configured deploy can be folded down to picker + actions.
 
   const jobId = selectedJob?.id ?? null;
   // Address the policy-config endpoint by the checkpoint's OWNER. `(owner, step)`
@@ -632,26 +619,59 @@ const DeployPanel: React.FC = () => {
     [robot],
   );
 
-  /** The robot's camera a binding names, or undefined once the record no
-   * longer has it (camera removed in Robot settings, or another robot
-   * selected). */
-  const recordCameraByName = useCallback(
-    (name: string | null | undefined) =>
-      name == null ? undefined : robotCameras.find((cam) => cam.name === name),
-    [robotCameras],
+  /**
+   * The camera bindings, DERIVED BY NAME rather than chosen: each camera the
+   * checkpoint was trained with takes the robot camera of the same name.
+   *
+   * There is no picker any more — the panel shows the robot's cameras exactly
+   * as Collect does (SessionCameraList), and a mismatch is reported rather than
+   * repaired here, because a camera's name is a property of the robot and
+   * Robot settings is the one place it is edited. Name matching is
+   * case-insensitive, but the PAYLOAD carries the robot record's own spelling.
+   *
+   * `display` is the bare name in bimanual mode (cameraMappings strips BiSO's
+   * `left_`/`right_` prefix), which is exactly what the robot record stores, so
+   * the round-trip still works: the rollout re-prefixes it back into the
+   * checkpoint's `left_<name>` feature.
+   */
+  const cameraBindings = useMemo(
+    () =>
+      cameraMap.map((mapping) => {
+        const camera =
+          robotCameras.find(
+            (c) => c.name.toLowerCase() === mapping.display.toLowerCase(),
+          ) ?? null;
+        const dims = policyConfig?.image_features[mapping.feature];
+        return {
+          mapping,
+          camera,
+          dims,
+          // A stored camera_index goes stale on replug, so presence is judged
+          // by unique_id against the live enumeration — the same check the
+          // preview cards use.
+          connected:
+            camera != null && isCameraConnected(camera, availableCameras),
+          resolutionDiffers:
+            camera != null &&
+            dims != null &&
+            (camera.width !== dims.width || camera.height !== dims.height),
+        };
+      }),
+    [cameraMap, robotCameras, policyConfig, availableCameras],
   );
 
-  /** Bound AND physically present. A stored camera_index goes stale on replug,
-   * so presence is judged by unique_id against the live enumeration — the same
-   * check the preview tiles use, and the same strictness Start had when
-   * bindings pointed straight at an enumerated device. */
-  const cameraIsReady = useCallback(
-    (name: string | null | undefined) => {
-      const cam = recordCameraByName(name);
-      return cam != null && isCameraConnected(cam, availableCameras);
-    },
-    [recordCameraByName, availableCameras],
+  /** Cameras the policy needs that this robot has nothing named for. Start is
+   * blocked on these: the rollout cannot invent the feed. */
+  const unmatchedCameras = cameraBindings.filter((b) => b.camera == null);
+  /** Matched by name but not enumerated right now (unplugged since the record
+   * was saved). Also blocks Start — the same strictness the picker had. */
+  const disconnectedCameras = cameraBindings.filter(
+    (b) => b.camera != null && !b.connected,
   );
+  /** Matched, present, but the robot captures at a different size than the
+   * policy trained on. A warning only: the rollout forwards the checkpoint's
+   * dims as `camera_dims` and the camera is opened at those. */
+  const mismatchedCameras = cameraBindings.filter((b) => b.resolutionDiffers);
 
   // Opening the studio is a freshness gesture, so it still re-pulls — but it is
   // no longer the ONLY thing that does, which is what made a run completing
@@ -660,14 +680,11 @@ const DeployPanel: React.FC = () => {
     if (open) refreshModels();
   }, [open, refreshModels]);
 
-  // Re-pull after a successful import so the new skill shows up right away —
-  // mirrors ModelsLibrary's onImported. Still explicit: the import posts to
-  // /jobs, so `jobs_changed` covers it, but a fire-and-forget broadcast the
-  // server drops when no socket is registered is not something the panel that
-  // just did the import should be relying on.
-  const handleImported = useCallback(() => {
-    refreshModels();
-  }, [refreshModels]);
+  // (Importing lives in the skills library's own header, which owns its modal
+  // and its own refetch — this panel no longer duplicates that entry point.
+  // Nothing is lost by dropping the local `handleImported`: the listing is the
+  // app-wide ModelsDataContext one, so the library's own refresh repopulates
+  // this picker as well.)
 
   // Apply a "Run on robot" prefill: source "job" selects that job (+ optional
   // step); source "hub" lazy-imports the repo, then selects the pseudo-job.
@@ -679,9 +696,11 @@ const DeployPanel: React.FC = () => {
     let cancelled = false;
     (async () => {
       setResolving(true);
-      // The settings (robot, checkpoint, cameras) are no longer collapsible —
-      // they render as soon as a skill is selected, which the prefill does
-      // below, so there is nothing to re-open here.
+      // A prefill is an intent to configure a run, so it slides the form open
+      // too — the same move Train's prefill effect makes. Without it the skill
+      // resolved below would land inside a form the user still has to open by
+      // hand, and the handoff would look like nothing happened.
+      toggleForm(true);
       try {
         if (deployPrefill.source === "job") {
           const job = await getJob(baseUrl, fetchWithHeaders, deployPrefill.id);
@@ -721,21 +740,25 @@ const DeployPanel: React.FC = () => {
     fetchWithHeaders,
     importSource,
     clearDeployPrefill,
+    toggleForm,
     toast,
     t,
   ]);
 
   // Manual skill pick: resolve the chosen model to a launchable job (its own
   // registry id, an already-imported repo, or a fresh lazy import).
+  //
+  // NOTHING is committed until that resolution succeeds. `selectedModelId`
+  // drives the picker's checkmark and `selectedJob` drives its label, the
+  // checkpoint list and the launch — so committing the id up front made a
+  // failed resolve leave the two disagreeing: the tick sat on the skill the
+  // user had just clicked while every other control, Start included, still
+  // belonged to the previous one. A failed pick now changes nothing at all,
+  // which is what the "leave the prior selection" catch below always meant.
   const handlePickSkill = useCallback(
     async (modelId: string) => {
-      setSelectedModelId(modelId);
       const model = models.find((m) => m.id === modelId);
       if (!model) return;
-      // New skill → drop the prior selection so the load effect picks the new
-      // job's latest checkpoint.
-      setSelectedRef(null);
-      setPendingStep(null);
       setResolving(true);
       try {
         // `job_id` is stamped by the server, which already ranks the runs
@@ -743,11 +766,10 @@ const DeployPanel: React.FC = () => {
         // 200 jobs and re-implement that ranking in TypeScript — a second copy
         // of the definition, kept in sync by hand, and blind to any run past
         // the scan limit.
+        let resolved: JobRecord | null = null;
         if (model.job_id) {
           try {
-            const job = await getJob(baseUrl, fetchWithHeaders, model.job_id);
-            setSelectedJob(job);
-            return;
+            resolved = await getJob(baseUrl, fetchWithHeaders, model.job_id);
           } catch {
             // The record went away between the listing and this click (deleted
             // in another tab, or from the Train panel). The weights may still be
@@ -755,10 +777,18 @@ const DeployPanel: React.FC = () => {
             // the path the old lookup took whenever it found no job at all.
           }
         }
-        // No run tracks it (a bare Hub repo, a scanned directory), or the one
-        // that did is gone — the lazy import registers one, as before.
-        const imported = await importSource(importSourceForModel(model));
-        if (imported) setSelectedJob(imported);
+        if (!resolved) {
+          // No run tracks it (a bare Hub repo, a scanned directory), or the one
+          // that did is gone — the lazy import registers one, as before.
+          resolved = (await importSource(importSourceForModel(model))) ?? null;
+        }
+        if (!resolved) return;
+        // New skill → drop the prior checkpoint selection so the load effect
+        // takes the new job's latest.
+        setSelectedRef(null);
+        setPendingStep(null);
+        setSelectedJob(resolved);
+        setSelectedModelId(modelId);
       } catch {
         // Resolution failed → leave the prior selection; a toast already fired
         // for the import path.
@@ -846,17 +876,6 @@ const DeployPanel: React.FC = () => {
       .then((cfg) => {
         if (cancelled) return;
         setPolicyConfig(cfg);
-        const mappings = cameraMappings(
-          Object.keys(cfg.image_features),
-          isBimanual,
-        );
-        setCameraBindings((prev) => {
-          const next: Record<string, string | null> = {};
-          for (const m of mappings) {
-            next[m.requestKey] = prev[m.requestKey] ?? null;
-          }
-          return next;
-        });
       })
       .catch((e) => {
         if (cancelled) return;
@@ -869,50 +888,14 @@ const DeployPanel: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [open, baseUrl, fetchWithHeaders, policyConfigJobId, selectedStep, isBimanual]);
+    // `policyConfigJobId` (staging's owner-addressed lookup), and no
+    // `isBimanual`: the effect no longer re-seeds camera bindings, so the arm
+    // layout is not an input to it any more.
+  }, [open, baseUrl, fetchWithHeaders, policyConfigJobId, selectedStep]);
 
-  // Auto-bind robot cameras whose names match a policy-expected camera, by
-  // name against the DISPLAY name (the bare name the user chose at record
-  // time — that's what the robot record stores). No device enumeration is
-  // involved any more: the binding names a RECORD camera, and the record is
-  // what the server resolves against.
-  useEffect(() => {
-    if (!policyConfig || robotCameras.length === 0) return;
-    setCameraBindings((prev) => {
-      let changed = false;
-      const next = { ...prev };
-      for (const m of cameraMap) {
-        if (next[m.requestKey] != null) continue;
-        const robotCam = robotCameras.find(
-          (c) => c.name.toLowerCase() === m.display.toLowerCase(),
-        );
-        if (robotCam) {
-          next[m.requestKey] = robotCam.name;
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [policyConfig, robotCameras, cameraMap]);
-
-  // Drop a binding the robot record no longer backs — the camera was removed
-  // in Robot settings, or another robot was selected. (A binding to a camera
-  // that is merely UNPLUGGED is kept: the tile says "disconnected" and Start
-  // stays disabled, so reconnecting it doesn't cost the user the binding.)
-  useEffect(() => {
-    if (!policyConfig) return;
-    setCameraBindings((prev) => {
-      let changed = false;
-      const next = { ...prev };
-      for (const [name, boundTo] of Object.entries(prev)) {
-        if (boundTo != null && !recordCameraByName(boundTo)) {
-          next[name] = null;
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [policyConfig, recordCameraByName]);
+  // (No binding effects: the pairing is derived by name in `cameraBindings`
+  // above, so there is no stored selection to seed, prune, or keep in step
+  // with the robot record.)
 
   // Poll inference status while visible so the guards reflect a live rollout.
   useEffect(() => {
@@ -957,9 +940,9 @@ const DeployPanel: React.FC = () => {
     checkpointArms != null &&
     checkpointIsBimanual !== isBimanual;
 
-  const allCamerasBound = cameraMap.every((m) =>
-    cameraIsReady(cameraBindings[m.requestKey]),
-  );
+  // Every camera the policy needs is matched by name AND plugged in.
+  const allCamerasReady =
+    unmatchedCameras.length === 0 && disconnectedCameras.length === 0;
 
   const inferenceActive = status?.inference_active === true;
 
@@ -1001,7 +984,7 @@ const DeployPanel: React.FC = () => {
     !robotCheckpointArmMismatch &&
     selectedRef != null &&
     !!policyConfig &&
-    allCamerasBound &&
+    allCamerasReady &&
     !temporalEnsembleInvalid &&
     !submitting &&
     !checkingExtra &&
@@ -1019,7 +1002,9 @@ const DeployPanel: React.FC = () => {
       followerReady: !!robot?.follower_ready,
       hasCheckpoint: selectedRef != null && !!policyConfig,
       armMismatch: robotCheckpointArmMismatch,
-      allCamerasBound,
+      // Same predicate, renamed: bindings are derived by name now, so "bound"
+      // means matched-and-plugged-in rather than picked from a dropdown.
+      allCamerasBound: allCamerasReady,
       temporalEnsembleInvalid,
       inferenceActive,
       leaderMissing,
@@ -1161,7 +1146,7 @@ const DeployPanel: React.FC = () => {
       }
     }
 
-    // Drops every CameraThumbnail's browser stream so the rollout subprocess can
+    // Drops every camera card's preview stream so the rollout subprocess can
     // open the same camera index via OpenCV without colliding on the device.
     setSubmitting(true);
     await new Promise((r) => setTimeout(r, 300));
@@ -1178,13 +1163,13 @@ const DeployPanel: React.FC = () => {
     // /policy-config, the server applies them.
     const cameraDimsPayload: Record<string, { width: number; height: number }> =
       {};
-    for (const m of cameraMap) {
-      const boundTo = cameraBindings[m.requestKey];
-      if (boundTo == null || !recordCameraByName(boundTo)) continue;
-      cameraBindingPayload[m.requestKey] = boundTo;
-      const dims = policyConfig.image_features[m.feature];
+    for (const { mapping, camera, dims } of cameraBindings) {
+      if (camera == null) continue;
+      // The robot record's own spelling, not the checkpoint's — the name
+      // matched case-insensitively and the server looks it up verbatim.
+      cameraBindingPayload[mapping.requestKey] = camera.name;
       if (dims?.width && dims?.height) {
-        cameraDimsPayload[m.requestKey] = {
+        cameraDimsPayload[mapping.requestKey] = {
           width: dims.width,
           height: dims.height,
         };
@@ -1278,10 +1263,27 @@ const DeployPanel: React.FC = () => {
     }
   };
 
-  const onCameraBindingChange = (name: string, value: string) => {
-    setCameraBindings((prev) => ({ ...prev, [name]: value }));
-  };
-
+  // No `onCameraBindingChange`: the pairing is derived by name in
+  // `cameraBindings` above, so there is no stored selection left to write.
+  //
+  // No `handleStop` either, and that one is a decision worth recording,
+  // because the two branches this file was merged from argued it opposite ways.
+  //
+  //   · The rework's note (b21bb1f7's Start ⇄ "View running session" toggle
+  //     could not be landed — `openInferenceSession` needs the session id the
+  //     POST returned, and a rollout this panel did not start has none) went on
+  //     to argue the panel should therefore KEEP its own stop, as the only way
+  //     to wind a run down after the session dialog has been closed.
+  //   · The coaching work removed it: a live rollout owns the modal
+  //     InferenceSessionDialog, which carries its own Stop, so a second stop
+  //     control on a panel the operator cannot see during a run is dead weight
+  //     the rest of the time and enabled only in the one state where it is
+  //     unreachable.
+  //
+  // The second is the later reading and the one the verb row is built around
+  // (RunVerbs is the whole action surface now), so it stands. If the first
+  // concern is real — a session dialog closed on a still-running rollout — the
+  // fix is a reopen path with the live session's id, not a bare stop button.
   const selectedSkillLabel = selectedJob ? jobDisplayName(selectedJob) : null;
 
   return (
@@ -1292,678 +1294,628 @@ const DeployPanel: React.FC = () => {
         ) : null}
       </PanelHeader>
 
-      {/* Skill picker — the panel's entry control. A real <Select> rather than
-          a PanelEntryControl because picking a skill IS the value here, not a
-          trigger that opens a form; it wears PANEL_ENTRY_CLASS and a dot so it
-          still reads as the same control as Collect's and Train's openers. */}
-      <div className="space-y-2">
-        <div className="relative">
-          <Select
-            value={selectedModelId ?? undefined}
-            onValueChange={handlePickSkill}
-            disabled={resolving}
-          >
-            {/* justify-start + ml-auto on the chevron: SelectTrigger defaults
-                to justify-between, which would shove the dot away from the
-                label once a third child is added. pr-9 reserves room on the
-                right for the Import button overlaid below, so the chevron
-                and the button's own gutter don't collide. */}
-            <SelectTrigger
-              className={cn(
-                PANEL_ENTRY_CLASS,
-                "justify-start pr-9 [&>svg]:ml-auto [&>svg]:shrink-0",
-              )}
-            >
-              <PanelEntryDot className="bg-sky-500" />
-              {selectedSkillLabel ? (
-                <DisplayName name={selectedSkillLabel} className="min-w-0" />
-              ) : (
-                <SelectValue placeholder={t("studio.deploy.picker.placeholder")} />
-              )}
-            </SelectTrigger>
-            <SelectContent>
-              {modelsLoading ? (
-                <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                  {t("studio.deploy.picker.loading")}
-                </div>
-              ) : models.length === 0 ? (
-                // "We could not ask" and "you own nothing" are different
-                // sentences, and the picker used to render the second for the
-                // first: a `/models` failure was caught into an empty array, so
-                // a backend hiccup or a dropped Hub listing read on screen as
-                // the user's skills having been deleted. The listing is only
-                // empty when the fetch actually succeeded and returned nothing.
-                <div
-                  className={cn(
-                    "px-2 py-1.5 text-xs",
-                    modelsError ? "text-destructive" : "text-muted-foreground",
-                  )}
-                >
-                  {modelsError
-                    ? t("studio.deploy.picker.error")
-                    : t("studio.deploy.picker.empty")}
-                </div>
-              ) : (
-                models.map((m) => (
-                  <SelectItem key={m.id} value={m.id}>
-                    <DisplayName name={m.name} className="min-w-0" />
-                    {/* `uppercase` is a no-op on Chinese but the tracking is
-                        not — drop both together on a caseless script. */}
-                    <span
-                      className={cn(
-                        "ml-2 text-[10px] text-muted-foreground",
-                        isCJK ? "" : "uppercase tracking-wide",
-                      )}
-                    >
-                      {m.source === "hub"
-                        ? t("studio.deploy.source.hub")
-                        : m.source === "both"
-                          ? t("studio.deploy.source.both")
-                          : t("studio.deploy.source.local")}
-                    </span>
-                    {/* A failed run that saved weights IS runnable, and the
-                        Train panel's card has always run one. It is offered
-                        here rather than silently withheld — but it says so,
-                        because a non-zero exit is a fact about the run the
-                        user should weigh before deploying it. */}
-                    {m.state === "failed" && (
-                      <span
-                        className={cn(
-                          "ml-2 text-[10px] text-amber-600 dark:text-amber-500",
-                          isCJK ? "" : "uppercase tracking-wide",
-                        )}
-                      >
-                        {t("studio.deploy.picker.failedBadge")}
-                      </span>
-                    )}
-                  </SelectItem>
-                ))
-              )}
-            </SelectContent>
-          </Select>
-          {/* An unreachable Hub used to look exactly like an empty shelf: the
-              rows simply were not there. Now the listing says which it is, and
-              keeps serving the last complete Hub result underneath. */}
-          {hubStatus && !hubStatus.ok && (
-            <p className="mt-1 px-1 text-[11px] text-amber-600 dark:text-amber-500">
-              {t("studio.deploy.picker.hubDegraded")}
+      {/* Run a skill — the panel's entry control, the same opener Collect
+          ("Record new dataset") and Train ("Start a new training") wear: it
+          slides the run's form open in place and folds the skills library to
+          its header while it is open. */}
+      <Collapsible
+        open={formOpen}
+        onOpenChange={toggleForm}
+        className="space-y-5"
+      >
+        <CollapsibleTrigger asChild>
+          <PanelEntryControl open={formOpen} dotClassName="bg-sky-500">
+            {t("studio.deploy.entry")}
+          </PanelEntryControl>
+        </CollapsibleTrigger>
+        <CollapsibleContent className={SLIDE}>
+          <div className="space-y-6">
+            {/* The form's one-line brief, in the slot and voice Train uses
+                ("Choose what to train on…"): under the opener, above the first
+                field label. It also covers what the Skill field's own helper
+                used to say, so that line is gone. */}
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {t("studio.deploy.intro")}
             </p>
-          )}
-          {/* Duplicate of ModelsLibrary's "Import skill" button, docked
-              inside the picker's own box (right edge) so it's visible
-              without opening the dropdown. A sibling overlay, not a child of
-              SelectTrigger — SelectTrigger is itself a <button>, and Radix
-              opens on pointerdown, so nesting would either be invalid HTML or
-              also trigger the dropdown. Sitting on top as an absolutely
-              positioned sibling means it alone receives the click. */}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={(e) => {
-              e.stopPropagation();
-              setImportModalOpen(true);
-            }}
-            disabled={resolving}
-            className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            title={t("studio.deploy.picker.import")}
-            aria-label={t("studio.deploy.picker.import")}
-          >
-            <Download className="h-3.5 w-3.5" />
-          </Button>
-        </div>
-        {!selectedJob ? (
-          <p className="text-xs text-muted-foreground">
-            {t("studio.deploy.picker.hint")}
-          </p>
-        ) : null}
-      </div>
-      <ImportModelModal
-        open={importModalOpen}
-        onOpenChange={setImportModalOpen}
-        onImported={handleImported}
-      />
 
-      {/* Everything below is flat and appears as soon as a skill is picked —
-          disclosure comes from the selection, not from a second click. The old
-          "Settings & configuration" collapsible was an extra step neither
-          Collect nor Train has. ------------------------------------------- */}
-      {selectedJob ? (
-        <div className="space-y-5">
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            {t("studio.deploy.intro")}
-          </p>
-
-          {/* Robot readiness — a warning, not a parameter, so no eyebrow. A
-              ready robot renders nothing: the robot menu already names the
-              selection and its arm layout. */}
-          <RobotStatus ready={!!robot && robot.follower_ready}>
-            {!robot ? (
-              t("studio.deploy.noRobot")
-            ) : (
-              /* The plural is on the follower ARM count — 2 for a bimanual
-                 robot, 1 otherwise. The number itself is never printed; it
-                 only picks the variant, replacing the old `{s}` splice.
-                 Coaching gets its own key AND its own gap scope: it teleoperates
-                 through the leader too, so a missing leader port is a real
-                 blocker there and noise in every other mode. */
-              <Trans
-                i18nKey={
-                  runMode === "coach"
-                    ? "studio.deploy.robotNotReadyCoach"
-                    : "studio.deploy.robotNotReady"
-                }
-                count={isBimanual ? 2 : 1}
-                values={{
-                  name: robot.name,
-                  gap: formatRobotSetupGap(
-                    t,
-                    robot,
-                    runMode === "coach" ? "all" : "follower",
-                  ),
-                }}
-                components={[<strong key="0" />]}
-              />
-            )}
-          </RobotStatus>
-
-          {/* Run mode. ABOVE the checkpoint and OUTSIDE the policy-config
-              guard, deliberately: it decides what every control below it
-              means, and it used to be the fourth field down and to vanish
-              entirely while a checkpoint's config was still loading. It has no
-              dependency on that config. ------------------------------------ */}
-          {/* The mode chooser used to live here, as a widget you set before
-              pressing a generic Start. The verb buttons at the bottom of the
-              panel are now the chooser AND the action: pressing one selects
-              that mode and launches it, so there is one decision instead of
-              two and nothing to leave in the wrong position. The options
-              below still follow whichever verb is armed. */}
-
-          {/* Checkpoint ------------------------------------------------------- */}
-          <div className="space-y-2">
-            <Label htmlFor="deploy-checkpoint">
-              {t("studio.deploy.checkpoint.label")}
-            </Label>
-            {checkpoints.length === 0 ? (
-                <Alert className="border-warn/40 text-warn [&>svg]:text-warn">
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertDescription>
-                    {t("studio.deploy.checkpoint.none")}
-                  </AlertDescription>
-                </Alert>
+            {/* Robot readiness — a warning, not a parameter, so no eyebrow. A
+                ready robot renders nothing: the robot menu already names the
+                selection and its arm layout. */}
+            <RobotStatus ready={!!robot && robot.follower_ready}>
+              {!robot ? (
+                t("studio.deploy.noRobot")
               ) : (
-                <CheckpointDropdown
-                  id="deploy-checkpoint"
-                  checkpoints={checkpoints}
-                  // Lineage-wide list: two entries can share a step, so the ref
-                  // is the only safe identity to select by.
-                  selectedRef={selectedRef}
-                  onChange={(c) => setSelectedRef(c.ref)}
-                  owners={checkpointOwnerMap}
+                /* The plural is on the follower ARM count — 2 for a bimanual
+                   robot, 1 otherwise. The number itself is never printed; it
+                   only picks the variant, replacing the old `{s}` splice.
+                   Coaching gets its own key AND its own gap scope: it
+                   teleoperates through the leader too, so a missing leader port
+                   is a real blocker there and noise in every other mode. */
+                <Trans
+                  i18nKey={
+                    runMode === "coach"
+                      ? "studio.deploy.robotNotReadyCoach"
+                      : "studio.deploy.robotNotReady"
+                  }
+                  count={isBimanual ? 2 : 1}
+                  values={{
+                    name: robot.name,
+                    gap: formatRobotSetupGap(
+                      t,
+                      robot,
+                      runMode === "coach" ? "all" : "follower",
+                    ),
+                  }}
+                  components={[<strong key="0" />]}
                 />
               )}
-              {robotCheckpointArmMismatch ? (
-                <Alert className="border-warn/40 text-warn [&>svg]:text-warn">
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertDescription>
-                    {/* Each branch is one complete key rather than shared
-                        fragments, so a translator owns the whole sentence. */}
-                    <Trans
-                      i18nKey={
-                        checkpointIsBimanual
-                          ? "studio.deploy.armMismatch.bimanualCheckpoint"
-                          : "studio.deploy.armMismatch.singleCheckpoint"
-                      }
-                      values={{
-                        dim: checkpointDim,
-                        arms: checkpointArms,
-                        name: robot?.name,
-                      }}
-                      components={[<strong key="0" />, <strong key="1" />]}
-                    />
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-          </div>
+            </RobotStatus>
 
-          {/* Run parameters — flat, each with its own <Label>; the old "Run
-              parameters" eyebrow sat above two fields that already say what
-              they are. --------------------------------------------------- */}
-          {policyConfig ? (
-            <>
-              {/* Coaching ALWAYS needs it, language-conditioned or not: the
-                  string is written into every recorded frame and the server
-                  refuses an empty one. Gating this on `requires_task` alone
-                  meant a plain ACT checkpoint gave a green panel, an enabled
-                  Start, and then a 400 naming a field that was not on screen
-                  and could not be made to appear. */}
-              {policyConfig.requires_task || runMode === "coach" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="deploy-task">
-                    {t("studio.deploy.task.label")}
-                  </Label>
-                  <Input
-                    id="deploy-task"
-                    value={task}
-                    onChange={(e) => setTask(e.target.value)}
-                    // The trained-on sentence, shown greyed rather than typed
-                    // in. Leaving the box empty sends it; clearing what you
-                    // typed brings it back. No invented example: a fake task
-                    // shown greyed in the same slot the REAL inherited task
-                    // uses is indistinguishable from one. When the lineage
-                    // yields nothing, say so instead.
-                    placeholder={
-                      defaultTask || t("studio.deploy.task.placeholderNone")
-                    }
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    {policyConfig.requires_task
-                      ? /* The policy type is an identifier — verbatim. */
-                        t("studio.deploy.task.hint", {
-                          policyType: policyConfig.policy_type ?? "",
-                        })
-                      : t("studio.deploy.task.hintCoach")}
-                    {/* Says where the greyed sentence comes from. Only while
-                        the box is EMPTY — once the operator types, the default
-                        is not what will be sent and claiming otherwise would be
-                        a lie. */}
-                    {task.trim() === "" && defaultTask
-                      ? ` ${t("studio.deploy.task.leaveEmpty")}`
-                      : ""}
-                  </p>
-                  {datasetTasks.length > 1 && (
-                    <div className="space-y-1">
-                      <p className="text-xs text-muted-foreground">
-                        {t("studio.deploy.task.multiTaskHint", {
-                          count: datasetTasks.length,
-                        })}
-                      </p>
-                      <div className="flex flex-wrap gap-1">
-                        {datasetTasks.map((t) => (
-                          <button
-                            key={t}
-                            type="button"
-                            onClick={() => setTask(t)}
-                            className={cn(
-                              "rounded border px-2 py-0.5 text-xs transition-colors",
-                              task === t
-                                ? "border-primary bg-primary/10"
-                                : "border-border hover:bg-muted",
-                            )}
-                          >
-                            {t}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ) : null}
-              {runMode !== "coach" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="deploy-duration">
-                    {t("studio.deploy.duration.label")}
-                  </Label>
-                  <NumberInput
-                    id="deploy-duration"
-                    min={1}
-                    value={durationS}
-                    onChange={(v) => {
-                      if (v !== undefined) setDurationS(v);
-                    }}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    {runMode === "eval"
-                      ? t("studio.deploy.duration.hint")
-                      : t("studio.deploy.duration.singleHint")}
-                  </p>
-                </div>
-              ) : null}
-              {runMode === "eval" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="deploy-episodes">
-                    {t("studio.deploy.episodes.label")}
-                  </Label>
-                  <NumberInput
-                    id="deploy-episodes"
-                    min={1}
-                    max={MAX_EVAL_EPISODES}
-                    value={evalEpisodes}
-                    onChange={(v) => {
-                      if (v !== undefined) setEvalEpisodes(v);
-                    }}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    {t("studio.deploy.episodes.scoreHint")}
-                  </p>
-                </div>
-              ) : null}
-              {runMode === "coach" ? (
-                <>
-                  {/* Readiness, stated before the operator commits an hour to
-                      it. Coaching corrects a policy's OWN failures, so it has
-                      nothing to work with until the policy sometimes succeeds:
-                      CR-DAgger (arXiv:2506.16685) recommends starting only once
-                      the base policy is at 10-20%, and below that the honest
-                      answer is more demonstrations, not more corrections. This
-                      is the cheapest possible place to say so — the alternative
-                      is discovering it after a session spent rescuing an arm
-                      that never got close. */}
-                  <div className="rounded-lg border border-border bg-muted/40 p-3">
-                    <p className="text-xs leading-relaxed text-muted-foreground">
-                      <span className="font-semibold text-foreground">
-                        Coaching pays off once the skill already works
-                        sometimes.
-                      </span>{" "}
-                      It learns from rescuing the policy's own mistakes, so it
-                      needs the policy to get far enough to make interesting
-                      ones — roughly a 1-in-10 success rate. If it fails
-                      immediately every time, record more demonstrations first;
-                      that's faster than correcting your way there.{" "}
-                      <span className="whitespace-nowrap">
-                        Score it above to check.
-                      </span>
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="deploy-corrections">
-                      {t("studio.deploy.coaching.correctionsLabel")}
-                    </Label>
-                    <NumberInput
-                      id="deploy-corrections"
-                      min={1}
-                      max={MAX_COACHING_CORRECTIONS}
-                      value={targetCorrections}
-                      onChange={(v) => {
-                        if (v !== undefined) setTargetCorrections(v);
-                      }}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      {t("studio.deploy.coaching.correctionsHint")}
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="deploy-coach-dataset">
-                      {t("studio.deploy.coaching.datasetLabel")}
-                    </Label>
-                    {/* `rollout_` is rendered as a fixed, unfocusable part of
-                        the field rather than left in the operator's text. It is
-                        not optional — lerobot refuses a rollout dataset whose
-                        repo name lacks it (rollout/context.py), and merge.py
-                        keys the lossless `intervention`-column drop on the same
-                        prefix — so it must never be something a person can
-                        delete or forget. What they type follows it. */}
-                    <div className="flex items-center rounded-md border border-input bg-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ring-offset-background">
-                      <span
-                        aria-hidden
-                        className="select-none pl-3 pr-0.5 font-mono text-sm text-muted-foreground"
-                      >
-                        rollout_
-                      </span>
-                      <Input
-                        id="deploy-coach-dataset"
-                        value={coachDatasetName}
-                        onChange={(e) => setCoachDatasetName(e.target.value)}
-                        placeholder={
-                          defaultCoachName ||
-                          t("studio.deploy.coaching.datasetFallback")
-                        }
-                        className="border-0 bg-transparent pl-0 font-mono shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                      />
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {/* <0> wraps the literal on-disk prefix, which is an
-                          identifier and stays in the Latin script. */}
-                      <Trans
-                        i18nKey="studio.deploy.coaching.datasetHint"
-                        values={{
-                          prefix: `rollout_${
-                            effectiveCoachName ||
-                            t("studio.deploy.coaching.datasetFallback")
-                          }_`,
-                        }}
-                        components={[<span key="0" className="font-mono" />]}
-                      />
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    <Label>{t("studio.deploy.coaching.leaderLabel")}</Label>
-                    <p
-                      className={`text-xs ${
-                        coachLeaderMissing
-                          ? "text-destructive"
-                          : "text-muted-foreground"
-                      }`}
-                    >
-                      {!robot
-                        ? t("studio.deploy.coaching.leaderNoRobot")
-                        : coachLeaderMissing
-                          ? t("studio.deploy.coaching.leaderMissing")
-                          : t("studio.deploy.coaching.leaderFrom", {
-                              name: robot.name,
-                              // Calibration file names — data, never translated.
-                              configs: isBimanual
-                                ? `${robot.leader_config} + ${robot.right_leader_config}`
-                                : robot.leader_config,
-                            })}
-                    </p>
-                    {isBimanual ? (
-                      <p className="text-xs text-warn">
-                        {t("studio.deploy.coaching.bimanualWarning")}
-                      </p>
-                    ) : null}
-                  </div>
-                </>
-              ) : null}
-              {runMode !== "coach" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="deploy-engine">
-                    {t("studio.deploy.engine.label")}
-                  </Label>
-                  <Select
-                    value={inferenceEngine}
-                    onValueChange={(v) =>
-                      setInferenceEngine(v as "sync" | "rtc")
-                    }
+            {/* Skill and Checkpoint share one row — the same two-column
+                grid Collect pairs Episode duration / Reset duration with.
+                They are one decision in two halves (which weights, which
+                step of them), and the second is meaningless without the
+                first, so the row is always two-up: with no skill picked the
+                Checkpoint column holds a disabled "Pick a skill first"
+                instead of collapsing. min-w-0 on both columns so a long
+                name truncates inside its half instead of widening it. */}
+            <div className="grid grid-cols-2 gap-4">
+              {/* Skill — the form's one mandatory field, built as Train's
+                  dataset field is: the current choice as a chip, otherwise the
+                  full-list picker docked in the same box.
+
+                  One way in, not two: the whole control is the popover's
+                  trigger, and ModelPicker's own CommandInput is the only
+                  search box (it also owns the loading / "no models yet" /
+                  "no match" states). The trigger wears SelectTrigger's own
+                  classes so it reads as the same kind of control as the
+                  Checkpoint dropdown beside it and the engine Select below —
+                  it can't BE a SelectTrigger, because what it opens is a
+                  Popover. Picking replaces the selection outright; there is
+                  no clear ✕, since a run always needs a skill and "none" is
+                  only ever the pre-selection state. */}
+              <div className="min-w-0 space-y-2">
+                <Label htmlFor="deploy-skill">
+                  {t("studio.deploy.skill.label")}
+                </Label>
+                {/* `models` is already the DEPLOYABLE projection of /skills —
+                    the server decides it (weights loadable AND nothing
+                    supersedes the row), which is a stricter and better-informed
+                    answer than the checkpoint_count deny-list this panel used
+                    to derive from the job registry. */}
+                <ModelPicker
+                  models={models}
+                  loading={modelsLoading}
+                  onPickExisting={(m) => handlePickSkill(m.id)}
+                >
+                  <button
+                    id="deploy-skill"
+                    type="button"
+                    disabled={resolving}
+                    className="flex h-10 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    <SelectTrigger id="deploy-engine">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {/* Option VALUES ("sync" / "rtc") are what the backend
-                          parses — only the labels are translated. */}
-                      <SelectItem value="sync">
-                        {t("studio.deploy.engine.sync")}
-                      </SelectItem>
-                      <SelectItem value="rtc">
-                        {t("studio.deploy.engine.rtc")}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    {inferenceEngine === "rtc"
-                      ? t("studio.deploy.engine.rtcHint")
-                      : t("studio.deploy.engine.syncHint")}
+                    {selectedSkillLabel ? (
+                      <DisplayName
+                        name={selectedSkillLabel}
+                        className="min-w-0"
+                      />
+                    ) : (
+                      <span className="truncate text-muted-foreground">
+                        {t("studio.deploy.picker.placeholder")}
+                      </span>
+                    )}
+                    <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+                  </button>
+                </ModelPicker>
+                {/* Listing health, kept from the coaching branch and moved OUT
+                    of the dropdown now that the picker owns its own empty
+                    state. "We could not ask" and "you own nothing" are
+                    different sentences, and an unreachable Hub used to look
+                    exactly like an empty shelf — the rows simply were not
+                    there. The picker still serves the last complete Hub result
+                    underneath. */}
+                {modelsError ? (
+                  <p className="text-xs text-destructive">
+                    {t("studio.deploy.picker.error")}
                   </p>
-                </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  {t("studio.deploy.engine.coachingNote")}
-                </p>
-              )}
-            </>
-          ) : null}
+                ) : hubStatus && !hubStatus.ok ? (
+                  <p className="text-[11px] text-amber-600 dark:text-amber-500">
+                    {t("studio.deploy.picker.hubDegraded")}
+                  </p>
+                ) : null}
+              </div>
+              {/* Checkpoint — the one control with nothing to offer until a skill is
+                  chosen, so it renders disabled saying so rather than vanishing.
 
-          {/* Cameras — a repeater, so it keeps its eyebrow. ------------------ */}
-          <FormSection title={t("studio.deploy.cameras.title")}>
-              {policyConfigLoading ? (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  {t("studio.deploy.cameras.loading")}
-                </div>
-              ) : policyConfigError ? (
-                <Alert variant="destructive">
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertDescription>
-                    {/* The error text is the backend's own — passed through. */}
-                    {t("studio.deploy.cameras.configError", {
-                      error: policyConfigError,
-                    })}
-                  </AlertDescription>
-                </Alert>
-              ) : !policyConfig ? null : cameraMap.length === 0 ? (
-                <p className="text-xs text-muted-foreground">
-                  {t("studio.deploy.cameras.none")}
-                </p>
-              ) : (
-                <div className="space-y-3">
+                  CheckpointDropdown's own trigger is sized for a card's action row
+                  (h-8, text-xs, w-auto); FIELD_TRIGGER puts it back on the studio's
+                  form-field size. Passed from here rather than changed in the
+                  component, because its other callers (JobCard's action line,
+                  ModelCard's w-36 slot) want the compact one. */}
+              <div className="min-w-0 space-y-2">
+                <Label htmlFor="deploy-checkpoint">
+                  {t("studio.deploy.checkpoint.label")}
+                </Label>
+                {!selectedJob ? (
+                  <CheckpointDropdown
+                    id="deploy-checkpoint"
+                    checkpoints={NO_CHECKPOINTS}
+                    selectedRef={null}
+                    onChange={() => {}}
+                    disabled
+                    placeholder={t("studio.deploy.checkpoint.pickSkillFirst")}
+                    className={FIELD_TRIGGER}
+                  />
+                ) : checkpoints.length === 0 ? (
+                  <Alert className="border-warn/40 text-warn [&>svg]:text-warn">
+                    <AlertTriangle className="h-4 w-4" />
+                    <AlertDescription>
+                      {t("studio.deploy.checkpoint.none")}
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <CheckpointDropdown
+                    id="deploy-checkpoint"
+                    checkpoints={checkpoints}
+                    // Lineage-wide list: two entries can share a step, so the
+                    // ref is the only safe identity to select by.
+                    selectedRef={selectedRef}
+                    onChange={(c) => setSelectedRef(c.ref)}
+                    owners={checkpointOwnerMap}
+                    className={FIELD_TRIGGER}
+                  />
+                )}
+              </div>
+            </div>
+
+            {/* Reading the checkpoint's config is what tells this panel the
+                policy's cameras, its task requirement and its arm count, so the
+                progress and the failure both belong under the checkpoint rather
+                than beside the fields they would have filled in. */}
+            {policyConfigLoading ? (
+              <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                {t("studio.deploy.cameras.loading")}
+              </p>
+            ) : null}
+            {policyConfigError ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  {/* The error text is the backend's own — passed through. */}
+                  {t("studio.deploy.cameras.configError", {
+                    error: policyConfigError,
+                  })}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            {robotCheckpointArmMismatch ? (
+              <Alert className="border-warn/40 text-warn [&>svg]:text-warn">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  {/* Each branch is one complete key rather than shared
+                      fragments, so a translator owns the whole sentence. */}
+                  <Trans
+                    i18nKey={
+                      checkpointIsBimanual
+                        ? "studio.deploy.armMismatch.bimanualCheckpoint"
+                        : "studio.deploy.armMismatch.singleCheckpoint"
+                    }
+                    values={{
+                      dim: checkpointDim,
+                      arms: checkpointArms,
+                      name: robot?.name,
+                    }}
+                    components={[<strong key="0" />, <strong key="1" />]}
+                  />
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            {/* Run parameters — flat, each with its own <Label>; the old "Run
+                parameters" eyebrow sat above two fields that already say what
+                they are. The block is no longer gated on the policy config
+                having loaded — that gate made half the form appear and vanish
+                with the skill. What IS gated is which fields a given run mode
+                actually uses. ---------------------------------------------- */}
+            <div className="space-y-2">
+              <Label htmlFor="deploy-task">
+                {t("studio.deploy.task.label")}
+              </Label>
+              <Input
+                id="deploy-task"
+                value={task}
+                onChange={(e) => setTask(e.target.value)}
+                // The trained-on sentence, shown greyed rather than typed in.
+                // Leaving the box empty sends it; clearing what you typed brings
+                // it back. No invented example: a fake task shown greyed in the
+                // same slot the REAL inherited task uses is indistinguishable
+                // from one. When the lineage yields nothing, say so instead.
+                placeholder={
+                  defaultTask || t("studio.deploy.task.placeholderNone")
+                }
+              />
+              {/* Whether the field is even read is a property of the checkpoint,
+                  so the helper answers that question in all three states rather
+                  than the field appearing and disappearing with the skill — plus
+                  a fourth: coaching writes the string into every recorded frame,
+                  so it is read even by a policy that ignores it.
+                  The policy type is an identifier — rendered verbatim. */}
+              <p className="text-xs text-muted-foreground">
+                {!policyConfig
+                  ? t("studio.deploy.task.hintUnknown")
+                  : policyConfig.requires_task
+                    ? t("studio.deploy.task.hint", {
+                        policyType: policyConfig.policy_type ?? "",
+                      })
+                    : runMode === "coach"
+                      ? t("studio.deploy.task.hintCoach")
+                      : t("studio.deploy.task.hintNotConditioned", {
+                          policyType: policyConfig.policy_type ?? "",
+                        })}
+                {/* Says where the greyed sentence comes from. Only while the box
+                    is EMPTY — once the operator types, the default is not what
+                    will be sent and claiming otherwise would be a lie. */}
+                {task.trim() === "" && defaultTask
+                  ? ` ${t("studio.deploy.task.leaveEmpty")}`
+                  : ""}
+              </p>
+              {datasetTasks.length > 1 && (
+                <div className="space-y-1">
                   <p className="text-xs text-muted-foreground">
-                    {t("studio.deploy.cameras.intro")}
+                    {t("studio.deploy.task.multiTaskHint", {
+                      count: datasetTasks.length,
+                    })}
                   </p>
-                  {cameraMap.map((m) => {
-                    const dims = policyConfig.image_features[m.feature];
-                    const value = cameraBindings[m.requestKey];
-                    const boundCamera = recordCameraByName(value);
-                    const connected =
-                      boundCamera != null &&
-                      isCameraConnected(boundCamera, availableCameras);
-                    return (
-                      <div key={m.requestKey} className="flex items-center gap-3">
-                        <div className="flex-1">
-                          <Label className="text-sm font-medium">{m.display}</Label>
+                  <div className="flex flex-wrap gap-1">
+                    {datasetTasks.map((candidate) => (
+                      <button
+                        key={candidate}
+                        type="button"
+                        onClick={() => setTask(candidate)}
+                        className={cn(
+                          "rounded border px-2 py-0.5 text-xs transition-colors",
+                          task === candidate
+                            ? "border-primary bg-primary/10"
+                            : "border-border hover:bg-muted",
+                        )}
+                      >
+                        {candidate}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+            {runMode !== "coach" ? (
+              <div className="space-y-2">
+                <Label htmlFor="deploy-duration">
+                  {t("studio.deploy.duration.label")}
+                </Label>
+                <NumberInput
+                  id="deploy-duration"
+                  min={1}
+                  value={durationS}
+                  onChange={(v) => {
+                    if (v !== undefined) setDurationS(v);
+                  }}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {runMode === "eval"
+                    ? t("studio.deploy.duration.hint")
+                    : t("studio.deploy.duration.singleHint")}
+                </p>
+              </div>
+            ) : null}
+            {runMode === "eval" ? (
+              <div className="space-y-2">
+                <Label htmlFor="deploy-episodes">
+                  {t("studio.deploy.episodes.label")}
+                </Label>
+                <NumberInput
+                  id="deploy-episodes"
+                  min={1}
+                  max={MAX_EVAL_EPISODES}
+                  value={evalEpisodes}
+                  onChange={(v) => {
+                    if (v !== undefined) setEvalEpisodes(v);
+                  }}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("studio.deploy.episodes.scoreHint")}
+                </p>
+              </div>
+            ) : null}
+            {runMode === "coach" ? (
+              <>
+                {/* Readiness, stated before the operator commits an hour to it.
+                    Coaching corrects a policy's OWN failures, so it has nothing
+                    to work with until the policy sometimes succeeds: CR-DAgger
+                    (arXiv:2506.16685) recommends starting only once the base
+                    policy is at 10-20%, and below that the honest answer is more
+                    demonstrations, not more corrections. This is the cheapest
+                    possible place to say so — the alternative is discovering it
+                    after a session spent rescuing an arm that never got close. */}
+                <div className="rounded-lg border border-border bg-muted/40 p-3">
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    <span className="font-semibold text-foreground">
+                      Coaching pays off once the skill already works sometimes.
+                    </span>{" "}
+                    It learns from rescuing the policy's own mistakes, so it
+                    needs the policy to get far enough to make interesting ones —
+                    roughly a 1-in-10 success rate. If it fails immediately every
+                    time, record more demonstrations first; that's faster than
+                    correcting your way there.{" "}
+                    <span className="whitespace-nowrap">
+                      Score it above to check.
+                    </span>
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="deploy-corrections">
+                    {t("studio.deploy.coaching.correctionsLabel")}
+                  </Label>
+                  <NumberInput
+                    id="deploy-corrections"
+                    min={1}
+                    max={MAX_COACHING_CORRECTIONS}
+                    value={targetCorrections}
+                    onChange={(v) => {
+                      if (v !== undefined) setTargetCorrections(v);
+                    }}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {t("studio.deploy.coaching.correctionsHint")}
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="deploy-coach-dataset">
+                    {t("studio.deploy.coaching.datasetLabel")}
+                  </Label>
+                  {/* `rollout_` is rendered as a fixed, unfocusable part of the
+                      field rather than left in the operator's text. It is not
+                      optional — lerobot refuses a rollout dataset whose repo
+                      name lacks it (rollout/context.py), and merge.py keys the
+                      lossless `intervention`-column drop on the same prefix — so
+                      it must never be something a person can delete or forget.
+                      What they type follows it. */}
+                  <div className="flex items-center rounded-md border border-input bg-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ring-offset-background">
+                    <span
+                      aria-hidden
+                      className="select-none pl-3 pr-0.5 font-mono text-sm text-muted-foreground"
+                    >
+                      rollout_
+                    </span>
+                    <Input
+                      id="deploy-coach-dataset"
+                      value={coachDatasetName}
+                      onChange={(e) => setCoachDatasetName(e.target.value)}
+                      placeholder={
+                        defaultCoachName ||
+                        t("studio.deploy.coaching.datasetFallback")
+                      }
+                      className="border-0 bg-transparent pl-0 font-mono shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {/* <0> wraps the literal on-disk prefix, which is an
+                        identifier and stays in the Latin script. */}
+                    <Trans
+                      i18nKey="studio.deploy.coaching.datasetHint"
+                      values={{
+                        prefix: `rollout_${
+                          effectiveCoachName ||
+                          t("studio.deploy.coaching.datasetFallback")
+                        }_`,
+                      }}
+                      components={[<span key="0" className="font-mono" />]}
+                    />
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label>{t("studio.deploy.coaching.leaderLabel")}</Label>
+                  <p
+                    className={cn(
+                      "text-xs",
+                      coachLeaderMissing
+                        ? "text-destructive"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {!robot
+                      ? t("studio.deploy.coaching.leaderNoRobot")
+                      : coachLeaderMissing
+                        ? t("studio.deploy.coaching.leaderMissing")
+                        : t("studio.deploy.coaching.leaderFrom", {
+                            name: robot.name,
+                            // Calibration file names — data, never translated.
+                            configs: isBimanual
+                              ? `${robot.leader_config} + ${robot.right_leader_config}`
+                              : robot.leader_config,
+                          })}
+                  </p>
+                  {isBimanual ? (
+                    <p className="text-xs text-warn">
+                      {t("studio.deploy.coaching.bimanualWarning")}
+                    </p>
+                  ) : null}
+                </div>
+              </>
+            ) : null}
+            {runMode !== "coach" ? (
+              <div className="space-y-2">
+                <Label htmlFor="deploy-engine">
+                  {t("studio.deploy.engine.label")}
+                </Label>
+                <Select
+                  value={inferenceEngine}
+                  onValueChange={(v) => setInferenceEngine(v as "sync" | "rtc")}
+                >
+                  <SelectTrigger id="deploy-engine">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {/* Option VALUES ("sync" / "rtc") are what the backend
+                        parses — only the labels are translated. */}
+                    <SelectItem value="sync">
+                      {t("studio.deploy.engine.sync")}
+                    </SelectItem>
+                    <SelectItem value="rtc">
+                      {t("studio.deploy.engine.rtc")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {inferenceEngine === "rtc"
+                    ? t("studio.deploy.engine.rtcHint")
+                    : t("studio.deploy.engine.syncHint")}
+                </p>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                {t("studio.deploy.engine.coachingNote")}
+              </p>
+            )}
+
+            {/* Cameras — literally Collect's list: the same component, the same
+                heading and sentence, the same cards, fed from the same place (the
+                selected robot's record). There is nothing to pick here because
+                nothing is picked: each camera the checkpoint was trained with
+                takes the robot camera of the SAME NAME (see cameraBindings), and
+                the only two ways that can go wrong are reported once, below. */}
+            <SessionCameraList
+              cameras={robotCameras}
+              paused={submitting || inferenceActive}
+              emptyLabel={
+                robot
+                  ? t("studio.deploy.cameras.robotHasNone")
+                  : t("studio.deploy.cameras.noRobot")
+              }
+            />
+
+            {/* One alert for both failure modes, and only when there is one: a
+                camera the policy names that the robot hasn't got (blocks Start —
+                the rollout cannot invent the feed), and a name match whose
+                resolution differs from the checkpoint's (a warning: the run
+                captures at the policy's size regardless). */}
+            {unmatchedCameras.length > 0 || mismatchedCameras.length > 0 ? (
+              <Alert
+                variant={unmatchedCameras.length > 0 ? "destructive" : undefined}
+                className={
+                  unmatchedCameras.length > 0
+                    ? undefined
+                    : "border-warn/40 text-warn [&>svg]:text-warn"
+                }
+              >
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription className="space-y-1">
+                  {unmatchedCameras.map((b) => (
+                    <p key={b.mapping.requestKey}>
+                      {/* The camera NAME is data (it is the robot record's own
+                          key), so it rides in as a value and <0> only makes it
+                          bold. */}
+                      <Trans
+                        i18nKey="studio.deploy.cameras.unmatched"
+                        values={{ name: b.mapping.display }}
+                        components={[<strong key="0" />]}
+                      />
+                    </p>
+                  ))}
+                  {/* `resolutionDiffers` is only ever true with both sides
+                      present; the guard is what tells the compiler so. */}
+                  {mismatchedCameras.map(({ mapping, camera, dims }) =>
+                    camera && dims ? (
+                      <p key={mapping.requestKey}>
+                        <Trans
+                          i18nKey="studio.deploy.cameras.resolutionMismatch"
+                          values={{
+                            name: camera.name,
+                            robotWidth: camera.width,
+                            robotHeight: camera.height,
+                            policyWidth: dims.width,
+                            policyHeight: dims.height,
+                          }}
+                          components={[<strong key="0" />]}
+                        />
+                      </p>
+                    ) : null,
+                  )}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            {/* Advanced parameters — same AdvancedSection trigger and inner
+                eyebrow/label/help-text rhythm as the Train form's AdvancedCard,
+                so the two panels read as one form. ACT-only for now: temporal
+                ensembling is an ACT config field, so for every other policy type
+                the block has nothing to hold and stays hidden. ------------- */}
+            {isAct ? (
+              <AdvancedSection
+                open={advancedOpen}
+                onOpenChange={setAdvancedOpen}
+                summary={t("studio.deploy.advanced.summary")}
+              >
+                <div className="space-y-6">
+                  <section className="space-y-3">
+                    <h4 className={eyebrow}>
+                      {t("studio.deploy.advanced.actionSelection")}
+                    </h4>
+                    <div className="flex items-center gap-3">
+                      <Switch
+                        id="deploy-temporal-ensemble"
+                        checked={temporalEnsemble}
+                        onCheckedChange={setTemporalEnsemble}
+                        className="data-[state=checked]:bg-primary"
+                      />
+                      <Label htmlFor="deploy-temporal-ensemble">
+                        {t("studio.deploy.advanced.temporalEnsemble")}
+                      </Label>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {t("studio.deploy.advanced.temporalEnsembleHint")}
+                    </p>
+                    {temporalEnsemble ? (
+                      <div className="space-y-2">
+                        <Label htmlFor="deploy-temporal-ensemble-coeff">
+                          {t("studio.deploy.advanced.coeffLabel")}
+                        </Label>
+                        <NumberInput
+                          id="deploy-temporal-ensemble-coeff"
+                          integer={false}
+                          step="0.001"
+                          min={0}
+                          value={temporalEnsembleCoeff}
+                          onChange={setTemporalEnsembleCoeff}
+                          placeholder={t(
+                            "studio.deploy.advanced.coeffPlaceholder",
+                            { value: DEFAULT_TEMPORAL_ENSEMBLE_COEFF },
+                          )}
+                          aria-invalid={temporalEnsembleInvalid}
+                          className={cn(
+                            "w-40",
+                            temporalEnsembleInvalid && "border-destructive",
+                          )}
+                        />
+                        {temporalEnsembleInvalid ? (
+                          <p className="text-xs text-destructive">
+                            {t("studio.deploy.advanced.coeffInvalid")}
+                          </p>
+                        ) : (
                           <p className="text-xs text-muted-foreground">
-                            {t("studio.deploy.cameras.captures", {
-                              width: dims.width,
-                              height: dims.height,
+                            {t("studio.deploy.advanced.coeffHint", {
+                              value: DEFAULT_TEMPORAL_ENSEMBLE_COEFF,
                             })}
                           </p>
-                          {boundCamera &&
-                          (boundCamera.width !== dims.width ||
-                            boundCamera.height !== dims.height) ? (
-                            <p className="text-xs text-muted-foreground">
-                              {t("studio.deploy.cameras.mismatch", {
-                                name: boundCamera.name,
-                                width: boundCamera.width,
-                                height: boundCamera.height,
-                              })}
-                            </p>
-                          ) : null}
-                          {boundCamera && !connected ? (
-                            <p className="text-xs text-destructive">
-                              {t("studio.deploy.cameras.disconnected")}
-                            </p>
-                          ) : null}
-                        </div>
-                        <Select
-                          value={value ?? undefined}
-                          onValueChange={(v) => onCameraBindingChange(m.requestKey, v)}
-                        >
-                          <SelectTrigger className="w-52">
-                            <SelectValue
-                              placeholder={t("studio.deploy.cameras.select")}
-                            />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {robotCameras.length === 0 ? (
-                              <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                                {t("studio.deploy.cameras.robotHasNone")}
-                              </div>
-                            ) : (
-                              robotCameras.map((cam) => (
-                                <SelectItem key={cam.name} value={cam.name}>
-                                  {cam.name} — {cam.width}×{cam.height}
-                                </SelectItem>
-                              ))
-                            )}
-                          </SelectContent>
-                        </Select>
-                        <CameraThumbnail
-                          cameraIndex={
-                            boundCamera && connected
-                              ? resolveCameraIndex(boundCamera, availableCameras)
-                              : undefined
-                          }
-                          uniqueId={boundCamera?.unique_id}
-                          paused={submitting || inferenceActive}
-                        />
+                        )}
                       </div>
-                    );
-                  })}
+                    ) : null}
+                  </section>
                 </div>
-              )}
-          </FormSection>
-
-          {/* Advanced parameters — same AdvancedSection trigger and inner
-              eyebrow/label/help-text rhythm as the Train form's AdvancedCard,
-              so the two panels read as one form. ACT-only for now: temporal
-              ensembling is an ACT config field, so for every other policy type
-              the block has nothing to hold and stays hidden. ------------- */}
-          {isAct ? (
-            <AdvancedSection
-              open={advancedOpen}
-              onOpenChange={setAdvancedOpen}
-              summary={t("studio.deploy.advanced.summary")}
-            >
-              <div className="space-y-6">
-                <section className="space-y-3">
-                  <h4 className={eyebrow}>
-                    {t("studio.deploy.advanced.actionSelection")}
-                  </h4>
-                  <div className="flex items-center gap-3">
-                    <Switch
-                      id="deploy-temporal-ensemble"
-                      checked={temporalEnsemble}
-                      onCheckedChange={setTemporalEnsemble}
-                      className="data-[state=checked]:bg-primary"
-                    />
-                    <Label htmlFor="deploy-temporal-ensemble">
-                      {t("studio.deploy.advanced.temporalEnsemble")}
-                    </Label>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {t("studio.deploy.advanced.temporalEnsembleHint")}
-                  </p>
-                  {temporalEnsemble ? (
-                    <div className="space-y-2">
-                      <Label htmlFor="deploy-temporal-ensemble-coeff">
-                        {t("studio.deploy.advanced.coeffLabel")}
-                      </Label>
-                      <NumberInput
-                        id="deploy-temporal-ensemble-coeff"
-                        integer={false}
-                        step="0.001"
-                        min={0}
-                        value={temporalEnsembleCoeff}
-                        onChange={setTemporalEnsembleCoeff}
-                        placeholder={t(
-                          "studio.deploy.advanced.coeffPlaceholder",
-                          { value: DEFAULT_TEMPORAL_ENSEMBLE_COEFF },
-                        )}
-                        aria-invalid={temporalEnsembleInvalid}
-                        className={cn(
-                          "w-40",
-                          temporalEnsembleInvalid && "border-destructive",
-                        )}
-                      />
-                      {temporalEnsembleInvalid ? (
-                        <p className="text-xs text-destructive">
-                          {t("studio.deploy.advanced.coeffInvalid")}
-                        </p>
-                      ) : (
-                        <p className="text-xs text-muted-foreground">
-                          {t("studio.deploy.advanced.coeffHint", {
-                            value: DEFAULT_TEMPORAL_ENSEMBLE_COEFF,
-                          })}
-                        </p>
-                      )}
-                    </div>
-                  ) : null}
-                </section>
-              </div>
-            </AdvancedSection>
-          ) : null}
-        </div>
-      ) : null}
+              </AdvancedSection>
+            ) : null}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
 
       {/* Deploy-started milestone — the effect above latches this true the
           first time the live InferenceSessionDialog closes after handleStart
@@ -1980,14 +1932,16 @@ const DeployPanel: React.FC = () => {
         />
       )}
 
-      {/* Actions — pinned directly above the skill library. Side by side so
-          the row sits level with Collect's and Train's single Start.
-          No Stop here: a live rollout owns the InferenceSessionDialog, which
-          is modal and carries its own Stop. A second stop control sitting on
-          a panel the operator cannot see during a run was dead weight the
-          rest of the time, and enabled only in the one state where it was
-          unreachable. -------------------------------------------------- */}
-      <div ref={actionsRef} className="mt-auto flex flex-col gap-2 pt-2">
+      {/* Actions — directly under the form at the panel's normal gap-5 rhythm;
+          the library below carries the column's stretch, so this row no longer
+          needs mt-auto.
+
+          The verbs ARE the actions: pressing one selects that run mode and
+          launches it in the same gesture, so there is nothing left in a
+          position to be wrong about. And no Stop beside them — see the note at
+          `selectedSkillLabel` for why the panel's own stop was dropped rather
+          than kept. ------------------------------------------------------- */}
+      <div ref={actionsRef} className="flex flex-col gap-2">
         <RunVerbs
           active={runMode}
           onArm={armRunMode}
@@ -2003,15 +1957,25 @@ const DeployPanel: React.FC = () => {
       </div>
 
       {/* Model / policy library — imported models + uploaded Hub repos.
-          Picking a card selects it as the skill above (step null → the
-          checkpoint loader falls back to the latest). mt-0 keeps it glued to
-          the actions block above, which carries the panel's mt-auto. */}
-      <LibrarySection className="mt-0">
+          Picking a card selects it as the skill in the form above (step null →
+          the checkpoint loader falls back to the latest). LibrarySection's own
+          stretch now stands (no mt-0 override): the opener and Start row
+          top-pack, the free space falls between them and this, and the library
+          sits at the column foot so its "Show all" footer lines up with
+          Collect's and Train's. Its body is a scrolling viewport, so expanding
+          scrolls inside it and the footer never moves. */}
+      <LibrarySection>
         <ModelsLibrary
+          open={libraryOpen}
+          onOpenChange={setLibraryOpen}
           onPick={(job, step) => {
             setPendingStep(step);
             setSelectedJob(job);
             setSelectedModelId(job.id);
+            // …and, like a prefill, slide the form open onto it: the skill a
+            // card selects is only configurable in there, so leaving the form
+            // shut would make the click look like it did nothing.
+            toggleForm(true);
           }}
         />
       </LibrarySection>

--- a/frontend/src/components/studio/TrainPanel.tsx
+++ b/frontend/src/components/studio/TrainPanel.tsx
@@ -5,8 +5,8 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Trans, useTranslation } from "react-i18next";
-import { Check, ChevronsUpDown, Loader2, Play, Plus, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { ChevronsUpDown, Loader2, Play } from "lucide-react";
 
 import { useStudio } from "@/contexts/StudioContext";
 import { useApi } from "@/contexts/ApiContext";
@@ -15,7 +15,6 @@ import { useDatasets } from "@/hooks/useDatasets";
 import { useSelectedDataset } from "@/hooks/useSelectedDataset";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Collapsible,
@@ -29,17 +28,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useTruncationTitle } from "@/hooks/useTruncationTitle";
 
 import { ModelItem } from "@/lib/modelsApi";
 import { useModels } from "@/hooks/useModels";
 import { JobRecord, getJob, importModel, jobDisplayName } from "@/lib/jobsApi";
 import { listJobCheckpoints } from "@/lib/checkpointsApi";
-import {
-  DatasetItem,
-  getDatasetInfo,
-  saveCustomDataset,
-} from "@/lib/replayApi";
-import { HUB_REPO_ID_RE } from "@/lib/repoId";
+import { getDatasetInfo, saveCustomDataset } from "@/lib/replayApi";
 import TrainingConfigurator, {
   FinetuneSeed,
   ResumeSeed,
@@ -81,71 +76,6 @@ function recordPolicyType(record: JobRecord): string | null {
   if (!type || type === UNKNOWN_POLICY_TYPE) return null;
   return type;
 }
-
-/** One search-result row: repo id + (local) episode count, lazily fetched, +
- * Hub marker for remote-only rows. Skips the network for Hub-only rows (a
- * remote meta.json read) — counts are shown "where available". */
-const DatasetResultRow: React.FC<{
-  item: DatasetItem;
-  selected: boolean;
-  onPick: () => void;
-}> = ({ item, selected, onPick }) => {
-  const { t } = useTranslation();
-  const { baseUrl, fetchWithHeaders } = useApi();
-  const [episodes, setEpisodes] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (item.source === "hub") return; // avoid a remote fetch just for a count
-    let cancelled = false;
-    getDatasetInfo(baseUrl, fetchWithHeaders, item.repo_id)
-      .then((info) => {
-        if (!cancelled) setEpisodes(info.total_episodes);
-      })
-      .catch(() => {
-        /* count is optional — leave it blank */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [item.repo_id, item.source, baseUrl, fetchWithHeaders]);
-
-  return (
-    <button
-      type="button"
-      onClick={onPick}
-      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted/50"
-    >
-      <span className="min-w-0 flex-1 truncate font-mono text-foreground">
-        {item.repo_id}
-      </span>
-      {episodes != null ? (
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {t("studio.train.dataset.row.episodes", { episodes })}
-        </span>
-      ) : null}
-      {/* A weighted merge and its unweighted sibling are otherwise
-          indistinguishable here, and picking the wrong one silently trains the
-          wrong mix. `=== true` on purpose: the flag is absent (unknown), not
-          false, for Hub-only rows. */}
-      {item.weighted === true ? (
-        <span
-          className="shrink-0 font-mono text-xs text-info"
-          title={t("studio.train.dataset.row.weightedTitle")}
-        >
-          {t("studio.train.dataset.row.weighted")}
-        </span>
-      ) : null}
-      {item.source === "hub" ? (
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {t("studio.train.dataset.row.hub")}
-        </span>
-      ) : null}
-      {selected ? (
-        <Check className="h-3.5 w-3.5 shrink-0 text-primary" />
-      ) : null}
-    </button>
-  );
-};
 
 /**
  * Studio panel 2 · Train. Mirrors the Collect panel's progressive disclosure:
@@ -363,7 +293,9 @@ const TrainPanel: React.FC = () => {
   const [selectedId, setSelectedId] = useState<string | null>(
     () => selectedDataset,
   );
-  const [query, setQuery] = useState("");
+  // Hover title for the picker trigger below — only raised when the id is
+  // actually clipped by the half-panel-wide control.
+  const selectedIdHover = useTruncationTitle(selectedId);
   // A prefill's episode subset, paired with the repo id it was seeded for —
   // dropped (via the repoId guard below) if the user then picks a different
   // dataset, so a stale subset can never silently apply to it.
@@ -465,30 +397,9 @@ const TrainPanel: React.FC = () => {
     if (selectedId) setSelectedDataset(selectedId);
   }, [selectedId, setSelectedDataset]);
 
-  // Search-driven picker: results only exist while a query is typed — there is
-  // no standing list.
-  const trimmedQuery = query.trim();
-  const matches = useMemo(() => {
-    const q = trimmedQuery.toLowerCase();
-    if (!q) return [];
-    return datasets.filter((d) => d.repo_id.toLowerCase().includes(q));
-  }, [datasets, trimmedQuery]);
-
-  // A well-formed `org/name` id that isn't in the library yet is offered as a
-  // public Hub dataset — the affordance that ANY public dataset can be trained
-  // on, not just the user's own.
-  const hubCandidate = useMemo(() => {
-    if (!HUB_REPO_ID_RE.test(trimmedQuery)) return null;
-    const q = trimmedQuery.toLowerCase();
-    if (datasets.some((d) => d.repo_id.toLowerCase() === q)) return null;
-    return trimmedQuery;
-  }, [datasets, trimmedQuery]);
-
-  // Picking a result replaces the selection and collapses the results by
-  // clearing the query.
+  // Picking a result replaces the selection; the picker closes itself.
   const pickDataset = (repoId: string) => {
     setSelectedId(repoId);
-    setQuery("");
   };
 
   // Selecting a not-yet-listed public Hub id also pins it (best-effort, same
@@ -496,7 +407,6 @@ const TrainPanel: React.FC = () => {
   // training can fetch it on demand.
   const addHubDataset = (repoId: string) => {
     setSelectedId(repoId);
-    setQuery("");
     saveCustomDataset(baseUrl, fetchWithHeaders, repoId)
       .then(() => refreshDatasets())
       .catch(() => {
@@ -560,122 +470,69 @@ const TrainPanel: React.FC = () => {
                 </p>
               </div>
             ) : (
-              <div className="space-y-2">
-                <Label htmlFor="train-dataset-search">
-                  {t("studio.train.dataset.label")}
-                </Label>
-                {selectedId ? (
-                  <div className="flex flex-wrap gap-1.5">
-                    <span className="inline-flex max-w-full items-center gap-1 rounded-md border border-border bg-muted/40 py-1 pl-2 pr-1 font-mono text-xs text-foreground">
-                      <span className="truncate">{selectedId}</span>
-                      <button
-                        type="button"
-                        aria-label={t("studio.train.dataset.remove", {
-                          repoId: selectedId,
-                        })}
-                        onClick={() => setSelectedId(null)}
-                        className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </span>
-                  </div>
-                ) : null}
-                {trainingEpisodeIndices && (
-                  <p className="text-xs text-muted-foreground">
-                    {datasetTotalEpisodes != null
-                      ? t("studio.train.dataset.episodeSubsetOfTotal", {
-                          used: trainingEpisodeIndices.length,
-                          total: datasetTotalEpisodes,
-                        })
-                      : t("studio.train.dataset.episodeSubset", {
-                          used: trainingEpisodeIndices.length,
-                        })}
-                  </p>
-                )}
-                <div className="relative">
-                  <Input
-                    id="train-dataset-search"
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    placeholder={t("studio.train.dataset.searchPlaceholder")}
-                    className="h-8 pr-8 text-sm"
-                  />
-                  {/* "Choose dataset" — browse the full Local/Hugging Face list
-                    instead of typing a search term. Docked on the right edge
-                    of the search bar itself (a sibling overlay, not nested in
-                    the <input>) so it's reachable without typing anything. */}
-                  <DatasetPicker
-                    datasets={datasets}
-                    loading={datasetsLoading}
-                    onPickExisting={(item) => pickDataset(item.repo_id)}
-                    hideSearch
-                  >
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="absolute right-0.5 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                      title={t("studio.train.dataset.choose")}
-                      aria-label={t("studio.train.dataset.choose")}
+            <div className="space-y-2">
+              <Label htmlFor="train-dataset">
+                {t("studio.train.dataset.label")}
+              </Label>
+              {/* One way in, not two: the whole control is the picker's
+                  trigger, and DatasetPicker's own search box is the only
+                  search — including the "use any public org/name" row, which
+                  moved into it (onPickHubId) rather than living in a second
+                  results list out here. The trigger wears SelectTrigger's own
+                  classes so it reads as the same kind of control as Starting
+                  point below it; it can't BE a SelectTrigger, because what it
+                  opens is a Popover. */}
+              <DatasetPicker
+                datasets={datasets}
+                loading={datasetsLoading}
+                onPickExisting={(item) => pickDataset(item.repo_id)}
+                onPickHubId={addHubDataset}
+              >
+                <button
+                  id="train-dataset"
+                  type="button"
+                  className="flex h-10 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {selectedId ? (
+                    // Repo ids outrun a half-panel trigger routinely, so the
+                    // full id stays one hover away — and only then (the hook
+                    // measures the span and leaves `title` undefined while the
+                    // id fits whole).
+                    <span
+                      className="min-w-0 truncate font-mono text-xs"
+                      {...selectedIdHover}
                     >
-                      <ChevronsUpDown className="h-3.5 w-3.5" />
-                    </Button>
-                  </DatasetPicker>
-                </div>
-                {trimmedQuery ? (
-                  <div className="max-h-56 divide-y divide-border overflow-auto rounded-md border border-border">
-                    {matches.map((d) => (
-                      <DatasetResultRow
-                        key={d.repo_id}
-                        item={d}
-                        selected={selectedId === d.repo_id}
-                        onPick={() => pickDataset(d.repo_id)}
-                      />
-                    ))}
-                    {hubCandidate ? (
-                      <button
-                        type="button"
-                        onClick={() => addHubDataset(hubCandidate)}
-                        className="flex w-full items-start gap-2 px-3 py-2 text-left text-sm hover:bg-muted/50"
-                      >
-                        <Plus className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate">
-                            {/* The typed repo id is DATA — one <0> slot, not a
-                              sentence stitched around it. */}
-                            <Trans
-                              i18nKey="studio.train.dataset.useHub"
-                              values={{ repoId: hubCandidate }}
-                              components={[
-                                <span key="0" className="font-mono" />,
-                              ]}
-                            />
-                          </span>
-                          <span className="block text-xs text-muted-foreground">
-                            {t("studio.train.dataset.useHubHint")}
-                          </span>
-                        </span>
-                      </button>
-                    ) : null}
-                    {matches.length === 0 && !hubCandidate ? (
-                      <p className="px-3 py-4 text-sm text-muted-foreground">
-                        {/* <0> holds the literal `org/name` id shape — syntax,
-                          so it is not translated. */}
-                        <Trans
-                          i18nKey="studio.train.dataset.noMatches"
-                          components={[<span key="0" className="font-mono" />]}
-                        />
-                      </p>
-                    ) : null}
-                  </div>
-                ) : null}
-                {!selectedId ? (
-                  <p className="text-xs text-muted-foreground">
-                    {t("studio.train.dataset.hint")}
-                  </p>
-                ) : null}
-              </div>
+                      {selectedId}
+                    </span>
+                  ) : (
+                    <span className="truncate text-muted-foreground">
+                      {t("studio.train.dataset.pick")}
+                    </span>
+                  )}
+                  <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+                </button>
+              </DatasetPicker>
+              {/* The prefill's episode subset, reported against the selection
+                  the trigger above now shows (it used to hang off the removed
+                  chip). */}
+              {trainingEpisodeIndices && (
+                <p className="text-xs text-muted-foreground">
+                  {datasetTotalEpisodes != null
+                    ? t("studio.train.dataset.episodeSubsetOfTotal", {
+                        used: trainingEpisodeIndices.length,
+                        total: datasetTotalEpisodes,
+                      })
+                    : t("studio.train.dataset.episodeSubset", {
+                        used: trainingEpisodeIndices.length,
+                      })}
+                </p>
+              )}
+              {!selectedId ? (
+                <p className="text-xs text-muted-foreground">
+                  {t("studio.train.dataset.hint")}
+                </p>
+              ) : null}
+            </div>
             )}
 
             {/* Starting point — the optional fine-tune base. Sits directly
@@ -808,10 +665,13 @@ const TrainPanel: React.FC = () => {
         </CollapsibleContent>
       </Collapsible>
 
-      {/* Start training — pinned directly above the jobs library, level with
-          Collect's and Deploy's actions. The configurator portals its real,
-          fully-gated button into the slot while the form is open. */}
-      <div className="mt-auto pt-2">
+      {/* Start training — directly under the form at the panel's normal gap-5
+          rhythm, level with Collect's and Deploy's actions; nothing in the
+          column is bottom-pinned any more. The wrapper stays because this slot
+          holds two things: the disabled stand-in shown while the form is shut,
+          and the portal target the configurator renders its real, fully-gated
+          button into while it is open. */}
+      <div>
         {!formOpen ? (
           <Button disabled className="w-full gap-2">
             <Play className="h-4 w-4" />
@@ -821,10 +681,13 @@ const TrainPanel: React.FC = () => {
         <div ref={setActionsEl} className={formOpen ? undefined : "hidden"} />
       </div>
 
-      {/* Training jobs library — local + remote runs as cards, pinned to the
-          panel foot like Collect's datasets and Deploy's models. mt-0 keeps it
-          glued to the actions slot above, which carries the panel's mt-auto. */}
-      <LibrarySection className="mt-0">
+      {/* Training jobs library — local + remote runs as cards. LibrarySection's
+          own stretch now stands (no mt-0 override): the opener and Start row
+          top-pack, the free space falls between them and this, and the library
+          sits at the column foot so its footer lines up with Collect's and
+          Deploy's. Its body floors at GRID_MIN_H and scrolls its detail card
+          inside that box, so selecting a run can't move it. */}
+      <LibrarySection>
         <JobsLibrary open={jobsOpen} onOpenChange={setJobsOpen} />
       </LibrarySection>
 

--- a/frontend/src/components/studio/panel/primitives.tsx
+++ b/frontend/src/components/studio/panel/primitives.tsx
@@ -183,13 +183,30 @@ export const RobotStatus: React.FC<{
     </Alert>
   );
 
-/** Pins a panel's library to the bottom of its column behind a hairline, so
- * the three libraries sit at the same level across the studio grid. */
+/**
+ * A panel's library, behind a hairline: it starts right after the panel's
+ * action row at the normal gap and STRETCHES to the foot of the column.
+ *
+ * Not `mt-auto` (which pushed the whole block down and left the slack as a gap
+ * above the rule) and not content-height either — `flex-1` in a `min-h-0`
+ * column, so the free space lands INSIDE the library, between its cards and
+ * its "Show all" footer, and the three columns' footers line up because they
+ * all end at the same place. `min-h-0` is what lets it shrink when a panel's
+ * form is open; below the grid's own min height the column scrolls instead.
+ *
+ * Every wrapper between this and the scrolling card viewport has to repeat
+ * `flex min-h-0 flex-1 flex-col`, or the height stops being handed down.
+ */
 export const LibrarySection: React.FC<{
   className?: string;
   children: React.ReactNode;
 }> = ({ className, children }) => (
-  <div className={cn("mt-auto border-t border-border pt-5", className)}>
+  <div
+    className={cn(
+      "flex min-h-0 flex-1 flex-col border-t border-border pt-5",
+      className,
+    )}
+  >
     {children}
   </div>
 );

--- a/frontend/src/i18n/locales/en/landing.ts
+++ b/frontend/src/i18n/locales/en/landing.ts
@@ -34,12 +34,26 @@ export default {
     // <0> is the mono repo-id span; {{repoId}} is the typed Hub id.
     useHub: "Use <0>{{repoId}}</0> from the Hub",
     useHubHint: "Public dataset — training fetches it on demand.",
+    row: {
+      // Abbreviated episode count on a picker row. {{episodes}} rather than
+      // {{count}}: this is a compact badge with no plural form.
+      episodes: "{{episodes}} ep",
+      // Source marker for a Hub-only row. Product name — same in every
+      // language, keyed so the two markers have one uniform shape.
+      hub: "Hub",
+      // Compact badge: this dataset carries per-episode sampling weights.
+      weighted: "weighted",
+      weightedTitle:
+        "Carries per-episode sampling weights — some episodes are sampled more often during training",
+    },
   },
   modelPicker: {
     searchPlaceholder: "Search models…",
     loading: "Loading models…",
     empty: "No models yet. Use “Add model” to train, download, or import one.",
     deleteAria: "Delete {{name}}",
+    // Badge on a run that exited non-zero but left usable weights.
+    failedBadge: "failed run",
   },
   addDatasetFromHub: {
     title: "Add a dataset from Hugging Face",

--- a/frontend/src/i18n/locales/en/landing.ts
+++ b/frontend/src/i18n/locales/en/landing.ts
@@ -31,6 +31,9 @@ export default {
     empty:
       "No datasets yet. Use “Add dataset” to record, download, or import one.",
     deleteAria: "Delete {{repoId}}",
+    // <0> is the mono repo-id span; {{repoId}} is the typed Hub id.
+    useHub: "Use <0>{{repoId}}</0> from the Hub",
+    useHubHint: "Public dataset — training fetches it on demand.",
   },
   modelPicker: {
     searchPlaceholder: "Search models…",

--- a/frontend/src/i18n/locales/en/studio.ts
+++ b/frontend/src/i18n/locales/en/studio.ts
@@ -176,18 +176,8 @@ export default {
       noMatches:
         "No matching datasets. Type a full <0>org/name</0> id to use any public Hugging Face dataset.",
       hint: "Yours, or any public Hugging Face dataset.",
-      row: {
-        // Abbreviated episode count on a search result. {{episodes}} rather
-        // than {{count}}: this is a compact badge with no plural form.
-        episodes: "{{episodes}} ep",
-        // Source marker for a Hub-only row. Product name — same in every
-        // language, keyed so the two markers have one uniform shape.
-        hub: "Hub",
-        // Compact badge: this dataset carries per-episode sampling weights.
-        weighted: "weighted",
-        weightedTitle:
-          "Carries per-episode sampling weights — some episodes are sampled more often during training",
-      },
+      // The per-row markers (episode count / weighted / Hub) live with the
+      // picker that renders them now: `landing.datasetPicker.row.*`.
     },
     startingPoint: {
       label: "Starting point",
@@ -245,8 +235,8 @@ export default {
       // Shown INSTEAD of `empty` when the listing could not be fetched —
       // an outage must not read as "you have no skills".
       error: "Couldn’t load skills. Check the server and try again.",
-      // Badge on a run that exited non-zero but left usable weights.
-      failedBadge: "failed run",
+      // The "failed run" row badge lives with the picker that renders it now:
+      // `landing.modelPicker.failedBadge`.
       hubDegraded: "Hub unreachable — showing your local skills and the last Hub listing.",
       // aria-label and title on the same button.
       import: "Import skill",

--- a/frontend/src/i18n/locales/en/studio.ts
+++ b/frontend/src/i18n/locales/en/studio.ts
@@ -167,6 +167,8 @@ export default {
         "Training on {{used}} of {{total}} episodes — adjust which ones from this dataset's viewer in My Library.",
       // aria-label and title on the same button.
       choose: "Choose dataset",
+      // Placeholder on the picker trigger before a dataset is chosen.
+      pick: "Pick a dataset",
       // <0> is the mono repo-id span; {{repoId}} is the typed Hub id.
       useHub: "Use <0>{{repoId}}</0> from the Hub",
       useHubHint: "Public dataset — training fetches it on demand.",
@@ -230,6 +232,12 @@ export default {
 
   deploy: {
     title: "Run",
+    // The panel's entry control — the opener that slides the run form open,
+    // matching collect.entry / train.entry.
+    entry: "Run a skill",
+    skill: {
+      label: "Skill *",
+    },
     picker: {
       placeholder: "Pick a skill",
       loading: "Loading skills…",
@@ -250,7 +258,9 @@ export default {
       local: "local",
       both: "local · hub",
     },
-    intro: "Run this skill on your robot, then start inference.",
+    // The run form's one-line brief, in the slot and voice Train uses.
+    intro:
+      "Pick a skill and its checkpoint, set how long it runs, and check the cameras — then start.",
     noRobot:
       "Select a robot to run on — use the robot menu in the top-right corner of this window.",
     // <0> wraps the robot name; {{gap}} is the rendered follower-scoped setup
@@ -315,6 +325,8 @@ export default {
     checkpoint: {
       label: "Checkpoint",
       none: "No checkpoints available for this skill yet.",
+      // Placeholder on the disabled dropdown shown before a skill is picked.
+      pickSkillFirst: "Pick a skill first",
     },
     // Checkpoint/robot arm-count mismatch. Each branch is one complete
     // sentence pair so word order is the translator's to choose. <0> is the
@@ -330,7 +342,13 @@ export default {
       label: "Task description",
       placeholder: "e.g., pick up the red block",
       // {{policyType}} is the policy identifier (act, smolvla, …) — data.
+      // The field is always shown, so the helper answers "is this even read?"
+      // in all three states: no skill picked yet, conditioned, not conditioned.
       hint: "This policy is language-conditioned ({{policyType}}).",
+      hintUnknown:
+        "Only language-conditioned policies use this — pick a skill to see whether yours does.",
+      hintNotConditioned:
+        "This policy ({{policyType}}) isn't language-conditioned — it ignores this.",
       // Appended to `hint` when the task was auto-filled from the checkpoint's
       // own training dataset. Leading space is added by the caller.
       prefilled: "Filled in from the dataset it was trained on.",
@@ -391,6 +409,17 @@ export default {
       disconnected: "Disconnected — reconnect it before starting",
       select: "Select a camera",
       robotHasNone: "This robot has no cameras — add them in Robot settings",
+      // Empty state of the read-only camera list when no robot is selected.
+      noRobot: "Select a robot to see its cameras.",
+      // A camera the checkpoint names that the robot has nothing matching.
+      // <0> emphasises the name; the name itself is DATA (the robot record's
+      // own key), interpolated, never translated.
+      unmatched:
+        "The policy expects camera <0>{{name}}</0> but this robot has no camera named “{{name}}” — rename one in Robot settings.",
+      // Matched by name, but the robot captures at a different size than the
+      // checkpoint trained at. All four numbers are raw pixel dimensions.
+      resolutionMismatch:
+        "<0>{{name}}</0> is set to {{robotWidth}}×{{robotHeight}} in Robot settings, but the policy trained at {{policyWidth}}×{{policyHeight}} — the run captures at the policy's size.",
     },
     thumbnail: {
       // The preview tile's two placeholder states.

--- a/frontend/src/i18n/locales/zh-CN/landing.ts
+++ b/frontend/src/i18n/locales/zh-CN/landing.ts
@@ -21,12 +21,19 @@ export default {
     deleteAria: "删除 {{repoId}}",
     useHub: "使用 Hub 上的 <0>{{repoId}}</0>",
     useHubHint: "公开数据集 — 训练时按需拉取。",
+    row: {
+      episodes: "{{episodes}} 片段",
+      hub: "Hub",
+      weighted: "带权重",
+      weightedTitle: "该数据集带有按回合的采样权重，训练时部分回合会被更频繁地采样",
+    },
   },
   modelPicker: {
     searchPlaceholder: "搜索模型…",
     loading: "正在加载模型…",
     empty: "还没有模型。使用“添加模型”来训练、下载或导入。",
     deleteAria: "删除 {{name}}",
+    failedBadge: "运行失败",
   },
   addDatasetFromHub: {
     title: "从 Hugging Face 添加数据集",

--- a/frontend/src/i18n/locales/zh-CN/landing.ts
+++ b/frontend/src/i18n/locales/zh-CN/landing.ts
@@ -19,6 +19,8 @@ export default {
     loading: "正在加载数据集…",
     empty: "还没有数据集。使用“添加数据集”来录制、下载或导入。",
     deleteAria: "删除 {{repoId}}",
+    useHub: "使用 Hub 上的 <0>{{repoId}}</0>",
+    useHubHint: "公开数据集 — 训练时按需拉取。",
   },
   modelPicker: {
     searchPlaceholder: "搜索模型…",

--- a/frontend/src/i18n/locales/zh-CN/studio.ts
+++ b/frontend/src/i18n/locales/zh-CN/studio.ts
@@ -128,12 +128,6 @@ export default {
       noMatches:
         "没有匹配的数据集。输入完整的 <0>org/name</0> id 即可使用任意公开的 Hugging Face 数据集。",
       hint: "你自己的数据集，或任意公开的 Hugging Face 数据集。",
-      row: {
-        episodes: "{{episodes}} 片段",
-        hub: "Hub",
-        weighted: "带权重",
-        weightedTitle: "该数据集带有按回合的采样权重，训练时部分回合会被更频繁地采样",
-      },
     },
     startingPoint: {
       label: "起点",
@@ -177,7 +171,6 @@ export default {
       loading: "正在加载技能…",
       empty: "还没有已训练或已导入的技能",
       error: "无法加载技能。请检查服务器后重试。",
-      failedBadge: "运行失败",
       hubDegraded: "无法连接 Hub — 正在显示本地技能和上次的 Hub 列表。",
       import: "导入技能",
       hint: "选择一个已训练的检查点，或已从 Hub 导入的技能，在机器人上运行。",

--- a/frontend/src/i18n/locales/zh-CN/studio.ts
+++ b/frontend/src/i18n/locales/zh-CN/studio.ts
@@ -122,6 +122,7 @@ export default {
       episodeSubsetOfTotal:
         "将使用 {{total}} 个回合中的 {{used}} 个进行训练 — 可在「我的库」中该数据集的查看器里调整。",
       choose: "选择数据集",
+      pick: "选择数据集",
       useHub: "使用 Hub 上的 <0>{{repoId}}</0>",
       useHubHint: "公开数据集 — 训练时按需拉取。",
       noMatches:
@@ -167,6 +168,10 @@ export default {
 
   deploy: {
     title: "运行",
+    entry: "运行技能",
+    skill: {
+      label: "技能 *",
+    },
     picker: {
       placeholder: "选择技能",
       loading: "正在加载技能…",
@@ -182,7 +187,7 @@ export default {
       local: "本地",
       both: "本地 · hub",
     },
-    intro: "在机器人上运行该技能，然后开始推理。",
+    intro: "选择技能及其检查点，设置运行时长，检查摄像头 — 然后开始。",
     noRobot: "选择要运行的机器人 — 使用本窗口右上角的机器人菜单。",
     robotNotReady_other:
       "<0>{{name}}</0>{{gap}}。请先打开机器人设置，然后再运行推理。（推理只使用从臂 — 无需配置主臂。）",
@@ -237,6 +242,7 @@ export default {
     checkpoint: {
       label: "检查点",
       none: "该技能暂无可用的检查点。",
+      pickSkillFirst: "请先选择技能",
     },
     armMismatch: {
       bimanualCheckpoint:
@@ -248,6 +254,9 @@ export default {
       label: "任务描述",
       placeholder: "例如：拿起红色方块",
       hint: "该策略以语言为条件（{{policyType}}）。",
+      hintUnknown: "只有以语言为条件的策略才会使用该字段 — 选择技能后即可确认。",
+      hintNotConditioned:
+        "该策略（{{policyType}}）不以语言为条件 — 会忽略该字段。",
       // 当任务描述是从该检查点自己的训练数据集自动填入时，追加在 hint 之后。
       // 前面的空格由调用方补上。
       prefilled: "已根据它训练所用的数据集自动填入。",
@@ -296,6 +305,11 @@ export default {
       disconnected: "已断开 — 请重新连接后再开始",
       select: "选择摄像头",
       robotHasNone: "该机器人没有摄像头 — 请在机器人设置中添加",
+      noRobot: "请选择机器人以查看其摄像头。",
+      unmatched:
+        "策略需要摄像头 <0>{{name}}</0>，但该机器人没有名为“{{name}}”的摄像头 — 请在机器人设置中重命名。",
+      resolutionMismatch:
+        "<0>{{name}}</0> 在机器人设置中为 {{robotWidth}}×{{robotHeight}}，而策略是在 {{policyWidth}}×{{policyHeight}} 下训练的 — 运行时按策略的分辨率采集。",
     },
     thumbnail: {
       released: "已释放",


### PR DESCRIPTION
Reworks the three studio panels so they share one shape: an opener that slides its form open in place, a full-width action row under it, and a library that stretches to the foot of the column. Single commit, frontend only, carved from the WIP studio branch and rebased onto current staging.

## What changes

- **Layout, all panels**: `LibrarySection` becomes the flexible element so slack lands inside the library; `CappedGrid` becomes a scrolling viewport; the three columns' footers line up.
- **Deploy panel**: "Run a skill" opener with a Skill | Checkpoint row; skill is a popover picker that hides runs with zero checkpoints; run parameters always visible with a three-state task hint; cameras render as the read-only `SessionCameraList` bound by name with one combined alert; `handlePickSkill` commits nothing until the job resolves.
- **Train panel**: dataset field becomes a single popover picker (`DatasetPicker` gains `onPickHubId`); the second results list and `DatasetResultRow` are retired.
- **Shared**: `SessionCameraList` takes `paused`; `ModelsLibrary` takes `open`/`onOpenChange`.

## Rebase notes

- The commit's Start ⇄ "View running session" toggle did **not** land: since the sessions surface, reopening the dialog needs the session id the start call returned, and `InferenceStatus` carries none. The panel keeps staging's Start + Stop pair with a `NOTE:` at `handleStop`. Landing the toggle needs a live-session lookup and is deferred.
- Git had auto-merged a broken import (`getDatasetInfo` dropped while staging's episode-count effect still calls it); restored.
- Two new `DatasetPicker` strings are routed through `landing.datasetPicker.useHub` / `useHubHint` (verbatim copies of the keys TrainPanel retired) so both languages render unchanged.
- Catalog keys retired by this commit are left in place (parity tests check orphans, not usage); a separate cleanup pass can delete them.

## Re-rebase onto 2026-09-02 staging (PRs #94, #95, #104, #110)

Rule applied: where the rework and the mainline disagree, the mainline wins.

- **Deploy Stop button removed** (mainline's coaching work replaced Start/Stop with `RunVerbs` and deleted `handleStop`; the rework's NOTE arguing to keep it is recorded in a comment above `selectedSkillLabel`). A reopen path carrying the live session id is the honest way to bring "view running session" back.
- **Mainline badges restored inside the rework's pickers** (second commit): the Train dataset picker's episode count (fetched only while a query narrows the list, matching the retired row's profile; a listing-level `total_episodes` would retire the fetch), `weighted` and `Hub` badges; the skill picker's amber "failed run" label. Keys moved to `landing.datasetPicker.row.*` / `landing.modelPicker.failedBadge`; dead `studio.*` keys deleted.
- The rework's client-side zero-checkpoint deny-list (`selectableModels`/`useJobsData`) was dropped: `/skills`' `deployable` answers it server-side and more strictly.
- `DatasetResultRow` (kept by #94 with a weighted badge) is deleted: the merged body never renders it; its badge lives in `DatasetPicker` now.
- Worth a look in the app: the `actionsRef` scroll anchor now runs under the Collapsible layout — arm each verb by hover and watch for a lurch.

## Checks

`tsc` both projects clean; lint delta 0 vs baseline; vitest 134/134; `npm run build` ok; `frontend/dist` untouched (CI rebuilds it).

A follow-up PR with the robot-action button affordance stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
