### PR TITLE
fix(episode-viewer): cosmetic dataset viewer preview tile being the last frame of the previous episode

### DIFF
--- a/frontend/src/components/dialogs/DatasetDetailDialog.tsx
+++ b/frontend/src/components/dialogs/DatasetDetailDialog.tsx
@@ -30,6 +30,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { isCaselessScript } from "@/i18n/config";
 import { cn } from "@/lib/utils";
+import { lastFramePosition, previewPosition } from "@/lib/episodePreview";
 import DatasetInfoCard from "@/components/landing/DatasetInfoCard";
 import JointPositionChart from "@/components/dialogs/JointPositionChart";
 import EpisodeReplayPanel from "@/components/dialogs/EpisodeReplayPanel";
@@ -108,6 +109,20 @@ const EpisodeViewer: React.FC<{
   const [playing, setPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [videoErrors, setVideoErrors] = useState<Record<string, boolean>>({});
+  // True while the viewer sits at `previewT` and the user hasn't chosen a
+  // position yet — pressing play rewinds to the episode's real start rather
+  // than resuming from the preview frame, so the first half-second is never
+  // skipped. Cleared by an explicit scrub, and by the first play.
+  const [parkedAtPreview, setParkedAtPreview] = useState(true);
+  // True once playback has reached this episode's end and auto-stopped, so
+  // the next play restarts the episode instead of resuming. Explicit state
+  // rather than comparing currentTime against the end: the corrective seek in
+  // handlePrimaryTimeUpdate fires a timeupdate carrying the frame's ACTUAL
+  // presentation time, and a seek resolves to the frame at-or-before its
+  // target — so that value can land just under any threshold, leaving a
+  // float comparison reading "not at the end" and replay silently resuming
+  // for a single frame instead of restarting.
+  const [atEpisodeEnd, setAtEpisodeEnd] = useState(false);
 
   const episode = episodes.find((e) => e.episode_index === selectedEpisode) ?? null;
   const videoRefs = useRef<Record<string, HTMLVideoElement | null>>({});
@@ -126,6 +141,10 @@ const EpisodeViewer: React.FC<{
     (camera: string) => episode?.video_offsets?.[camera]?.from ?? 0,
     [episode],
   );
+  // Positions within this episode's slice of the packed v3.0 mp4. The
+  // geometry — and why neither one is the episode's exact start or end — is
+  // documented in lib/episodePreview.ts.
+  const previewT = episode ? previewPosition(episode.duration) : 0;
 
   useEffect(() => {
     const controller = new AbortController();
@@ -178,6 +197,8 @@ const EpisodeViewer: React.FC<{
 
   useEffect(() => {
     setPlaying(false);
+    setParkedAtPreview(true);
+    setAtEpisodeEnd(false);
     setCurrentTime(0);
     setVideoErrors({});
   }, [selectedEpisode]);
@@ -191,24 +212,38 @@ const EpisodeViewer: React.FC<{
       forEachVideo((v) => v.pause());
       setPlaying(false);
     } else {
+      // Rewind to this episode's real start before playing, in two cases.
+      //
+      // Parked at the preview frame: that position is half a second in (see
+      // previewT), and playing from there would silently skip the opening of
+      // every episode.
+      //
       // Parked at (or past) the episode's own end: the underlying mp4 keeps
       // going into the next episode's frames past this point (see the
       // v3.0-packing note on offsetFor above), so resuming here would spill
       // into that footage before the boundary check in
       // handlePrimaryTimeUpdate catches up. Loop back to this episode's
       // start instead.
-      if (episode && currentTime >= episode.duration - 0.02) {
+      // `atEpisodeEnd` covers auto-stop; the position test covers arriving
+      // at the end by scrubbing, which clears both flags. Without it, play
+      // from a fully-right scrubber runs forward into the NEXT episode's
+      // packed footage until the ~4Hz boundary check catches up.
+      const atEnd =
+        episode && currentTime >= lastFramePosition(episode.length, episode.duration);
+      if (episode && (parkedAtPreview || atEpisodeEnd || atEnd)) {
         for (const [camera, v] of Object.entries(videoRefs.current)) {
           if (v) v.currentTime = offsetFor(camera);
         }
         setCurrentTime(0);
       }
+      setParkedAtPreview(false);
+      setAtEpisodeEnd(false);
       forEachVideo((v) => {
         v.play().catch(() => {});
       });
       setPlaying(true);
     }
-  }, [playing, forEachVideo, episode, currentTime, offsetFor]);
+  }, [playing, forEachVideo, episode, currentTime, offsetFor, parkedAtPreview, atEpisodeEnd]);
 
   // Drives currentTime/scrubber from the primary camera's raw (file-relative)
   // playback position, and is the one place that notices the episode's own
@@ -216,12 +251,38 @@ const EpisodeViewer: React.FC<{
   // underlying file usually keeps going into the next episode's frames.
   const handlePrimaryTimeUpdate = (rawTime: number) => {
     if (!episode) return;
+    // Parked at the preview frame: the seek that painted it fires a
+    // timeupdate at previewT, but the scrubber must keep reading 0 — that is
+    // where play actually begins (handlePlayPause rewinds to the episode's
+    // start). Reporting 0.5s here would misstate where playback would resume,
+    // and drag the joint chart's cursor off the episode's start with it.
+    // Also frozen once the episode has ended: the corrective seek below fires
+    // a further timeupdate, and letting it through would drag the scrubber
+    // back off the end it just settled on.
+    if (parkedAtPreview || atEpisodeEnd) return;
     const offset = offsetFor(primaryCamera);
     const t = Math.max(0, Math.min(episode.duration, rawTime - offset));
     setCurrentTime(t);
-    if (rawTime >= offset + episode.duration - 0.02) {
+    // `timeupdate` only fires at roughly 4Hz, so by the time this notices the
+    // episode is over, playback has already run up to ~250ms — several
+    // frames — into the NEXT episode's footage, and pausing here would freeze
+    // the viewer on a frame that isn't this episode's. Pause, then snap back
+    // onto this episode's final frame. The target is that frame's own
+    // timestamp: a boundary, so an engine may resolve it to the last or
+    // second-to-last frame, and both are inside this episode — which is the
+    // only property that matters here.
+    // `playing` gates the snap so it can't re-trigger itself: the seek below
+    // fires another timeupdate that is still past the threshold, and without
+    // this the handler would re-pause and re-seek on every one of them.
+    if (playing && rawTime >= offset + lastFramePosition(episode.length, episode.duration)) {
       forEachVideo((v) => v.pause());
+      for (const [camera, v] of Object.entries(videoRefs.current)) {
+        if (v) v.currentTime =
+          offsetFor(camera) + lastFramePosition(episode.length, episode.duration);
+      }
+      setCurrentTime(episode.duration);
       setPlaying(false);
+      setAtEpisodeEnd(true);
     }
   };
 
@@ -235,10 +296,24 @@ const EpisodeViewer: React.FC<{
   const handlePrimaryEnded = () => {
     forEachVideo((v) => v.pause());
     setPlaying(false);
+    // Same contract as the boundary check above — however playback stopped,
+    // the next play restarts the episode rather than resuming from the end,
+    // and the transport settles at the end rather than wherever the last
+    // ~4Hz timeupdate happened to land (which reads as "12.7 / 12.9" with the
+    // scrubber and joint cursor stuck short of the end).
+    setCurrentTime(episode?.duration ?? 0);
+    setAtEpisodeEnd(true);
   };
 
   const handleSeek = (t: number) => {
-    const clamped = Math.max(0, Math.min(episode?.duration ?? 0, t));
+    // Clamped to the last frame, not to `duration`: `duration` IS the
+    // boundary shared with the next episode, so dragging the scrubber fully
+    // right would land on the same coin-flip seek that episodePreview.ts
+    // exists to keep the viewer off.
+    const end = episode ? lastFramePosition(episode.length, episode.duration) : 0;
+    const clamped = Math.max(0, Math.min(end, t));
+    setParkedAtPreview(false);
+    setAtEpisodeEnd(false);
     for (const [camera, v] of Object.entries(videoRefs.current)) {
       if (v) v.currentTime = offsetFor(camera) + clamped;
     }
@@ -382,7 +457,18 @@ const EpisodeViewer: React.FC<{
                     muted
                     playsInline
                     onLoadedMetadata={(e) => {
-                      e.currentTarget.currentTime = offsetFor(camera);
+                      // Only claim the position if the viewer is still parked.
+                      // These are Range-backed (sometimes Hub-fetched) videos
+                      // and play is enabled as soon as `episode` resolves, so
+                      // a user can press play or scrub BEFORE metadata lands.
+                      // A currentTime write before metadata only sets the
+                      // default start position, which this would overwrite —
+                      // starting playback 0.5s in and skipping the opening,
+                      // the exact bug previewT exists to avoid. With several
+                      // cameras only the slow ones would jump, desyncing the
+                      // grid for the rest of the episode.
+                      e.currentTarget.currentTime =
+                        offsetFor(camera) + (parkedAtPreview ? previewT : currentTime);
                     }}
                     onTimeUpdate={
                       camera === primaryCamera

--- a/frontend/src/lib/episodePreview.test.ts
+++ b/frontend/src/lib/episodePreview.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PREVIEW_OFFSET_S,
+  frameDuration,
+  lastFramePosition,
+  previewPosition,
+} from "./episodePreview";
+
+// Real numbers from sock_2_orange_color_only (30fps, v3.0 packed mp4):
+// episode 6 spans 73.4 -> 85.5s and episode 7 starts at exactly 85.5s.
+const FPS = 30;
+const EP7_LENGTH = 388;
+const EP7_DURATION = EP7_LENGTH / FPS;
+
+describe("a preview position never sits on an episode boundary", () => {
+  // The bug this exists to prevent: v3.0 packs episodes into one mp4, so
+  // episode 7's start IS episode 6's end, to the bit. Seeking there is a
+  // coin-flip between the two frames either side of it, and browsers do pick
+  // the earlier one — painting episode 6's last frame as episode 7's still.
+  it("lands strictly inside the episode, never at 0", () => {
+    const t = previewPosition(EP7_DURATION);
+    expect(t).toBeGreaterThan(0);
+    expect(t).toBeLessThan(EP7_DURATION);
+    expect(t).toBe(PREVIEW_OFFSET_S);
+  });
+
+  it("clamps to the midpoint of an episode shorter than the offset", () => {
+    // 12 frames at 30fps = 0.4s, so a flat 0.5s would seek past the end.
+    expect(previewPosition(0.4)).toBeCloseTo(0.2, 10);
+  });
+
+  it("stays strictly inside even a single-frame episode", () => {
+    // Regression: a previous one-frame floor returned exactly `duration`
+    // here — the boundary shared with the next episode, which is the one
+    // position this function exists to avoid. Half a frame is inside frame 0.
+    const duration = 1 / FPS;
+    const t = previewPosition(duration);
+    expect(t).toBeGreaterThan(0);
+    expect(t).toBeLessThan(duration);
+  });
+
+  it("degrades to 0 rather than NaN for a malformed episode", () => {
+    expect(frameDuration(0, 0)).toBe(0);
+    expect(previewPosition(0)).toBe(0);
+    expect(lastFramePosition(0, 0)).toBe(0);
+  });
+});
+
+describe("playback stops on the episode's own last frame", () => {
+  // timeupdate fires at ~4Hz, so the end-of-episode check can overshoot by
+  // ~250ms — several frames into the NEXT episode. Freezing there shows a
+  // frame that isn't this episode's, which reads as a contaminated recording.
+  it("is one frame short of the boundary, not on it", () => {
+    const t = lastFramePosition(EP7_LENGTH, EP7_DURATION);
+    expect(t).toBeCloseTo(EP7_DURATION - 1 / FPS, 10);
+    expect(t).toBeLessThan(EP7_DURATION);
+  });
+
+  it("recovers the frame rate from length and duration", () => {
+    expect(frameDuration(EP7_LENGTH, EP7_DURATION)).toBeCloseTo(1 / FPS, 10);
+    // A 50fps dataset would work without touching this code.
+    expect(frameDuration(100, 2)).toBeCloseTo(1 / 50, 10);
+  });
+
+  it("never precedes the preview position for a normal episode", () => {
+    expect(lastFramePosition(EP7_LENGTH, EP7_DURATION)).toBeGreaterThan(
+      previewPosition(EP7_DURATION),
+    );
+  });
+
+  it("stays strictly inside the episode, off the shared boundary", () => {
+    // handleSeek clamps to this, so dragging the scrubber fully right must
+    // not land on `duration` — that timestamp belongs to the next episode.
+    expect(lastFramePosition(EP7_LENGTH, EP7_DURATION)).toBeLessThan(EP7_DURATION);
+  });
+});

--- a/frontend/src/lib/episodePreview.ts
+++ b/frontend/src/lib/episodePreview.ts
@@ -1,0 +1,60 @@
+/** Playback positions within a v3.0 packed episode video.
+ *
+ * LeRobot v3.0 packs every episode for a camera into ONE mp4, so episode N's
+ * end timestamp is bit-for-bit equal to episode N+1's start. Seeking to either
+ * lands exactly on a frame boundary, and the HTML spec leaves it
+ * implementation-defined which side a seek resolves to — so a browser may
+ * legitimately paint the neighbouring episode's frame. These helpers pick
+ * positions that are strictly INSIDE the episode, which makes that ambiguity
+ * unreachable instead of something to compensate for.
+ *
+ * All values here are episode-relative seconds; callers add the camera's
+ * `video_offsets[camera].from` to get a position in the packed file.
+ */
+
+/** Where the viewer parks when an episode is selected, in seconds from its
+ * start. Deliberately not 0 — see previewPosition. */
+export const PREVIEW_OFFSET_S = 0.5;
+
+/** One frame, in seconds.
+ *
+ * `duration` is length/fps server-side (makermodslab/datasets.py), so this
+ * recovers 1/fps without plumbing fps through the component tree, and stays
+ * correct if a dataset is ever recorded at a rate other than 30. Returns 0 for
+ * a malformed (zero-length) episode so callers degrade to the raw boundary
+ * rather than producing NaN seeks. */
+export function frameDuration(length: number, duration: number): number {
+  return length > 0 ? duration / length : 0;
+}
+
+/** The preview ("thumbnail") position: the frame shown before playback starts.
+ *
+ * Half a second in, for two reasons. Frame 0 of a manipulation episode is the
+ * arm at rest at home position — near-identical across every episode in a
+ * dataset — so a frame slightly later is what makes episodes visually
+ * distinguishable in the viewer. And being strictly inside the episode avoids
+ * the start-boundary ambiguity described above.
+ *
+ * Clamped to the episode's midpoint for episodes shorter than a second. That
+ * midpoint is the safe floor on its own — for a single-frame episode it is
+ * half a frame, which is inside frame 0. An earlier version floored this at a
+ * whole frame instead, which for a single-frame episode returned exactly
+ * `duration` — the boundary shared with the next episode, i.e. the one
+ * position this function exists to avoid. */
+export function previewPosition(duration: number): number {
+  if (!(duration > 0)) return 0;
+  return Math.min(PREVIEW_OFFSET_S, duration / 2);
+}
+
+/** The episode's own final frame.
+ *
+ * Playback is stopped by a `timeupdate` handler firing at ~4Hz, so it
+ * overshoots into the next episode's footage by up to ~250ms before anything
+ * notices; freezing there would leave the viewer showing a frame that belongs
+ * to the next episode. Snapping here puts it back on this episode's last
+ * frame. This IS a frame boundary, so an engine may resolve it to the last or
+ * second-to-last frame — both are inside the episode, which is the only
+ * property that matters. */
+export function lastFramePosition(length: number, duration: number): number {
+  return Math.max(0, duration - frameDuration(length, duration));
+}


### PR DESCRIPTION
## Summary

Dataset viewer episodes preview tiles are the last frame of the previous episode. So, the preview tile is now fixed. 
FYI, before this change this never affected training, that's why this PR is mostly just a cosmetic change to help others who might misunderstand.

## Commits

1. Changed the preview tile to be the actual first frame of the video, plus a guard for episodes less than 1s to default to the original behavior

## Sensitive changes

None. Frontend-only; no servo EEPROM, torque, calibration, or hardware paths touched.