### PR TITLE
fix(datasets): show a recorded dataset in the library without a reload

### DIFF
--- a/frontend/src/hooks/useDatasets.test.ts
+++ b/frontend/src/hooks/useDatasets.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { SessionChangedEvent } from "@/hooks/useActiveSession";
+
+// Hoisted so the (hoisted) vi.mock factories can close over them.
+// `api` is a stable reference on purpose — useDatasets' `refresh` is a
+// useCallback keyed on it, and a fresh object per render would re-fire its
+// mount effect forever.
+const h = vi.hoisted(() => ({
+  api: { baseUrl: "http://test", fetchWithHeaders: vi.fn() },
+  listDatasets: vi.fn(async () => []),
+  state: { sessionEvent: null as SessionChangedEvent | null },
+}));
+const { listDatasets } = h;
+
+vi.mock("@/contexts/ApiContext", () => ({ useApi: () => h.api }));
+vi.mock("@/lib/replayApi", () => ({ listDatasets: h.listDatasets }));
+vi.mock("@/hooks/useActiveSession", () => ({
+  useSessionEvent: () => h.state.sessionEvent,
+}));
+
+import { useDatasets } from "./useDatasets";
+
+const evt = (over: Partial<SessionChangedEvent>): SessionChangedEvent => ({
+  kind: "recording",
+  active: false,
+  phase: null,
+  receivedAt: Date.now(),
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.state.sessionEvent = null;
+});
+
+describe("useDatasets session-event refetch", () => {
+  it("refetches when a recording session ends", async () => {
+    const { rerender } = renderHook(() => useDatasets());
+    await waitFor(() => expect(listDatasets).toHaveBeenCalledTimes(1));
+
+    h.state.sessionEvent = evt({ kind: "recording", active: false });
+    rerender();
+
+    await waitFor(() => expect(listDatasets).toHaveBeenCalledTimes(2));
+  });
+
+  it("refetches when an inference (coaching) session ends", async () => {
+    const { rerender } = renderHook(() => useDatasets());
+    await waitFor(() => expect(listDatasets).toHaveBeenCalledTimes(1));
+
+    h.state.sessionEvent = evt({ kind: "inference", active: false });
+    rerender();
+
+    await waitFor(() => expect(listDatasets).toHaveBeenCalledTimes(2));
+  });
+
+  it("ignores the event already present at mount", async () => {
+    h.state.sessionEvent = evt({ kind: "recording", active: false, receivedAt: 1000 });
+    const { rerender } = renderHook(() => useDatasets());
+    await waitFor(() => expect(listDatasets).toHaveBeenCalledTimes(1));
+
+    rerender();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(listDatasets).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores an active:true (session started) transition", async () => {
+    const { rerender } = renderHook(() => useDatasets());
+    await waitFor(() => expect(listDatasets).toHaveBeenCalledTimes(1));
+
+    h.state.sessionEvent = evt({ kind: "recording", active: true });
+    rerender();
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(listDatasets).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores session kinds that never touch datasets", async () => {
+    const { rerender } = renderHook(() => useDatasets());
+    await waitFor(() => expect(listDatasets).toHaveBeenCalledTimes(1));
+
+    h.state.sessionEvent = evt({ kind: "teleoperation", active: false });
+    rerender();
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(listDatasets).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useDatasets.ts
+++ b/frontend/src/hooks/useDatasets.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useApi } from "@/contexts/ApiContext";
+import { useSessionEvent } from "@/hooks/useActiveSession";
 import { DatasetItem, listDatasets } from "@/lib/replayApi";
 
 export const useDatasets = () => {
@@ -18,6 +19,25 @@ export const useDatasets = () => {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // A recording or coaching (DAgger) session that just ended may have added a
+  // local dataset — or removed one. `session_changed` is a droppable refetch
+  // hint (see useActiveSession): re-pull the listing when one ends. Needed
+  // because this hook's mount effect fires only once per page load and the
+  // studio panels that call it never unmount within a visit, so nothing else
+  // re-pulls after a session. The `seenAt` ref ignores the event already
+  // present at mount, so this never double-fires with the mount effect.
+  const sessionEvent = useSessionEvent();
+  const seenAt = useRef(sessionEvent?.receivedAt ?? 0);
+  useEffect(() => {
+    if (!sessionEvent || sessionEvent.receivedAt === seenAt.current) return;
+    seenAt.current = sessionEvent.receivedAt;
+    if (sessionEvent.active) return;
+    if (sessionEvent.kind !== "recording" && sessionEvent.kind !== "inference") {
+      return;
+    }
+    refresh();
+  }, [sessionEvent, refresh]);
 
   return { datasets, loading, refresh };
 };

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -915,6 +915,14 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
                         request.dataset_repo_id, request.resume
                     )
 
+                # The session changed the local dataset listing — a fresh
+                # dataset on the happy path, a removed one on the discard
+                # branches above (whose helpers also invalidate, so this is
+                # idempotent). Drop the cached /datasets listing BEFORE the
+                # release hint so a client that refetches on the hint sees the
+                # new state instead of a <=45s-stale one.
+                invalidate_dataset_listing_cache()
+
                 recording_active = False
                 # Final release: record_with_web_events' own finally already
                 # released torque and disconnected before this ran, so the

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -915,13 +915,16 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
                         request.dataset_repo_id, request.resume
                     )
 
-                # The session changed the local dataset listing — a fresh
-                # dataset on the happy path, a removed one on the discard
-                # branches above (whose helpers also invalidate, so this is
-                # idempotent). Drop the cached /datasets listing BEFORE the
-                # release hint so a client that refetches on the hint sees the
-                # new state instead of a <=45s-stale one.
-                invalidate_dataset_listing_cache()
+                # The happy path adds a dataset to the local listing and nothing
+                # else drops the cache for it; a quit removes one. Invalidate for
+                # both, BEFORE the release hint, so a client that refetches on
+                # the hint sees the new state instead of a <=45s-stale one. The
+                # zero-episode-no-quit case is left to _discard_empty_dataset,
+                # which invalidates itself iff it actually removed a directory —
+                # a session that created nothing (e.g. a connect failure) must
+                # not force a needless Hub re-fan-out.
+                if saved_episodes > 0 or discard_requested:
+                    invalidate_dataset_listing_cache()
 
                 recording_active = False
                 # Final release: record_with_web_events' own finally already

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -3675,8 +3675,11 @@ def _finalise_coaching_locked(rc: int | None, cs: _CoachSession, *, aborted: boo
         _discard_empty_coaching_dataset(cs)
     # The corrections dataset (kept, or just removed above) changed the local
     # /datasets listing. Drop its cache before `_go_idle_locked` emits the
-    # release hint so a client refetching on the hint sees the new state.
-    invalidate_dataset_listing_cache()
+    # release hint so a client refetching on the hint sees the new state. Skip
+    # it when the runner never reported a repo id — nothing reached disk, so a
+    # drop would only force a needless Hub re-fan-out.
+    if cs.dataset_repo_id is not None:
+        invalidate_dataset_listing_cache()
     _go_idle_locked()
     _last_result = {
         "inference_active": False,

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -92,6 +92,7 @@ from .dagger_protocol import (
     parse_event as parse_dagger_event,
     parse_fields as parse_dagger_fields,
 )
+from .datasets import invalidate_dataset_listing_cache
 from .eval_protocol import (
     CMD_EPISODE,
     CMD_QUIT,
@@ -3672,6 +3673,10 @@ def _finalise_coaching_locked(rc: int | None, cs: _CoachSession, *, aborted: boo
         # the chance to record something, and a directory we cannot explain is
         # one we keep. See `_discard_empty_coaching_dataset` for the guards.
         _discard_empty_coaching_dataset(cs)
+    # The corrections dataset (kept, or just removed above) changed the local
+    # /datasets listing. Drop its cache before `_go_idle_locked` emits the
+    # release hint so a client refetching on the hint sees the new state.
+    invalidate_dataset_listing_cache()
     _go_idle_locked()
     _last_result = {
         "inference_active": False,

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -2699,6 +2699,33 @@ def test_worker_invalidates_dataset_listing_after_saving_episodes(
         assert datasets._listing_cache is None
 
 
+def test_worker_leaves_the_listing_cache_alone_when_the_session_created_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """A session that failed before saving anything created no dataset, so the
+    listing did not change — dropping its cache would only force the next
+    /datasets to re-fan-out to the Hub for no reason. (A zero-episode session
+    that DID leave a directory is cleaned up by _discard_empty_dataset, which
+    invalidates on its own.)"""
+    import time
+
+    import makermodslab.datasets as datasets
+    import makermodslab.record as record
+
+    def _boom_connecting(cfg, events, **kwargs):
+        record.current_phase = "connecting_follower"
+        raise RuntimeError("Failed to connect to follower on COM_FOLLOWER")
+
+    sentinel = {"at": time.monotonic(), "value": [{"repo_id": "old/ds"}]}
+    with datasets._listing_cache_lock:
+        datasets._listing_cache = sentinel
+
+    _start_session_with_fake_work(monkeypatch, _boom_connecting)
+
+    with datasets._listing_cache_lock:
+        assert datasets._listing_cache is sentinel
+
+
 # ---------------------------------------------------------------------------
 # I8: shutdown_event() has no UI to poll and no "press Stop again" gesture
 # available, but handle_stop_recording()'s first call is deliberately

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -2669,6 +2669,36 @@ def test_worker_reports_ok_outcome_on_clean_end(monkeypatch: pytest.MonkeyPatch,
     assert status["saved_episodes"] == 2
 
 
+def test_worker_invalidates_dataset_listing_after_saving_episodes(
+    monkeypatch: pytest.MonkeyPatch, tmp_lerobot_home
+) -> None:
+    """A session that saved episodes must drop the cached /datasets listing so
+    the new dataset appears on the next fetch instead of after the 45s TTL. The
+    happy path used to skip this — only the discard / zero-episode branches
+    invalidated — so a dataset recorded right after a listing load stayed
+    invisible until the TTL lapsed or an unrelated mutation cleared the cache."""
+    import time
+
+    import makermodslab.datasets as datasets
+    import makermodslab.record as record
+
+    class _FakeDataset:
+        num_episodes = 1
+
+    def _clean_work(cfg, events, **kwargs):
+        record.current_phase = "completed"
+        record.saved_episodes = 1
+        return _FakeDataset()
+
+    with datasets._listing_cache_lock:
+        datasets._listing_cache = {"at": time.monotonic(), "value": [{"repo_id": "old/ds"}]}
+
+    _start_session_with_fake_work(monkeypatch, _clean_work)
+
+    with datasets._listing_cache_lock:
+        assert datasets._listing_cache is None
+
+
 # ---------------------------------------------------------------------------
 # I8: shutdown_event() has no UI to poll and no "press Stop again" gesture
 # available, but handle_stop_recording()'s first call is deliberately

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -3789,6 +3789,32 @@ def test_coaching_terminal_payload_keeps_the_dataset_and_tally(monkeypatch) -> N
     assert result["coaching_dataset"] == "rollout_shirt_fixes_20260818_120000"
 
 
+def test_coaching_finalise_invalidates_the_dataset_listing(monkeypatch) -> None:
+    """A coaching session leaves a corrections dataset on disk (or removes an
+    empty one). Either way the /datasets listing changed, so its cache must be
+    dropped — nothing on the coaching teardown path did this, so the corrections
+    dataset stayed invisible until the 45s TTL lapsed."""
+    import time
+
+    from makermodslab import datasets, rollout
+
+    for aborted in (False, True):
+        session = rollout._CoachSession(request=_coaching_request(), corrections_target=5)
+        session.corrections_saved = 3
+        session.dataset_repo_id = "rollout_shirt_fixes_20260818_120000"
+        monkeypatch.setattr(rollout, "inference_active", True)
+        monkeypatch.setattr(rollout, "_coach_session", session)
+        monkeypatch.setattr(rollout, "_inference_meta", {})
+        with datasets._listing_cache_lock:
+            datasets._listing_cache = {"at": time.monotonic(), "value": [{"repo_id": "old/ds"}]}
+
+        with rollout._state_lock:
+            rollout._finalise_coaching_locked(0 if not aborted else None, session, aborted=aborted)
+
+        with datasets._listing_cache_lock:
+            assert datasets._listing_cache is None, f"aborted={aborted}"
+
+
 def test_coaching_stop_reports_aborted_but_keeps_the_partial_tally(monkeypatch) -> None:
     """Unlike an aborted EVAL — which must not claim an accuracy it never
     measured — a stopped coaching session loses nothing by reporting its count.

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -3815,6 +3815,32 @@ def test_coaching_finalise_invalidates_the_dataset_listing(monkeypatch) -> None:
             assert datasets._listing_cache is None, f"aborted={aborted}"
 
 
+def test_coaching_finalise_leaves_the_listing_cache_alone_when_no_dataset_was_created(
+    monkeypatch,
+) -> None:
+    """A coaching session killed before lerobot wrote meta/info.json has no
+    dataset_repo_id — nothing landed on disk, so the listing cache must be left
+    intact rather than forcing a needless Hub re-fan-out."""
+    import time
+
+    from makermodslab import datasets, rollout
+
+    session = rollout._CoachSession(request=_coaching_request(), corrections_target=5)
+    # dataset_repo_id stays None — the runner never reported one.
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_coach_session", session)
+    monkeypatch.setattr(rollout, "_inference_meta", {})
+    sentinel = {"at": time.monotonic(), "value": []}
+    with datasets._listing_cache_lock:
+        datasets._listing_cache = sentinel
+
+    with rollout._state_lock:
+        rollout._finalise_coaching_locked(None, session, aborted=True)
+
+    with datasets._listing_cache_lock:
+        assert datasets._listing_cache is sentinel
+
+
 def test_coaching_stop_reports_aborted_but_keeps_the_partial_tally(monkeypatch) -> None:
     """Unlike an aborted EVAL — which must not claim an accuracy it never
     measured — a stopped coaching session loses nothing by reporting its count.


### PR DESCRIPTION
## Summary

Auto refreshes the local cache to include the newly recorded Dagger and recording session so no manual refresh is needed.

## Commits

1. `fix(record): invalidate the dataset listing after a saved session` — the recording worker's happy path (episodes saved, not discarded) never dropped the backend listing cache, so a newly recorded dataset was absent from `GET /datasets` for up to 45 seconds.
2. `fix(rollout): invalidate the dataset listing when a coaching session ends` — `_finalise_coaching_locked`, the single convergence point for the finished, aborted, and error endings, never dropped the cache either, so a coaching corrections dataset had the same delay.
3. `fix(datasets): re-pull the listing when a session ends` — `useDatasets` only fetched on mount and the studio panels never unmount within a visit, so it now subscribes to the `session_changed` hint and re-pulls when a recording or inference session ends, ignoring the event present at mount and session starts.
4. `fix(datasets): only invalidate the listing when a dataset changed` — narrowed the two backend calls to sessions that actually created or removed a dataset, so a failed-to-connect recording or a coaching run that never got a repo id does not force the next `GET /datasets` to re-fan-out to the Hub.

## Sensitive changes

None. No servo, torque, calibration, or hardware-control code is touched. The backend changes are cache invalidation only; the frontend change is a data refetch on an existing WebSocket hint.
