### PR TITLE
fix(record): prepare cameras, codecs and CAN alignment before recording

### DIFF
--- a/internal_docs/journal/2026-09-09.md
+++ b/internal_docs/journal/2026-09-09.md
@@ -1,0 +1,10 @@
+# 2026-09-09 — Recording episode preparation
+
+- Workspace: `/private/tmp/makermodslab-recording-warmup`, branch `codex/recording-warmup`, based on main `ceea335e` after PR109.
+- Source finding: pinned LeRobot DatasetWriter starts streaming workers at frame0; worker opens codec only after first image. Starting threads or warming a throwaway encoder does not prepare the actual episode context.
+- Implemented a Lab encoder extension adapting the pinned worker with attribution: opens the actual per-episode codec/container before accepting frames; validates camera dimensions first; bounded readiness/cancel; frame0 consumes the same ready workers rather than reopening. No dummy frames encoded, no dataset counter/timestamp/stat writes during preparation.
+- Recording now stays `preparing` while it reads processed camera observations, prepares encoders, and performs strict CAN follower alignment. The existing reset alignment stays fail-soft; preparation refuses an unsuccessful chase. Startup ramp completion uses a measured hold when already aligned. Feetech motion behavior stays unchanged.
+- Repeats readiness each episode/re-take. Hardware cleanup precedes encoder close; failed output artifacts are preserved, ordinary cancellation discards empty temporary outputs.
+- Validation: 157 tests passed in `tests/test_recording_preparation.py` and `tests/test_record.py`; scoped Ruff check/format pass; synchronous worker tests verify codec open before first dequeue, RGB/depth frame PTS0 and realframe-only stats. Real DatasetWriter integration checks frame0 action/camera/index/timestamp alignment using fake workers. No hardware, service, real thread, benchmark, or performance measurement run.
+- Limitation: explicit codec open removes known lazy initialization; first encode can still incur work. Camera exposure stability and sustained FPS are not measured. This change cannot promise all first-seconds warnings disappear on a physical rig.
+- Remaining: coordinator review and authorized PR publication; changes left uncommitted.

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -1711,12 +1711,14 @@ class _LeaderTargetSource:
         teleop_action_processor,
         robot_action_processor,
         ttl_s: float = 1.0 / MAKER_RETURN_FPS,
+        strict: bool = False,
     ) -> None:
         self._robot = robot
         self._teleop = teleop
         self._teleop_action_processor = teleop_action_processor
         self._robot_action_processor = robot_action_processor
         self._ttl_s = ttl_s
+        self._strict = strict
         self._lock = threading.Lock()
         self._split: list[tuple[object, dict[str, float]]] = []
         self._read_at: float | None = None
@@ -1742,6 +1744,8 @@ class _LeaderTargetSource:
             processed = self._teleop_action_processor((action, observation))
             robot_action = self._robot_action_processor((processed, observation))
         except Exception as e:
+            if self._strict:
+                raise RuntimeError("Cannot read the leader during recording preparation") from e
             if not self._warned:
                 logger.warning(f"Could not read the leader to re-align the follower: {e}")
                 self._warned = True
@@ -1773,6 +1777,7 @@ def _realign_follower_to_leader(
     teleop_action_processor,
     robot_action_processor,
     abort_event=None,
+    require_settled: bool = False,
 ) -> bool:
     """Walk a CAN follower to the leader's CURRENT pose at a bounded rate.
 
@@ -1802,9 +1807,9 @@ def _realign_follower_to_leader(
     first passthrough tick. ``maker_targets_from_action`` carries the full
     rationale for the two callers differing.
 
-    Never raises and never aborts the session: the return reports ``(ok,
-    reason)``, a failure is logged, and the caller drops back into ordinary
-    passthrough (today's behaviour).
+    By default, failures are logged and passthrough may resume. Episode
+    preparation sets ``require_settled=True`` instead: a failed move or leader
+    read raises before any recorded frames, and the startup ramp must be ready.
 
     Returns True when passthrough may resume — the move finished, settled,
     stopped short, or there was nothing to do. False ONLY when the abort event
@@ -1825,6 +1830,8 @@ def _realign_follower_to_leader(
         return True
 
     if teleop is None:
+        if require_settled:
+            raise RuntimeError("Cannot prepare CAN follower without a leader")
         logger.warning("No leader to re-align the CAN follower to; resuming passthrough as-is")
         return True
 
@@ -1832,9 +1839,13 @@ def _realign_follower_to_leader(
     # says both that it meant to and why it didn't.
     logger.info("Re-aligning the follower to the leader before passthrough resumes")
 
-    source = _LeaderTargetSource(robot, teleop, teleop_action_processor, robot_action_processor)
+    source = _LeaderTargetSource(
+        robot, teleop, teleop_action_processor, robot_action_processor, strict=require_settled
+    )
     targets = source.split()
     if not targets:
+        if require_settled:
+            raise RuntimeError("No leader targets for recording preparation")
         logger.warning("No leader target to re-align the CAN follower to; resuming passthrough unaligned")
         return True
 
@@ -1853,7 +1864,25 @@ def _realign_follower_to_leader(
             continue
         if ok:
             continue
+        if require_settled:
+            raise RuntimeError(f"Follower did not settle before recording: {reason}")
         logger.warning(f"The follower did not fully re-align to the leader ({reason}); continuing")
+    if require_settled and not cut_short:
+        # Already-aligned arms can return without a send, leaving the pinned
+        # follower's connect-time startup ramp armed. Send its CURRENT measured
+        # pose once so the stock follower finishes that ramp without motion.
+        for device, _pose in targets:
+            if abort_event is not None and abort_event.is_set():
+                return False
+            if (
+                getattr(device, "_synced", None) is False
+                and getattr(device.config, "startup_sync_speed_deg", None) is not None
+            ):
+                observation = device.get_observation()
+                hold = {f"{motor}.pos": observation[f"{motor}.pos"] for motor in device.bus.motors}
+                device.send_action(hold)
+                if device._synced is False:
+                    raise RuntimeError("Follower startup synchronization is not ready for recording")
     return not cut_short
 
 
@@ -2336,8 +2365,28 @@ def record_with_web_events(
     # release is attempted immediately: the bus may already be unreachable.
     ended_normally = False
 
+    from .recording_preparation import install_episode_preparation, prepare_recording_episode
+
+    prepared_encoder = None
+
+    def cancelled():
+        return bool(web_events.get("stop_recording") or _release_now.is_set())
+
+    prepare_alignment = partial(realign, require_settled=True)
     try:
+        prepared_encoder = install_episode_preparation(dataset)
         while saved_episodes < cfg.dataset.num_episodes:
+            _set_phase("preparing")
+            phase_start_time = None
+            if not prepare_recording_episode(
+                robot,
+                dataset,
+                prepared_encoder,
+                prepare_alignment,
+                cancelled,
+                observation_processor=process_observation,
+            ):
+                break
             # RECORDING PHASE - with dataset (matches original record.py exactly)
             _set_phase("recording")
             phase_start_time = time.time()
@@ -2609,6 +2658,8 @@ def record_with_web_events(
                 teleop.disconnect()
         finally:
             releasing = False
+            if prepared_encoder is not None:
+                prepared_encoder.close(preserve_failure=not ended_normally)
 
     if cfg.dataset.push_to_hub:
         # Same bare-id hazard as the UploadManager path, and the same single

--- a/makermodslab/recording_preparation.py
+++ b/makermodslab/recording_preparation.py
@@ -1,0 +1,275 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+# Copyright 2026 MakerMods. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prepare actual episode encoders before starting the recording clock.
+
+The worker loop and streaming setup are adapted from the SHA-pinned LeRobot
+video_utils._CameraEncoderThread/StreamingVideoEncoder (eaab69339). The fork
+has no preparation hook: opening threads alone defers codec creation until
+frame zero. This local extension opens the SAME contexts used by the episode,
+without encoding dummy frames or touching dataset counters/stats/timestamps.
+Codec open removes known lazy initialization; first-encode costs and achievable
+camera/encoder throughput still need hardware measurement.
+"""
+
+import contextlib
+import logging
+import queue
+import shutil
+import tempfile
+import threading
+import time
+from fractions import Fraction
+from pathlib import Path
+
+import av
+import numpy as np
+from PIL import Image
+
+from lerobot.datasets.video_utils import StreamingVideoEncoder, _CameraEncoderThread, quantize_depth
+
+logger = logging.getLogger(__name__)
+
+
+def image_dimensions(image):
+    shape = image.shape
+    if len(shape) == 3 and shape[0] in (1, 3):
+        shape = (shape[1], shape[2], shape[0])
+    if len(shape) not in (2, 3) or shape[0] <= 0 or shape[1] <= 0:
+        raise ValueError(f"Invalid camera frame shape for recording: {image.shape}")
+    return int(shape[1]), int(shape[0])
+
+
+class _PreparedCameraEncoder(_CameraEncoderThread):
+    def __init__(self, *, dimensions, **kwargs):
+        super().__init__(**kwargs)
+        self.dimensions = dimensions
+        self.ready = threading.Event()
+        self.preparation_error = None
+
+    def run(self):
+        from lerobot.datasets.compute_stats import RunningQuantileStats, auto_downsample_height_width
+
+        container = None
+        output_stream = None
+        stats_tracker = RunningQuantileStats()
+        frame_count = 0
+        try:
+            container = av.open(str(self.video_path), "w")
+            output_stream = container.add_stream(
+                self.video_encoder.vcodec,
+                self.fps,
+                options=self.video_encoder.get_codec_options(self.encoder_threads, as_strings=True),
+            )
+            output_stream.pix_fmt = self.video_encoder.pix_fmt
+            output_stream.width, output_stream.height = self.dimensions
+            output_stream.time_base = Fraction(1, self.fps)
+            output_stream.codec_context.open()
+            container.start_encoding()
+            self.ready.set()
+
+            while not self.stop_event.is_set():
+                try:
+                    frame_data = self.frame_queue.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+                if frame_data is None:
+                    break
+                if isinstance(frame_data, np.ndarray):
+                    if frame_data.ndim == 3 and frame_data.shape[0] in (1, 3):
+                        frame_data = frame_data.transpose(1, 2, 0)
+                    if not self.is_depth and frame_data.dtype != np.uint8:
+                        frame_data = (frame_data * 255).astype(np.uint8)
+                if frame_data.ndim == 2:
+                    frame_data = frame_data[..., None]
+                if image_dimensions(frame_data) != self.dimensions:
+                    raise ValueError("Camera dimensions changed after episode preparation")
+                if not self.is_depth:
+                    video_frame = av.VideoFrame.from_image(Image.fromarray(frame_data))
+                else:
+                    video_frame = quantize_depth(
+                        frame_data,
+                        depth_min=self.video_encoder.depth_min,
+                        depth_max=self.video_encoder.depth_max,
+                        shift=self.video_encoder.shift,
+                        use_log=self.video_encoder.use_log,
+                        video_backend=self.video_encoder.video_backend,
+                    )
+                video_frame.pts = frame_count
+                video_frame.time_base = Fraction(1, self.fps)
+                packet = output_stream.encode(video_frame)
+                if packet:
+                    container.mux(packet)
+                img_chw = frame_data.transpose(2, 0, 1)
+                img_downsampled = auto_downsample_height_width(img_chw)
+                channels = img_downsampled.shape[0]
+                stats_tracker.update(img_downsampled.transpose(1, 2, 0).reshape(-1, channels))
+                frame_count += 1
+            if frame_count:
+                packet = output_stream.encode()
+                if packet:
+                    container.mux(packet)
+            container.close()
+            container = None
+            self.result_queue.put(("ok", stats_tracker.get_statistics() if frame_count >= 2 else None))
+        except Exception as exc:
+            self.preparation_error = exc
+            logger.exception("Episode encoder failed: %s", self.video_path)
+            self.result_queue.put(("error", str(exc)))
+        finally:
+            if container is not None:
+                with contextlib.suppress(Exception):
+                    container.close()
+            self.ready.set()  # Failure also releases the readiness waiter.
+
+
+class PreparedStreamingVideoEncoder(StreamingVideoEncoder):
+    def __init__(self, original):
+        super().__init__(
+            fps=original.fps,
+            rgb_encoder=original._rgb_encoder,
+            depth_encoder=original._depth_encoder,
+            queue_maxsize=original.queue_maxsize,
+            encoder_threads=original._encoder_threads,
+        )
+        self._prepared_signature = None
+        self._preserve_failure = False
+
+    def prepare(self, images, temp_dir, depth_video_keys, cancelled, timeout_s=15.0):
+        if self._episode_active:
+            raise RuntimeError("Previous episode encoder is still active")
+        # Validate all cameras before creating any avoidable output artifacts.
+        dimensions = {key: image_dimensions(image) for key, image in images.items()}
+        if not images:
+            return not cancelled()
+        if not Path(temp_dir).is_dir():
+            raise ValueError("Recording dataset directory does not exist")
+        if cancelled():
+            return False
+        signature = (tuple(images), tuple(depth_video_keys), Path(temp_dir))
+        self._preserve_failure = False
+        self._dropped_frames.clear()
+        self._episode_active = True
+        try:
+            for key in images:
+                frame_queue = queue.Queue(maxsize=self.queue_maxsize)
+                result_queue = queue.Queue(maxsize=1)
+                stop = threading.Event()
+                path = Path(tempfile.mkdtemp(dir=temp_dir)) / f"{key.replace('/', '_')}_streaming.mp4"
+                worker = _PreparedCameraEncoder(
+                    dimensions=dimensions[key],
+                    video_path=path,
+                    fps=self.fps,
+                    video_encoder=self._depth_encoder if key in depth_video_keys else self._rgb_encoder,
+                    frame_queue=frame_queue,
+                    result_queue=result_queue,
+                    stop_event=stop,
+                    encoder_threads=self._encoder_threads,
+                )
+                self._frame_queues[key] = frame_queue
+                self._result_queues[key] = result_queue
+                self._stop_events[key] = stop
+                self._video_paths[key] = path
+                self._threads[key] = worker
+                worker.start()
+            deadline = time.monotonic() + timeout_s
+            for worker in self._threads.values():
+                while not worker.ready.wait(timeout=0.05):
+                    if cancelled():
+                        self.cancel_episode()
+                        return False
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("Timed out preparing episode video encoders")
+                if worker.preparation_error is not None:
+                    raise RuntimeError(
+                        "Could not prepare episode video encoder"
+                    ) from worker.preparation_error
+            if cancelled():
+                self.cancel_episode()
+                return False
+            self._prepared_signature = signature
+            return True
+        except Exception:
+            self._preserve_failure = True
+            self.cancel_episode()
+            raise
+
+    def start_episode(self, video_keys, temp_dir, depth_video_keys=None):
+        # DatasetWriter still calls this for frame zero. Consume preparation
+        # exactly once, without closing and recreating the ready contexts.
+        signature = (tuple(video_keys), tuple(depth_video_keys or []), Path(temp_dir))
+        if self._episode_active and signature == self._prepared_signature:
+            self._prepared_signature = None
+            return
+        raise RuntimeError("Episode encoder was not prepared before frame zero")
+
+    def close(self, preserve_failure=False):
+        self._preserve_failure = self._preserve_failure or preserve_failure
+        super().close()
+
+    def cancel_episode(self):
+        if not self._episode_active:
+            return
+        for event in self._stop_events.values():
+            event.set()
+        deadline = time.monotonic() + 1.0
+        for key, worker in self._threads.items():
+            if worker.ident is not None:
+                worker.join(timeout=max(0.0, deadline - time.monotonic()))
+            if worker.is_alive():
+                logger.warning(
+                    "Encoder still exiting; preserving temporary output: %s", self._video_paths[key]
+                )
+            elif not self._preserve_failure:
+                shutil.rmtree(self._video_paths[key].parent, ignore_errors=True)
+        self._cleanup()
+        self._episode_active = False
+        self._prepared_signature = None
+
+
+def install_episode_preparation(dataset):
+    """Return our encoder, or None for non-streaming/custom writer paths."""
+    writer = getattr(dataset, "writer", None)
+    original = getattr(writer, "_streaming_encoder", None)
+    if type(original) is not StreamingVideoEncoder:
+        return None
+    if original._episode_active:
+        raise RuntimeError("Cannot replace an encoder during an active episode")
+    prepared = PreparedStreamingVideoEncoder(original)
+    writer._streaming_encoder = prepared
+    original.close()
+    return prepared
+
+
+def prepare_recording_episode(robot, dataset, encoder, realign, cancelled, observation_processor=None):
+    """Prepare camera capture/codec context and align before any recorded frame."""
+    from lerobot.utils.feature_utils import build_dataset_frame
+
+    if cancelled():
+        return False
+    observation = None
+    if encoder is not None or getattr(robot, "cameras", None):
+        observation = robot.get_observation()
+        if observation_processor is not None:
+            observation = observation_processor(observation)
+    if cancelled():
+        return False
+    if encoder is not None:
+        frame = build_dataset_frame(dataset.features, observation, prefix="observation")
+        images = {key: frame[key] for key in dataset.meta.video_keys}
+        if not encoder.prepare(images, dataset.root, list(dataset.meta.depth_keys), cancelled):
+            return False
+    # Camera/codec preparation is a holding gap: chase the current leader LAST,
+    # so its movement during initialization cannot become a first-frame jump.
+    return not (cancelled() or realign() is False or cancelled())

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -3852,3 +3852,100 @@ def test_teleop_connect_failure_releases_both_devices(
     assert isinstance(error, RuntimeError) and "leader bus" in str(error)
     # Both devices released, follower first.
     assert [s["label"] for s in seen] == ["robot", "teleop"]
+
+
+def test_episode_preparation_precedes_timer_and_record_loop(monkeypatch, tmp_lerobot_home):
+    from makermodslab import record
+
+    calls = []
+
+    def prepare(*args, **kwargs):
+        assert record.current_phase == "preparing"
+        assert record.phase_start_time is None
+        calls.append("prepare")
+        return True
+
+    def loop(events):
+        assert record.current_phase == "recording"
+        assert record.phase_start_time is not None
+        calls.append("record")
+        events.update(stop_recording=True)
+
+    monkeypatch.setattr("makermodslab.recording_preparation.prepare_recording_episode", prepare)
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files", lambda *a, **k: ("l", "f")
+    )
+    _, robot, error, dataset_calls = _run_record_session(
+        monkeypatch, _RecRobot(_RecReturnBus()), record_loop_side_effect=loop
+    )
+    assert error is None
+    assert calls == ["prepare", "record"]
+    assert robot.disconnected
+    assert "save_episode" not in dataset_calls
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+def test_preparation_failure_or_cancel_never_records_and_cleans_up(monkeypatch, tmp_lerobot_home, cancel):
+    calls = []
+    encoder = type("Encoder", (), {"close": lambda self, **kwargs: calls.append("encoder_closed")})()
+    monkeypatch.setattr("makermodslab.recording_preparation.install_episode_preparation", lambda _: encoder)
+
+    def prepare(*args, **kwargs):
+        if cancel:
+            return False
+        raise RuntimeError("codec preparation failed")
+
+    monkeypatch.setattr("makermodslab.recording_preparation.prepare_recording_episode", prepare)
+    monkeypatch.setattr(
+        "makermodslab.utils.robot_factory.setup_calibration_files", lambda *a, **k: ("l", "f")
+    )
+    _, robot, error, dataset_calls = _run_record_session(
+        monkeypatch, _RecRobot(_RecReturnBus()), record_loop_side_effect=lambda _: calls.append("record")
+    )
+    assert (error is None) is cancel
+    assert robot.disconnected
+    assert calls == ["encoder_closed"]
+    assert "save_episode" not in dataset_calls
+
+
+def test_strict_preparation_refuses_failed_can_alignment(monkeypatch):
+    from makermodslab import record
+
+    monkeypatch.setattr(record, "return_maker_arms_to_rest", lambda *a, **k: [(False, "stalled")])
+    with pytest.raises(RuntimeError, match="did not settle"):
+        record._realign_follower_to_leader(
+            _RealignRobot(),
+            _RealignTeleop({"shoulder_pan.pos": 10}),
+            "maker",
+            _identity,
+            _identity,
+            require_settled=True,
+        )
+    # The reset phase keeps its existing fail-soft behavior.
+    assert record._realign_follower_to_leader(
+        _RealignRobot(), _RealignTeleop({"shoulder_pan.pos": 10}), "maker", _identity, _identity
+    )
+
+
+def test_strict_preparation_finishes_pending_startup_sync_with_measured_hold(monkeypatch):
+    from types import SimpleNamespace
+
+    from makermodslab import record
+
+    robot = _RealignRobot()
+    robot._synced = False
+    robot.config = SimpleNamespace(startup_sync_speed_deg=1)
+    robot.bus = SimpleNamespace(motors={"shoulder_pan": object()})
+    robot.get_observation = lambda: {"shoulder_pan.pos": 9.5}
+    sent = []
+
+    def send(action):
+        sent.append(action)
+        robot._synced = True
+
+    robot.send_action = send
+    _capture_realign(monkeypatch)
+    assert record._realign_follower_to_leader(
+        robot, _RealignTeleop({"shoulder_pan.pos": 10}), "maker", _identity, _identity, require_settled=True
+    )
+    assert sent == [{"shoulder_pan.pos": 9.5}]

--- a/tests/test_recording_preparation.py
+++ b/tests/test_recording_preparation.py
@@ -1,0 +1,253 @@
+# Copyright 2026 MakerMods. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Readiness/lifecycle seams with fake codecs and workers; no thread starts."""
+
+import queue
+import threading
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from makermodslab import recording_preparation as prep
+
+
+class FakeWorker:
+    fail_start = False
+    fail_open = False
+    pending = False
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.ready = threading.Event()
+        self.preparation_error = None
+        self.ident = None
+        self.alive = False
+
+    def start(self):
+        if self.fail_start:
+            raise RuntimeError("thread creation failed")
+        self.ident = 1
+        self.alive = True
+        if self.fail_open:
+            self.preparation_error = RuntimeError("codec open failed")
+        if not self.pending:
+            self.ready.set()
+
+    def is_alive(self):
+        return self.alive
+
+    def join(self, timeout):
+        assert self.ident is not None
+        self.alive = False
+
+
+@pytest.fixture
+def encoder(monkeypatch):
+    monkeypatch.setattr(prep, "_PreparedCameraEncoder", FakeWorker)
+    original = SimpleNamespace(
+        fps=30, _rgb_encoder=object(), _depth_encoder=object(), queue_maxsize=4, _encoder_threads=2
+    )
+    return prep.PreparedStreamingVideoEncoder(original)
+
+
+def test_preparation_preserves_actual_workers_for_frame0_and_resets_next_episode(encoder, tmp_path):
+    images = {
+        "observation.images.left_cam": np.zeros((8, 10, 3), np.uint8),
+        "observation.images.right_cam": np.zeros((8, 10, 3), np.uint8),
+    }
+    encoder._dropped_frames = {"old": 4}
+    assert encoder.prepare(images, tmp_path, [], lambda: False)
+    workers = dict(encoder._threads)
+    assert encoder._dropped_frames == {}
+    assert all(q.empty() for q in encoder._frame_queues.values())
+    encoder.start_episode(list(images), tmp_path)
+    assert encoder._threads == workers
+    with pytest.raises(RuntimeError, match="not prepared"):
+        encoder.start_episode(list(images), tmp_path)
+    encoder.cancel_episode()
+    assert encoder.prepare(images, tmp_path, [], lambda: False)
+    assert all(encoder._threads[key] is not worker for key, worker in workers.items())
+    encoder.cancel_episode()
+
+
+@pytest.mark.parametrize("failure", ["fail_start", "fail_open"])
+def test_preparation_failure_preserves_original_error_and_ends_workers(
+    encoder, tmp_path, monkeypatch, failure
+):
+    monkeypatch.setattr(FakeWorker, failure, True)
+    with pytest.raises(RuntimeError):
+        encoder.prepare({"camera": np.zeros((8, 8, 3), np.uint8)}, tmp_path, [], lambda: False)
+    assert not encoder._episode_active
+    assert not encoder._threads
+    assert list(tmp_path.iterdir())  # Failure artifacts preserved for diagnosis.
+
+
+def test_cancel_and_timeout_are_bounded_and_do_not_feed_frames(encoder, tmp_path, monkeypatch):
+    monkeypatch.setattr(FakeWorker, "pending", True)
+    calls = iter([False, True])
+    assert not encoder.prepare({"camera": np.zeros((8, 8, 3), np.uint8)}, tmp_path, [], lambda: next(calls))
+    assert not encoder._episode_active
+    assert not list(tmp_path.iterdir())
+    with pytest.raises(TimeoutError):
+        encoder.prepare({"camera": np.zeros((8, 8, 3), np.uint8)}, tmp_path, [], lambda: False, timeout_s=0)
+    assert not encoder._episode_active
+
+
+def test_invalid_shape_creates_no_artifact(encoder, tmp_path):
+    with pytest.raises(ValueError):
+        encoder.prepare({"camera": np.zeros((0, 8, 3), np.uint8)}, tmp_path, [], lambda: False)
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("depth", [False, True])
+def test_worker_opens_actual_context_before_dequeue_without_dummy_frames(monkeypatch, tmp_path, depth):
+    # Run the worker body synchronously with fake PyAV; no service or thread.
+    events = []
+    encoded = []
+    stream = SimpleNamespace(codec_context=SimpleNamespace(open=lambda: events.append("codec_open")))
+
+    def encode(frame=None):
+        if frame is not None:
+            encoded.append((frame.pts, frame.time_base))
+        return []
+
+    stream.encode = encode
+    container = SimpleNamespace(
+        add_stream=lambda *a, **k: stream,
+        start_encoding=lambda: events.append("header"),
+        close=lambda: None,
+        mux=lambda _: None,
+    )
+    monkeypatch.setattr(prep.av, "open", lambda *a, **k: container)
+    monkeypatch.setattr(prep.av, "VideoFrame", SimpleNamespace(from_image=lambda _: SimpleNamespace()))
+    monkeypatch.setattr(prep, "quantize_depth", lambda *a, **k: SimpleNamespace())
+    config = SimpleNamespace(vcodec="fake", pix_fmt="fake", get_codec_options=lambda *a, **k: {})
+    if depth:
+        from lerobot.configs.video import DepthEncoderConfig
+
+        config = object.__new__(DepthEncoderConfig)
+        config.vcodec = "fake"
+        config.pix_fmt = "fake"
+        config.get_codec_options = lambda *a, **k: {}
+    q = queue.Queue()
+    shape = (8, 10) if depth else (8, 10, 3)
+    q.put(np.zeros(shape, np.uint16 if depth else np.uint8))
+    q.put(np.ones(shape, np.uint16 if depth else np.uint8))
+    q.put(None)
+    original_get = q.get
+
+    def get(*a, **k):
+        events.append("dequeue")
+        return original_get(*a, **k)
+
+    q.get = get
+    result = queue.Queue()
+    worker = prep._PreparedCameraEncoder(
+        dimensions=(10, 8),
+        video_path=tmp_path / "video.mp4",
+        fps=30,
+        video_encoder=config,
+        frame_queue=q,
+        result_queue=result,
+        stop_event=threading.Event(),
+    )
+    worker.run()
+    assert worker.preparation_error is None
+    assert events[:3] == ["codec_open", "header", "dequeue"]
+    assert [pts for pts, _ in encoded] == [0, 1]
+    assert all(float(tb) == 1 / 30 for _, tb in encoded)
+    status, stats = result.get_nowait()
+    assert status == "ok"
+    assert stats["count"].item() == 160  # Exactly two real 8x10 frames.
+
+
+def test_prepare_uses_processed_camera_frame_then_aligns_without_dataset_write(monkeypatch, tmp_path):
+    calls = []
+    raw = np.zeros((8, 10, 3), np.uint8)
+    processed = np.ones((8, 10, 3), np.uint8)
+    robot = SimpleNamespace(cameras={"left_cam": object()}, get_observation=lambda: {"left_cam": raw})
+    dataset = SimpleNamespace(
+        root=tmp_path,
+        features={
+            "observation.images.left_cam": {
+                "dtype": "video",
+                "shape": (8, 10, 3),
+                "names": ["height", "width", "channels"],
+            }
+        },
+        meta=SimpleNamespace(video_keys=["observation.images.left_cam"], depth_keys=[]),
+    )
+
+    def prepare(images, *args):
+        calls.append("codec")
+        assert images["observation.images.left_cam"] is processed
+        return True
+
+    encoder = SimpleNamespace(prepare=prepare)
+
+    def align():
+        calls.append("align")
+        return True
+
+    assert prep.prepare_recording_episode(
+        robot,
+        dataset,
+        encoder,
+        align,
+        lambda: False,
+        observation_processor=lambda obs: {"left_cam": processed},
+    )
+    assert calls == ["codec", "align"]
+
+
+def test_nonstreaming_and_custom_encoders_are_unchanged():
+    for existing in (None, object()):
+        dataset = SimpleNamespace(writer=SimpleNamespace(_streaming_encoder=existing))
+        assert prep.install_episode_preparation(dataset) is None
+        assert dataset.writer._streaming_encoder is existing
+
+
+def test_real_dataset_writer_keeps_frame0_camera_action_alignment(encoder, tmp_path):
+    from lerobot.datasets.dataset_writer import DatasetWriter
+    from lerobot.utils.constants import DEFAULT_FEATURES
+
+    keys = ["observation.images.left_cam", "observation.images.right_cam"]
+    features = {**DEFAULT_FEATURES, "action": {"dtype": "float32", "shape": (1,), "names": ["joint.pos"]}}
+    for key in keys:
+        features[key] = {"dtype": "video", "shape": (8, 10, 3), "names": ["height", "width", "channels"]}
+    meta = SimpleNamespace(features=features, total_episodes=0, video_keys=keys, depth_keys=[], fps=30)
+    writer = DatasetWriter(
+        meta=meta,
+        root=tmp_path,
+        rgb_encoder=object(),
+        depth_encoder=object(),
+        streaming_encoder=encoder,
+        encoder_threads=None,
+        batch_encoding_size=1,
+    )
+    warmup = {key: np.zeros((8, 10, 3), np.uint8) for key in keys}
+    assert encoder.prepare(warmup, tmp_path, [], lambda: False)
+    assert writer.episode_buffer["size"] == 0
+    assert writer.episode_buffer["timestamp"] == []
+    assert all(q.empty() for q in encoder._frame_queues.values())
+    real = {key: np.full((8, 10, 3), index + 11, np.uint8) for index, key in enumerate(keys)}
+    writer.add_frame({**real, "action": np.array([23], np.float32), "task": "pick"})
+    assert writer.episode_buffer["frame_index"] == [0]
+    assert writer.episode_buffer["timestamp"] == [0.0]
+    assert writer.episode_buffer["size"] == 1
+    assert writer.episode_buffer["action"][0].item() == 23
+    for key in keys:
+        np.testing.assert_array_equal(encoder._frame_queues[key].get_nowait(), real[key])
+    encoder.cancel_episode()


### PR DESCRIPTION
## Changes

The recorder currently initializes video codecs after the first recorded frame, and CAN follower startup alignment can consume the beginning of an episode. Move preparation ahead of the episode timer on top of #109.

Before each episode or retake, read processed camera frames, open the actual per-camera codec contexts, and align CAN followers with their leaders. Frame zero reuses those contexts: preparation adds no dummy frames, dataset timestamps, actions, or image statistics. Stop cancels preparation; failed preparation follows existing hardware cleanup. Existing reset alignment behavior and Feetech motion remain unchanged.

The encoder extension adapts the SHA-pinned LeRobot worker because that version has no preparation hook. It preserves RGB/depth settings and keeps initialization out of the recorded phase.

## Validation

157 focused tests passed, including the actual pinned DatasetWriter with fake workers to verify frame-zero camera/action/timestamp alignment. Tests cover readiness, context reuse, cancellation, failure cleanup, RGB/depth timestamps, and strict CAN alignment. Applicable static checks passed; API snapshot regeneration was skipped because the API is unchanged.

No hardware or performance measurement was run. Explicit codec opening removes known lazy initialization, but first-encode work and camera exposure settling may remain; this does not promise that every startup slow-loop warning disappears.
