### PR TITLE
fix(cameras): preview requests 640x480 so a third USB 2 camera can stream

### DIFF
--- a/makermodslab/camera_preview.py
+++ b/makermodslab/camera_preview.py
@@ -35,6 +35,19 @@ logger = logging.getLogger(__name__)
 TARGET_FPS = 15.0
 JPEG_QUALITY = 70
 
+# Capture resolution requested before the first read. Without a request cv2
+# takes the camera's DEFAULT format — 1920x1080 on the rig's KD-USB cameras —
+# and the UVC driver reserves isochronous bandwidth for that format's packet
+# size whether or not the (already MJPEG) frames fill it. Two 1080p
+# reservations exhaust one USB 2 hub, so a three-camera bimanual rig's third
+# preview opened but never delivered a frame (measured 2026-09-02: 25/25/0 fps
+# at default vs 30/30/30 fps at 640x480 on the same hub). A thumbnail needs no
+# more than the recorder's own 640x480; the camera's frame RATE is left alone
+# because `_frames` already paces clients to TARGET_FPS, and a camera-side cap
+# only slowed the first frame in testing.
+PREVIEW_WIDTH = 640
+PREVIEW_HEIGHT = 480
+
 # Same per-platform backend pin as recording (record._platform_backend) and the
 # /available-cameras enumeration: CAP_ANY can pick different backends across
 # calls on macOS, silently reordering indices, so a preview could show a
@@ -182,6 +195,11 @@ class CameraPreviewManager:
                             f"Camera {index} could not be opened — it may be unplugged or in use "
                             "by another application."
                         )
+                    # Request the thumbnail size BEFORE the first read (see
+                    # PREVIEW_WIDTH): the format negotiated here is what the
+                    # USB bandwidth reservation is sized for.
+                    cap.set(cv2.CAP_PROP_FRAME_WIDTH, PREVIEW_WIDTH)
+                    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, PREVIEW_HEIGHT)
                     entry.cap = cap
                     # Keep entry.index describing the handle that actually
                     # exists: this open may be a re-open of an entry created

--- a/tests/test_camera_preview.py
+++ b/tests/test_camera_preview.py
@@ -40,9 +40,16 @@ class FakeVideoCapture:
         self.backend = backend
         self.opened = True
         self.released = False
+        # (prop, value) pairs in call order — the resolution request must land
+        # before the first read, so tests can assert on ordering too.
+        self.props: list[tuple[int, float]] = []
 
     def isOpened(self) -> bool:  # noqa: N802 — cv2's camelCase API
         return self.opened
+
+    def set(self, prop: int, value: float) -> bool:
+        self.props.append((prop, value))
+        return True
 
     def read(self):
         if not self.opened:
@@ -126,6 +133,25 @@ def test_two_clients_share_one_capture_last_release_frees_it(
     gen_b.close()
     assert fake_captures[0].released
     assert manager._captures == {}
+
+
+def test_preview_requests_thumbnail_resolution_before_first_read(
+    fake_captures: list[FakeVideoCapture],
+) -> None:
+    """The open path must ask for PREVIEW_WIDTH x PREVIEW_HEIGHT before a frame
+    is read: cv2 otherwise keeps the camera's default (1080p on the rig's USB
+    cameras) and its USB bandwidth reservation starves a third camera."""
+    manager = CameraPreviewManager()
+    gen = manager.open_stream(0)
+    next(gen)
+    gen.close()
+
+    cap = fake_captures[0]
+    assert cap.props == [
+        (camera_preview.cv2.CAP_PROP_FRAME_WIDTH, camera_preview.PREVIEW_WIDTH),
+        (camera_preview.cv2.CAP_PROP_FRAME_HEIGHT, camera_preview.PREVIEW_HEIGHT),
+    ]
+    assert (camera_preview.PREVIEW_WIDTH, camera_preview.PREVIEW_HEIGHT) == (640, 480)
 
 
 def test_distinct_indices_get_distinct_captures(fake_captures: list[FakeVideoCapture]) -> None:


### PR DESCRIPTION
## Summary
- The MJPEG preview never asked cv2 for a size, so each capture ran at the camera's default 1920x1080@30. The UVC driver reserves isochronous bandwidth for the negotiated format's packet size, and two 1080p reservations exhaust one USB 2 hub — a three-camera bimanual rig's third preview opened, returned 200, and never delivered a frame (the loser rotates with open order, so it looked like a flaky camera).
- `camera_preview._acquire` now requests `PREVIEW_WIDTH x PREVIEW_HEIGHT` (640x480, the recorder's own size) before the first read. The camera-side frame rate is left alone: `_frames` already paces clients to `TARGET_FPS`, and a camera cap only delayed the first frame in testing.
- Requesting MJPG would not have helped: macOS already negotiates MJPEG (the cameras' raw `yuvs` modes fall to 5 fps at 1080p), as `record.py` notes. Recording was never affected because it requests the record's size.

## Measurements (rig, three KD-USB cameras on one USB 2 hub, cv2 direct, 5 s)
| mode | cam 0 | cam 1 | cam 2 |
|---|---|---|---|
| default (1920x1080) | 25 fps | 25 fps | 0 fps, never a frame |
| 640x480 | 30 fps | 30 fps | 30 fps |
| 640x480 + CAP_PROP_FPS 15 | 15 fps | 15 fps | 13 fps, first frame 0.6 s |

Verified on the rig after a server restart: all three tiles live in the bimanual robot's settings.

## Tests
- `tests/test_camera_preview.py`: the fake capture records `set` calls; new `test_preview_requests_thumbnail_resolution_before_first_read`. 19 passed; ruff check/format clean.

Based on `main` (an ancestor of `staging`; the touched files are identical on both), so it applies to either branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
