### PR TITLE
fix(build): ship real URDF meshes in the frontend bundle

### DIFF
--- a/frontend/.gitattributes
+++ b/frontend/.gitattributes
@@ -34,6 +34,9 @@ saved_model/**/* filter=lfs diff=lfs merge=lfs -text
 *.zst filter=lfs diff=lfs merge=lfs -text
 *tfevents* filter=lfs diff=lfs merge=lfs -text
 *.stl filter=lfs diff=lfs merge=lfs -text
+# Metal meshes use uppercase extensions; keep rules out of public so Vite
+# cannot copy them into dist and override the plain-binary bundle rule.
+public/metal-urdf/meshes/*.STL filter=lfs diff=lfs merge=lfs -text
 *.lockb filter=lfs diff=lfs merge=lfs -text
 
 # Build output: store as plain binary (overrides LFS) so the wheel can ship real files

--- a/frontend/public/maker-urdf/.gitattributes
+++ b/frontend/public/maker-urdf/.gitattributes
@@ -1,1 +1,0 @@
-meshes/*.stl filter=lfs diff=lfs merge=lfs -text

--- a/frontend/public/metal-urdf/.gitattributes
+++ b/frontend/public/metal-urdf/.gitattributes
@@ -1,1 +1,0 @@
-meshes/*.STL filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
The URDF-specific `.gitattributes` files added in #120 sit under `frontend/public`, so Vite copies them into `frontend/dist`. Those nested rules override the bundle's `dist/** -filter` setting and turn its meshes into LFS pointers during the CI commit.

Keep the rules in `frontend/.gitattributes`: the existing lowercase STL rule covers Maker, and a source-only uppercase STL rule covers Metal. Remove both public attribute files so the automatic rebuild ships real mesh bytes.

Validation: production build; all 52 Maker and 10 Metal meshes verified as binary STL; no `.gitattributes` in the generated bundle; source meshes use LFS and dist meshes do not. Pre-commit passed.
