### PR TITLE
Preview: MolmoAct2 rollout support (training deferred)

### DIFF
--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -128,6 +128,7 @@ from .utils.config import (
     validate_dataset_repo_id,
 )
 from .utils.errors import friendly_hint, is_cleanup_error
+from .utils.system import molmoact2_device_warning, molmoact2_rtc_conflict, policy_inference_args
 
 logger = logging.getLogger(__name__)
 
@@ -2065,6 +2066,23 @@ def _classify_outcome(rc: int | None, rollout_started: bool, error_text: str | N
     return "failed"
 
 
+def _checkpoint_policy_config(policy_path: str) -> dict[str, Any]:
+    """The checkpoint's own `config.json`, or `{}` when it can't be read.
+
+    `policy_path` is always a resolved LOCAL `pretrained_model` dir by the time
+    the command builders run (`_resolve_policy_path` downloads Hub refs first),
+    so this is one small file read with no network. Empty on ANY failure —
+    missing file, unreadable JSON, a dir that isn't a checkpoint — because every
+    consumer's fallback is "add no extra flags", which is exactly the behaviour
+    that predates this and keeps the unit tests' fake paths working.
+    """
+    try:
+        raw = json.loads((Path(policy_path) / "config.json").read_text())
+    except Exception:
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
 def _rollout_cli_args(request: InferenceRequest, policy_path: str, robot_args: list[str]) -> list[str]:
     """The rollout flags, without the interpreter/module prefix.
 
@@ -2078,8 +2096,21 @@ def _rollout_cli_args(request: InferenceRequest, policy_path: str, robot_args: l
     added for one is never missing from the other. Coaching mode is the third
     front-end (`makermodslab.dagger_runner`) and layers `--strategy.*` /
     `--dataset.*` / `--teleop.*` on top; `robot_args` carries the teleop block
-    for it, built alongside the `--robot.*` block in `_prepare_robot`."""
+    for it, built alongside the `--robot.*` block in `_prepare_robot`.
+
+    Raises ValueError when the requested engine cannot drive the checkpoint at
+    all (RTC on a discrete MolmoAct2 — see `molmoact2_rtc_conflict`). The
+    startup worker turns that into a normal startup failure, which is strictly
+    better than the alternative: lerobot raises the same refusal itself, but
+    only after loading a multi-GB VLM onto the accelerator."""
     coaching = request.coaching
+    # The checkpoint's own saved config — read once here so both the required
+    # `--policy.*` flags and the engine check below answer from the same file.
+    policy_config = _checkpoint_policy_config(policy_path)
+    if not coaching and request.inference_engine == "rtc":
+        conflict = molmoact2_rtc_conflict(policy_config)
+        if conflict:
+            raise ValueError(conflict)
     args = [
         # Coaching replaces the strategy wholesale (see `_coaching_cli_args`);
         # every other run is a plain autonomous rollout.
@@ -2139,6 +2170,15 @@ def _rollout_cli_args(request: InferenceRequest, policy_path: str, robot_args: l
             f"--policy.temporal_ensemble_coeff={request.temporal_ensemble_coeff}",
             "--policy.n_action_steps=1",
         ]
+    # Per-policy-type flags this lerobot pin REQUIRES (see
+    # utils/system.policy_inference_args). Empty for every policy but MolmoAct2
+    # today, whose `inference_action_mode` has no usable default: the config
+    # field is None unless the checkpoint saved one, and the policy raises on
+    # None rather than picking a head. Appended last so it can never be
+    # shadowed by an earlier `--policy.*` in this list, and read from the
+    # checkpoint rather than hardcoded so a discrete checkpoint keeps its own
+    # choice.
+    args += policy_inference_args(policy_config)
     return args
 
 
@@ -2964,6 +3004,27 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
         logger.info("Inference startup abandoned during model download (stop requested)")
         return
 
+    # 1b. Checkpoint-derived checks, now that the config.json is on disk and
+    #     BEFORE step 2 opens the serial bus. `_rollout_cli_args` raises on the
+    #     same engine conflict — that is the guarantee every front-end funnels
+    #     through — but it runs after the preflight, so relying on it alone
+    #     would energize an arm for a session that could never start.
+    policy_config = _checkpoint_policy_config(policy_path)
+    if not request.coaching and request.inference_engine == "rtc":
+        conflict = molmoact2_rtc_conflict(policy_config)
+        if conflict:
+            logger.info("Refusing inference start: %s", conflict)
+            _fail_startup(conflict)
+            return
+    # Warn-but-allow, like the arm-identity findings below and surfaced through
+    # the same `meta["warning"]`: nothing in this pin REQUIRES CUDA, so this is
+    # an expectation-setter, not a gate (see molmoact2_device_warning).
+    startup_warnings: list[str] = []
+    device_warning = molmoact2_device_warning(policy_config, _detect_device())
+    if device_warning:
+        logger.warning("%s", device_warning)
+        startup_warnings.append(device_warning)
+
     # 2. Preflight + stage the arm (opens the serial bus). This is the first
     #    robot-touching step, deliberately AFTER the download.
     try:
@@ -3043,10 +3104,13 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
                 "log_path": str(log_path),
                 "phase": carried_phase,
             }
-            # Warn-but-allow arm-identity findings, surfaced once via the status
-            # payload now that the POST returned before the preflight ran.
-            if identity_warnings:
-                meta["warning"] = " ".join(identity_warnings)
+            # Warn-but-allow findings, surfaced once via the status payload now
+            # that the POST returned before the preflight ran: the pre-download
+            # ones from step 1b, then the arm-identity ones from the preflight.
+            # Joined into the one `warning` string the status payload has always
+            # carried, so no client has to learn a new shape to see both.
+            if warnings := [*startup_warnings, *identity_warnings]:
+                meta["warning"] = " ".join(warnings)
             _inference_meta = meta
             # This run now owns a log file. Recorded outside the meta too, so it
             # survives the meta being cleared at session end and the endpoint can

--- a/makermodslab/utils/errors.py
+++ b/makermodslab/utils/errors.py
@@ -126,6 +126,36 @@ def friendly_hint(error_text: str | None) -> str | None:
             "The GPU ran out of memory. Turn on mixed precision (AMP), lower the batch size, "
             "or run on a larger GPU."
         )
+    # lerobot's own `require_package(pkg, extra=...)` message, which names the
+    # extra in a form no other error uses: "'scipy' is required but not
+    # installed. Install it with: pip install 'lerobot[molmoact2]'". Matched on
+    # the bracketed extra so the hint keeps working whichever of the extra's
+    # three packages is the missing one.
+    if "lerobot[molmoact2]" in low:
+        return (
+            "This MolmoAct2 checkpoint needs an optional package that isn't installed here. "
+            "Install it with `pip install 'lerobot[molmoact2]'` (transformers + peft + scipy), "
+            "then start the run again."
+        )
+    # MolmoAct2 is the one policy whose checkpoint can be internally unrunnable:
+    # `inference_action_mode` has no default (the policy raises on None), and a
+    # checkpoint trained for one head cannot be run with the other. MakerMods
+    # Lab fills a MISSING mode in from the checkpoint's own training mode
+    # (rollout._rollout_cli_args), so what reaches here is a real head mismatch.
+    #
+    # Keyed on the raised sentences, NOT on the bare field name: lerobot logs
+    # the effective policy config, so `inference_action_mode` alone appears in
+    # the log tail of runs that failed for entirely unrelated reasons.
+    if (
+        "cannot run continuous inference" in low
+        or "cannot run discrete inference" in low
+        or "requires `inference_action_mode` to be set explicitly" in low
+    ):
+        return (
+            "This MolmoAct2 checkpoint can't run the action head it was asked for. It was "
+            "trained for discrete or continuous actions, not both — pick a checkpoint whose "
+            "action_mode matches, or re-export it with action_mode='both'."
+        )
     if "libtorchcodec" in low or "library not loaded: @rpath/libavutil" in low:
         return (
             "The trainer's video decoder (torchcodec) couldn't load its FFmpeg libraries on this "

--- a/makermodslab/utils/naming.py
+++ b/makermodslab/utils/naming.py
@@ -32,6 +32,17 @@ from collections.abc import Hashable, Sequence
 # lerobot/policies/factory.py (get_policy_class / make_policy_config). Defined
 # once here as the single source of truth for recognizing a model's policy type
 # from its tags / name / card; update alongside lerobot pin bumps.
+#
+# This is a RECOGNITION vocabulary, not a menu: it decides whether a Hub tag or
+# a repo-name prefix names a policy, so a type missing from it makes a perfectly
+# good model list with `policy_type: null`. It is therefore mirrored WHOLE from
+# the pin rather than curated down to what MakerMods Lab can train — the
+# training picker is server.py's `_POLICY_TYPE_TO_LEROBOT`, a separate and
+# deliberately smaller list.
+#
+# Verified against the b968c0c01 pin with
+# `PreTrainedConfig.get_known_choices()` (19 types); the eight below the blank
+# line had drifted out of the mirror across pin bumps.
 KNOWN_POLICY_TYPES = {
     "tdmpc",
     "diffusion",
@@ -44,6 +55,14 @@ KNOWN_POLICY_TYPES = {
     "smolvla",
     "wall_x",
     "pi0_fast",
+    "eo1",
+    "evo1",
+    "fastwam",
+    "groot",
+    "lingbot_va",
+    "molmoact2",
+    "vla_jepa",
+    "xvla",
 }
 
 # Longest-first for name-prefix matching, so a shorter type can never shadow a

--- a/makermodslab/utils/system.py
+++ b/makermodslab/utils/system.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import BaseModel
@@ -275,7 +276,130 @@ POLICY_EXTRAS: dict[str, tuple[str, str]] = {
     "pi0_fast": ("transformers", "lerobot[pi]"),
     "pi05": ("transformers", "lerobot[pi]"),
     "diffusion": ("diffusers", "lerobot[diffusion]"),
+    # MolmoAct2's `lerobot[molmoact2]` extra is transformers + peft + scipy, but
+    # only TRANSFORMERS is a construction-time requirement for a rollout on this
+    # pin, so that is what we probe:
+    #   * peft is reached only from `_apply_lora_adapters`, i.e. when
+    #     `enable_lora_vlm` is set — a training-side option;
+    #   * scipy is the discrete action tokenizer, required by
+    #     `MolmoAct2PackInputsProcessorStep.__post_init__` only when the
+    #     checkpoint's `action_mode` is "discrete" or "both". The released
+    #     `lerobot/MolmoAct2-*-LeRobot` checkpoints save `action_mode:
+    #     "continuous"`, which is the one value that skips it.
+    # Probing either would report needs_extra && !available for a checkpoint
+    # that runs fine, and DeployPanel REFUSES to launch on that — a false
+    # blocker is worse than a buried ImportError. Revisit when MolmoAct2
+    # training lands, or if a "both"/"discrete" checkpoint ships.
+    "molmoact2": ("transformers", "lerobot[molmoact2]"),
 }
+
+
+# --------------------------------------------------------------------------- #
+# Policy runtime requirements
+# --------------------------------------------------------------------------- #
+# Sibling of POLICY_EXTRAS above, and the same shape of question: not "which
+# package does this policy need installed" but "which flags does this lerobot
+# pin REQUIRE to run this policy at all". Kept here rather than in rollout.py
+# because three front-ends will want the same answer — the rollout/eval/coaching
+# subprocess builders today, a MolmoAct2 training config later, and the remote
+# inference policy server after that.
+#
+# Everything below is a pure function of the checkpoint's own saved config.json
+# (the dict lerobot writes next to the weights), so it is trivially testable and
+# has no import-time cost.
+
+MOLMOACT2 = "molmoact2"
+
+# `--policy.*` overrides are applied by lerobot ON TOP of the checkpoint's saved
+# config (RolloutConfig.__post_init__ → PreTrainedConfig.from_pretrained(
+# cli_overrides=...)), which is why filling a gap here is enough and why
+# overriding a value the checkpoint deliberately saved would be wrong.
+
+
+def molmoact2_inference_action_mode(policy_config: Mapping[str, Any]) -> str:
+    """The action mode a MolmoAct2 rollout will actually run in.
+
+    `MolmoAct2Config.inference_action_mode` defaults to None and
+    `_resolve_inference_action_mode` raises on None — "MolmoAct2 inference
+    requires `inference_action_mode` to be set explicitly" — so a checkpoint
+    that never saved one cannot be rolled out at all without an override.
+
+    The released `lerobot/MolmoAct2-SO100_101-LeRobot` config DOES save
+    ``"inference_action_mode": "continuous"``, so this only fills a gap: a
+    locally fine-tuned checkpoint, or a raw `allenai/MolmoAct2` repo. The
+    default mirrors the checkpoint's TRAINING mode, because forcing continuous
+    onto an `action_mode="discrete"` checkpoint raises in `__post_init__` —
+    which would turn "no mode saved" into a different, equally fatal error.
+    """
+    saved = policy_config.get("inference_action_mode")
+    if saved in ("continuous", "discrete"):
+        return str(saved)
+    return "discrete" if policy_config.get("action_mode") == "discrete" else "continuous"
+
+
+def policy_inference_args(policy_config: Mapping[str, Any]) -> list[str]:
+    """Extra ``--policy.*`` rollout flags this pin requires for a checkpoint.
+
+    Keyed on the checkpoint's own ``type``; empty for every policy that needs
+    nothing (act, smolvla, pi0, …), which is all of them but MolmoAct2 today.
+    Deliberately emits NOTHING when the checkpoint already saved an explicit
+    choice — a rollout must run the policy the way its config says.
+    """
+    if policy_config.get("type") != MOLMOACT2:
+        return []
+    if policy_config.get("inference_action_mode") in ("continuous", "discrete"):
+        return []
+    return [f"--policy.inference_action_mode={molmoact2_inference_action_mode(policy_config)}"]
+
+
+def molmoact2_rtc_conflict(policy_config: Mapping[str, Any]) -> str | None:
+    """Why RTC can't drive this MolmoAct2 checkpoint, or None when it can.
+
+    `MolmoAct2Policy.supports_rtc()` is literally
+    ``inference_action_mode == "continuous"``, and `build_rollout_context`
+    turns a False into a ValueError — but only AFTER loading a multi-GB VLM
+    onto the accelerator. Answering from the saved config costs nothing and
+    fails in the launch panel instead. Only meaningful for MolmoAct2: every
+    other policy's RTC support is decided elsewhere (upstream's
+    `supports_rtc_inference`), and this returns None for them rather than
+    pretending to know.
+    """
+    if policy_config.get("type") != MOLMOACT2:
+        return None
+    if molmoact2_inference_action_mode(policy_config) == "continuous":
+        return None
+    return (
+        "Real-Time Chunking needs continuous actions, and this MolmoAct2 checkpoint runs "
+        "discrete ones. Use the standard (sync) inference engine for it."
+    )
+
+
+def molmoact2_device_warning(policy_config: Mapping[str, Any], device: str) -> str | None:
+    """Why a MolmoAct2 rollout on `device` is likely to disappoint, or None.
+
+    A WARNING and deliberately not a refusal. Nothing in this lerobot pin
+    requires CUDA: the only CUDA-specific code is the action-flow graph cache,
+    and `ActionCudaGraphManager.can_use_action_flow` returns False off-CUDA and
+    falls back to the eager loop. So refusing would be MakerMods Lab inventing
+    a hardware requirement lerobot does not state — the honest thing is to say
+    what the operator is in for and let them decide.
+
+    What they are in for is the model's size, not a missing kernel: MolmoAct2
+    is a ~7B vision-language model queried inside a 30 Hz control loop.
+
+    `device` is injected (rollout passes `_detect_device()`) so this stays a
+    pure function and the tests never touch a real accelerator.
+    """
+    if policy_config.get("type") != MOLMOACT2:
+        return None
+    if device == "cuda":
+        return None
+    return (
+        "MolmoAct2 is a ~7B vision-language model and this machine has no CUDA GPU "
+        f"(running on {device}). Expect very slow inference, or an out-of-memory failure. "
+        "Run it on a machine with an NVIDIA GPU for a usable control rate."
+    )
+
 
 # One install manager per install target (lerobot[smolvla] / lerobot[pi] / …),
 # created lazily so pi0 and pi0_fast share the lerobot[pi] install.

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for makermodslab.utils.naming — the pure title/collision rules shared
-by the jobs registry and the models listing. No filesystem, no Hub, no registry:
-every case here is a string in and a string out."""
+by the jobs registry and the models listing. No filesystem and no Hub: every
+case here is a string in and a string out, with one deliberate exception —
+`test_known_policy_types_mirror_the_lerobot_pin` reads lerobot's policy registry,
+because the vocabulary those string transforms match against is only correct
+relative to the pin."""
 
 from __future__ import annotations
 
@@ -87,6 +90,25 @@ def test_policy_type_from_name() -> None:
     # derive_imported_title consults this only for a timestamped (generated)
     # name, and leaves `smolvla_base` whole.
     assert policy_type_from_name("smolvla_base") == "smolvla"
+    assert policy_type_from_name("molmoact2_orange_box_2026-01-01_10-00-00") == "molmoact2"
+
+
+def test_known_policy_types_mirror_the_lerobot_pin() -> None:
+    """KNOWN_POLICY_TYPES is a RECOGNITION vocabulary, not a menu: a type
+    missing from it makes a perfectly good model list with `policy_type: null`,
+    with nothing anywhere raising. It had silently drifted eight types behind
+    the pin, which is the failure this asserts against.
+
+    The one test in this file that touches the registry (see the module
+    docstring) — everything else here is a pure string transform. On a lerobot
+    pin bump the correct response is to update the constant, not the test; a
+    type MakerMods Lab cannot train still belongs here, because the training
+    picker is server.py's separate `_POLICY_TYPE_TO_LEROBOT`."""
+    import lerobot.policies  # noqa: F401  — eager registration of every policy config
+    from lerobot.configs.policies import PreTrainedConfig
+    from makermodslab.utils.naming import KNOWN_POLICY_TYPES
+
+    assert set(PreTrainedConfig.get_known_choices()) == KNOWN_POLICY_TYPES
 
 
 # ── suffix ladders ───────────────────────────────────────────────────────────

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -5347,3 +5347,206 @@ def test_single_arm_coaching_is_not_caught_by_that_guard(monkeypatch) -> None:
 
     req = _coaching_request()
     assert req.mode != "bimanual"
+
+
+# --- MolmoAct2: the flags the lerobot pin requires --------------------------
+#
+# `_rollout_cli_args` reads the checkpoint's own config.json to decide these,
+# so the tests below write a real (tiny) one into tmp_path. Every other test in
+# this file passes a path that does not exist, which is the "{} → add nothing"
+# fallback and is why none of them changed.
+
+
+def _checkpoint_dir(tmp_path, config: dict) -> str:
+    """A pretrained_model dir holding just the config.json the builder reads."""
+    d = tmp_path / "pretrained_model"
+    d.mkdir(parents=True)
+    (d / "config.json").write_text(json.dumps(config))
+    return str(d)
+
+
+def test_rollout_cli_args_add_nothing_for_act_and_smolvla(tmp_path) -> None:
+    """The required-flag machinery must be invisible to every policy that
+    doesn't need it — including on the eval and coaching front-ends."""
+    from makermodslab.rollout import _rollout_cli_args
+
+    for policy_type in ("act", "smolvla"):
+        path = _checkpoint_dir(tmp_path / policy_type, {"type": policy_type})
+        args = _rollout_cli_args(_stub_request(), path, [])
+        assert not any(a.startswith("--policy.inference_action_mode") for a in args)
+
+
+def test_rollout_cli_args_set_molmoact2_inference_action_mode(tmp_path) -> None:
+    """MolmoAct2Config.inference_action_mode has no usable default — the policy
+    raises "requires `inference_action_mode` to be set explicitly" on None — so
+    a checkpoint that saved none is unrunnable without this override."""
+    from makermodslab.rollout import _rollout_cli_args
+
+    path = _checkpoint_dir(tmp_path, {"type": "molmoact2", "action_mode": "both"})
+    args = _rollout_cli_args(_stub_request(), path, [])
+    assert "--policy.inference_action_mode=continuous" in args
+
+
+def test_rollout_cli_args_respect_a_checkpoints_own_action_mode(tmp_path) -> None:
+    """The released lerobot/MolmoAct2-*-LeRobot config already saves
+    inference_action_mode=continuous. Overriding a saved choice would be how a
+    discrete checkpoint silently gets run through the wrong head."""
+    from makermodslab.rollout import _rollout_cli_args
+
+    path = _checkpoint_dir(
+        tmp_path,
+        {"type": "molmoact2", "action_mode": "continuous", "inference_action_mode": "continuous"},
+    )
+    args = _rollout_cli_args(_stub_request(), path, [])
+    assert not any(a.startswith("--policy.inference_action_mode") for a in args)
+
+
+def test_eval_runner_cmd_carries_the_molmoact2_flag(tmp_path) -> None:
+    """Same reason the temporal-ensemble flags are tested on both front-ends:
+    an eval must drive the policy exactly the way a single rollout would."""
+    from makermodslab.rollout import InferenceRequest, _build_eval_runner_cmd
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        eval_episodes=5,
+    )
+    path = _checkpoint_dir(tmp_path, {"type": "molmoact2", "action_mode": "both"})
+    cmd = _build_eval_runner_cmd(req, path, [])
+    assert "makermodslab.eval_runner" in cmd
+    assert "--policy.inference_action_mode=continuous" in cmd
+
+
+def test_rtc_is_refused_for_a_discrete_molmoact2_checkpoint(tmp_path) -> None:
+    """MolmoAct2Policy.supports_rtc() is `inference_action_mode ==
+    "continuous"`, and build_rollout_context raises on a False — but only after
+    loading a multi-GB VLM onto the accelerator and with a message naming
+    `--inference.type`, a flag no UI user can reach."""
+    from makermodslab.rollout import InferenceRequest, _rollout_cli_args
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        inference_engine="rtc",
+    )
+    path = _checkpoint_dir(tmp_path, {"type": "molmoact2", "inference_action_mode": "discrete"})
+    with pytest.raises(ValueError, match="Real-Time Chunking"):
+        _rollout_cli_args(req, path, [])
+
+
+def test_rtc_is_allowed_for_a_continuous_molmoact2_checkpoint(tmp_path) -> None:
+    from makermodslab.rollout import InferenceRequest, _rollout_cli_args
+
+    req = InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref="user/repo@checkpoints/000050",
+        inference_engine="rtc",
+    )
+    path = _checkpoint_dir(tmp_path, {"type": "molmoact2", "inference_action_mode": "continuous"})
+    args = _rollout_cli_args(req, path, [])
+    assert "--inference.type=rtc" in args
+
+
+def test_molmoact2_hints_name_the_extra_and_the_action_head() -> None:
+    """Both failures are otherwise opaque: lerobot's require_package message
+    names a pip extra, and the action-mode refusal names a config field."""
+    from makermodslab.utils.errors import friendly_hint
+
+    extra = friendly_hint(
+        "ImportError: 'scipy' is required but not installed. "
+        "Install it with: pip install 'lerobot[molmoact2]'"
+    )
+    assert extra is not None and "lerobot[molmoact2]" in extra
+
+    head = friendly_hint(
+        "ValueError: MolmoAct2 checkpoint was trained with action_mode='discrete' "
+        "and cannot run continuous inference."
+    )
+    assert head is not None and "action_mode" in head
+
+    # The bare field name is NOT a trigger: lerobot logs the effective policy
+    # config, so it appears in the log tail of unrelated failures too.
+    assert friendly_hint("inference_action_mode: continuous") is None
+
+
+def test_molmoact2_on_a_non_cuda_host_warns_but_still_starts(monkeypatch, tmp_path) -> None:
+    """Warn-but-allow, on the same `meta["warning"]` channel the arm-identity
+    findings use. Nothing in this lerobot pin REQUIRES CUDA — the action-flow
+    CUDA graph falls back off-CUDA — so a refusal would be MakerMods Lab
+    inventing a hardware requirement lerobot does not state. The device is
+    injected; nothing here touches a real accelerator.
+
+    Same harness as the return-to-initial-position test: every hardware-touching
+    preflight and the subprocess itself are stubbed, the startup worker runs
+    inline, and HOME is redirected so the log lands in tmp."""
+    from makermodslab import rollout
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda cfg, arm_type="so101": cfg)
+    monkeypatch.setattr(rollout, "_preflight_arm_identity", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "_preflight_motor_registers", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "_detect_device", lambda: "mps")
+    # Restored by monkeypatch at teardown, so this test can't leak a claimed
+    # session into the next one.
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(rollout, "_inference_meta", {})
+
+    checkpoint = _checkpoint_dir(tmp_path, {"type": "molmoact2", "inference_action_mode": "continuous"})
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: checkpoint)
+
+    class _FakeProc:
+        pid = 4321
+
+        def __init__(self, cmd, **kwargs):
+            self.stdin = io.BytesIO()
+            self.stdout = _EmptyStdout()
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(rollout.subprocess, "Popen", _FakeProc)
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+
+    result = rollout.handle_start_inference(_stub_request())
+    # Started, not refused — that is the whole point of a warning.
+    assert result["success"] is True, result
+    warning = rollout._inference_meta.get("warning")
+    assert warning is not None
+    assert "mps" in warning
+    assert "CUDA" in warning
+
+
+def test_an_act_checkpoint_on_the_same_host_gets_no_device_warning(monkeypatch, tmp_path) -> None:
+    """The guard keys on the checkpoint's policy type, so it is one `!=` away
+    from warning about every ACT run on every Mac in the building."""
+    from makermodslab import rollout
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda cfg, arm_type="so101": cfg)
+    monkeypatch.setattr(rollout, "_preflight_arm_identity", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "_preflight_motor_registers", lambda *a, **k: [])
+    monkeypatch.setattr(rollout, "_detect_device", lambda: "mps")
+    monkeypatch.setattr(rollout, "inference_active", False)
+    monkeypatch.setattr(rollout, "_inference_meta", {})
+
+    checkpoint = _checkpoint_dir(tmp_path, {"type": "act"})
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: checkpoint)
+
+    class _FakeProc:
+        pid = 4322
+
+        def __init__(self, cmd, **kwargs):
+            self.stdin = io.BytesIO()
+            self.stdout = _EmptyStdout()
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(rollout.subprocess, "Popen", _FakeProc)
+    monkeypatch.setattr(rollout.threading, "Thread", _SyncThread)
+
+    assert rollout.handle_start_inference(_stub_request())["success"] is True
+    assert rollout._inference_meta.get("warning") is None

--- a/tests/test_utils_system.py
+++ b/tests/test_utils_system.py
@@ -143,6 +143,104 @@ def test_policy_extra_maps_policies_to_install_targets() -> None:
     assert handle_get_policy_extra("diffusion")["install_target"] == "lerobot[diffusion]"
 
 
+def test_policy_extra_molmoact2_probes_transformers_not_peft_or_scipy() -> None:
+    """MolmoAct2's extra is transformers + peft + scipy, but only transformers
+    is a construction-time requirement for a rollout on this pin: peft is
+    reached only under enable_lora_vlm, and scipy only when the checkpoint's
+    action_mode is "discrete"/"both" (the released checkpoints save
+    "continuous"). Probing either would report the extra missing for a
+    checkpoint that runs fine, and DeployPanel refuses to launch on that."""
+    from makermodslab.utils.system import handle_get_policy_extra
+
+    molmo = handle_get_policy_extra("molmoact2")
+    assert molmo["needs_extra"] is True
+    assert molmo["package"] == "transformers"
+    assert molmo["install_target"] == "lerobot[molmoact2]"
+    assert "lerobot[molmoact2]" in molmo["install_hint"]
+
+
+# ── policy runtime requirements (policy_inference_args & friends) ────────────
+#
+# Pure functions of a checkpoint's saved config.json — no filesystem here, the
+# dicts below stand in for the file rollout.py reads.
+
+
+def test_policy_inference_args_are_empty_for_every_other_policy() -> None:
+    from makermodslab.utils.system import policy_inference_args
+
+    assert policy_inference_args({"type": "act"}) == []
+    assert policy_inference_args({"type": "smolvla"}) == []
+    # An unreadable / missing config.json arrives as {} — add nothing rather
+    # than guessing, and let the subprocess report whatever is really wrong.
+    assert policy_inference_args({}) == []
+
+
+def test_policy_inference_args_fill_in_a_missing_molmoact2_action_mode() -> None:
+    """MolmoAct2Config.inference_action_mode defaults to None and the policy
+    raises on None, so a checkpoint that saved no mode cannot be rolled out at
+    all without this override."""
+    from makermodslab.utils.system import policy_inference_args
+
+    assert policy_inference_args({"type": "molmoact2", "action_mode": "both"}) == [
+        "--policy.inference_action_mode=continuous"
+    ]
+    # A discrete-only checkpoint gets discrete: forcing continuous onto it
+    # raises in MolmoAct2Config.__post_init__, which would swap one fatal
+    # error for another.
+    assert policy_inference_args({"type": "molmoact2", "action_mode": "discrete"}) == [
+        "--policy.inference_action_mode=discrete"
+    ]
+
+
+def test_policy_inference_args_leave_an_explicit_molmoact2_mode_alone() -> None:
+    """The released lerobot/MolmoAct2-*-LeRobot configs already save
+    inference_action_mode; a rollout must run the policy the way its own config
+    says, so there is nothing to override."""
+    from makermodslab.utils.system import policy_inference_args
+
+    saved = {"type": "molmoact2", "action_mode": "continuous", "inference_action_mode": "continuous"}
+    assert policy_inference_args(saved) == []
+    saved_discrete = {"type": "molmoact2", "action_mode": "both", "inference_action_mode": "discrete"}
+    assert policy_inference_args(saved_discrete) == []
+
+
+def test_molmoact2_rtc_conflict_only_blocks_discrete_checkpoints() -> None:
+    """MolmoAct2Policy.supports_rtc() is `inference_action_mode ==
+    "continuous"`, and build_rollout_context turns a False into a ValueError —
+    but only after loading a multi-GB VLM. Answer from the saved config."""
+    from makermodslab.utils.system import molmoact2_rtc_conflict
+
+    assert molmoact2_rtc_conflict({"type": "molmoact2", "inference_action_mode": "continuous"}) is None
+    assert molmoact2_rtc_conflict({"type": "molmoact2", "action_mode": "both"}) is None
+    conflict = molmoact2_rtc_conflict({"type": "molmoact2", "inference_action_mode": "discrete"})
+    assert conflict is not None
+    assert "continuous" in conflict
+    # Every other policy's RTC support is decided upstream — don't pretend to
+    # know it here.
+    assert molmoact2_rtc_conflict({"type": "act"}) is None
+    assert molmoact2_rtc_conflict({}) is None
+
+
+def test_molmoact2_device_warning_is_advisory_and_names_the_device() -> None:
+    """A WARNING, not a gate: nothing in this pin requires CUDA (the action-flow
+    CUDA graph falls back off-CUDA), so this only sets expectations about a ~7B
+    VLM in a 30 Hz loop. The device is injected — no real detection here."""
+    from makermodslab.utils.system import molmoact2_device_warning
+
+    molmo = {"type": "molmoact2", "inference_action_mode": "continuous"}
+    assert molmoact2_device_warning(molmo, "cuda") is None
+
+    for device in ("mps", "cpu"):
+        warning = molmoact2_device_warning(molmo, device)
+        assert warning is not None
+        assert device in warning
+        assert "CUDA" in warning
+
+    # Every other policy is unaffected — ACT on MPS is an ordinary, fast run.
+    assert molmoact2_device_warning({"type": "act"}, "mps") is None
+    assert molmoact2_device_warning({}, "cpu") is None
+
+
 def test_policy_extra_core_policy_needs_nothing() -> None:
     from makermodslab.utils.system import handle_get_policy_extra
 


### PR DESCRIPTION
> **Preview — rollout only, training deferred, not exercised on a CUDA host.** Everything here is verified by unit tests against the pinned lerobot fork (`b968c0c01`), which already registers `molmoact2`. Frontend untouched (studio panels are being reworked). Draft until someone runs it on an NVIDIA box.

## What this adds

- **Checkpoint-aware `--policy.inference_action_mode`** — the pin requires the field to be non-`None`. The published `lerobot/MolmoAct2-SO100_101-LeRobot` config already saves `continuous`; forcing the flag would break `action_mode="discrete"` checkpoints, so `policy_inference_args` emits it only when a checkpoint saved none, defaulting to the checkpoint's own training mode.
- **Extras detection** — `POLICY_EXTRAS["molmoact2"]` probes `transformers` (required at construction), not `peft` (training-only) or `scipy` (discrete-mode only), so a runnable checkpoint isn't refused.
- **RTC gate** — MolmoAct2 supports RTC for continuous checkpoints; `inference_engine="rtc"` is refused for discrete ones *before* the serial bus opens (the fork's own check fires only after loading a multi-GB VLM). The general RTC path is untouched.
- **Advisory non-CUDA warning** — the pin has no CUDA requirement (the CUDA-graph fast path falls back), so a non-CUDA host gets a warning through the existing `meta["warning"]` surface, not a refusal.
- **Policy-type registry** — `KNOWN_POLICY_TYPES` is a mirror of the pin's registry (its consumers degrade to `null`, so a missing type is a silent bug); it gains the nine types it was behind, with a test asserting the mirror.
- **Error hints** for the missing extra and the action-mode errors.

The pure helpers live in `utils/system.py` beside `POLICY_EXTRAS`, reusable by training and the remote-inference policy server later. No request/response model changed; the OpenAPI snapshot is untouched.

## Verification

377 tests across the touched files plus both contract ratchets; ruff / format / pre-commit green.

## Known gaps (not in this PR)

- The task string is validated only for coaching sessions, though MolmoAct2 is language-conditioned — needs a `policy_type` request field (frontend already has it in hand) or a UI requirement.
- The checkpoint's base VLM is downloaded inside the subprocess **after** the Lab's progress bar reports done — a first run sits silently in `starting` for minutes (follow-up in progress).
- The extras installer would install PyPI `lerobot[molmoact2]` over the SHA-pinned fork — pre-existing for every extra (follow-up in progress).
- Frontend: hide the RTC toggle for discrete checkpoints; require the task box for language-conditioned policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
