### PR TITLE
studio: keep camera previews and the studio open across a visit

### DIFF
--- a/frontend/src/components/dialogs/RobotConfigDialog.tsx
+++ b/frontend/src/components/dialogs/RobotConfigDialog.tsx
@@ -79,6 +79,7 @@ import so101ManualStartPose from "@/assets/calibration/so101-manual-start-pose.j
 import CameraConfiguration, {
   CameraConfig,
 } from "@/components/recording/CameraConfiguration";
+import { readCamerasActive, writeCamerasActive } from "@/lib/cameraPrefs";
 import CalibrationLibrary from "@/components/calibration/CalibrationLibrary";
 import {
   Collapsible,
@@ -754,7 +755,16 @@ const RobotConfigWindow = ({
   // Off by default so merely opening the settings window never grabs a camera.
   // The user explicitly starts a scan, which is when cameras are turned on,
   // enumerated, and the browser permission prompt is requested.
-  const [camerasActive, setCamerasActive] = useState(false);
+  //
+  // Once they HAVE turned it on for this robot, that answer is remembered and
+  // replayed on the next open (see lib/cameraPrefs): the window mounts fresh
+  // every time, so without this the switch snapped back to off and previews
+  // had to be re-opened by hand after every visit. A robot the user has never
+  // switched on still reads false, so the "never grabs a camera on its own"
+  // property holds for the case it was written for.
+  const [camerasActive, setCamerasActive] = useState(() =>
+    readCamerasActive(robotName),
+  );
 
   // No releaseStreamsRef call here, on purpose. CameraConfiguration stays
   // mounted and drops its own streams when `active` goes false — that is what
@@ -763,6 +773,10 @@ const RobotConfigWindow = ({
   // would never come back.
   const handleCamerasActiveChange = (active: boolean) => {
     setCamerasActive(active);
+    // Persist on the user's gesture only. Writing from an effect on
+    // `camerasActive` would also persist states the code sets for its own
+    // reasons, which is not the same thing as what the user chose.
+    writeCamerasActive(robotName, active);
   };
 
   useEffect(() => {

--- a/frontend/src/components/studio/CollectHandoff.test.tsx
+++ b/frontend/src/components/studio/CollectHandoff.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { StudioProvider } from "@/contexts/StudioContext";
+
+// The upload hook talks to the backend and polls; the handoff's contract here
+// is only that it ASKS for the push, so the transport is stubbed out.
+const start = vi.fn(async () => null);
+vi.mock("@/hooks/useDatasetUpload", () => ({
+  useDatasetUpload: () => ({ uploading: false, start }),
+}));
+
+const setSelectedDataset = vi.fn();
+vi.mock("@/hooks/useSelectedDataset", () => ({
+  useSelectedDataset: () => ({ selectedDataset: null, setSelectedDataset }),
+}));
+
+import CollectHandoff from "./CollectHandoff";
+
+const setup = (
+  recorded: React.ComponentProps<typeof CollectHandoff>["recorded"],
+) => {
+  const onDismiss = vi.fn();
+  render(
+    <StudioProvider>
+      <CollectHandoff recorded={recorded} onDismiss={onDismiss} />
+    </StudioProvider>,
+  );
+  return { onDismiss };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("the handoff banner", () => {
+  it("renders nothing before a session has finished", () => {
+    const { container } = render(
+      <StudioProvider>
+        <CollectHandoff recorded={null} onDismiss={vi.fn()} />
+      </StudioProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the saved dataset and offers the next step", () => {
+    setup({ repo_id: "makermods/sock_sort", saved_episodes: 5 });
+    expect(screen.getByText(/makermods\/sock_sort/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /train on this/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hands dismissal back to the owner of the payload", () => {
+    const { onDismiss } = setup({ repo_id: "makermods/sock_sort" });
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});
+
+// These two are the reason the banner is rendered unconditionally in the
+// always-mounted Collect panel rather than only when someone is looking at it.
+// They used to run because a finished session NAVIGATED to the Launchpad,
+// mounting the banner there; the studio now stays open, so nothing else would
+// trigger them.
+describe("the side effects that used to ride on the navigation home", () => {
+  // Each case needs its OWN repo id: the auto-push is guarded by a
+  // module-level set of already-pushed ids, so reusing one here would report a
+  // missing upload that the guard had merely deduplicated.
+  it("preselects the fresh dataset so Train opens onto it", () => {
+    setup({ repo_id: "makermods/preselect", saved_episodes: 5 });
+    expect(setSelectedDataset).toHaveBeenCalledWith("makermods/preselect");
+  });
+
+  it("kicks off the Hub push for a namespaced repo", () => {
+    setup({ repo_id: "makermods/autopush", saved_episodes: 5 });
+    expect(start).toHaveBeenCalled();
+  });
+
+  // That guard is itself load-bearing — a remount must not fire a second,
+  // redundant upload of the same dataset.
+  it("does not push the same dataset twice", () => {
+    setup({ repo_id: "makermods/pushed_once", saved_episodes: 5 });
+    expect(start).toHaveBeenCalledTimes(1);
+    setup({ repo_id: "makermods/pushed_once", saved_episodes: 5 });
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  // A repo id with no namespace means the user wasn't logged in at record
+  // time, so a push could only 401.
+  it("stays manual when the repo has no namespace", () => {
+    setup({ repo_id: "sock_sort", saved_episodes: 5 });
+    expect(start).not.toHaveBeenCalled();
+  });
+});
+
+describe("a session that saved nothing", () => {
+  // Nothing is on disk, so there is no repo to train on, preselect or upload.
+  const empty = { repo_id: "makermods/gone", discarded_empty: true };
+
+  it("says so instead of offering a dataset", () => {
+    setup(empty);
+    expect(
+      screen.queryByRole("button", { name: /train on this/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("neither preselects nor uploads", () => {
+    setup(empty);
+    expect(setSelectedDataset).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/studio/CollectHandoff.tsx
+++ b/frontend/src/components/studio/CollectHandoff.tsx
@@ -1,42 +1,34 @@
 import React, { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { useLocation, useNavigate } from "react-router-dom";
 import { CheckCircle, Loader2, Trash2, Upload as UploadIcon, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-import { useStudio } from "@/contexts/StudioContext";
+import { useStudio, type RecordedInfo } from "@/contexts/StudioContext";
 import { useSelectedDataset } from "@/hooks/useSelectedDataset";
 import { useDatasetUpload } from "@/hooks/useDatasetUpload";
 import UploadDatasetDialog from "@/components/landing/UploadDatasetDialog";
 import MilestoneReveal from "@/components/onboarding/MilestoneReveal";
 import { useOnceFlag } from "@/lib/onboarding/storage";
 
-/** Router-state payload left by the Recording page when a session ends (see
- * Recording.tsx). Replaces the old /upload page hop. */
-interface RecordedInfo {
-  repo_id: string;
-  saved_episodes?: number;
-  // Set when the session saved zero episodes and the backend discarded the
-  // (empty) dataset directory — nothing is on disk.
-  discarded_empty?: boolean;
-}
-
 /**
- * Post-recording handoff banner on the Launchpad. Reads the `recorded` payload
- * the Recording page leaves in router state and offers the two next steps that
- * used to live on the /upload page + home info card: train on the just-recorded
- * dataset, or upload it to the Hub. Dismissible; clears the router state so it
- * doesn't resurrect on re-render.
+ * Post-recording handoff banner, rendered at the top of the studio's Collect
+ * panel. Offers the two next steps that used to live on the /upload page + home
+ * info card: train on the just-recorded dataset, or upload it to the Hub. It
+ * also carries two side effects that are the real payload — preselecting the
+ * dataset for Train, and kicking off the automatic Hub push — so it has to
+ * mount after every saved session, not just when someone is looking at it.
+ *
+ * The `recorded` payload comes from StudioContext. It used to arrive in router
+ * state, stamped by a navigate("/") that also closed the studio; a session now
+ * leaves the user in the studio, so there is no navigation to hang it on.
  */
-const CollectHandoff: React.FC = () => {
+const CollectHandoff: React.FC<{
+  recorded: RecordedInfo | null;
+  onDismiss: () => void;
+}> = ({ recorded, onDismiss }) => {
   const { t } = useTranslation();
-  const location = useLocation();
-  const navigate = useNavigate();
   const { setSelectedDataset } = useSelectedDataset();
   const { openStudio, collectForm } = useStudio();
-
-  const recorded = location.state?.recorded as RecordedInfo | undefined;
-  const [dismissed, setDismissed] = useState(false);
 
   const discardedEmpty = recorded?.discarded_empty ?? false;
   // A discarded (empty) session left nothing on disk, so there's no repo id to
@@ -56,28 +48,30 @@ const CollectHandoff: React.FC = () => {
     if (repoId) setSelectedDataset(repoId);
   }, [repoId, setSelectedDataset]);
 
+  // Keyed on the payload, NOT on mount. This banner used to remount for each
+  // session (it was driven by router state on a page the user navigated back
+  // to), so an empty dep array fired exactly once per recording. It now lives
+  // in the always-mounted Collect panel, where a mount-only effect would run
+  // once with no payload and never again — the milestone would never show.
+  // markSeen flips `seen` synchronously, so this settles after one pass.
   useEffect(() => {
     if (
+      recorded &&
       !discardedEmpty &&
-      (recorded?.saved_episodes ?? 0) > 0 &&
+      (recorded.saved_episodes ?? 0) > 0 &&
       !hasSeenRecordingMilestone
     ) {
       setShowRecordingMilestone(true);
       markRecordingMilestoneSeen();
     }
-    // Runs once for this recorded payload — hasSeenRecordingMilestone and
-    // markRecordingMilestoneSeen are stable for the component's lifetime.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [
+    recorded,
+    discardedEmpty,
+    hasSeenRecordingMilestone,
+    markRecordingMilestoneSeen,
+  ]);
 
-  if (!recorded || dismissed) return null;
-
-  const dismiss = () => {
-    setDismissed(true);
-    // Clear the router state so a reload / re-render doesn't bring the banner
-    // back for a session already handled.
-    navigate(".", { replace: true, state: null });
-  };
+  if (!recorded) return null;
 
   const trainOnThis = () => {
     if (!repoId) return;
@@ -156,7 +150,7 @@ const CollectHandoff: React.FC = () => {
             variant="ghost"
             size="icon"
             aria-label={t("studio.common.dismiss")}
-            onClick={dismiss}
+            onClick={onDismiss}
             className="h-7 w-7 shrink-0 text-muted-foreground"
           >
             <X className="h-4 w-4" />

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
 import { Check, GitMerge, RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,6 +21,7 @@ import { useStudio } from "@/contexts/StudioContext";
 import MergeDatasetsDialog from "@/components/landing/MergeDatasetsDialog";
 import type { MergeStatus } from "@/lib/replayApi";
 import RecordingForm from "@/components/studio/RecordingForm";
+import CollectHandoff from "@/components/studio/CollectHandoff";
 import RecordingSessionDialog, {
   RecordedInfo,
   RecordingConfig,
@@ -62,7 +62,6 @@ const CollectPanel: React.FC = () => {
   const { selectedRecord } = useRobots();
   const { datasets, loading: datasetsLoading, refresh } = useDatasets();
   const { selectedDataset, setSelectedDataset } = useSelectedDataset();
-  const navigate = useNavigate();
   const { toast } = useToast();
 
   // The recording-form draft lives in StudioContext so filled-in parameters
@@ -70,10 +69,11 @@ const CollectPanel: React.FC = () => {
   const {
     collectForm,
     updateCollectForm,
-    closeStudio,
     mergePrefill,
     clearMergePrefill,
     openStudio,
+    lastRecorded,
+    setLastRecorded,
   } = useStudio();
   const {
     formOpen,
@@ -240,27 +240,31 @@ const CollectPanel: React.FC = () => {
   };
 
   // Every exit path of the session dialog lands here. A `recorded` payload
-  // (clean finish / "keep episodes") closes the studio and stamps the router
-  // state the CollectHandoff banner reads — same contract the old /recording
-  // page fulfilled by navigating home.
+  // (clean finish / "keep episodes") hands the session off to the banner at the
+  // top of this panel.
+  //
+  // The studio deliberately stays OPEN. This used to closeStudio() and
+  // navigate("/") — the contract the old /recording page fulfilled by going
+  // home — which dropped the user on the Launchpad after every session, away
+  // from the library and Train panel that are the actual next steps. The
+  // payload moved to StudioContext at the same time, because with no
+  // navigation there is no router state to stamp.
   const handleRecordingExit = useCallback(
     (recorded?: RecordedInfo) => {
       setActiveRecording(null);
       setSessionCount((n) => n + 1);
       if (recorded) {
-        // A dataset was saved: fold the record-new form so the next studio
-        // visit opens onto the library (with the fresh dataset preselected by
-        // CollectHandoff). A discarded (empty) session keeps the form + draft
-        // open for a retry.
+        // A dataset was saved: fold the record-new form so the panel opens onto
+        // the library (with the fresh dataset preselected by CollectHandoff). A
+        // discarded (empty) session keeps the form + draft open for a retry.
         if (!recorded.discarded_empty) {
           updateCollectForm({ formOpen: false });
           setLibraryOpen(true);
         }
-        closeStudio();
-        navigate("/", { state: { recorded } });
+        setLastRecorded(recorded);
       }
     },
-    [closeStudio, navigate, updateCollectForm],
+    [setLastRecorded, updateCollectForm],
   );
 
   // Gate for the pinned Start button: robot ready + every required parameter
@@ -277,6 +281,14 @@ const CollectPanel: React.FC = () => {
         step="1"
         title={t("studio.collect.title")}
         dataTour="studio-collect"
+      />
+
+      {/* Post-session handoff. Renders nothing until a session saves something,
+          but stays mounted so its Hub auto-push and dataset preselection are
+          not conditional on the user looking at this panel. */}
+      <CollectHandoff
+        recorded={lastRecorded}
+        onDismiss={() => setLastRecorded(null)}
       />
 
       {/* Record new dataset — the form slides open in place (no dialog). */}

--- a/frontend/src/contexts/StudioContext.tsx
+++ b/frontend/src/contexts/StudioContext.tsx
@@ -9,6 +9,17 @@ import type { ResumeSeed } from "@/components/training/TrainingConfigurator";
 
 export type StudioPanel = "collect" | "train" | "deploy";
 
+/** What a finished recording session leaves behind for the Collect panel's
+ * handoff banner. Mirrors RecordingSessionDialog's RecordedInfo; declared here
+ * rather than imported so the provider doesn't depend on a dialog module. */
+export interface RecordedInfo {
+  repo_id: string;
+  saved_episodes?: number;
+  /** The session saved zero episodes and the backend discarded the (empty)
+   * dataset directory — nothing is on disk to train on or upload. */
+  discarded_empty?: boolean;
+}
+
 /** The Collect panel's recording-form draft. Lives in this provider (mounted
  * above the router) so filled-in parameters survive navigating to /recording
  * and back — the panel itself unmounts with the Launchpad route. */
@@ -137,6 +148,12 @@ interface StudioContextValue {
   /** Collect's recording-form draft — see CollectFormState. */
   collectForm: CollectFormState;
   updateCollectForm: (patch: Partial<CollectFormState>) => void;
+  /** The most recent finished recording session, or null once handled. Drives
+   * the Collect panel's handoff banner. Lives here rather than in router state
+   * because a session no longer sends the user back to the Launchpad — the
+   * studio stays open, so there is no navigation to hang the payload on. */
+  lastRecorded: RecordedInfo | null;
+  setLastRecorded: (recorded: RecordedInfo | null) => void;
 }
 
 const StudioContext = createContext<StudioContextValue | null>(null);
@@ -153,6 +170,7 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({
   const [mergePrefill, setMergePrefill] = useState<MergePrefill | null>(null);
   const [collectForm, setCollectForm] =
     useState<CollectFormState>(DEFAULT_COLLECT_FORM);
+  const [lastRecorded, setLastRecorded] = useState<RecordedInfo | null>(null);
 
   const updateCollectForm = useCallback(
     (patch: Partial<CollectFormState>) =>
@@ -206,6 +224,8 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({
       clearMergePrefill,
       collectForm,
       updateCollectForm,
+      lastRecorded,
+      setLastRecorded,
     }),
     [
       open,
@@ -223,6 +243,7 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({
       clearMergePrefill,
       collectForm,
       updateCollectForm,
+      lastRecorded,
     ],
   );
 

--- a/frontend/src/lib/cameraPrefs.test.ts
+++ b/frontend/src/lib/cameraPrefs.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { readCamerasActive, writeCamerasActive } from "./cameraPrefs";
+
+const KEY = "makermodslab.camerasActive";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("the camera switch is remembered per robot", () => {
+  // The point of the whole module: Robot settings mounts fresh on every open,
+  // so without this the switch snapped back to off and previews had to be
+  // reopened by hand after every visit.
+  it("replays a robot's switch-on across a remount", () => {
+    writeCamerasActive("desk_isaac", true);
+    expect(readCamerasActive("desk_isaac")).toBe(true);
+  });
+
+  // Cameras are a per-robot fact — a three-camera rig and a bare arm on the
+  // next bench must not inherit each other's answer.
+  it("does not leak one robot's answer to another", () => {
+    writeCamerasActive("desk_isaac", true);
+    expect(readCamerasActive("openbooth_lab_left")).toBe(false);
+  });
+
+  // Off is the default, so switching off has to restore the default rather
+  // than persist a second kind of "on".
+  it("forgets a robot switched back off", () => {
+    writeCamerasActive("desk_isaac", true);
+    writeCamerasActive("desk_isaac", false);
+    expect(readCamerasActive("desk_isaac")).toBe(false);
+    // Stored as an absence, not as `false` — the map only holds robots the
+    // user actually uses cameras with.
+    expect(JSON.parse(localStorage.getItem(KEY) ?? "{}")).toEqual({});
+  });
+
+  it("defaults a never-seen robot to off", () => {
+    expect(readCamerasActive("brand_new")).toBe(false);
+  });
+});
+
+describe("a corrupt or foreign value never breaks the dialog", () => {
+  // This key is read during the settings window's first render. A throw here
+  // would take the whole window down, so every bad shape has to read as "off"
+  // rather than propagate.
+  it.each([
+    ["unparsable", "{not json"],
+    ["an array", "[1,2,3]"],
+    ["a bare string", '"on"'],
+    ["null", "null"],
+  ])("reads %s as off", (_label, raw) => {
+    localStorage.setItem(KEY, raw);
+    expect(() => readCamerasActive("desk_isaac")).not.toThrow();
+    expect(readCamerasActive("desk_isaac")).toBe(false);
+  });
+
+  it("recovers by overwriting the bad value on the next write", () => {
+    localStorage.setItem(KEY, "{not json");
+    writeCamerasActive("desk_isaac", true);
+    expect(readCamerasActive("desk_isaac")).toBe(true);
+  });
+});

--- a/frontend/src/lib/cameraPrefs.ts
+++ b/frontend/src/lib/cameraPrefs.ts
@@ -1,0 +1,59 @@
+/**
+ * Remembers, per robot, whether the user had the Robot settings camera section
+ * switched on.
+ *
+ * The settings window mounts fresh on every open and unmounts on close, which
+ * is what makes its drafts reset — but it also meant the camera switch snapped
+ * back to off every time, so a user who had already configured and previewed
+ * their cameras had to turn them on again on each visit.
+ *
+ * Off is still the default for a robot the user has never turned cameras on
+ * for: opening the window must not grab a camera on its own. What is stored
+ * here is the user's own explicit switch-on, replayed — not a new decision made
+ * on their behalf.
+ *
+ * Keyed by robot because cameras are a per-robot fact: a rig with three USB
+ * cameras and a bare arm on the next bench should not inherit each other's
+ * answer. Stale entries for renamed or deleted robots are harmless — they are
+ * just booleans nothing reads.
+ */
+
+const KEY = "makermodslab.camerasActive";
+
+type PrefMap = Record<string, boolean>;
+
+const readAll = (): PrefMap => {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    // Anything but a plain object means the key was written by something else
+    // (or an older shape); treat it as absent rather than throwing on read.
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as PrefMap;
+  } catch {
+    // Unavailable (private mode, quota) or unparsable — default everyone off.
+    return {};
+  }
+};
+
+/** Whether this robot's camera section should come up already switched on. */
+export const readCamerasActive = (robotName: string): boolean =>
+  readAll()[robotName] === true;
+
+/** Record the user's switch position for this robot. */
+export const writeCamerasActive = (robotName: string, active: boolean): void => {
+  try {
+    const all = readAll();
+    // Delete rather than store `false`: off is the default, so an absent key
+    // says the same thing and the map stays as small as the set of robots the
+    // user actually uses cameras with.
+    if (active) all[robotName] = true;
+    else delete all[robotName];
+    localStorage.setItem(KEY, JSON.stringify(all));
+  } catch {
+    // storage unavailable — the in-memory switch still works for this visit
+  }
+};

--- a/frontend/src/pages/Launchpad.tsx
+++ b/frontend/src/pages/Launchpad.tsx
@@ -12,7 +12,6 @@ import NewPolicyBanner from "@/components/launchpad/NewPolicyBanner";
 import ActivityStrip from "@/components/launchpad/ActivityStrip";
 import LibrarySheet from "@/components/launchpad/LibrarySheet";
 import RobotCorner from "@/components/launchpad/RobotCorner";
-import CollectHandoff from "@/components/studio/CollectHandoff";
 import CoachHandoff from "@/components/studio/CoachHandoff";
 import StudioOverlay from "@/components/studio/StudioOverlay";
 import { useStudio } from "@/contexts/StudioContext";
@@ -76,7 +75,11 @@ const Launchpad = () => {
       {/* justify-center holds the whole stack (hero → banner) in the middle
           of the viewport rather than hugging the header. */}
       <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center gap-10 px-4 py-8 sm:px-6">
-        <CollectHandoff />
+        {/* No CollectHandoff here. It moved into the studio's Collect panel
+            when a finished recording session stopped closing the studio and
+            navigating home — there is no longer a router-state payload for a
+            Launchpad-level banner to read. CoachHandoff still works that way:
+            an inference session does return here. */}
         <CoachHandoff />
         <Hero search={search} onSearchChange={setSearch} />
         <PolicySlider search={search} />


### PR DESCRIPTION
Two ease-of-life fixes. Both come down to state being thrown away at a boundary the user did not think they were crossing.

## 1 · The camera switch is remembered per robot

Robot settings mounts fresh on every open — that is what makes its port and camera drafts reset. It also reset the camera switch, so after configuring and previewing your cameras you had to switch them back on every single visit.

The switch position is now stored per robot and replayed on the next open.

- **Off is still the default** for a robot nobody has ever turned cameras on for, so "opening the window never grabs a camera on its own" still holds for the case it was written for. What is stored is the user's own explicit switch-on, replayed — not a decision made on their behalf.
- **Keyed by robot**, because cameras are a per-robot fact: a three-camera rig and a bare arm on the next bench must not inherit each other's answer.
- Switching off **deletes** the entry rather than storing `false`, so the map only holds robots you actually use cameras with.
- Every bad stored shape reads as off. This key is read during the settings window's first render, so a throw there would take the whole window down.

## 2 · A finished recording session stays in the studio

`handleRecordingExit` used to `closeStudio()` and `navigate("/")` — the contract the old `/recording` page fulfilled by going home. It dropped you on the Launchpad after every session, away from the dataset library and Train panel that are the actual next steps. The studio now stays open.

That **moved the handoff banner**, because the banner was reached only *by* that navigation: its payload lived in router state, and with no navigation there is nothing to stamp. It now reads the payload from `StudioContext` and renders at the top of the Collect panel.

This is the part worth reviewing, because the banner is not just pixels — it also carries:

- the **dataset preselection** that makes Train open onto the fresh dataset, and
- the **automatic Hub push**.

Both have to happen after every saved session, not only when someone is looking at the banner, which is why it is rendered unconditionally in the always-mounted Collect panel and returns `null` until there is a payload.

One consequence caught on the way: the first-recording **milestone effect was keyed on mount**. That was once per session while the banner remounted on the Launchpad; in the always-mounted Collect panel it would have fired once with no payload and never again. It is keyed on the payload now.

`<CollectHandoff />` is removed from the Launchpad, where it can no longer receive anything. `CoachHandoff` is untouched — an inference session really does navigate home.

## Training was already correct

Worth stating plainly since it was part of the ask: **starting training already stayed in the studio and is unchanged.** `launchJob` calls `openJobMonitor`, which sets the studio open on the Train panel; its `navigate("/")` is guarded on being off-Launchpad and only exists so the legacy `/training` route lands where the overlay lives. Across the whole tree `closeStudio()` has exactly three call sites, all of them StudioOverlay's own ESC handler and close buttons — no training path closes the studio.

## Verification

- `npx tsc --noEmit` on both projects — clean
- `npm run lint` — no new errors (4 pre-existing: `ui/command.tsx`, `useSpotlightTarget.ts`, `tailwind.config.ts` ×2)
- `npx vitest run` — **288/288** pass, up from 270; **18 new tests** covering the storage helper (per-robot isolation, off-deletes, corrupt values) and the handoff's contract (render, preselection, auto-push, the no-double-push guard, discarded-empty sessions)
- All pre-commit hooks green
- Drove it in the running app: switch on → Quit → reopen comes back **on** with previews live; a second robot still defaults **off**; on→off clears the entry. Studio renders correctly with the new banner slot.

`frontend/dist/` deliberately not committed — CI rebuilds it on merge.