### PR TITLE
fix(calibration): keep the zero-pose live joint readout in order

### DIFF
--- a/makermodslab/arms/base.py
+++ b/makermodslab/arms/base.py
@@ -146,6 +146,24 @@ REQUIRED_ATTRIBUTES: tuple[str, ...] = (
 CALIBRATION_KINDS: tuple[str, ...] = ("range_sweep", "steps", "panel")
 
 
+def _in_joint_order(device: Any, positions: dict[str, float]) -> dict[str, float]:
+    """Reorder a position read to the device's own joint sequence.
+
+    A raw reader may return joints in bus reply-arrival order — the Star 102
+    leader over FashionStar UART does, and that order reshuffles between calls
+    — while the calibration wizard renders the readout in dict order. Pin it to
+    the device's declared joint list (``motor_names`` on the leader,
+    ``_joint_motor_names`` on a follower); a name the device does not list is
+    kept, after the ordered ones, rather than dropped.
+    """
+    order = getattr(device, "motor_names", None) or getattr(device, "_joint_motor_names", None)
+    if not order:
+        return positions
+    ordered = {name: positions[name] for name in order if name in positions}
+    ordered.update({name: value for name, value in positions.items() if name not in ordered})
+    return ordered
+
+
 @dataclass(frozen=True)
 class FollowerPreflight:
     """One follower a flow is about to hand to a subprocess (see
@@ -368,15 +386,22 @@ class ArmFamily(ABC):
         wins, the bus's ``sync_read("Present_Position")`` (the Metal follower)
         is the fallback, and a device with neither reads as empty. A failure
         is the caller's to skip.
+
+        The result is ordered by the device's own joint sequence: the Star 102
+        leader's raw reader hands joints back in UART reply-arrival order, which
+        reshuffles between calls, and the wizard renders the readout in dict
+        order — so an unpinned order churns the rows five times a second.
         """
         reader = getattr(device, "_read_raw_positions", None)
         if reader is not None:
-            return {m: float(v) for m, v in reader().items()}
-        bus = getattr(device, "bus", None)
-        sync_read = getattr(bus, "sync_read", None)
-        if sync_read is None:
-            return {}
-        return {m: float(v) for m, v in sync_read("Present_Position").items()}
+            raw = {m: float(v) for m, v in reader().items()}
+        else:
+            bus = getattr(device, "bus", None)
+            sync_read = getattr(bus, "sync_read", None)
+            if sync_read is None:
+                return {}
+            raw = {m: float(v) for m, v in sync_read("Present_Position").items()}
+        return _in_joint_order(device, raw)
 
     def calibrate(self, device: Any, device_type: str, ui: CalibrationUI) -> dict[str, Any]:
         """Run this family's "steps" procedure and return the calibration to write.

--- a/tests/test_arm_registry.py
+++ b/tests/test_arm_registry.py
@@ -618,6 +618,37 @@ def test_read_positions_default_prefers_the_raw_reader_then_the_bus() -> None:
     assert family.read_positions(_Bare()) == {}
 
 
+def test_read_positions_orders_joints_by_the_devices_own_sequence() -> None:
+    """The Star 102 leader's raw reader hands joints back in UART reply-arrival
+    order, which reshuffles between calls; the CAN followers do not. The wizard
+    renders the readout in dict order, so read_positions pins that order to the
+    device's own joint sequence (``motor_names`` on the leader,
+    ``_joint_motor_names`` on a follower). A name the device does not list is
+    kept, after the ordered ones, rather than dropped."""
+
+    canonical = ["shoulder_pan", "shoulder_lift", "elbow_flex", "gripper"]
+
+    class _ShuffledLeader:
+        motor_names = canonical
+
+        def _read_raw_positions(self):
+            return {"elbow_flex": 3.0, "gripper": 4.0, "shoulder_pan": 1.0, "shoulder_lift": 2.0}
+
+    class _ShuffledFollowerBus:
+        def sync_read(self, register):
+            assert register == "Present_Position"
+            return {"gripper": 9.0, "extra": 0.0, "shoulder_pan": 6.0}
+
+    class _ShuffledFollower:
+        _joint_motor_names = ["shoulder_pan", "gripper"]
+        bus = _ShuffledFollowerBus()
+
+    family = make_arm_family("nine")
+
+    assert list(family.read_positions(_ShuffledLeader())) == canonical
+    assert list(family.read_positions(_ShuffledFollower())) == ["shoulder_pan", "gripper", "extra"]
+
+
 def test_non_families_are_refused(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(registry, "_FAMILIES", dict(registry._FAMILIES))
     with pytest.raises(TypeError, match="ArmFamily"):


### PR DESCRIPTION
## Summary

Zeroing a Star arm showed the live joint list reshuffling its rows several times a second. The readout is now pinned to the arm's own joint order, so the rows stay put.

## Commits

1. Order the zero-pose live joint readout by the arm's own joint sequence, and add a regression test.

## Sensitive changes

None.