### PR TITLE
fix(rollout): refuse Real-Time Chunking server-side for policies that cannot run it

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -327,7 +327,7 @@
         "type": "object"
       },
       "CheckpointPolicyConfigResponse": {
-        "description": "jobs.py JobRegistry.get_policy_config_summary — the UX-relevant slice\nof a checkpoint's pretrained_model/config.json. policy_type passes through\nfrom the file's \"type\" key (null when absent); state_dim/action_dim are\nnull when the checkpoint omits the feature. trained_on_robot_type is the\nraw lerobot robot_type of the checkpoint's training dataset (recovered via\ntrain_config.json), null when it can't be established — the fine-tune\npanel compares it against the selected dataset's arm.",
+        "description": "jobs.py JobRegistry.get_policy_config_summary — the UX-relevant slice\nof a checkpoint's pretrained_model/config.json. policy_type passes through\nfrom the file's \"type\" key (null when absent); state_dim/action_dim are\nnull when the checkpoint omits the feature. trained_on_robot_type is the\nraw lerobot robot_type of the checkpoint's training dataset (recovered via\ntrain_config.json), null when it can't be established — the fine-tune\npanel compares it against the selected dataset's arm.\n\nsupports_rtc says whether this architecture can run the Real-Time Chunking\ninference engine; null means the policy type isn't one the server knows\n(a fork newer than jobs.policy_type_supports_rtc's table), which the client\nmust read as \"offer it and let the server decide\", not as \"no\". The route\ndeclares no exclude_none/exclude_unset, so the key is always present.",
         "properties": {
           "action_dim": {
             "anyOf": [
@@ -373,6 +373,17 @@
             ],
             "title": "State Dim"
           },
+          "supports_rtc": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supports Rtc"
+          },
           "trained_on_robot_type": {
             "anyOf": [
               {
@@ -389,6 +400,7 @@
           "policy_type",
           "image_features",
           "requires_task",
+          "supports_rtc",
           "state_dim",
           "action_dim",
           "trained_on_robot_type"

--- a/frontend/src/components/landing/InferenceModal.tsx
+++ b/frontend/src/components/landing/InferenceModal.tsx
@@ -312,6 +312,22 @@ const InferenceModal: React.FC<Props> = ({
     };
   }, [open, baseUrl, fetchWithHeaders, jobId, selectedStep, isBimanual]);
 
+  // Real-Time Chunking is an ARCHITECTURE capability, not a per-run taste: the
+  // server refuses `inference_engine: "rtc"` with a 400 for a checkpoint whose
+  // policy type can't run guided chunk prediction (ACT, diffusion, pi0_fast,
+  // tdmpc, vqbet…), before any slot or hardware is held. `supports_rtc: null`
+  // means the server doesn't KNOW the type — a policy newer than its table — so
+  // it stays on offer and the subprocess decides, same fail-open discipline.
+  const rtcAvailable = policyConfig?.supports_rtc !== false;
+
+  // Picking a checkpoint that can't run RTC drops a stale "rtc" selection back
+  // to the server default. Runs on the config that just landed (the fetch above
+  // swaps policyConfig in one setState), so the reset is a single render behind
+  // the step change and the launch below can't carry "rtc" for it.
+  useEffect(() => {
+    if (!rtcAvailable) setInferenceEngine("sync");
+  }, [rtcAvailable]);
+
   // If the selected robot has cameras whose names match a policy-expected
   // camera, auto-bind them. Match against the DISPLAY name (the bare name the
   // user chose at record time — that's what the robot record stores), not the
@@ -674,7 +690,9 @@ const InferenceModal: React.FC<Props> = ({
                   <SelectItem value="sync">
                     {t("landing.inference.engineSync")}
                   </SelectItem>
-                  <SelectItem value="rtc">
+                  {/* Disabled rather than hidden: a checkpoint that can't run
+                      RTC should say so, not silently offer one engine. */}
+                  <SelectItem value="rtc" disabled={!rtcAvailable}>
                     {t("landing.inference.engineRtc")}
                   </SelectItem>
                 </SelectContent>
@@ -684,6 +702,11 @@ const InferenceModal: React.FC<Props> = ({
                   ? t("landing.inference.engineRtcHint")
                   : t("landing.inference.engineSyncHint")}
               </p>
+              {rtcAvailable ? null : (
+                <p className="text-xs text-muted-foreground">
+                  {t("landing.inference.engineRtcUnavailable")}
+                </p>
+              )}
             </div>
           </div>
 

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -868,6 +868,22 @@ const DeployPanel: React.FC = () => {
     };
   }, [open, baseUrl, fetchWithHeaders, policyConfigJobId, selectedStep, isBimanual]);
 
+  // Real-Time Chunking is an ARCHITECTURE capability, not a per-run taste: the
+  // server refuses `inference_engine: "rtc"` with a 400 for a checkpoint whose
+  // policy type can't run guided chunk prediction (ACT, diffusion, pi0_fast,
+  // tdmpc, vqbet…), before any slot or hardware is held. `supports_rtc: null`
+  // means the server doesn't KNOW the type — a policy newer than its table — so
+  // it stays on offer and the subprocess decides, same fail-open discipline.
+  const rtcAvailable = policyConfig?.supports_rtc !== false;
+
+  // Picking a checkpoint that can't run RTC drops a stale "rtc" selection back
+  // to the server default. Runs on the config that just landed (the fetch above
+  // swaps policyConfig in one setState), so the reset is a single render behind
+  // the checkpoint change and the launch below can't carry "rtc" for it.
+  useEffect(() => {
+    if (!rtcAvailable) setInferenceEngine("sync");
+  }, [rtcAvailable]);
+
   // Auto-bind robot cameras whose names match a policy-expected camera, by
   // name against the DISPLAY name (the bare name the user chose at record
   // time — that's what the robot record stores). No device enumeration is
@@ -1764,7 +1780,9 @@ const DeployPanel: React.FC = () => {
                       <SelectItem value="sync">
                         {t("studio.deploy.engine.sync")}
                       </SelectItem>
-                      <SelectItem value="rtc">
+                      {/* Disabled rather than hidden: a checkpoint that can't
+                          run RTC should say so, not silently offer one engine. */}
+                      <SelectItem value="rtc" disabled={!rtcAvailable}>
                         {t("studio.deploy.engine.rtc")}
                       </SelectItem>
                     </SelectContent>
@@ -1774,6 +1792,11 @@ const DeployPanel: React.FC = () => {
                       ? t("studio.deploy.engine.rtcHint")
                       : t("studio.deploy.engine.syncHint")}
                   </p>
+                  {rtcAvailable ? null : (
+                    <p className="text-xs text-muted-foreground">
+                      {t("studio.deploy.engine.rtcUnavailable")}
+                    </p>
+                  )}
                 </div>
               ) : (
                 <p className="text-xs text-muted-foreground">

--- a/frontend/src/i18n/locales/en/landing.ts
+++ b/frontend/src/i18n/locales/en/landing.ts
@@ -430,6 +430,10 @@ export default {
       "Real-Time Chunking overlaps inference with motion, removing the pause between action chunks. It also changes how actions are generated — compare against Sync before trusting a result.",
     engineSyncHint:
       "One policy forward per control step. The arm pauses briefly between action chunks.",
+    // Shown under the picker when the selected checkpoint's architecture can't
+    // run RTC (the server refuses it), which also disables the option.
+    engineRtcUnavailable:
+      "Real-Time Chunking isn't available for this checkpoint's policy.",
     camerasSection: "Cameras",
     policyConfigLoading: "Reading policy config…",
     // {{message}} is the raw error text (backend or JS) — not ours to translate.

--- a/frontend/src/i18n/locales/en/studio.ts
+++ b/frontend/src/i18n/locales/en/studio.ts
@@ -375,6 +375,10 @@ export default {
         "One policy forward per control step. The arm pauses briefly between action chunks.",
       rtcHint:
         "Real-Time Chunking overlaps inference with motion, removing the pause between action chunks. It also changes how actions are generated — compare against Sync before trusting a result.",
+      // Shown under the picker when the selected checkpoint's architecture
+      // can't run RTC (the server refuses it), which also disables the option.
+      rtcUnavailable:
+        "Real-Time Chunking isn't available for this checkpoint's policy.",
       // Shown INSTEAD of the picker in coaching mode, which is pinned to sync.
       coachingNote:
         "Coaching always uses the Sync engine. Real-Time Chunking makes the arm jump back toward its pre-correction pose when the policy resumes, which isn't safe with a hand nearby.",

--- a/frontend/src/i18n/locales/zh-CN/landing.ts
+++ b/frontend/src/i18n/locales/zh-CN/landing.ts
@@ -348,6 +348,9 @@ export default {
     engineRtcHint:
       "Real-Time Chunking 让推理与运动重叠，消除动作块之间的停顿。它同时改变了动作的生成方式 —— 在采信结果前请与 Sync 对比。",
     engineSyncHint: "每个控制步进行一次策略前向计算。机械臂在动作块之间会短暂停顿。",
+    // 当所选检查点的架构无法运行 RTC（服务端会拒绝）时显示在选择器下方，
+    // 同时该选项也会被禁用。
+    engineRtcUnavailable: "该检查点的策略不支持 Real-Time Chunking。",
     camerasSection: "摄像头",
     policyConfigLoading: "正在读取策略配置…",
     policyConfigError: "无法加载策略配置：{{message}}",

--- a/frontend/src/i18n/locales/zh-CN/studio.ts
+++ b/frontend/src/i18n/locales/zh-CN/studio.ts
@@ -279,6 +279,9 @@ export default {
         "每个控制步执行一次策略前向推理。机械臂在动作块之间会短暂停顿。",
       rtcHint:
         "Real-Time Chunking 让推理与运动重叠进行，消除动作块之间的停顿。它也改变了动作的生成方式 — 在采信结果之前请先与 Sync 对比。",
+      // 当所选检查点的架构无法运行 RTC（服务端会拒绝）时显示在选择器下方，
+      // 同时该选项也会被禁用。
+      rtcUnavailable: "该检查点的策略不支持 Real-Time Chunking。",
       // 指导模式固定使用 sync，因此显示这句话来代替引擎选择器。
       coachingNote:
         "指导始终使用 Sync 引擎。Real-Time Chunking 会让策略恢复时机械臂朝纠正前的姿态弹回，手就在旁边时这并不安全。",

--- a/frontend/src/lib/checkpointsApi.ts
+++ b/frontend/src/lib/checkpointsApi.ts
@@ -20,6 +20,13 @@ export interface PolicyConfigSummary {
   policy_type: string | null;
   image_features: Record<string, { height: number; width: number }>;
   requires_task: boolean;
+  /** Whether this checkpoint's ARCHITECTURE can run the Real-Time Chunking
+   * inference engine. `false` means the server refuses `inference_engine:
+   * "rtc"` for it with a 400 before any hardware is claimed, so the dialogs
+   * take the option off the menu. `null` means "not established" — a policy
+   * type newer than the server's table — and must be read as "offer it and let
+   * the server decide", never as "no". */
+  supports_rtc: boolean | null;
   // Flat proprioceptive state / action widths from the checkpoint. For an
   // SO-101 arm this is 6 (one per joint); a bimanual-trained checkpoint carries
   // 12 (two arms). The inference modal compares state_dim against the selected

--- a/frontend/src/lib/mockHub.ts
+++ b/frontend/src/lib/mockHub.ts
@@ -354,6 +354,9 @@ const policyConfig = (policy: string): PolicyConfigSummary => ({
     wrist: { height: 480, width: 640 },
   },
   requires_task: policy === "smolvla" || policy === "pi05",
+  // Mirrors the server's table (jobs.policy_type_supports_rtc): the VLAs run
+  // Real-Time Chunking, ACT and the other regression policies don't.
+  supports_rtc: policy === "smolvla" || policy === "pi05",
   state_dim: 6,
   action_dim: 6,
 });

--- a/frontend/src/lib/sessionApi.ts
+++ b/frontend/src/lib/sessionApi.ts
@@ -86,6 +86,9 @@ export interface InferenceSessionOptions {
   duration_s?: number;
   checkpoint_state_dim?: number;
   eval_episodes?: number;
+  // "rtc" is also refused (400) when the checkpoint's ARCHITECTURE can't run
+  // Real-Time Chunking — read `supports_rtc` off the checkpoint's policy-config
+  // summary and don't offer the engine for it (PolicyConfigSummary).
   inference_engine?: "sync" | "rtc";
   temporal_ensemble_coeff?: number;
   skip_identity_check?: boolean;

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -1664,6 +1664,90 @@ def _list_hub_checkpoints(api, repo_id: str) -> list[JobCheckpoint]:
 
 _LANGUAGE_CONDITIONED_POLICY_TYPES = {"smolvla", "pi0", "pi0_fast", "pi05"}
 
+# Policy types whose class declares Real-Time Chunking support in the pinned
+# lerobot fork. See policy_type_supports_rtc for how this list was derived and
+# why it is a hand-mirrored table rather than a live import.
+_RTC_CAPABLE_POLICY_TYPES = frozenset({"evo1", "groot", "molmoact2", "pi0", "pi05", "smolvla"})
+
+# Every policy type registered via @PreTrainedConfig.register_subclass in the
+# pinned fork. Membership is what separates "this architecture cannot do RTC"
+# (False) from "we've never heard of it" (None) — a type we don't know about is
+# one the fork gained after this table was written, and guessing False for it
+# would refuse a run the subprocess would have accepted.
+_KNOWN_POLICY_TYPES = frozenset(
+    {
+        "act",
+        "diffusion",
+        "eo1",
+        "evo1",
+        "fastwam",
+        "gaussian_actor",
+        "groot",
+        "lingbot_va",
+        "molmoact2",
+        "multi_task_dit",
+        "pi0",
+        "pi0_fast",
+        "pi05",
+        "smolvla",
+        "tdmpc",
+        "vla_jepa",
+        "vqbet",
+        "wall_x",
+        "xvla",
+    }
+)
+
+
+def policy_type_supports_rtc(policy_type: str) -> bool | None:
+    """Whether a checkpoint of this architecture can run the Real-Time Chunking
+    inference engine (``--inference.type=rtc``).
+
+    True/False for a policy type registered in the pinned lerobot fork; None for
+    anything else, which means "not established", never "no" — callers must not
+    refuse a run on None, they must let the subprocess decide (same
+    silent-when-unreadable discipline as read_pretrained_policy_type).
+
+    **How it decides, and why.** The fork's own authority is
+    ``lerobot.rollout.inference.rtc.supports_rtc_inference(policy)``, which
+    takes an INSTANTIATED policy and asks two things: that ``policy.supports_rtc()``
+    returns True, and that ``predict_action_chunk`` binds ``inference_delay`` and
+    ``prev_chunk_left_over``. Neither can be evaluated here:
+
+    * ``supports_rtc`` is a plain instance method on every policy in the fork
+      (not a classmethod), so there is nothing to call without building the
+      policy — and MolmoAct2's reads ``self.config``.
+    * Reaching the classes at all means importing ``lerobot.policies.factory``,
+      which costs ~2 s and pulls ``transformers`` into the API process on the
+      first RTC launch. Optional-extra policies would also raise ImportError on
+      an install without their extra, turning a capability question into a
+      crash.
+
+    So the table above is a hand-mirrored read of the fork's classes, verified
+    against ``supports_rtc_inference``'s two criteria at class level on the
+    pinned SHA (b968c0c01). Six types declare support — evo1, groot, molmoact2,
+    pi0, pi05, smolvla — and all six accept the RTC call shape; every other
+    registered type inherits ``PreTrainedPolicy.supports_rtc`` (``return False``).
+    Notably **pi0_fast does NOT support RTC** even though its siblings do.
+    Change the fork's pin, re-check this table (test_rollout.py has a drift
+    test that reads the fork's sources without importing them).
+
+    **MolmoAct2 is reported True on purpose, and it is the one approximation
+    here.** Its ``supports_rtc`` is ``self.config.inference_action_mode ==
+    "continuous"`` — a per-CHECKPOINT condition, not a per-architecture one, and
+    the field defaults to None. The class does implement RTC semantics, so this
+    answers the architecture question honestly and leaves the config-level
+    condition to the subprocess, which still raises for a discrete-mode
+    MolmoAct2 checkpoint. Erring the other way would refuse continuous-mode
+    checkpoints that RTC genuinely runs.
+    """
+    if policy_type in _RTC_CAPABLE_POLICY_TYPES:
+        return True
+    if policy_type in _KNOWN_POLICY_TYPES:
+        return False
+    return None
+
+
 # None of _LANGUAGE_CONDITIONED_POLICY_TYPES has a legitimate from-scratch
 # mode: each builds a pretrained backbone (a vision-language model for
 # smolvla, a PaliGemma+expert stack for pi0/pi05/pi0_fast) from a bare config
@@ -5180,6 +5264,14 @@ class JobRegistry:
             "policy_type": policy_type,
             "image_features": image_features,
             "requires_task": policy_type in _LANGUAGE_CONDITIONED_POLICY_TYPES,
+            # Whether this architecture can run the Real-Time Chunking engine,
+            # so the launch UI can offer the engine choice only where it works
+            # instead of letting the run die inside the subprocess with the arm
+            # already claimed. null = unknown type (a fork newer than our table)
+            # — the UI must treat that as "offer it", matching the server-side
+            # guard in rollout.handle_start_inference, which only refuses on a
+            # definite False.
+            "supports_rtc": (policy_type_supports_rtc(policy_type) if isinstance(policy_type, str) else None),
             # Flat proprioceptive state / action widths. For an SO-101 arm this
             # is 6 (one per joint); a bimanual-trained checkpoint carries 12
             # (two arms). The inference modal compares this against the selected

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -105,7 +105,12 @@ from .eval_protocol import (
     parse_episode_end_reason,
     parse_event,
 )
-from .jobs import download_hub_checkpoint_ref, make_snapshot_progress_tqdm
+from .jobs import (
+    download_hub_checkpoint_ref,
+    make_snapshot_progress_tqdm,
+    policy_type_supports_rtc,
+    read_pretrained_policy_type,
+)
 from .models import (
     _downloaded_model_dir,
     _has_loadable_weights,
@@ -3416,6 +3421,38 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
             "status_code": 400,
             "message": f"Unrecognised policy ref: {request.policy_ref!r}",
         }
+
+    # Real-Time Chunking is a per-ARCHITECTURE capability, and the subprocess
+    # only discovers that after the policy is loaded and the arm is already
+    # claimed — `build_rollout_context` raises "RTC inference is not supported
+    # by policy type ..." out of `supports_rtc_inference(policy)`. An ACT run
+    # launched with rtc therefore spent a model download and a full arm+camera
+    # preflight to die on a message no UI user can act on. Refuse it here
+    # instead, off the checkpoint's own config.json.
+    #
+    # Only runs for rtc (sync is always fine), so the config read — a few KB,
+    # local for a local ref and a cached hf_hub_download for a Hub one — is paid
+    # once per RTC launch, not on every start. `@root` refs are handed to
+    # read_pretrained_policy_type as the bare repo id, which is where that shape
+    # keeps its config.json.
+    #
+    # Fail-open on both unknowns: an unreadable config (offline, private repo)
+    # gives None, and so does a policy type newer than
+    # policy_type_supports_rtc's table. Neither is evidence of anything, and the
+    # subprocess still guards.
+    if request.inference_engine == "rtc":
+        root_ref = _HUB_ROOT_REF_RE.match(request.policy_ref)
+        policy_type = read_pretrained_policy_type(root_ref.group("repo") if root_ref else request.policy_ref)
+        if policy_type and policy_type_supports_rtc(policy_type) is False:
+            _release_slot()
+            return {
+                "success": False,
+                "status_code": 400,
+                "message": (
+                    f"Real-Time Chunking isn't available for {policy_type} checkpoints; "
+                    "use the standard (sync) engine."
+                ),
+            }
 
     # Resolve the camera bindings against the robot record now (one small JSON
     # read, no hardware). A binding that names a camera the record doesn't have

--- a/makermodslab/schemas/jobs.py
+++ b/makermodslab/schemas/jobs.py
@@ -123,11 +123,18 @@ class CheckpointPolicyConfigResponse(BaseModel):
     null when the checkpoint omits the feature. trained_on_robot_type is the
     raw lerobot robot_type of the checkpoint's training dataset (recovered via
     train_config.json), null when it can't be established — the fine-tune
-    panel compares it against the selected dataset's arm."""
+    panel compares it against the selected dataset's arm.
+
+    supports_rtc says whether this architecture can run the Real-Time Chunking
+    inference engine; null means the policy type isn't one the server knows
+    (a fork newer than jobs.policy_type_supports_rtc's table), which the client
+    must read as "offer it and let the server decide", not as "no". The route
+    declares no exclude_none/exclude_unset, so the key is always present."""
 
     policy_type: str | None
     image_features: dict[str, CheckpointImageFeature]
     requires_task: bool
+    supports_rtc: bool | None
     state_dim: int | None
     action_dim: int | None
     trained_on_robot_type: str | None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4765,6 +4765,40 @@ def test_policy_config_summary_arm_is_none_when_unrecoverable(
     assert reg.get_policy_config_summary(rec.id, 0)["trained_on_robot_type"] is None
 
 
+@pytest.mark.parametrize(
+    ("policy_type", "expected"),
+    [("act", False), ("smolvla", True), ("some_future_policy", None)],
+)
+def test_policy_config_summary_reports_rtc_support(tmp_path, tmp_lerobot_home, policy_type, expected) -> None:
+    """The launch UI gates its inference-engine choice on this, so the key is
+    always present — null meaning "unknown type", not "no"."""
+    from makermodslab.jobs import JobRegistry
+
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text(_json.dumps({"type": policy_type}))
+
+    reg = JobRegistry(tmp_path / "root")
+    rec = reg.register_imported(str(model))
+    summary = reg.get_policy_config_summary(rec.id, 0)
+    assert "supports_rtc" in summary
+    assert summary["supports_rtc"] is expected
+
+
+def test_policy_config_summary_rtc_is_none_when_the_type_is_unreadable(tmp_path, tmp_lerobot_home) -> None:
+    from makermodslab.jobs import JobRegistry
+
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text(_json.dumps({"input_features": {}}))
+
+    reg = JobRegistry(tmp_path / "root")
+    rec = reg.register_imported(str(model))
+    summary = reg.get_policy_config_summary(rec.id, 0)
+    assert summary["policy_type"] is None
+    assert summary["supports_rtc"] is None
+
+
 # --- Deliberate stop vs genuine failure -------------------------------------
 #
 # Regression cover for the defect where every press of Stop landed in run

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -1032,6 +1032,174 @@ def test_handle_start_inference_rejects_non_positive_ensemble_coeff() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Real-Time Chunking capability — the table, and the pre-flight guard that
+# refuses an rtc launch on an architecture that cannot run it. Both matter
+# because the fork only discovers this AFTER the policy is loaded and the arm
+# is claimed (lerobot/rollout/context.py, supports_rtc_inference).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("policy_type", "expected"),
+    [
+        # Declare supports_rtc() -> True in the pinned fork.
+        ("smolvla", True),
+        ("pi0", True),
+        ("pi05", True),
+        ("evo1", True),
+        ("groot", True),
+        # Per-CONFIG in the fork (inference_action_mode == "continuous"), so the
+        # architecture answer is True and the subprocess enforces the rest.
+        ("molmoact2", True),
+        # Inherit PreTrainedPolicy.supports_rtc -> False.
+        ("act", False),
+        ("diffusion", False),
+        ("tdmpc", False),
+        ("vqbet", False),
+        # The sibling that does NOT support it, unlike pi0/pi05.
+        ("pi0_fast", False),
+        # Not registered in the pinned fork: "not established", never "no".
+        ("some_future_policy", None),
+        ("", None),
+    ],
+)
+def test_policy_type_supports_rtc_decisions(policy_type: str, expected: bool | None) -> None:
+    from makermodslab.rollout import policy_type_supports_rtc
+
+    assert policy_type_supports_rtc(policy_type) is expected
+
+
+def test_rtc_table_matches_the_pinned_fork() -> None:
+    """Drift guard: the table is a hand-mirrored read of lerobot's policy
+    classes, so re-derive it from the fork's SOURCES on every run.
+
+    Reads the files rather than importing them — importing
+    lerobot.policies.factory costs ~2 s and pulls transformers, which is
+    exactly the cost policy_type_supports_rtc exists to avoid.
+    """
+    import re as _re
+
+    import lerobot.policies as _policies_pkg
+    from makermodslab.jobs import _KNOWN_POLICY_TYPES, _RTC_CAPABLE_POLICY_TYPES
+
+    root = Path(_policies_pkg.__file__).parent
+    registered: set[str] = set()
+    declares_rtc: set[str] = set()
+    for cfg in root.rglob("configuration_*.py"):
+        for name in _re.findall(r'@PreTrainedConfig\.register_subclass\("([^"]+)"\)', cfg.read_text()):
+            registered.add(name)
+            modeling = cfg.with_name(cfg.name.replace("configuration_", "modeling_", 1))
+            if modeling.is_file() and "def supports_rtc(" in modeling.read_text():
+                declares_rtc.add(name)
+
+    assert registered, f"no registered policy types found under {root}"
+    assert registered == set(_KNOWN_POLICY_TYPES)
+    assert declares_rtc == set(_RTC_CAPABLE_POLICY_TYPES)
+
+
+def _rtc_request(policy_ref: str = "user/repo@checkpoints/000050", **kwargs):
+    from makermodslab.rollout import InferenceRequest
+
+    return InferenceRequest(
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        policy_ref=policy_ref,
+        inference_engine="rtc",
+        **kwargs,
+    )
+
+
+def test_handle_start_inference_refuses_rtc_on_an_act_checkpoint(monkeypatch) -> None:
+    """400 in the launch panel, before the model download and before any port
+    is opened — and the session slot is handed back."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "read_pretrained_policy_type", lambda ref: "act")
+    monkeypatch.setattr(
+        rollout.camera_preview_manager,
+        "stop_all",
+        lambda: pytest.fail("refused start must not disturb the camera previews"),
+    )
+    monkeypatch.setattr(
+        rollout.threading, "Thread", lambda *a, **k: pytest.fail("no startup worker may spawn")
+    )
+
+    result = rollout.handle_start_inference(_rtc_request())
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert result["message"] == (
+        "Real-Time Chunking isn't available for act checkpoints; use the standard (sync) engine."
+    )
+    assert rollout.inference_active is False
+
+
+def test_handle_start_inference_allows_rtc_on_a_supporting_checkpoint(monkeypatch) -> None:
+    """A smolvla checkpoint passes the RTC gate — proven by the request landing
+    on the NEXT guard (camera bindings with no robot record) instead."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(rollout, "read_pretrained_policy_type", lambda ref: "smolvla")
+
+    result = rollout.handle_start_inference(_rtc_request(camera_bindings={"front": "wrist"}))
+
+    assert result["success"] is False
+    assert "Real-Time Chunking" not in result["message"]
+    assert "No robot selected" in result["message"]
+    assert rollout.inference_active is False
+
+
+def test_handle_start_inference_allows_rtc_on_an_unknown_policy_type(monkeypatch) -> None:
+    """A type newer than our table, and an unreadable config, both mean "not
+    established" — neither may refuse a run the subprocess would accept."""
+    from makermodslab import rollout
+
+    for policy_type in ("some_future_policy", None):
+        monkeypatch.setattr(rollout, "read_pretrained_policy_type", lambda ref, t=policy_type: t)
+        result = rollout.handle_start_inference(_rtc_request(camera_bindings={"front": "wrist"}))
+        assert "Real-Time Chunking" not in result["message"]
+        assert rollout.inference_active is False
+
+
+def test_handle_start_inference_reads_no_config_for_the_sync_engine(monkeypatch) -> None:
+    """sync runs on every architecture, so the gate must not cost a config read
+    (which is an hf_hub_download for a Hub ref) on the ordinary path."""
+    from makermodslab import rollout
+
+    monkeypatch.setattr(
+        rollout,
+        "read_pretrained_policy_type",
+        lambda ref: pytest.fail("sync must not read the checkpoint config"),
+    )
+    req = _rtc_request(camera_bindings={"front": "wrist"})
+    req.inference_engine = "sync"
+    result = rollout.handle_start_inference(req)
+    # Stopped by the NEXT guard (bindings with no robot record), not this one.
+    assert result["success"] is False
+    assert "No robot selected" in result["message"]
+
+
+def test_rtc_gate_asks_about_a_root_ref_by_its_bare_repo_id(monkeypatch) -> None:
+    """'user/repo@root' means the repo root IS the pretrained dir, which is
+    where read_pretrained_policy_type looks for a plain repo id. Passing the
+    suffixed ref through would fail the lookup and silently skip the guard."""
+    from makermodslab import rollout
+
+    seen: list[str] = []
+
+    def _record(ref: str) -> str:
+        seen.append(ref)
+        return "act"
+
+    monkeypatch.setattr(rollout, "read_pretrained_policy_type", _record)
+    result = rollout.handle_start_inference(_rtc_request(policy_ref="user/repo@root"))
+
+    assert seen == ["user/repo"]
+    assert result["status_code"] == 400
+    assert "Real-Time Chunking" in result["message"]
+
+
+# ---------------------------------------------------------------------------
 # handle_start_inference — the arm-count 409 guard (fires before any port opens)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> **Now based directly on `staging`** (was stacked on #108 → #107). Rebased on 2026-09-03: the two commits reference nothing from #108, and the DeployPanel hunks were re-applied onto `staging`'s current layout (same +/- lines, one indentation level deeper). #107/#108 are not prerequisites.

Replaces #100 (frontend-only, now conflicting) with a server-side guard **plus** the dialog wiring driven by the new field.

## Why

The inference engine is a per-rollout choice. RTC only works for policies that implement guided chunk prediction; on ACT it failed inside the `lerobot-rollout` subprocess after the arm was already claimed. #100 hid the toggle for ACT alone, which under-covers (`pi0_fast`, `diffusion`, `tdmpc`, `vqbet`, … also cannot run it) and leaves the API accepting RTC from any non-UI client.

## What

- **`policy_type_supports_rtc(policy_type) -> bool | None`** in `jobs.py`. A hand-mirrored table of the pinned fork's classes rather than a live import: `import lerobot.policies.factory` costs ~2 s and pulls `transformers` into the API process, and the fork's `supports_rtc` is an instance method (MolmoAct2's reads its config), so class-level evaluation is not possible. Capable: `evo1`, `groot`, `pi0`, `pi05`, `smolvla`, `molmoact2`. Not capable: `act`, `diffusion`, `eo1`, `fastwam`, `gaussian_actor`, `lingbot_va`, `multi_task_dit`, `pi0_fast`, `tdmpc`, `vla_jepa`, `vqbet`, `wall_x`, `xvla`. Unknown → `None`, never refused.
- **Refusal before the arm is claimed** in `handle_start_inference`: only when `inference_engine == "rtc"` (sync starts read no config), a `repo@root` ref is normalised to the bare repo, and the 400 mirrors the coaching-mode RTC refusal (`_release_slot()` + dict shape, no new error code). Unreadable config and unknown types fail open; the subprocess still guards.
- **`/policy-config` gains `supports_rtc: bool | None`** beside `requires_task` (response model + OpenAPI snapshot; adds a required nullable field, no route or ratchet change).
- **Drift guard**: `test_rtc_table_matches_the_pinned_fork` re-derives both sets by reading the fork's `configuration_*.py` / `modeling_*.py` sources (no import), so a pin bump that adds a policy or an RTC override fails this test instead of silently under- or over-refusing.

## Decisions worth a look

- **MolmoAct2 is recorded as capable.** Its `supports_rtc` is per-checkpoint (`inference_action_mode == "continuous"`). The class implements RTC semantics, so refusing at the type level would block continuous-mode checkpoints RTC genuinely runs; a discrete-mode checkpoint + RTC still fails in the subprocess exactly as today.
- **`pi0_fast` lands on the refuse side**, unlike `pi0`/`pi05`: it has no `supports_rtc` override in the pin.

## Frontend half (second commit)

Both dialogs read `supports_rtc` from the checkpoint's policy config. When it is `false` the RTC option is disabled with a one-line explanation (disabled rather than hidden, so the missing engine is explained), and a stale RTC selection resets to sync in an effect so the request never carries it. `null`/absent still offers it; the server guards. Deploy's coach-mode forcing and coaching note are untouched. Strings in en + zh-CN; the mock Hub payload mirrors the capability table.

**Manual checklist**: ACT checkpoint ⇒ RTC greyed out with the explanation line; SmolVLA/pi0/pi05 ⇒ RTC selectable; select RTC on SmolVLA then switch to an ACT checkpoint ⇒ snaps back to Sync and Start launches without a 400; same in the Launchpad inference modal and once in 中文.

## Checks

Frontend: `tsc` both projects clean; lint delta 0 vs the 37-problem baseline; vitest 241/241 across i18n, studio, inference and lib; build ok, `frontend/dist` untouched.

Backend: 
`pytest tests/test_rollout.py tests/test_jobs.py tests/test_api_contract.py tests/test_api_errors.py`: 719 passed (incl. `test_openapi_snapshot_is_fresh`). ruff check/format clean; pre-commit (mypy, bandit, openapi regen) passes. Note: with `HF_HUB_OFFLINE=1` set, 10 unrelated cloud-upload tests in `test_jobs.py` fail; unset, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


