### PR TITLE
refactor(config): move MakerMods Lab's own state to ~/.makermods/makermodslab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,15 +125,20 @@ server.py defines a single `ConnectionManager` with a background `_broadcast_wor
 
 ### Persistent state on disk
 
-All under `~/.cache/huggingface/lerobot/` (managed in [utils/config.py](makermodslab/utils/config.py); writes are atomic):
+Two roots, split by who owns the data (all paths managed in [utils/config.py](makermodslab/utils/config.py); writes are atomic). **Import the constants; never spell a path.**
 
-- `calibration/teleoperators/so_leader/*.json`, `calibration/robots/so_follower/*.json` — named calibrations (leader = "teleop", follower = "robot")
+**MakerMods Lab's own state** lives under `MAKERMODSLAB_HOME` = `~/.makermods/makermodslab/` (env var `MAKERMODSLAB_HOME` overrides it — the test suite points it at a tmp dir before importing anything, which also switches the legacy migration off):
+
 - `robots/*.json` — per-robot records: arm layout (`mode: single|bimanual` with right-arm fields), ports, cameras, calibration names, `motor_power`
-- `makermodslab_biso/` — bimanual calibration staging
+- `biso_staging/` — bimanual calibration staging (lerobot reads it through an explicit `calibration_dir`, so it need not sit in lerobot's cache)
 - `ports/{leader,follower}_port.txt` — last-used serial ports
-- `dismissed_hub_jobs.json`, `saved_custom_{datasets,models}.json`, `hidden_{datasets,models}.json` — UI-level bookkeeping
+- `dismissed_hub_jobs.json`, `saved_custom_{datasets,models}.json`, `hidden_{datasets,models}.json`, `excluded_episodes.json` — UI-level bookkeeping
 - `instance_id.txt` — this install's stable node identity (32-hex, minted on first read; how peers recognize this machine across restarts and address changes)
 - `nodes.json` — saved peer nodes (url + name only; identity is re-verified on load, never trusted from disk)
+
+**lerobot's data** stays under `~/.cache/huggingface/lerobot/` (`HF_LEROBOT_HOME`): datasets, models, `outputs/train/` (local policies and run history), and the calibration libraries — `calibration/teleoperators/so_leader/*.json`, `calibration/robots/so_follower/*.json` (leader = "teleop", follower = "robot") — because lerobot's device classes read them from there.
+
+Versions before the split wrote the first group beside the second. `migrate_legacy_state` moves each entry once, on server startup, only when nothing exists at the new path (the newer file always wins), and never under a `MAKERMODSLAB_HOME` override. A new state file goes under `MAKERMODSLAB_HOME`; it does not need a migration row unless it existed before the split.
 
 `device_type` in API requests is `"teleop"` or `"robot"` (mapped to leader/follower paths). `robot_type` in port endpoints is `"leader"` or `"follower"`. Don't conflate the two vocabularies.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,14 +131,14 @@ Two roots, split by who owns the data (all paths managed in [utils/config.py](ma
 
 - `robots/*.json` — per-robot records: arm layout (`mode: single|bimanual` with right-arm fields), ports, cameras, calibration names, `motor_power`
 - `biso_staging/` — bimanual calibration staging (lerobot reads it through an explicit `calibration_dir`, so it need not sit in lerobot's cache)
-- `ports/{leader,follower}_port.txt` — last-used serial ports
+- `ports/{leader,follower}_port.txt` — last-used serial ports (legacy: read as a fallback, nothing writes them any more)
 - `dismissed_hub_jobs.json`, `saved_custom_{datasets,models}.json`, `hidden_{datasets,models}.json`, `excluded_episodes.json` — UI-level bookkeeping
 - `instance_id.txt` — this install's stable node identity (32-hex, minted on first read; how peers recognize this machine across restarts and address changes)
 - `nodes.json` — saved peer nodes (url + name only; identity is re-verified on load, never trusted from disk)
 
 **lerobot's data** stays under `~/.cache/huggingface/lerobot/` (`HF_LEROBOT_HOME`): datasets, models, `outputs/train/` (local policies and run history), and the calibration libraries — `calibration/teleoperators/so_leader/*.json`, `calibration/robots/so_follower/*.json` (leader = "teleop", follower = "robot") — because lerobot's device classes read them from there.
 
-Versions before the split wrote the first group beside the second. `migrate_legacy_state` moves each entry once, on server startup, only when nothing exists at the new path (the newer file always wins), and never under a `MAKERMODSLAB_HOME` override. A new state file goes under `MAKERMODSLAB_HOME`; it does not need a migration row unless it existed before the split.
+Versions before the split wrote the first group beside the second. `migrate_legacy_state` runs once at server startup: a file moves only when nothing exists at the new path (the newer file wins), a directory present at both places is merged name by name under the same rule, whatever is left behind is named in one warning, and nothing runs under a `MAKERMODSLAB_HOME` override — so setting the override on an install that already has state starts it fresh, including a newly minted instance id that peers will see as a new node. A new state file goes under `MAKERMODSLAB_HOME`; it does not need a migration row unless it existed before the split. Two log dirs deliberately still sit in the lerobot cache: rollout.py's `inference_logs/` and merge.py's sibling — logs, not state; move them with a constant when there is a reason to.
 
 `device_type` in API requests is `"teleop"` or `"robot"` (mapped to leader/follower paths). `robot_type` in port endpoints is `"leader"` or `"follower"`. Don't conflate the two vocabularies.
 

--- a/frontend/docs/localization.md
+++ b/frontend/docs/localization.md
@@ -669,7 +669,8 @@ With DevTools open, do the same action in both languages and diff:
 - **Network** — request bodies and headers must be identical.
 - **Application → Local Storage** — the only difference is `makerlab:language`.
 - **On disk** — after recording a dataset or saving a robot config while in another
-  language, files under `~/.cache/huggingface/lerobot/` must still be pure ASCII.
+  language, files under `~/.makermods/makermodslab/` (robot records, ports) and
+  `~/.cache/huggingface/lerobot/` (datasets, calibrations) must still be pure ASCII.
 
 ---
 

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -265,6 +265,7 @@ from .teleoperate import (
 from .train import TrainingRequest
 from .update import handle_run_update, handle_update_check
 from .utils.config import (
+    HOME_IS_OVERRIDDEN,
     add_dismissed_hub_job,
     add_hidden_dataset,
     add_hidden_model,
@@ -284,6 +285,7 @@ from .utils.config import (
     is_robot_record_clean,
     is_valid_robot_name,
     list_robot_records,
+    migrate_legacy_state,
     port_slot_conflict,
     prune_dismissed_hub_jobs,
     remove_hidden_dataset,
@@ -4509,6 +4511,20 @@ def delete_robot(name: str):
     if delete_robot_record(name):
         return {"status": "success"}
     return JSONResponse(status_code=404, content={"status": "error", "message": "Robot not found"})
+
+
+@app.on_event("startup")
+def migrate_state_home():
+    """Move pre-split state from lerobot's cache into MAKERMODSLAB_HOME.
+
+    Registered FIRST so it runs before any other startup work; every reader
+    of the moved entries is lazy (robot records, ports, the node registry's
+    saved peers, the instance id), so startup is early enough. Skipped under
+    a MAKERMODSLAB_HOME override — see utils/config.HOME_IS_OVERRIDDEN.
+    """
+    if HOME_IS_OVERRIDDEN:
+        return
+    migrate_legacy_state()
 
 
 @app.on_event("startup")

--- a/makermodslab/utils/config.py
+++ b/makermodslab/utils/config.py
@@ -19,6 +19,7 @@ import platform
 import re
 import shutil
 import uuid
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Literal
 
@@ -26,7 +27,42 @@ logger = logging.getLogger(__name__)
 
 RobotSide = Literal["leader", "follower"]
 
-# Define the calibration config paths (shared between features)
+# ---------------------------------------------------------------------------
+# Where MakerMods Lab keeps ITS OWN state.
+#
+# lerobot owns ``~/.cache/huggingface/lerobot``: datasets, models, the
+# calibration libraries its device classes read, and training outputs (local
+# policies live there because they ARE models). Everything that is MakerMods
+# Lab's rather than lerobot's — robot records, saved ports, UI bookkeeping,
+# node identity, the bimanual staging area, and (next) extensions — lives under
+# this root instead, so a user finds the app's files under the app's name and
+# a lerobot cache wipe does not take the robot setup with it.
+#
+# ``MAKERMODSLAB_HOME`` overrides the root (containers, a shared machine, and
+# the test suite, which points it at a tmp dir before anything is imported).
+# An override also switches OFF the legacy migration below: whoever set it is
+# pointing at a place they chose, and silently moving old files there would
+# be a surprise — the test suite relies on exactly that to never touch a
+# developer's real state.
+# ---------------------------------------------------------------------------
+LEGACY_STATE_ROOT = os.path.expanduser("~/.cache/huggingface/lerobot")
+
+
+def resolve_makermodslab_home(env: Mapping[str, str] | None = None) -> str:
+    """The MakerMods Lab state root: ``$MAKERMODSLAB_HOME`` or ``~/.makermods/makermodslab``."""
+    env = os.environ if env is None else env
+    override = env.get("MAKERMODSLAB_HOME")
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+    return os.path.expanduser(os.path.join("~", ".makermods", "makermodslab"))
+
+
+MAKERMODSLAB_HOME = resolve_makermodslab_home()
+HOME_IS_OVERRIDDEN = bool(os.environ.get("MAKERMODSLAB_HOME"))
+
+# Define the calibration config paths (shared between features). These stay
+# under lerobot's cache: lerobot's device classes read their calibration from
+# there, and the library IS lerobot calibration data.
 CALIBRATION_BASE_PATH_TELEOP = os.path.expanduser("~/.cache/huggingface/lerobot/calibration/teleoperators")
 CALIBRATION_BASE_PATH_ROBOTS = os.path.expanduser("~/.cache/huggingface/lerobot/calibration/robots")
 LEADER_CONFIG_PATH = os.path.join(CALIBRATION_BASE_PATH_TELEOP, "so_leader")
@@ -125,12 +161,12 @@ def default_slot_config_name(record_name: str, mode: object, arm: str, arm_type:
 
 
 # Define port storage path
-PORT_CONFIG_PATH = os.path.expanduser("~/.cache/huggingface/lerobot/ports")
+PORT_CONFIG_PATH = os.path.join(MAKERMODSLAB_HOME, "ports")
 LEADER_PORT_FILE = os.path.join(PORT_CONFIG_PATH, "leader_port.txt")
 FOLLOWER_PORT_FILE = os.path.join(PORT_CONFIG_PATH, "follower_port.txt")
 
 # Robot config records (per-robot JSON metadata)
-ROBOTS_PATH = os.path.expanduser("~/.cache/huggingface/lerobot/robots")
+ROBOTS_PATH = os.path.join(MAKERMODSLAB_HOME, "robots")
 
 # Staging root for bimanual (BiSO) sessions. lerobot's BiSO devices take ONE
 # calibration_dir + ONE base id and load each sub-arm as "<base>_left.json" /
@@ -141,7 +177,7 @@ ROBOTS_PATH = os.path.expanduser("~/.cache/huggingface/lerobot/robots")
 # root as "<base>_left.json"/"<base>_right.json" for lerobot to load. The copy is
 # unconditional every session (see stage_bimanual_calibrations) so a recalibrated
 # library file always refreshes its stale staging alias.
-MAKERMODSLAB_BISO_STAGING_PATH = os.path.expanduser("~/.cache/huggingface/lerobot/makermodslab_biso")
+MAKERMODSLAB_BISO_STAGING_PATH = os.path.join(MAKERMODSLAB_HOME, "biso_staging")
 
 # Fallback base id when a bimanual start request carries no robot name (older
 # frontends). Filesystem-safe and stable; a single unnamed bimanual robot reuses
@@ -151,26 +187,26 @@ DEFAULT_BIMANUAL_BASE = "bimanual"
 # Hub-job ids the user dismissed from the jobs UI (JSON list of strings). The
 # HF Jobs API has no delete — a finished job stays in list_jobs() indefinitely
 # — so hiding a dead run from the untracked list must be persisted locally.
-DISMISSED_HUB_JOBS_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/dismissed_hub_jobs.json")
+DISMISSED_HUB_JOBS_FILE = os.path.join(MAKERMODSLAB_HOME, "dismissed_hub_jobs.json")
 
 # Hub dataset repo ids the user typed straight into the picker and chose to keep
 # ("Use org/name"). They aren't in the user's own namespace listing and have no
 # local copy, so they'd vanish after selection unless we persist them here and
 # fold them back into the merged /datasets listing.
-SAVED_CUSTOM_DATASETS_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/saved_custom_datasets.json")
+SAVED_CUSTOM_DATASETS_FILE = os.path.join(MAKERMODSLAB_HOME, "saved_custom_datasets.json")
 
 # Hub MODEL repo ids the user pinned via the "Add model" chooser — the models
 # mirror of SAVED_CUSTOM_DATASETS_FILE (same rationale: a foreign-namespace repo
 # with no local copy vanishes from the /models listing unless persisted here).
-SAVED_CUSTOM_MODELS_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/saved_custom_models.json")
+SAVED_CUSTOM_MODELS_FILE = os.path.join(MAKERMODSLAB_HOME, "saved_custom_models.json")
 
 # Hub dataset/model repo ids the user removed from their pickers ("hidden").
 # Hiding NEVER touches the Hub repo — it only filters the merged listing, so a
 # repo the user's own namespace listing keeps returning stays gone until they
 # re-add it (re-pinning auto-unhides). Persisted like the dismissed hub jobs
 # (JSON list on disk, a set in memory).
-SAVED_HIDDEN_DATASETS_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/hidden_datasets.json")
-SAVED_HIDDEN_MODELS_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/hidden_models.json")
+SAVED_HIDDEN_DATASETS_FILE = os.path.join(MAKERMODSLAB_HOME, "hidden_datasets.json")
+SAVED_HIDDEN_MODELS_FILE = os.path.join(MAKERMODSLAB_HOME, "hidden_models.json")
 
 # Per-dataset episode indices the user excluded from training (curation, not
 # deletion — the episode stays on disk and in every listing/upload, it's just
@@ -178,18 +214,18 @@ SAVED_HIDDEN_MODELS_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/hidd
 # JSON object keyed by repo_id -> list[int], unlike the flat repo-id lists
 # above, since the thing being persisted is per-dataset state, not membership
 # in one shared collection.
-EXCLUDED_EPISODES_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/excluded_episodes.json")
+EXCLUDED_EPISODES_FILE = os.path.join(MAKERMODSLAB_HOME, "excluded_episodes.json")
 
 # Stable per-install identity, minted on first read. The node registry uses it
 # to recognize a peer across restarts and address changes (a machine's IP or
 # MagicDNS name can change; its instance id doesn't).
-INSTANCE_ID_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/instance_id.txt")
+INSTANCE_ID_FILE = os.path.join(MAKERMODSLAB_HOME, "instance_id.txt")
 
 # The node registry's saved peer list: [{"url": ..., "name": ...}, ...]. Only
 # url + name are persisted — identity (instance_id/version/capabilities) is
 # deliberately NOT: a peer is re-verified against its live /api/v1/health on
 # load/probe, so stale identity can never be served from disk.
-NODES_FILE = os.path.expanduser("~/.cache/huggingface/lerobot/nodes.json")
+NODES_FILE = os.path.join(MAKERMODSLAB_HOME, "nodes.json")
 
 # Tag stamped on every dataset pushed to the Hub from MakerMods Lab, so we can later
 # query the Hub for MakerMods Lab-produced datasets and compute usage metrics.
@@ -216,6 +252,67 @@ def with_makermodslab_tag(tags: list[str] | None) -> list[str]:
         if tag not in out:
             out.append(tag)
     return out
+
+
+# State that versions before the MAKERMODSLAB_HOME split wrote beside lerobot's
+# files: (name under LEGACY_STATE_ROOT, this module's attribute holding the new
+# path). The attribute is looked up AT CALL TIME so a redirected constant (the
+# test fixtures) is honoured. Calibration libraries and training outputs are
+# deliberately absent — they stay where lerobot reads them.
+_LEGACY_STATE_ENTRIES: tuple[tuple[str, str], ...] = (
+    ("ports", "PORT_CONFIG_PATH"),
+    ("robots", "ROBOTS_PATH"),
+    ("makermodslab_biso", "MAKERMODSLAB_BISO_STAGING_PATH"),
+    ("dismissed_hub_jobs.json", "DISMISSED_HUB_JOBS_FILE"),
+    ("saved_custom_datasets.json", "SAVED_CUSTOM_DATASETS_FILE"),
+    ("saved_custom_models.json", "SAVED_CUSTOM_MODELS_FILE"),
+    ("hidden_datasets.json", "SAVED_HIDDEN_DATASETS_FILE"),
+    ("hidden_models.json", "SAVED_HIDDEN_MODELS_FILE"),
+    ("excluded_episodes.json", "EXCLUDED_EPISODES_FILE"),
+    ("instance_id.txt", "INSTANCE_ID_FILE"),
+    ("nodes.json", "NODES_FILE"),
+)
+
+
+def migrate_legacy_state(legacy_root: str | None = None) -> list[str]:
+    """Move MakerMods Lab state written beside lerobot's cache into MAKERMODSLAB_HOME.
+
+    One-shot and idempotent: an entry moves only when it exists at the legacy
+    location and NOTHING exists at the new one. A destination that already
+    exists is the live state and wins — so an old version run after the split
+    cannot clobber newer files on the next upgrade, and a second call is a
+    no-op. A failed move is logged and skipped; the app then starts with that
+    entry at its defaults rather than refusing to start. Returns the
+    destinations written (for the startup log and the tests).
+
+    The caller decides WHEN this runs (server startup, before the first read
+    of any entry — every reader here is lazy) and whether it runs at all
+    (never under a ``MAKERMODSLAB_HOME`` override; see the note on
+    HOME_IS_OVERRIDDEN).
+    """
+    root = LEGACY_STATE_ROOT if legacy_root is None else legacy_root
+    moved: list[str] = []
+    for legacy_name, attr in _LEGACY_STATE_ENTRIES:
+        src = os.path.join(root, legacy_name)
+        dst = globals()[attr]
+        if not os.path.lexists(src) or os.path.lexists(dst):
+            continue
+        try:
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.move(src, dst)
+        except OSError as exc:
+            logger.warning("Could not migrate %s -> %s: %s", src, dst, exc)
+            continue
+        moved.append(dst)
+    if moved:
+        logger.info(
+            "Moved %d MakerMods Lab state entr%s from %s to %s",
+            len(moved),
+            "y" if len(moved) == 1 else "ies",
+            root,
+            os.path.dirname(moved[0]) if len(moved) == 1 else MAKERMODSLAB_HOME,
+        )
+    return moved
 
 
 def _atomic_write_text(path: str, content: str) -> None:

--- a/makermodslab/utils/config.py
+++ b/makermodslab/utils/config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import json
 import logging
 import os
@@ -274,45 +275,112 @@ _LEGACY_STATE_ENTRIES: tuple[tuple[str, str], ...] = (
 )
 
 
+def _remove_path(path: str) -> None:
+    """Best-effort removal of a file, symlink or directory tree."""
+    if os.path.islink(path) or os.path.isfile(path):
+        with contextlib.suppress(OSError):
+            os.remove(path)
+    elif os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _move_entry(src: str, dst: str) -> bool:
+    """Move ``src`` to ``dst`` without ever leaving a half-written ``dst``.
+
+    ``shutil.move`` is a rename on one filesystem but copy-then-delete across
+    two — and ``~/.cache/huggingface`` symlinked onto a big external drive is
+    a common lerobot setup, which puts the two roots on different volumes. A
+    copy that dies half-way (disk full, one unreadable file) would leave a
+    partial ``dst`` that the destination-wins rule then treats as the live
+    state forever. So the move lands in a sibling ``<dst>.migrating`` first
+    and is renamed into place only once complete; on failure the sibling is
+    removed and ``src`` is untouched (``shutil.move`` deletes the source only
+    after a full copy).
+    """
+    staging = dst + ".migrating"
+    _remove_path(staging)
+    try:
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.move(src, staging)
+        os.replace(staging, dst)
+    except OSError as exc:
+        logger.warning("Could not migrate %s -> %s: %s", src, dst, exc)
+        _remove_path(staging)
+        return False
+    return True
+
+
+def _merge_dir(src: str, dst: str) -> tuple[int, int]:
+    """Move the entries of legacy dir ``src`` that ``dst`` lacks; keep the rest.
+
+    Returns (moved, left). ``src`` is removed once nothing is left in it.
+    """
+    moved = left = 0
+    for name in sorted(os.listdir(src)):
+        s, d = os.path.join(src, name), os.path.join(dst, name)
+        if os.path.lexists(d):
+            left += 1
+        elif _move_entry(s, d):
+            moved += 1
+        else:
+            left += 1
+    if left == 0:
+        with contextlib.suppress(OSError):
+            os.rmdir(src)
+    return moved, left
+
+
 def migrate_legacy_state(legacy_root: str | None = None) -> list[str]:
     """Move MakerMods Lab state written beside lerobot's cache into MAKERMODSLAB_HOME.
 
-    One-shot and idempotent: an entry moves only when it exists at the legacy
-    location and NOTHING exists at the new one. A destination that already
-    exists is the live state and wins — so an old version run after the split
-    cannot clobber newer files on the next upgrade, and a second call is a
-    no-op. A failed move is logged and skipped; the app then starts with that
-    entry at its defaults rather than refusing to start. Returns the
-    destinations written (for the startup log and the tests).
+    One-shot and idempotent. A FILE entry moves only when nothing exists at
+    the new path: a destination that already exists is the live state and
+    wins, so an old version run after the split cannot clobber newer files on
+    the next upgrade, and a second call is a no-op. A DIRECTORY entry that
+    exists at both places is merged name by name under the same rule — the
+    new location's directories get created empty by ordinary reads
+    (``list_robot_records`` makes ``robots/`` on every listing), so a
+    new → old → new round-trip would otherwise strand every robot record the
+    old version wrote in between. Whatever is left behind is named in one
+    WARNING per start, so a user can find it. A failed move is logged and
+    skipped; the app then starts with that entry at its defaults rather than
+    refusing to start. Returns the destinations written.
 
     The caller decides WHEN this runs (server startup, before the first read
     of any entry — every reader here is lazy) and whether it runs at all
-    (never under a ``MAKERMODSLAB_HOME`` override; see the note on
-    HOME_IS_OVERRIDDEN).
+    (never under a ``MAKERMODSLAB_HOME`` override; see HOME_IS_OVERRIDDEN).
     """
     root = LEGACY_STATE_ROOT if legacy_root is None else legacy_root
-    moved: list[str] = []
+    written: list[str] = []
+    left_behind: list[str] = []
     for legacy_name, attr in _LEGACY_STATE_ENTRIES:
         src = os.path.join(root, legacy_name)
         dst = globals()[attr]
-        if not os.path.lexists(src) or os.path.lexists(dst):
+        if not os.path.lexists(src):
             continue
-        try:
-            os.makedirs(os.path.dirname(dst), exist_ok=True)
-            shutil.move(src, dst)
-        except OSError as exc:
-            logger.warning("Could not migrate %s -> %s: %s", src, dst, exc)
+        if not os.path.lexists(dst):
+            if _move_entry(src, dst):
+                written.append(dst)
             continue
-        moved.append(dst)
-    if moved:
+        if os.path.isdir(src) and not os.path.islink(src) and os.path.isdir(dst):
+            moved, left = _merge_dir(src, dst)
+            if moved:
+                written.append(dst)
+            if left:
+                left_behind.append(src)
+        else:
+            left_behind.append(src)
+    if written:
         logger.info(
-            "Moved %d MakerMods Lab state entr%s from %s to %s",
-            len(moved),
-            "y" if len(moved) == 1 else "ies",
-            root,
-            os.path.dirname(moved[0]) if len(moved) == 1 else MAKERMODSLAB_HOME,
+            "Moved %d MakerMods Lab state entries from %s to %s", len(written), root, MAKERMODSLAB_HOME
         )
-    return moved
+    if left_behind:
+        logger.warning(
+            "Legacy MakerMods Lab state left in place because a newer copy exists under %s: %s",
+            MAKERMODSLAB_HOME,
+            ", ".join(left_behind),
+        )
+    return written
 
 
 def _atomic_write_text(path: str, content: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,20 @@ if os.environ.setdefault("MAKERMODSLAB_OUTPUT_ROOT", _TEST_OUTPUT_ROOT) == _TEST
 else:  # pragma: no cover - only when the caller pinned a root themselves
     shutil.rmtree(_TEST_OUTPUT_ROOT, ignore_errors=True)
 
+# Same mechanism for the app's own state root. `makermodslab.utils.config`
+# resolves MAKERMODSLAB_HOME at import, so this too must precede any import
+# of the package. Two effects: every state constant (robot records, ports, the
+# node list, the instance id, the UI bookkeeping files) points into a tmp dir
+# even in a test that forgets the `tmp_lerobot_home` fixture — and, because
+# the override is set, the server's startup migration is skipped, so a test
+# run can never move a developer's real pre-split state anywhere (least of
+# all into a tmp dir that is deleted at exit).
+_TEST_STATE_HOME = tempfile.mkdtemp(prefix="makermodslab-home-")
+if os.environ.setdefault("MAKERMODSLAB_HOME", _TEST_STATE_HOME) == _TEST_STATE_HOME:
+    atexit.register(shutil.rmtree, _TEST_STATE_HOME, ignore_errors=True)
+else:  # pragma: no cover - only when the caller pinned a home themselves
+    shutil.rmtree(_TEST_STATE_HOME, ignore_errors=True)
+
 
 @pytest.fixture
 def client() -> Iterator[TestClient]:
@@ -56,19 +70,25 @@ def client() -> Iterator[TestClient]:
 
 @pytest.fixture
 def tmp_lerobot_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect every persisted-state path under `~/.cache/huggingface/lerobot/`
-    into a tmp directory.
+    """Redirect every persisted-state path — lerobot's cache AND the app's own
+    MAKERMODSLAB_HOME — into per-test tmp directories.
 
     Patches the module-level constants in `makermodslab.utils.config` so any code
     importing them through `from makermodslab.utils.config import LEADER_CONFIG_PATH`
     sees the redirected path. Also sets `HF_LEROBOT_HOME` env var for any
     consumer (e.g. `makermodslab.datasets._lerobot_cache_root`) reading it directly.
+    Returns the lerobot-cache half (calibration libraries live there); the app's
+    state half is `tmp_path / "makermodslab"`, reachable as `cfg.MAKERMODSLAB_HOME`.
     """
     cache = tmp_path / "lerobot"
     cache.mkdir()
     monkeypatch.setenv("HF_LEROBOT_HOME", str(cache))
+    home = tmp_path / "makermodslab"
+    home.mkdir()
 
     from makermodslab.utils import config as cfg
+
+    monkeypatch.setattr(cfg, "MAKERMODSLAB_HOME", str(home))
 
     teleop_dir = cache / "calibration" / "teleoperators" / "so101_leader"
     robot_dir = cache / "calibration" / "robots" / "so101_follower"
@@ -79,8 +99,8 @@ def tmp_lerobot_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # touches a Maker calibration writes into the developer's real ~/.cache.
     maker_leader_cfg_dir = cache / "configs" / "rebot_102_leader"
     maker_follower_cfg_dir = cache / "configs" / "maker_follower"
-    port_dir = cache / "ports"
-    robots_dir = cache / "robots"
+    port_dir = home / "ports"
+    robots_dir = home / "robots"
     for d in (
         teleop_dir,
         robot_dir,
@@ -105,7 +125,7 @@ def tmp_lerobot_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(cfg, "PORT_CONFIG_PATH", str(port_dir))
     monkeypatch.setattr(cfg, "LEADER_PORT_FILE", str(port_dir / "leader_port.txt"))
     monkeypatch.setattr(cfg, "FOLLOWER_PORT_FILE", str(port_dir / "follower_port.txt"))
-    monkeypatch.setattr(cfg, "DISMISSED_HUB_JOBS_FILE", str(cache / "dismissed_hub_jobs.json"))
+    monkeypatch.setattr(cfg, "DISMISSED_HUB_JOBS_FILE", str(home / "dismissed_hub_jobs.json"))
     # The pinned ("saved custom") and hidden repo-id lists. These leak the
     # HARDEST of the lot: every merged /datasets and /models listing folds them
     # in, so on a developer machine whose real saved_custom_models.json has
@@ -115,16 +135,16 @@ def tmp_lerobot_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # access precisely so a patched constant is honoured, and it holds no
     # in-memory copy, so redirecting the constant here is sufficient — there is
     # no cache to clear afterwards.
-    monkeypatch.setattr(cfg, "SAVED_CUSTOM_DATASETS_FILE", str(cache / "saved_custom_datasets.json"))
-    monkeypatch.setattr(cfg, "SAVED_CUSTOM_MODELS_FILE", str(cache / "saved_custom_models.json"))
-    monkeypatch.setattr(cfg, "SAVED_HIDDEN_DATASETS_FILE", str(cache / "hidden_datasets.json"))
-    monkeypatch.setattr(cfg, "SAVED_HIDDEN_MODELS_FILE", str(cache / "hidden_models.json"))
-    monkeypatch.setattr(cfg, "EXCLUDED_EPISODES_FILE", str(cache / "excluded_episodes.json"))
+    monkeypatch.setattr(cfg, "SAVED_CUSTOM_DATASETS_FILE", str(home / "saved_custom_datasets.json"))
+    monkeypatch.setattr(cfg, "SAVED_CUSTOM_MODELS_FILE", str(home / "saved_custom_models.json"))
+    monkeypatch.setattr(cfg, "SAVED_HIDDEN_DATASETS_FILE", str(home / "hidden_datasets.json"))
+    monkeypatch.setattr(cfg, "SAVED_HIDDEN_MODELS_FILE", str(home / "hidden_models.json"))
+    monkeypatch.setattr(cfg, "EXCLUDED_EPISODES_FILE", str(home / "excluded_episodes.json"))
     # BiSO staging root — without this, any bimanual staging test writes into the
-    # developer's real ~/.cache dir.
-    monkeypatch.setattr(cfg, "MAKERMODSLAB_BISO_STAGING_PATH", str(cache / "makermodslab_biso"))
+    # developer's real state dir.
+    monkeypatch.setattr(cfg, "MAKERMODSLAB_BISO_STAGING_PATH", str(home / "biso_staging"))
     # Persisted node-registry peer list.
-    monkeypatch.setattr(cfg, "NODES_FILE", str(cache / "nodes.json"))
+    monkeypatch.setattr(cfg, "NODES_FILE", str(home / "nodes.json"))
 
     return cache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,12 +51,13 @@ else:  # pragma: no cover - only when the caller pinned a root themselves
 # even in a test that forgets the `tmp_lerobot_home` fixture — and, because
 # the override is set, the server's startup migration is skipped, so a test
 # run can never move a developer's real pre-split state anywhere (least of
-# all into a tmp dir that is deleted at exit).
+# all into a tmp dir that is deleted at exit). Set UNCONDITIONALLY, unlike the
+# output root: MAKERMODSLAB_HOME is a production override a station or a
+# container exports, and honouring an exported value here would point the
+# `client` fixture at that machine's real state.
 _TEST_STATE_HOME = tempfile.mkdtemp(prefix="makermodslab-home-")
-if os.environ.setdefault("MAKERMODSLAB_HOME", _TEST_STATE_HOME) == _TEST_STATE_HOME:
-    atexit.register(shutil.rmtree, _TEST_STATE_HOME, ignore_errors=True)
-else:  # pragma: no cover - only when the caller pinned a home themselves
-    shutil.rmtree(_TEST_STATE_HOME, ignore_errors=True)
+os.environ["MAKERMODSLAB_HOME"] = _TEST_STATE_HOME
+atexit.register(shutil.rmtree, _TEST_STATE_HOME, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/test_maker_arm.py
+++ b/tests/test_maker_arm.py
@@ -19,7 +19,7 @@ from makermodslab.utils import config as cfg
 
 def test_records_written_before_the_maker_arm_read_back_as_so101(tmp_lerobot_home: Path) -> None:
     """A record with no arm_type on disk is an SO-101 by definition."""
-    robots = tmp_lerobot_home / "robots"
+    robots = Path(cfg.ROBOTS_PATH)
     robots.mkdir(exist_ok=True)
     (robots / "legacy.json").write_text('{"name": "legacy", "mode": "single", "leader_port": "/dev/a"}')
 
@@ -32,7 +32,7 @@ def test_records_written_before_the_maker_arm_read_back_as_so101(tmp_lerobot_hom
 def test_a_corrupted_arm_type_on_disk_falls_back_rather_than_raising(tmp_lerobot_home: Path) -> None:
     """Same contract as motor_power's clamp: a bad value must never make a
     robot unopenable."""
-    robots = tmp_lerobot_home / "robots"
+    robots = Path(cfg.ROBOTS_PATH)
     robots.mkdir(exist_ok=True)
     (robots / "weird.json").write_text('{"name": "weird", "arm_type": "definitely-not-an-arm"}')
 
@@ -128,7 +128,7 @@ def test_deleting_a_maker_calibration_leaves_same_named_so101_records_alone(
     """The two libraries are separate namespaces: an SO-101 record naming
     "armA" points at a different file from a Maker record naming "armA", so a
     Maker delete must not unassign the SO-101 robot."""
-    robots = tmp_lerobot_home / "robots"
+    robots = Path(cfg.ROBOTS_PATH)
     robots.mkdir(exist_ok=True)
     cfg.save_robot_record("so_bot", {"arm_type": "so101", "follower_config": "armA"}, allow_create=True)
     cfg.save_robot_record("maker_bot", {"arm_type": "maker", "follower_config": "armA"}, allow_create=True)

--- a/tests/test_state_home.py
+++ b/tests/test_state_home.py
@@ -1,0 +1,130 @@
+"""MAKERMODSLAB_HOME resolution and the one-shot migration out of lerobot's cache.
+
+The migration is pure filesystem work with no clock and no network, so it is
+tested against real tmp dirs. Every destination is read from the config
+module's globals at call time, which is what lets these tests point them into
+tmp without touching a developer's real state.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from makermodslab.utils import config as cfg
+
+
+def test_default_home_is_under_the_makermods_dotdir() -> None:
+    assert cfg.resolve_makermodslab_home({}) == os.path.expanduser("~/.makermods/makermodslab")
+
+
+def test_env_override_wins_and_is_expanded(tmp_path: Path) -> None:
+    assert cfg.resolve_makermodslab_home({"MAKERMODSLAB_HOME": str(tmp_path)}) == str(tmp_path)
+    assert cfg.resolve_makermodslab_home({"MAKERMODSLAB_HOME": "~/x"}) == os.path.expanduser("~/x")
+
+
+def test_empty_override_falls_back_to_the_default() -> None:
+    assert cfg.resolve_makermodslab_home({"MAKERMODSLAB_HOME": ""}) == cfg.resolve_makermodslab_home({})
+
+
+def test_every_moved_constant_lives_under_the_home() -> None:
+    for _legacy_name, attr in cfg._LEGACY_STATE_ENTRIES:
+        assert getattr(cfg, attr).startswith(cfg.MAKERMODSLAB_HOME), attr
+
+
+def test_calibration_libraries_stay_in_the_lerobot_cache() -> None:
+    assert not cfg.CALIBRATION_BASE_PATH_TELEOP.startswith(cfg.MAKERMODSLAB_HOME)
+    assert not cfg.CALIBRATION_BASE_PATH_ROBOTS.startswith(cfg.MAKERMODSLAB_HOME)
+
+
+@pytest.fixture
+def split(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """A legacy root and a home, with every destination constant pointed at the home."""
+    legacy = tmp_path / "legacy"
+    home = tmp_path / "home"
+    legacy.mkdir()
+    monkeypatch.setattr(cfg, "MAKERMODSLAB_HOME", str(home))
+    for _legacy_name, attr in cfg._LEGACY_STATE_ENTRIES:
+        new_name = os.path.basename(getattr(cfg, attr))
+        monkeypatch.setattr(cfg, attr, str(home / new_name))
+    return legacy, home
+
+
+def test_migration_moves_files_and_dirs(split: tuple[Path, Path]) -> None:
+    legacy, home = split
+    (legacy / "robots").mkdir()
+    (legacy / "robots" / "bot.json").write_text("{}")
+    (legacy / "nodes.json").write_text("[]")
+    (legacy / "instance_id.txt").write_text("a" * 32)
+
+    moved = cfg.migrate_legacy_state(str(legacy))
+
+    assert sorted(moved) == sorted([cfg.ROBOTS_PATH, cfg.NODES_FILE, cfg.INSTANCE_ID_FILE])
+    assert (home / "robots" / "bot.json").read_text() == "{}"
+    assert (home / "nodes.json").read_text() == "[]"
+    assert not (legacy / "robots").exists()
+    assert not (legacy / "nodes.json").exists()
+
+
+def test_migration_renames_the_biso_staging_dir(split: tuple[Path, Path]) -> None:
+    legacy, home = split
+    (legacy / "makermodslab_biso" / "bimanual").mkdir(parents=True)
+
+    cfg.migrate_legacy_state(str(legacy))
+
+    assert (home / "biso_staging" / "bimanual").is_dir()
+    assert str(home / "biso_staging") == cfg.MAKERMODSLAB_BISO_STAGING_PATH
+
+
+def test_existing_destination_wins(split: tuple[Path, Path]) -> None:
+    legacy, home = split
+    (legacy / "nodes.json").write_text("old")
+    home.mkdir()
+    (home / "nodes.json").write_text("new")
+
+    assert cfg.migrate_legacy_state(str(legacy)) == []
+    assert (home / "nodes.json").read_text() == "new"
+    assert (legacy / "nodes.json").read_text() == "old"
+
+
+def test_migration_is_idempotent_and_tolerates_a_missing_legacy_root(split: tuple[Path, Path]) -> None:
+    legacy, _home = split
+    (legacy / "ports").mkdir()
+    (legacy / "ports" / "leader_port.txt").write_text("/dev/ttyUSB0")
+
+    first = cfg.migrate_legacy_state(str(legacy))
+    second = cfg.migrate_legacy_state(str(legacy))
+    nowhere = cfg.migrate_legacy_state(str(legacy / "does-not-exist"))
+
+    assert first == [cfg.PORT_CONFIG_PATH]
+    assert second == []
+    assert nowhere == []
+
+
+def test_a_failed_move_is_skipped_not_fatal(
+    split: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    legacy, home = split
+    (legacy / "nodes.json").write_text("[]")
+    (legacy / "robots").mkdir()
+
+    def boom(src: str, dst: str) -> None:
+        if src.endswith("nodes.json"):
+            raise OSError("disk says no")
+        os.rename(src, dst)
+
+    monkeypatch.setattr(cfg.shutil, "move", boom)
+
+    moved = cfg.migrate_legacy_state(str(legacy))
+
+    assert moved == [cfg.ROBOTS_PATH]
+    assert (legacy / "nodes.json").exists()
+    assert (home / "robots").is_dir()
+
+
+def test_the_suite_runs_under_an_override_so_startup_never_migrates_real_state() -> None:
+    # conftest pins MAKERMODSLAB_HOME before the package is imported; the
+    # server's startup hook keys off this flag to skip the migration.
+    assert cfg.HOME_IS_OVERRIDDEN is True

--- a/tests/test_state_home.py
+++ b/tests/test_state_home.py
@@ -128,3 +128,95 @@ def test_the_suite_runs_under_an_override_so_startup_never_migrates_real_state()
     # conftest pins MAKERMODSLAB_HOME before the package is imported; the
     # server's startup hook keys off this flag to skip the migration.
     assert cfg.HOME_IS_OVERRIDDEN is True
+
+
+def test_a_half_copied_destination_is_rolled_back_and_retried(
+    split: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cross-filesystem copy that dies part-way must not leave a partial
+    destination for the destination-wins rule to mistake for live state."""
+    legacy, home = split
+    (legacy / "robots").mkdir()
+    (legacy / "robots" / "a.json").write_text("{}")
+    (legacy / "robots" / "b.json").write_text("{}")
+    real_move = cfg.shutil.move
+
+    def half_copy(src: str, dst: str) -> None:
+        os.makedirs(dst)
+        Path(dst, "a.json").write_text("{}")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cfg.shutil, "move", half_copy)
+    assert cfg.migrate_legacy_state(str(legacy)) == []
+    assert not (home / "robots").exists()
+    assert not (home / "robots.migrating").exists()
+    assert sorted(p.name for p in (legacy / "robots").iterdir()) == ["a.json", "b.json"]
+
+    monkeypatch.setattr(cfg.shutil, "move", real_move)
+    assert cfg.migrate_legacy_state(str(legacy)) == [cfg.ROBOTS_PATH]
+    assert sorted(p.name for p in (home / "robots").iterdir()) == ["a.json", "b.json"]
+
+
+def test_directories_present_at_both_places_are_merged_name_by_name(
+    split: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+) -> None:
+    """The new → old → new round-trip: the new version created an (empty or
+    partly filled) robots/ dir, the old version then wrote records beside
+    lerobot's files. Names the new dir lacks move over; clashes stay put
+    and are named in a warning."""
+    legacy, home = split
+    (legacy / "robots").mkdir()
+    (legacy / "robots" / "old_only.json").write_text("old")
+    (legacy / "robots" / "both.json").write_text("old")
+    (home / "robots").mkdir(parents=True)
+    (home / "robots" / "both.json").write_text("new")
+
+    with caplog.at_level("WARNING"):
+        written = cfg.migrate_legacy_state(str(legacy))
+
+    assert written == [cfg.ROBOTS_PATH]
+    assert (home / "robots" / "old_only.json").read_text() == "old"
+    assert (home / "robots" / "both.json").read_text() == "new"
+    assert [p.name for p in (legacy / "robots").iterdir()] == ["both.json"]
+    assert "left in place" in caplog.text and str(legacy / "robots") in caplog.text
+
+
+def test_an_empty_new_directory_does_not_block_the_legacy_one(split: tuple[Path, Path]) -> None:
+    """list_robot_records creates robots/ on every listing; that must not count
+    as 'the destination exists' against a legacy dir full of records."""
+    legacy, home = split
+    (legacy / "robots").mkdir()
+    (legacy / "robots" / "bot.json").write_text("{}")
+    (home / "robots").mkdir(parents=True)
+
+    assert cfg.migrate_legacy_state(str(legacy)) == [cfg.ROBOTS_PATH]
+    assert (home / "robots" / "bot.json").exists()
+    assert not (legacy / "robots").exists()  # emptied, so removed
+
+
+def test_the_server_startup_hook_migrates_when_home_is_not_overridden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi.testclient import TestClient
+
+    import makermodslab.server as srv
+
+    calls: list[int] = []
+    monkeypatch.setattr(srv, "HOME_IS_OVERRIDDEN", False)
+    monkeypatch.setattr(srv, "migrate_legacy_state", lambda: calls.append(1) or [])
+    with TestClient(srv.app):
+        pass
+    assert calls == [1]
+
+
+def test_the_server_startup_hook_skips_under_an_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi.testclient import TestClient
+
+    import makermodslab.server as srv
+
+    calls: list[int] = []
+    monkeypatch.setattr(srv, "HOME_IS_OVERRIDDEN", True)
+    monkeypatch.setattr(srv, "migrate_legacy_state", lambda: calls.append(1) or [])
+    with TestClient(srv.app):
+        pass
+    assert calls == []

--- a/tools/leader_compliance.py
+++ b/tools/leader_compliance.py
@@ -74,7 +74,19 @@ import threading
 import time
 from pathlib import Path
 
-ROBOTS_PATH = Path(os.path.expanduser("~/.cache/huggingface/lerobot/robots"))
+
+def _makermodslab_home() -> Path:
+    """Mirror of makermodslab.utils.config.resolve_makermodslab_home, kept
+    inline so this script stays standalone: $MAKERMODSLAB_HOME, else
+    ~/.makermods/makermodslab. Robot records live under it, not in lerobot's
+    cache (see CLAUDE.md, "Persistent state on disk")."""
+    override = os.environ.get("MAKERMODSLAB_HOME")
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path.home() / ".makermods" / "makermodslab"
+
+
+ROBOTS_PATH = _makermodslab_home() / "robots"
 
 # Feetech STS3215 register ranges. Torque_Limit is 0-1000 in the servo's own
 # units (it is a permille of Max_Torque_Limit, not a percentage).


### PR DESCRIPTION
## Summary

MakerMods Lab's own on-disk state moves out of lerobot's cache into a root of its own, `MAKERMODSLAB_HOME` = `~/.makermods/makermodslab/` (env-overridable). This lands first so everything that follows (the extension system, whose folders live under this root) is built on the new surface.

**Moved:** robot records, saved ports, the bimanual calibration staging dir (`makermodslab_biso` → `biso_staging`), the UI bookkeeping files (dismissed hub jobs, saved custom and hidden datasets/models, excluded episodes), the instance id and the saved node list.

**Stays in `~/.cache/huggingface/lerobot/`:** datasets, models, `outputs/train/`, and the calibration libraries, because lerobot's device classes read them there.

## Migration

`migrate_legacy_state` runs once as the first server startup hook. Every reader of a moved path is lazy, so startup is early enough.

- A file moves only when nothing exists at the new path; the newer file wins, so a downgrade-then-upgrade cannot clobber it.
- A directory present at both places is merged name by name under the same rule. Listing robots creates `robots/` on every page load, so without this a new → old → new round-trip would strand every record the old version wrote in between.
- Every move is staged as `<dst>.migrating` and renamed into place, so a cross-filesystem copy that dies part-way (disk full, one unreadable file; common when `~/.cache/huggingface` is symlinked to another drive) never leaves a partial destination.
- Whatever is left behind is named in one warning per start. A failed move is logged and skipped; the app starts either way.
- Never runs under a `MAKERMODSLAB_HOME` override. The test suite sets one before importing the package, so tests can neither touch nor move a developer's real state.

## Testing

- `tests/test_state_home.py`: home resolution, moves, the rename, destination-wins, merge, empty-new-dir, rollback of a half copy, idempotence, failure tolerance, both branches of the startup hook.
- Full suite: 2804 passed. `ruff` clean. OpenAPI snapshot unchanged.
- Independent adversarial review of the commit (reads before the hook, remaining hardcoded paths across Python/tests/frontend/docs/workflows/systemd, symlinks, override edge cases, node identity, concurrent servers) found the three items fixed in the second commit and nothing else.

## What to check on a real machine

First launch after upgrading moves your existing `robots/`, `instance_id.txt`, `nodes.json` (and whichever other entries exist) into `~/.makermods/makermodslab/`; the server log says what moved. Robots, ports, the node list and the hidden/pinned lists should look exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PhBh5gAyQyRgesoVYoYHZ
