### PR TITLE
chore(deps): bump lerobot pin to pick up the leader unwrap fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ dependencies = [
     "websockets>=15.0.1",
     "uvicorn>=0.24.0",
     "psutil>=5.9.0",
-    # Pinned to makermods-robotics/lerobot @ arm/makermods-combined (b968c0c01), the
+    # Pinned to makermods-robotics/lerobot @ arm/makermods-combined (eaab69339), the
     # two-parent merge of robot/makermods-maker-arm (af9072a8c — the previous pin,
-    # via the Maker-Mods org) and arm/makermods-metal (2503a5d7a). Upstream v0.6.2
+    # via the Maker-Mods org) and arm/makermods-metal (85a3000d4). Upstream v0.6.2
     # base; a strict superset of the Maker-only pin, adding the Metal arm's
     # MetalFollower/BiMetalFollower (7-DOF Damiao CAN) and metal_leader stack.
     # Pinned by SHA, not branch name — a moving pin makes every unrelated failure
@@ -33,7 +33,7 @@ dependencies = [
     # Star Arm 102 leader speaks. NEVER the fork's `metal` extra here — it
     # drags in Pinocchio (`pin`, no Windows wheels) that only the
     # not-yet-integrated gravity leader needs.
-    "lerobot[core_scripts,feetech,training,maker,damiao,rebot] @ git+https://github.com/makermods-robotics/lerobot.git@b968c0c015e16699a225070f677dc644543707f0",
+    "lerobot[core_scripts,feetech,training,maker,damiao,rebot] @ git+https://github.com/makermods-robotics/lerobot.git@eaab69339120787948776e4354dcee09f501fd16",
     # Windows-only: real DirectShow camera names for /available-cameras so the
     # frontend can match a camera to its browser deviceId (issues #12, #16).
     # Guarded by try/except at the call site, so its absence degrades gracefully.

--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ wheels = [
 [[package]]
 name = "lerobot"
 version = "0.6.2"
-source = { git = "https://github.com/makermods-robotics/lerobot.git?rev=b968c0c015e16699a225070f677dc644543707f0#b968c0c015e16699a225070f677dc644543707f0" }
+source = { git = "https://github.com/makermods-robotics/lerobot.git?rev=eaab69339120787948776e4354dcee09f501fd16#eaab69339120787948776e4354dcee09f501fd16" }
 dependencies = [
     { name = "cmake" },
     { name = "draccus" },
@@ -1006,7 +1006,7 @@ test = [
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27" },
-    { name = "lerobot", extras = ["core-scripts", "feetech", "training", "maker", "damiao", "rebot"], git = "https://github.com/makermods-robotics/lerobot.git?rev=b968c0c015e16699a225070f677dc644543707f0" },
+    { name = "lerobot", extras = ["core-scripts", "feetech", "training", "maker", "damiao", "rebot"], git = "https://github.com/makermods-robotics/lerobot.git?rev=eaab69339120787948776e4354dcee09f501fd16" },
     { name = "makermodslab", extras = ["test"], marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psutil", specifier = ">=5.9.0" },


### PR DESCRIPTION
Bumps the `arm/makermods-combined` lerobot pin from `b968c0c01` to `eaab69339`, which merges in lerobot `85a3000d4` (fix(rebot_102_leader): unwrap raw angles in leader-frame degrees).

**Why:** the leader's multi-turn unwrap window was sized in follower degrees with only the direction's sign undone. For joints where the direction carries a scale — the Metal preset's `elbow_flex`, direction −0.667 — the window edge landed exactly on the leader's raw extreme, so any overshoot unwrapped a spurious full turn and the follower elbow snapped from its 180° limit to 0. The fix sizes the window as `range/direction` (identical behaviour when |direction| = 1) and adds regression tests.

**Scope:** `pyproject.toml` pin + comment, and the matching `uv.lock` re-resolve — only the lerobot rev changed (158 packages resolved, zero version drift). No source changes in lerobot's dependency set, so nothing else moves.

Validated in lerobot: all 11 `tests/teleoperators/test_rebot_102_leader.py` tests pass, including the two new regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3QDwTbkNZNyf6uYK7JNqd