### PR TITLE
fix(replay): accept a settled ease-in by measured residual; refuse cross-arm-type datasets

### DIFF
--- a/makermodslab/replay.py
+++ b/makermodslab/replay.py
@@ -39,12 +39,17 @@ from pydantic import BaseModel
 from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 
 from .api_errors import ErrorCode
-from .arm_capabilities import uses_feetech_bus
+from .arm_capabilities import ARM_TYPE_LABEL, arm_type_from_robot_type, uses_feetech_bus
 from .arm_identity import verify_devices
-from .datasets import get_episode_action_series
+from .datasets import get_episode_action_series, read_dataset_robot_type
 from .maker_rest_pose import capture_maker_pose, return_maker_to_pose
 from .motor_power import FOLLOWER, clear_goal_velocity, reset_torque_limit
-from .rest_pose import RETURN_CEILING_S, capture_rest_pose, return_to_rest_pose
+from .rest_pose import (
+    RETURN_CEILING_S,
+    _clamp_to_representable_range,
+    capture_rest_pose,
+    return_to_rest_pose,
+)
 from .session_events import notify_session_changed
 from .teleoperate import _cleanup_after_setup_failure, force_disable_torque
 from .torque import release_maker_torque
@@ -77,6 +82,27 @@ EASE_ARRIVE_TOLERANCE = 2.0
 # docstring). Keeps the same 0.5x-of-arrival-tolerance ratio as the raw-ticks
 # defaults (RETURN_STALL_MIN_PROGRESS=10 is half of RETURN_ARRIVE_TOLERANCE=20).
 EASE_STALL_MIN_PROGRESS = 1.0
+
+# How far a *settled* ease-in may still be from frame 0 and still be good
+# enough to start playback, in the same normalized units as
+# EASE_ARRIVE_TOLERANCE (~9-10 deg on the arm joints).
+#
+# EASE_ARRIVE_TOLERANCE's 2.0 units is ~22-39 ticks (~2-3 deg), which sits
+# INSIDE the standing error an STS3215 holds in position mode at lerobot's
+# P=16 — and frame 0 of a recorded episode routinely parks joints against
+# their calibrated endpoints (shoulder_lift recorded at -103 and clamped to
+# the -100 hard stop, elbow near +96, a gripper under a torque cap), which is
+# exactly where that error is largest. Teleop and record run the same return
+# loop and merely LOG a "settled" verdict; replay's ease-in was the one place
+# it was fatal, and exactness doesn't matter here: the ease-in exists only so
+# frame 0 doesn't snap the arm from wherever it happened to be, so a joint a
+# few units short just means the first send_action moves it a few more
+# degrees. A `settled` whose largest per-joint |present - target| is at or
+# under this bound is therefore accepted (loudly) and playback starts; a
+# `settled` with a LARGER residual — and every `stalled` / `ceiling` /
+# `comm-error` / `no-pose` verdict — stays fatal, because those mean a stuck
+# or latched joint, or an arm posed genuinely far from frame 0.
+EASE_SETTLED_MAX_RESIDUAL = 10.0
 
 # How far behind real time a frame may be before it is dropped rather than
 # fired late. Below this, ordinary jitter is absorbed by the pacing wait; above
@@ -240,6 +266,29 @@ def handle_start_replay(request: ReplayRequest, websocket_manager=None) -> dict[
                 "success": False,
                 "status_code": 400,
                 "message": "Could not read this episode's recorded actions — it may not be downloaded locally yet.",
+            }
+
+        # Joint NAMES can match while the arm family doesn't: Maker and Metal
+        # share all seven, and only their units differ, so neither the
+        # action_features comparison below nor the frame-0 bus keying can tell
+        # them apart. lerobot tags the recording robot in the dataset's
+        # meta/info.json, so check that FIRST — before _connect_follower, so a
+        # refused replay never energizes the arm.
+        #
+        # An untagged, imported or community dataset resolves to None, and that
+        # stays SILENT (same rule the merge / cross-arm fine-tune warnings
+        # follow): "not established" is not "mismatched", and the joint-name
+        # checks below remain the guard for those, exactly as before.
+        dataset_arm = arm_type_from_robot_type(read_dataset_robot_type(request.repo_id))
+        if dataset_arm is not None and dataset_arm != request.arm_type:
+            robot_label = ARM_TYPE_LABEL.get(request.arm_type, f"a {request.arm_type} arm")
+            return {
+                "success": False,
+                "status_code": 400,
+                "message": (
+                    f"This dataset was recorded on {ARM_TYPE_LABEL[dataset_arm]}, but the "
+                    f"connected robot is {robot_label} — replay it on a matching robot."
+                ),
             }
 
         try:
@@ -415,6 +464,35 @@ def _bus_keyed(action: dict[str, float], bus) -> dict[str, float]:
     return keyed
 
 
+def _ease_in_residual(bus, targets: dict[str, float]) -> dict[str, float] | None:
+    """Per-joint |present - target| after a `settled` ease-in, normalized units.
+
+    Read fresh rather than parsed out of return_to_rest_pose's reason string:
+    the reason is prose meant for humans, and (bool, str) is the contract every
+    teleop/record caller of return_to_rest_pose depends on, so the verdict is
+    not the place to smuggle numbers through. Compares against the SAME clamped
+    targets the return itself drove to (_clamp_to_representable_range) — a
+    recorded action beyond a motor's calibrated span is clamped on both the
+    write and the read path, so an unclamped comparison would measure a joint
+    resting perfectly on its hard stop as several units off.
+
+    Returns None when the read fails or reports no motor we have a target for;
+    the caller must treat that as "unknown", i.e. keep the fatal path.
+    """
+    clamped = _clamp_to_representable_range(getattr(bus, "motors", None) or {}, targets)
+    try:
+        positions = bus.sync_read("Present_Position", normalize=True)
+    except Exception as e:
+        logger.warning(f"Could not measure how far the ease-in settled from the first frame: {e}")
+        return None
+    residual = {
+        motor: abs(float(positions[motor]) - float(target))
+        for motor, target in clamped.items()
+        if motor in positions
+    }
+    return residual or None
+
+
 def _ensure_uncapped(robot: SO101Follower, label: str) -> None:
     """Clear the RAM Goal_Velocity profile cap and verify it actually took.
 
@@ -513,6 +591,31 @@ def _replay_worker(
                     abort_event=_stop_event,
                     label="follower arm",
                 )
+            # A `settled` verdict says every motor STOPPED short of target, which
+            # on this arm is the ordinary outcome of easing into a frame 0 that
+            # parks joints on their endpoints — not a fault. Measure how short it
+            # actually stopped and start playback anyway when that is within
+            # EASE_SETTLED_MAX_RESIDUAL (Feetech only: the CAN return already
+            # judges by convergence and has no equivalent verdict).
+            settled_too_far: tuple[str, float] | None = None
+            if not arrived and feetech and reason.startswith("settled"):
+                residual = _ease_in_residual(robot.bus, _bus_keyed(frame0, robot.bus))
+                if residual is not None:
+                    worst_joint, worst = max(residual.items(), key=lambda item: item[1])
+                    if worst <= EASE_SETTLED_MAX_RESIDUAL:
+                        logger.warning(
+                            "Ease-in settled %.1f normalized units short of the episode's first "
+                            "frame on %s (%s), within the %.1f-unit bound — starting playback; the "
+                            "first frames will carry those joints the rest of the way",
+                            worst,
+                            worst_joint,
+                            ", ".join(f"{m}={d:.1f}" for m, d in sorted(residual.items())),
+                            EASE_SETTLED_MAX_RESIDUAL,
+                        )
+                        arrived = True
+                    else:
+                        settled_too_far = (worst_joint, worst)
+
             if not arrived and reason != "cut-short":
                 with _state_lock:
                     _replay_meta["phase"] = "error"
@@ -522,10 +625,19 @@ def _replay_worker(
                     # generic guess — the frontend shows hint in preference to
                     # error, so a static "may be posed too far" message was
                     # hiding the real diagnosis from the user.
-                    _replay_meta["hint"] = (
-                        f"The arm didn't settle at this episode's starting position ({reason}). "
-                        "Try again, or reposition it closer first."
-                    )
+                    if settled_too_far is not None:
+                        worst_joint, worst = settled_too_far
+                        _replay_meta["hint"] = (
+                            "The arm didn't settle at this episode's starting position: "
+                            f"{worst_joint} stopped {worst:.1f} normalized units away, past the "
+                            f"{EASE_SETTLED_MAX_RESIDUAL:.0f}-unit bound for starting playback "
+                            f"({reason}). Try again, or reposition it closer first."
+                        )
+                    else:
+                        _replay_meta["hint"] = (
+                            f"The arm didn't settle at this episode's starting position ({reason}). "
+                            "Try again, or reposition it closer first."
+                        )
                 # Fall through to the graceful return below instead of
                 # returning here — an ease-in that didn't arrive still left
                 # the arm mid-air under torque, and the drop straight to

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -34,6 +34,12 @@ def _reset_replay_globals(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(replay, "replay_thread", None)
     monkeypatch.setattr(replay, "_replay_meta", {})
     monkeypatch.setattr(replay, "_replay_started_at", None)
+    # _stop_event is a real Event, not reassignable state monkeypatch can undo:
+    # a test that drives handle_stop_replay leaves it SET, which would make the
+    # next worker test skip playback before it began. Clear it on both edges.
+    replay._stop_event.clear()
+    yield
+    replay._stop_event.clear()
 
 
 def _stub_request():
@@ -171,6 +177,92 @@ def test_handle_start_replay_rejects_action_name_mismatch(monkeypatch) -> None:
     assert result["success"] is False
     assert result["status_code"] == 400
     assert "match" in result["message"].lower() or "joint" in result["message"].lower()
+
+
+# --- cross-arm datasets are refused before the arm is energized --------------
+#
+# The joint-name checks catch SO-101 (6 joints) vs Maker/Metal (7), but Maker
+# and Metal share all seven names and differ only in their action units, so a
+# Metal dataset replayed on a Maker arm passed every existing check. lerobot
+# tags the recording robot in meta/info.json; an untagged or community dataset
+# resolves to None and must stay allowed (silence, not a false alarm).
+
+
+def _arm_type_case(monkeypatch, robot_type, arm_type, motors=("shoulder_pan", "gripper")):
+    """Start a replay whose dataset carries `robot_type` against a robot of
+    `arm_type`; the dataset's joint names deliberately don't map, so a start
+    that gets PAST the arm-type check still fails — on the joint-name message,
+    with _connect_follower recorded as called."""
+    from makermodslab.replay import ReplayRequest, handle_start_replay
+
+    monkeypatch.setattr("makermodslab.replay.read_dataset_robot_type", lambda repo_id: robot_type)
+    monkeypatch.setattr(
+        "makermodslab.replay.get_episode_action_series",
+        lambda repo_id, episode_index: {
+            "action_names": [f"{m}.pos" for m in motors],
+            "timestamps": [0.0],
+            "values": [[1.0, 2.0]],
+        },
+    )
+
+    class _FakeRobot:
+        action_features = {"a_joint_this_dataset_never_names.pos": float}
+
+    connects: list[str] = []
+
+    def _connect(request):
+        connects.append(request.arm_type)
+        return _FakeRobot(), []
+
+    monkeypatch.setattr("makermodslab.replay._connect_follower", _connect)
+    monkeypatch.setattr("makermodslab.replay._cleanup_after_setup_failure", lambda *a, **k: None)
+
+    request = ReplayRequest(
+        repo_id="alice/pick",
+        episode_index=0,
+        follower_port="/dev/ttyUSB0",
+        follower_config="robot_a",
+        arm_type=arm_type,
+    )
+    return handle_start_replay(request), connects
+
+
+def test_handle_start_replay_rejects_a_maker_dataset_on_an_so101(monkeypatch) -> None:
+    result, connects = _arm_type_case(monkeypatch, "maker_follower", "so101")
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "Maker arm" in result["message"] and "SO-101 arm" in result["message"]
+    assert connects == []  # refused BEFORE the arm was energized
+
+
+def test_handle_start_replay_rejects_a_metal_dataset_on_a_maker_arm(monkeypatch) -> None:
+    """The case the joint-name checks structurally cannot catch: same seven
+    names on both sides, different action units."""
+    result, connects = _arm_type_case(monkeypatch, "metal_follower", "maker")
+
+    assert result["success"] is False
+    assert result["status_code"] == 400
+    assert "Metal arm" in result["message"] and "Maker arm" in result["message"]
+    assert connects == []
+
+
+@pytest.mark.parametrize("robot_type", [None, "aloha", "so100", "", "koch_follower"])
+def test_handle_start_replay_allows_a_dataset_whose_arm_cant_be_established(monkeypatch, robot_type) -> None:
+    """None / unrecognized stays silent, and so100 normalises to so101 — all of
+    these must fall through to the existing joint-name check instead."""
+    result, connects = _arm_type_case(monkeypatch, robot_type, "so101")
+
+    assert result["success"] is False  # the joint-name check, not the arm check
+    assert "recorded on" not in result["message"]
+    assert connects == ["so101"]  # got past the arm-type check
+
+
+def test_handle_start_replay_allows_a_matching_arm_type(monkeypatch) -> None:
+    result, connects = _arm_type_case(monkeypatch, "bi_maker_follower", "maker")
+
+    assert "recorded on" not in result["message"]
+    assert connects == ["maker"]
 
 
 def test_handle_start_replay_returns_400_when_episode_has_no_action_data(monkeypatch) -> None:
@@ -606,6 +698,174 @@ def test_stop_and_wait_timeout_budgets_two_returns_not_one() -> None:
     from makermodslab.rest_pose import RETURN_CEILING_S
 
     assert _STOP_AND_WAIT_TIMEOUT_S >= 2 * RETURN_CEILING_S + 5.0
+
+
+# --- a settled-but-close ease-in must not abort the replay -------------------
+#
+# EASE_ARRIVE_TOLERANCE (2.0 normalized units, ~22-39 ticks) is inside the
+# standing error an STS3215 holds in position mode at lerobot's P=16, and frame
+# 0 routinely parks joints on their calibrated endpoints where that error is
+# largest — so the return loop reported "settled short of target" and replay
+# treated it as fatal ("The arm didn't settle at this episode's starting
+# position"). Observed on the so101-finc arm. The ease-in only exists so frame 0
+# doesn't snap the arm from wherever it was, so a few units short is fine;
+# a stuck joint, or an arm posed genuinely far away, is not.
+
+
+class _EaseBus:
+    """A bus that reports a fixed Present_Position for the residual read."""
+
+    def __init__(self, present, motors=None, read_raises=False):
+        self.motors = dict.fromkeys(present) if motors is None else motors
+        self.present = dict(present)
+        self.read_raises = read_raises
+        self.reads = 0
+
+    def sync_read(self, reg, normalize=True):
+        assert reg == "Present_Position"
+        self.reads += 1
+        if self.read_raises:
+            raise RuntimeError("bus gone")
+        return dict(self.present)
+
+    def disconnect(self, disable_torque=False):
+        pass
+
+
+class _EaseRobot:
+    def __init__(self, bus):
+        self.bus = bus
+        self.actions: list[dict] = []
+
+    def send_action(self, action):
+        self.actions.append(dict(action))
+
+    def get_observation(self):
+        return {}
+
+
+_EASE_FRAMES = {
+    "action_names": ["shoulder_pan.pos", "gripper.pos"],
+    "timestamps": [0.0, 0.01],
+    "values": [[10.0, 1.0], [11.0, 1.0]],
+}
+
+
+def _run_ease_in_worker(monkeypatch, verdict, bus):
+    """Drive _replay_worker with a canned ease-in verdict and a fake bus."""
+    from makermodslab import replay
+
+    monkeypatch.setattr(replay, "replay_active", True)
+    monkeypatch.setattr(replay, "capture_rest_pose", lambda bus, normalize=False: {"shoulder_pan": 10})
+    monkeypatch.setattr(replay, "_ensure_uncapped", lambda robot, label: None)
+    monkeypatch.setattr(replay, "force_disable_torque", lambda robot, label: None)
+
+    def fake_return_to_rest_pose(
+        bus, target, abort_event=None, label="arm", normalize=False, tolerance=None, stall_min_progress=None
+    ):
+        # normalize=True is the ease-in; the raw-ticks call is the stopping return.
+        return verdict if normalize else (True, "returned: max delta 0 ticks ()")
+
+    monkeypatch.setattr(replay, "return_to_rest_pose", fake_return_to_rest_pose)
+
+    robot = _EaseRobot(bus)
+    replay._replay_worker(robot, _EASE_FRAMES, None)
+    return replay, robot
+
+
+def test_ease_in_settled_within_the_bound_plays_the_episode(monkeypatch, caplog) -> None:
+    """shoulder_pan stops 4.0 units short of frame 0 — inside the bound, so
+    playback runs and the session ends clean."""
+    bus = _EaseBus({"shoulder_pan": 6.0, "gripper": 1.0})
+    verdict = (False, "settled short of target after 3.0s, remaining 4.0 units (shoulder_pan=4.0)")
+
+    with caplog.at_level("WARNING"):
+        replay, robot = _run_ease_in_worker(monkeypatch, verdict, bus)
+
+    assert len(robot.actions) == len(_EASE_FRAMES["timestamps"])  # every frame sent
+    assert replay._replay_meta["phase"] == "done"
+    assert replay._replay_meta.get("error") is None
+    assert replay._replay_meta.get("hint") is None
+    assert any("starting playback" in r.getMessage() for r in caplog.records)
+
+
+def test_ease_in_settled_too_far_stays_fatal_and_names_the_joint(monkeypatch) -> None:
+    """15 units short is not the servo's standing error — it is an arm posed
+    somewhere else, or a joint that gave up."""
+    bus = _EaseBus({"shoulder_pan": -5.0, "gripper": 1.0})
+    verdict = (False, "settled short of target after 3.0s, remaining 15.0 units (shoulder_pan=15.0)")
+
+    replay, robot = _run_ease_in_worker(monkeypatch, verdict, bus)
+
+    assert robot.actions == []  # playback never started
+    assert replay._replay_meta["phase"] == "error"
+    hint = replay._replay_meta["hint"]
+    assert "starting position" in hint
+    assert "shoulder_pan" in hint
+    assert "15.0" in hint
+
+
+def test_ease_in_stalled_stays_fatal_even_when_the_arm_is_at_target(monkeypatch) -> None:
+    """Only `settled` is forgiven — a stalled joint is still fighting, and the
+    verdict must not be re-litigated by a Present_Position read."""
+    bus = _EaseBus({"shoulder_pan": 10.0, "gripper": 1.0})
+    verdict = (False, "stalled after 3.0s, remaining 0.0 units (shoulder_pan=0.0)")
+
+    replay, robot = _run_ease_in_worker(monkeypatch, verdict, bus)
+
+    assert bus.reads == 0  # no residual read on a non-settled verdict
+    assert robot.actions == []
+    assert replay._replay_meta["phase"] == "error"
+    assert "stalled" in replay._replay_meta["hint"]
+
+
+def test_ease_in_settled_stays_fatal_when_the_residual_read_fails(monkeypatch) -> None:
+    """An unmeasurable residual is unknown, not small — keep the fatal path."""
+    bus = _EaseBus({"shoulder_pan": 10.0, "gripper": 1.0}, read_raises=True)
+    verdict = (False, "settled short of target after 3.0s, remaining 4.0 units (shoulder_pan=4.0)")
+
+    replay, robot = _run_ease_in_worker(monkeypatch, verdict, bus)
+
+    assert bus.reads == 1
+    assert robot.actions == []
+    assert replay._replay_meta["phase"] == "error"
+
+
+def test_ease_in_residual_compares_against_the_clamped_target() -> None:
+    """A recorded -103 is clamped to the -100 the bus can actually write and
+    read back, so a joint resting on its hard stop is 0 units off, not 3."""
+    from lerobot.motors import MotorNormMode
+    from makermodslab.replay import _ease_in_residual
+
+    class _Motor:
+        def __init__(self, norm_mode):
+            self.norm_mode = norm_mode
+
+    class _Bus:
+        motors = {
+            "shoulder_lift": _Motor(MotorNormMode.RANGE_M100_100),
+            "gripper": _Motor(MotorNormMode.RANGE_0_100),
+        }
+
+        def sync_read(self, reg, normalize=True):
+            assert reg == "Present_Position" and normalize is True
+            return {"shoulder_lift": -100.0, "gripper": 2.5}
+
+    residual = _ease_in_residual(_Bus(), {"shoulder_lift": -103.0, "gripper": 0.9})
+
+    assert residual == {"shoulder_lift": 0.0, "gripper": pytest.approx(1.6)}
+
+
+def test_ease_in_residual_is_none_when_no_motor_reads_back() -> None:
+    from makermodslab.replay import _ease_in_residual
+
+    class _Bus:
+        motors = {"shoulder_pan": None}
+
+        def sync_read(self, reg, normalize=True):
+            return {}
+
+    assert _ease_in_residual(_Bus(), {"shoulder_pan": 1.0}) is None
 
 
 def test_replay_status_elapsed_freezes_once_the_session_ends(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

Replaying an SO-101 dataset on a second, well-calibrated SO-101 (`so101-finc`) failed every time with:

> The arm didn't settle at this episode's starting position (settled short of target after …)

The ease-in to frame 0 uses `return_to_rest_pose(normalize=True, tolerance=EASE_ARRIVE_TOLERANCE=2.0)`. 2.0 normalized units is ~22–39 ticks (~2–3°), which sits **inside** the standing error an STS3215 holds in position mode at lerobot's P=16 — and frame 0 of every recorded episode parks joints on their calibrated endpoints (shoulder_lift recorded at −103 and clamped to the −100 hard stop, elbow near +96, the gripper under its 50 % torque cap), exactly where that error is largest. Teleop and record run the same return loop and merely log a `settled` verdict; replay's ease-in was the one place it was fatal, and exactness does not matter there: the ease-in exists only so frame 0 doesn't snap the arm. The `home` arm happened to land inside tolerance; the finc arm's motors sit a few ticks differently.

## Change

**Ease-in (`_replay_worker`, Feetech only)**
- New `EASE_SETTLED_MAX_RESIDUAL = 10.0` beside the existing ease-in constants, with the reasoning in the comment.
- After a `settled` verdict, `_ease_in_residual()` takes one fresh normalized `Present_Position` read against the same `_clamp_to_representable_range` targets the return drove to. If the worst joint is within the bound, a warning names every joint's delta and playback starts through the unchanged branch (`_ensure_uncapped`, phase `playing`, pacing loop).
- Settled past the bound, `stalled`, `ceiling`, `comm-error`, `no-pose` and an unreadable read stay fatal. The settled-too-far hint now names the joint, its distance and the bound.
- `return_to_rest_pose` / `_run_return_loop` keep their `(bool, str)` contract; the vendored autocal twin and the CAN branch are untouched.

**Cross-arm-type refusal (`handle_start_replay`)**
- Before `_connect_follower` — so a refused replay never energizes the arm — the dataset's `robot_type` is mapped through `arm_type_from_robot_type` (the same helper the merge / fine-tune cross-arm warnings use) and compared with the robot record's `arm_type`. A definite mismatch returns 400 naming both arms via `ARM_TYPE_LABEL`.
- This closes the hole the joint-name check misses: Maker and Metal share all seven joint names and differ only in units. Untagged / community datasets resolve to `None` and stay silent (`so100` counts as SO-101), falling through to the existing joint-name checks exactly as before.
- No new `ErrorCode`, no route or schema change; `docs/api/openapi.json` is unchanged.

## Tests

`tests/test_replay.py`: 32 → 45. Settled-within-bound plays every frame and ends `done`; settled-too-far → `error` with a hint naming the joint; `stalled` stays fatal and performs no residual read; a raising read stays fatal; `_ease_in_residual` clamping (−103 target vs −100 read is residual 0); maker-on-so101 and metal-on-maker refused with `_connect_follower` never called; `None` / `""` / `aloha` / `so100` / `koch_follower` fall through; matching types pass.

ruff clean, `pre-commit run --all-files` all 20 hooks passed on this diff.

## Not in scope

A calibration-identity guard: datasets carry only `robot_type` (no calibration name or ranges), so there is nothing to compare at replay time. Normalized units are calibration-relative, which is the only implicit protection today. A real guard needs the recorder to stamp calibration identity into the dataset first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
