### PR TITLE
Fix remote leader startup, arm viewers, and inference cleanup

### DIFF
--- a/frontend/src/components/dialogs/RemoteTeleopDialog.tsx
+++ b/frontend/src/components/dialogs/RemoteTeleopDialog.tsx
@@ -471,7 +471,7 @@ const RemoteTeleopDialogBody: React.FC<Omit<RemoteTeleopDialogProps, "open">> = 
         jointsKey={jointsKey === "joints" ? "joints_deg" : "joints_deg_right"}
       />
     ) : (
-      <UrdfViewer jointsKey={jointsKey} variant="light" compact />
+      <UrdfViewer armType={hostedArmType ?? robot?.arm_type ?? "so101"} jointsKey={jointsKey} variant="light" compact />
     );
 
   return (

--- a/makermodslab/drtc/_session_glue.py
+++ b/makermodslab/drtc/_session_glue.py
@@ -257,6 +257,42 @@ def return_step(start_poses: list, abort_event: threading.Event):
 # --- the interrupt shield -----------------------------------------------------
 
 
+def disconnect_robot(robot, connected: bool) -> None:
+    """Release startup failures even when the device's disconnect guard refuses.
+
+    A camera/configuration failure can leave an open, energized bus while
+    robot.is_connected is false. Release components independently in that case.
+    """
+    if connected:
+        try:
+            robot.disconnect()
+            return
+        except Exception:
+            # Complete the fallback before propagating the original failure.
+            disconnect_robot(robot, False)
+            raise
+    from ..torque import device_buses, force_disable_torque
+
+    problems = []
+
+    def attempt(what, fn, *args, **kwargs):
+        try:
+            return shielded(what, fn, *args, reraise=True, **kwargs)
+        except Exception as exc:
+            problems.append(f"{what}: {exc}")
+            return None
+
+    problems.extend(attempt("disabling startup torque", force_disable_torque, robot) or [])
+    for name, camera in (getattr(robot, "cameras", None) or {}).items():
+        if getattr(camera, "is_connected", False):
+            attempt(f"closing camera {name}", camera.disconnect)
+    for bus in device_buses(robot):
+        if getattr(bus, "is_connected", False):
+            attempt("closing startup bus", bus.disconnect, disable_torque=False)
+    if problems:
+        raise RuntimeError("; ".join(problems))
+
+
 def shielded(what: str, fn, *args, attempts: int = 2, reraise: bool = False, **kwargs):
     """Run one TEARDOWN step so that no interrupt can skip the steps after it.
 

--- a/makermodslab/drtc/robot_rtc.py
+++ b/makermodslab/drtc/robot_rtc.py
@@ -151,6 +151,7 @@ from ._session_glue import (
     LoopControl,
     _shielded_disconnect,
     capture_start_poses_or_warn,
+    disconnect_robot,
     ease_in_field,
     ease_into_first_action,
     emit,
@@ -313,39 +314,43 @@ async def run(cfg: RobotSideRTCConfig) -> None:
     emit(EVENT_READY, format_ready(url, room))
 
     robot = make_robot_from_config(cfg.robot)
-    robot.connect()
-
-    # Un-throttle the servos before anything commands them. `Torque_Limit` is a
-    # RAM register that SURVIVES between sessions on one power-up, so a cap an
-    # earlier auto-calibration left behind would silently throttle this whole
-    # run: the arm tracks the policy sluggishly, everything looks healthy, and
-    # nothing anywhere says why. Feetech-only, like the register itself. Stated
-    # here rather than lifted into the glue because a source assertion pins the
-    # call site (see tests/test_drtc_robot_rtc.py, and the note in
-    # _session_glue's docstring on what deliberately did not move).
-    if feetech_buses(robot):
-        for warning in reset_torque_limit(robot, FOLLOWER):
-            print(f"[robot] WARNING: {warning}")
-
-    # Only now is it safe to read stdin — see LoopControl.start_command_pump for
-    # why the pump cannot start before connect().
-    control.start_command_pump()
-
-    schema, state_keys, action_keys = robot_wire_schema(robot)
-    print(
-        f"[robot] hardware schema: state={len(state_keys)} action={len(action_keys)} cameras={schema.cameras}"
-    )
-    print(f"[robot]   state keys : {state_keys}")
-    print(f"[robot]   action keys: {action_keys}")
-
-    # Capture where the operator left the arm, now — after connect, before
-    # anything moves — so every exit path can drive it back there while torque
-    # is still on.
-    start_poses = capture_start_poses_or_warn(robot, cfg.return_to_rest)
-
+    connected = False
+    start_poses = []
     portal = None
-    camera_timing = CameraTimingMonitor(getattr(robot, "cameras", {}))
+    camera_timing = None
     try:
+        robot.connect()
+        connected = True
+
+        # Un-throttle the servos before anything commands them. `Torque_Limit` is a
+        # RAM register that SURVIVES between sessions on one power-up, so a cap an
+        # earlier auto-calibration left behind would silently throttle this whole
+        # run: the arm tracks the policy sluggishly, everything looks healthy, and
+        # nothing anywhere says why. Feetech-only, like the register itself. Stated
+        # here rather than lifted into the glue because a source assertion pins the
+        # call site (see tests/test_drtc_robot_rtc.py, and the note in
+        # _session_glue's docstring on what deliberately did not move).
+        if feetech_buses(robot):
+            for warning in reset_torque_limit(robot, FOLLOWER):
+                print(f"[robot] WARNING: {warning}")
+
+        # Only now is it safe to read stdin — see LoopControl.start_command_pump for
+        # why the pump cannot start before connect().
+        control.start_command_pump()
+
+        schema, state_keys, action_keys = robot_wire_schema(robot)
+        print(
+            f"[robot] hardware schema: state={len(state_keys)} action={len(action_keys)} cameras={schema.cameras}"
+        )
+        print(f"[robot]   state keys : {state_keys}")
+        print(f"[robot]   action keys: {action_keys}")
+
+        # Capture where the operator left the arm, now — after connect, before
+        # anything moves — so every exit path can drive it back there while torque
+        # is still on.
+        start_poses = capture_start_poses_or_warn(robot, cfg.return_to_rest)
+
+        camera_timing = CameraTimingMonitor(getattr(robot, "cameras", {}))
         camera_timing.start()
         codec = getattr(VideoCodec, cfg.video_codec.upper())
 
@@ -755,7 +760,8 @@ async def run(cfg: RobotSideRTCConfig) -> None:
         raise
     finally:
         shielded("the STOPPING event", emit, EVENT_STOPPING, attempts=1)
-        camera_timing.stop()
+        if camera_timing is not None:
+            shielded("stopping camera diagnostics", camera_timing.stop)
         # Order is load-bearing: the return needs torque, and it is
         # robot.disconnect() that releases it. QUIT is the one path that skips
         # the return — it means "stop now", and the caller has accepted that
@@ -792,7 +798,7 @@ async def run(cfg: RobotSideRTCConfig) -> None:
         # `reraise`: a disconnect that genuinely FAILS still ends the process
         # non-zero and without a BYE — the parent reads that as the child
         # dying, which is the truth. Only the interrupt is swallowed.
-        shielded("the torque release (robot.disconnect)", robot.disconnect, reraise=True)
+        shielded("the torque release (robot.disconnect)", disconnect_robot, robot, connected, reraise=True)
         shielded("the BYE event", emit, EVENT_BYE, attempts=1)
 
 

--- a/makermodslab/drtc/robot_sync.py
+++ b/makermodslab/drtc/robot_sync.py
@@ -167,6 +167,7 @@ from ._session_glue import (
     LoopControl,
     _shielded_disconnect,
     capture_start_poses_or_warn,
+    disconnect_robot,
     ease_in_field,
     ease_into_first_action,
     emit,
@@ -314,41 +315,44 @@ async def run(cfg: RobotSideConfig) -> None:
     emit(EVENT_READY, format_ready(url, room))
 
     robot = make_robot_from_config(cfg.robot)
-    robot.connect()
-
-    # Un-throttle the servos before anything commands them. `Torque_Limit` is a
-    # RAM register that SURVIVES between sessions on one power-up, so a cap an
-    # earlier auto-calibration left behind (the bench robot's record carries
-    # motor_power=38, i.e. 38% torque) would silently throttle this whole run:
-    # the arm tracks the policy sluggishly, everything looks healthy, and
-    # nothing anywhere says why. Every Lab session does this at start
-    # (`rollout._preflight_motor_registers`, teleop, record); a hand-run
-    # `robot_sync` did not, so it was the one entrypoint that inherited the cap.
-    # Feetech-only, like the register itself — `feetech_buses` is empty for the
-    # Koch/OMX arms this entrypoint also registers, and reset_torque_limit
-    # never raises (per-motor failures come back as warnings).
-    if feetech_buses(robot):
-        for warning in reset_torque_limit(robot, FOLLOWER):
-            print(f"[robot] WARNING: {warning}")
-
-    # Only now is it safe to read stdin — see LoopControl.start_command_pump for
-    # why the pump cannot start before connect().
-    control.start_command_pump()
-
-    schema, state_keys, action_keys = robot_wire_schema(robot)
-    print(
-        f"[robot] hardware schema: state={len(state_keys)} action={len(action_keys)} cameras={schema.cameras}"
-    )
-    print(f"[robot]   state keys : {state_keys}")
-    print(f"[robot]   action keys: {action_keys}")
-
-    # Capture where the operator left the arm, now — after connect, before
-    # anything moves — so every exit path can drive it back there while torque
-    # is still on.
-    start_poses = capture_start_poses_or_warn(robot, cfg.return_to_rest)
-
+    connected = False
+    start_poses = []
     portal = None
     try:
+        robot.connect()
+        connected = True
+
+        # Un-throttle the servos before anything commands them. `Torque_Limit` is a
+        # RAM register that SURVIVES between sessions on one power-up, so a cap an
+        # earlier auto-calibration left behind (the bench robot's record carries
+        # motor_power=38, i.e. 38% torque) would silently throttle this whole run:
+        # the arm tracks the policy sluggishly, everything looks healthy, and
+        # nothing anywhere says why. Every Lab session does this at start
+        # (`rollout._preflight_motor_registers`, teleop, record); a hand-run
+        # `robot_sync` did not, so it was the one entrypoint that inherited the cap.
+        # Feetech-only, like the register itself — `feetech_buses` is empty for the
+        # Koch/OMX arms this entrypoint also registers, and reset_torque_limit
+        # never raises (per-motor failures come back as warnings).
+        if feetech_buses(robot):
+            for warning in reset_torque_limit(robot, FOLLOWER):
+                print(f"[robot] WARNING: {warning}")
+
+        # Only now is it safe to read stdin — see LoopControl.start_command_pump for
+        # why the pump cannot start before connect().
+        control.start_command_pump()
+
+        schema, state_keys, action_keys = robot_wire_schema(robot)
+        print(
+            f"[robot] hardware schema: state={len(state_keys)} action={len(action_keys)} cameras={schema.cameras}"
+        )
+        print(f"[robot]   state keys : {state_keys}")
+        print(f"[robot]   action keys: {action_keys}")
+
+        # Capture where the operator left the arm, now — after connect, before
+        # anything moves — so every exit path can drive it back there while torque
+        # is still on.
+        start_poses = capture_start_poses_or_warn(robot, cfg.return_to_rest)
+
         codec = getattr(VideoCodec, cfg.video_codec.upper())
 
         portal_cfg = PortalRobotConfig(room)
@@ -621,7 +625,7 @@ async def run(cfg: RobotSideConfig) -> None:
         # non-zero and without a BYE, exactly as it did before — the parent
         # reads that as the child dying, which is the truth. Only the interrupt
         # is swallowed.
-        shielded("the torque release (robot.disconnect)", robot.disconnect, reraise=True)
+        shielded("the torque release (robot.disconnect)", disconnect_robot, robot, connected, reraise=True)
         shielded("the BYE event", emit, EVENT_BYE, attempts=1)
 
 

--- a/makermodslab/remote_host.py
+++ b/makermodslab/remote_host.py
@@ -382,6 +382,10 @@ def host_joint_data(observation: dict, ranges: dict, arm_type: str, bimanual: bo
             if feetech
             else observation_degrees(observation, prefix=prefix)
         )
+        if not feetech:
+            family = arm_registry.get(arm_type)
+            if family.telemetry_kind == "urdf":
+                result[f"joints{suffix}"] = family.urdf_joint_positions(result[f"joints_deg{suffix}"])
         if not bimanual:
             break
     return result

--- a/makermodslab/remote_teleoperate.py
+++ b/makermodslab/remote_teleoperate.py
@@ -59,8 +59,7 @@ from .arm_identity import verify_devices
 from .nodes import NodeNotFoundError, NodeUnreachableError, PeerJobRefusalError, node_registry
 from .remote_host import (
     REMOTE_EXTRA_HINT,
-    observation_degrees,
-    observation_to_urdf_joints,
+    host_joint_data,
     remote_extra_available,
 )
 from .session_events import notify_session_changed
@@ -407,7 +406,6 @@ def handle_start_remote_teleoperation(
 
     ranges = dict(descriptor.get("joint_ranges_deg") or {})
     fps = int(descriptor["fps"])
-    feetech = uses_feetech_bus(request.arm_type)
     is_bimanual = request.mode == "bimanual"
     camera_names = [c["name"] for c in cameras]
 
@@ -432,23 +430,9 @@ def handle_start_remote_teleoperation(
                     if now - last_broadcast >= _BROADCAST_INTERVAL_S:
                         try:
                             joint_data: dict[str, Any] = {"type": "joint_update", "timestamp": now}
-                            if feetech:
-                                joint_data["joints"] = observation_to_urdf_joints(
-                                    observation, ranges, prefix="left_" if is_bimanual else ""
-                                )
-                                if is_bimanual:
-                                    joint_data["joints_right"] = observation_to_urdf_joints(
-                                        observation, ranges, prefix="right_"
-                                    )
-                            else:
-                                joint_data["joints"] = {}
-                                joint_data["joints_deg"] = observation_degrees(
-                                    observation, prefix="left_" if is_bimanual else ""
-                                )
-                                if is_bimanual:
-                                    joint_data["joints_deg_right"] = observation_degrees(
-                                        observation, prefix="right_"
-                                    )
+                            joint_data.update(
+                                host_joint_data(observation, ranges, request.arm_type, is_bimanual)
+                            )
                             if websocket_manager and websocket_manager.active_connections:
                                 websocket_manager.broadcast_joint_data_sync(joint_data)
                             last_broadcast = now

--- a/makermodslab/utils/config.py
+++ b/makermodslab/utils/config.py
@@ -710,13 +710,16 @@ def setup_calibration_files(
     return leader_config_name, follower_config_name
 
 
-def setup_leader_calibration_file(leader_config: str, arm_type: object = DEFAULT_ARM_TYPE) -> str:
+def setup_leader_calibration_file(
+    leader_config: str, arm_type: object = DEFAULT_ARM_TYPE, leader_kind: object = None
+) -> str:
     """Leader twin of setup_follower_calibration_file (remote teleoperation
     opens ONLY the leader). Validates the assigned config exists in the arm
-    type's leader library and returns its stem — lerobot's `id`."""
+    type's leader library and returns its stem — lerobot's `id`.
+    ``leader_kind`` selects the library for a multi-leader family."""
     _require_assigned_config(leader_config, "leader")
     leader_config_name = os.path.splitext(leader_config)[0]
-    leader_library = leader_config_path_for(arm_type)
+    leader_library = leader_config_path_for(arm_type, leader_kind)
     target = os.path.join(leader_library, f"{leader_config_name}.json")
     if not os.path.exists(target):
         raise FileNotFoundError(
@@ -1499,12 +1502,14 @@ def stage_bimanual_leader_calibrations(
     leader_left: str,
     leader_right: str,
     arm_type: object = DEFAULT_ARM_TYPE,
+    leader_kind: object = None,
 ) -> tuple[str, str]:
     """Leader twin of stage_bimanual_follower_calibrations (remote
-    teleoperation opens only the leaders). Returns (leader_staging_dir, base)."""
+    teleoperation opens only the leaders). Returns (leader_staging_dir, base).
+    ``leader_kind`` selects the source library for a multi-leader family."""
     leader_staging = _bimanual_leader_staging_dir(base)
     _stage_one_side(
-        leader_config_path_for(arm_type), leader_staging, base, leader_left, leader_right, "leader"
+        leader_config_path_for(arm_type, leader_kind), leader_staging, base, leader_left, leader_right, "leader"
     )
     return leader_staging, base
 

--- a/tests/test_drtc_robot_rtc.py
+++ b/tests/test_drtc_robot_rtc.py
@@ -130,8 +130,10 @@ def test_both_engines_tear_down_the_same_way() -> None:
         ]
         return [node.args[0].value for node in sorted(steps, key=lambda n: n.lineno)]
 
-    assert labels(ROBOT_RTC) == labels(ROBOT_SYNC)
-    assert labels(ROBOT_RTC) == [
+    rtc_labels = labels(ROBOT_RTC)
+    assert rtc_labels[1] == "stopping camera diagnostics"
+    assert [label for label in rtc_labels if label != "stopping camera diagnostics"] == labels(ROBOT_SYNC)
+    assert labels(ROBOT_SYNC) == [
         "the STOPPING event",
         "the RETURNING event",
         "the return to the start pose",

--- a/tests/test_drtc_startup_cleanup.py
+++ b/tests/test_drtc_startup_cleanup.py
@@ -1,0 +1,141 @@
+# Copyright 2026 MakerMods. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Execute each entrypoint's startup/teardown with fake devices, without Portal.
+
+The coroutine is compiled from its real source to avoid importing optional FFI
+and policy packages. These are behavior tests, not assertions about AST shape.
+"""
+
+import ast
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from makermodslab.drtc import _session_glue as glue
+
+
+@pytest.mark.parametrize("engine", ["robot_sync", "robot_rtc"])
+@pytest.mark.parametrize("failure", ["partial_connect", "post_connect_print", "after_capture"])
+def test_startup_failure_always_releases_robot(engine, failure):
+    calls = []
+
+    class Bus:
+        is_connected = True
+        motors = {"elbow": object(), "gripper": object()}
+
+        def disable_torque(self, motor, num_retry):
+            calls.append(f"disable:{motor}")
+
+        def disconnect(self, disable_torque):
+            assert disable_torque is False
+            calls.append("bus_closed")
+            self.is_connected = False
+
+    class Robot:
+        bus = Bus()
+        cameras = {
+            "opened": SimpleNamespace(is_connected=True, disconnect=lambda: calls.append("camera_closed")),
+            "failed": SimpleNamespace(is_connected=False, disconnect=lambda: pytest.fail("never connected")),
+        }
+
+        def connect(self):
+            calls.append("connect")
+            if failure == "partial_connect":
+                raise RuntimeError("configuration failed after opening bus")
+
+        def disconnect(self):
+            calls.append("disconnect")
+
+    def startup_print(*args, **kwargs):
+        if failure == "post_connect_print":
+            raise BrokenPipeError("parent exited")
+
+    robot = Robot()
+    path = Path(__file__).parents[1] / "makermodslab" / "drtc" / f"{engine}.py"
+    run = next(
+        n for n in ast.parse(path.read_text()).body if isinstance(n, ast.AsyncFunctionDef) and n.name == "run"
+    )
+    run.args.args[0].annotation = None
+    run.returns = None
+    ns = {
+        "LoopControl": lambda: SimpleNamespace(
+            start_command_pump=lambda: None,
+            quit_event=SimpleNamespace(is_set=lambda: False),
+            abort_event=None,
+        ),
+        "load_env": lambda: None,
+        "emit": lambda *args: None,
+        "format_ready": lambda *args: "",
+        "make_robot_from_config": lambda _: robot,
+        "feetech_buses": lambda _: [],
+        "robot_wire_schema": lambda _: (SimpleNamespace(cameras=[]), [], []),
+        "print": startup_print,
+        "capture_start_poses_or_warn": lambda *args: ["captured"],
+        "VideoCodec": SimpleNamespace(),  # unknown codec fails AFTER pose capture
+        "CameraTimingMonitor": lambda *args: SimpleNamespace(
+            start=lambda: None, stop=lambda: calls.append("timing_stopped")
+        ),
+        "shielded": glue.shielded,
+        "disconnect_robot": glue.disconnect_robot,
+        "say": lambda *args: None,
+        "return_step": lambda *args: lambda: calls.append("return"),
+    }
+    ns.update(
+        {
+            name: name
+            for name in ("EVENT_READY", "EVENT_ERROR", "EVENT_STOPPING", "EVENT_RETURNING", "EVENT_BYE")
+        }
+    )
+    exec(compile(ast.Module(body=[run], type_ignores=[]), str(path), "exec"), ns)
+    cfg = SimpleNamespace(
+        livekit_url="unused",
+        livekit_room="unused",
+        livekit_token="unused",
+        robot=None,
+        return_to_rest=True,
+        video_codec="bad",
+    )
+    with pytest.raises((RuntimeError, BrokenPipeError, AttributeError)):
+        asyncio.run(ns["run"](cfg))
+    if failure == "partial_connect":
+        assert calls == ["connect", "disable:elbow", "disable:gripper", "camera_closed", "bus_closed"]
+    else:
+        assert calls[-1] == "disconnect"
+        assert ("return" in calls) == (failure == "after_capture")
+        if failure == "after_capture":
+            assert calls.index("return") < calls.index("disconnect")
+
+
+def test_partial_disconnect_continues_after_camera_failure():
+    calls = []
+
+    def failed_camera():
+        calls.append("camera")
+        raise RuntimeError("camera release failed")
+
+    bus = SimpleNamespace(
+        is_connected=True,
+        motors={"elbow": object()},
+        disable_torque=lambda *args, **kwargs: calls.append("torque_off"),
+        disconnect=lambda **kwargs: calls.append("bus_closed"),
+    )
+    robot = SimpleNamespace(
+        bus=bus,
+        cameras={"bad": SimpleNamespace(is_connected=True, disconnect=failed_camera)},
+    )
+    with pytest.raises(RuntimeError, match="camera release failed"):
+        glue.disconnect_robot(robot, False)
+    assert calls == ["torque_off", "camera", "bus_closed"]

--- a/tests/test_remote_can.py
+++ b/tests/test_remote_can.py
@@ -56,9 +56,13 @@ def test_station_publishes_every_can_joint_in_degrees(family, bimanual):
     observation = {f"{prefix}{motor}.pos": i + 0.5 for prefix in prefixes for i, motor in enumerate(motors)}
     expected = {motor: i + 0.5 for i, motor in enumerate(motors)}
     result = remote_host.host_joint_data(observation, {}, family, bimanual)
-    assert result == (
-        {"joints_deg": expected, "joints_deg_right": expected} if bimanual else {"joints_deg": expected}
-    )
+    assert result["joints_deg"] == expected
+    assert result["joints"]
+    if bimanual:
+        assert result["joints_deg_right"] == expected
+        assert result["joints_right"]
+    else:
+        assert "joints_right" not in result
     descriptor = {"arm_type": family, "motors": remote_teleoperate.leader_motors(observation)}
     assert remote_teleoperate.schema_mismatch(descriptor, family, descriptor["motors"]) is None
     assert remote_teleoperate.schema_mismatch(descriptor, "metal" if family == "maker" else "maker", None)

--- a/tests/test_remote_leader_calibration.py
+++ b/tests/test_remote_leader_calibration.py
@@ -1,0 +1,81 @@
+# Copyright 2026 MakerMods. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Remote leader builders must stage from the selected leader's real library."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from makermodslab.utils import config as cfg
+from makermodslab.utils.robot_factory import build_leader_config
+
+
+def _request(mode, leader_kind):
+    return SimpleNamespace(
+        arm_type="metal",
+        mode=mode,
+        leader_kind=leader_kind,
+        robot_name="remote",
+        leader_config="left",
+        right_leader_config="right",
+        leader_port="/dev/leader",
+        right_leader_port="/dev/right-leader",
+        follower_port="",
+        right_follower_port="",
+    )
+
+
+def _libraries(leader_kind):
+    star = Path(cfg.MAKER_LEADER_CONFIG_PATH)
+    metal = Path(cfg.METAL_LEADER_CONFIG_PATH)
+    return (metal, star) if leader_kind == "metal" else (star, metal)
+
+
+@pytest.mark.parametrize("mode", ["single", "bimanual"])
+@pytest.mark.parametrize("leader_kind", [None, "star", "metal"])
+def test_remote_leader_build_uses_selected_library(tmp_lerobot_home, mode, leader_kind):
+    selected, other = _libraries(leader_kind)
+    # The same names in both libraries must not make a wrong-library read pass.
+    for side in ("left", "right"):
+        (selected / f"{side}.json").write_text(f"selected-{side}")
+        (other / f"{side}.json").write_text(f"wrong-{side}")
+
+    leader = build_leader_config(_request(mode, leader_kind))
+    is_metal = leader_kind == "metal"
+    if mode == "single":
+        assert leader.type == ("metal_leader" if is_metal else "rebot_102_leader_metal")
+        assert (leader.id, leader.port) == ("left", "/dev/leader")
+    else:
+        assert leader.type == ("bi_metal_leader" if is_metal else "bi_rebot_102_leader")
+        assert (leader.left_arm_config.port, leader.right_arm_config.port) == (
+            "/dev/leader",
+            "/dev/right-leader",
+        )
+        for side in ("left", "right"):
+            staged = leader.calibration_dir / f"{leader.id}_{side}.json"
+            assert staged.read_text() == f"selected-{side}"
+
+
+@pytest.mark.parametrize("mode", ["single", "bimanual"])
+@pytest.mark.parametrize("leader_kind", [None, "star", "metal"])
+def test_remote_leader_build_rejects_calibration_only_in_other_library(tmp_lerobot_home, mode, leader_kind):
+    selected, other = _libraries(leader_kind)
+    for side in ("left", "right"):
+        (other / f"{side}.json").write_text("wrong-library")
+
+    with pytest.raises(FileNotFoundError) as error:
+        build_leader_config(_request(mode, leader_kind))
+    assert str(selected) in str(error.value)
+    assert "left.json" in str(error.value)

--- a/tests/test_remote_viewer_telemetry.py
+++ b/tests/test_remote_viewer_telemetry.py
@@ -1,0 +1,49 @@
+# Copyright 2026 MakerMods. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Remote CAN telemetry uses the same family mapping as local viewers."""
+
+import pytest
+
+from makermodslab import remote_host, teleoperate
+from makermodslab.arms import registry
+
+
+@pytest.mark.parametrize("arm_type", ["maker", "metal"])
+@pytest.mark.parametrize("bimanual", [False, True])
+def test_remote_viewer_matches_local_family_mapping(arm_type, bimanual):
+    family = registry.get(arm_type)
+    sides = [("left_", 30), ("right_", -45)] if bimanual else [("", 30)]
+    observation = {
+        f"{prefix}{motor}.pos": angle
+        for prefix, angle in sides
+        for motor in (
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_yaw",
+            "wrist_roll",
+            "gripper",
+        )
+    }
+    actual = remote_host.host_joint_data(observation, {}, arm_type, bimanual)
+    local = teleoperate.get_can_joint_data(None, family, bimanual, 123, observation=observation)
+    del local["type"]
+    del local["timestamp"]
+    assert actual == local
+    assert actual["joints"]
+    assert actual["joints_deg"]["shoulder_pan"] == 30
+    if bimanual:
+        assert actual["joints_right"] != actual["joints"]
+        assert actual["joints_deg_right"]["shoulder_pan"] == -45


### PR DESCRIPTION
Fixes three regressions found after PR #139: Metal remote-controller starts now select the correct Star/Metal calibration library; remote Maker/Metal viewers receive the correct model and URDF joint updates; sync and RTC inference clean up connections and partial startup failures, including broken stdout.

Validation: 275 focused Python tests passed, including real calibration builders and fake-device startup-failure regressions. Both TypeScript projects and touched lint/format checks passed. No live hardware or transport testing performed.
