### PR TITLE
Fix remote host and operator config construction

### DIFF
--- a/makermodslab/utils/robot_factory.py
+++ b/makermodslab/utils/robot_factory.py
@@ -53,6 +53,8 @@ as subprocess CLI args, not as config objects, so it does not use this
 module — the follower-only asymmetry lives there, not here.
 """
 
+from types import SimpleNamespace
+
 # Eager, deliberately: every device config class the three families build is
 # imported HERE at module import (server.py imports this module through
 # teleoperate/record), so a missing or broken CAN extra — `maker`, `damiao`,
@@ -133,6 +135,19 @@ def build_single_configs(request, cameras=None):
     return family.build_single_configs(request, cameras, leader_config_name, follower_config_name)
 
 
+def _with_unused_ports(request, side: str):
+    """Adapt a one-sided remote request to the family's paired builder.
+
+    The discarded config still needs port fields, but it is never connected.
+    Keep the actual request and its API schema unchanged, and preserve every
+    supplied field, including the selected side's ports and leader kind.
+    """
+    fields = dict(vars(request))
+    for prefix in ("", "right_"):
+        fields.setdefault(f"{prefix}{side}_port", "")
+    return SimpleNamespace(**fields)
+
+
 def build_follower_config(request, cameras=None):
     """Build only the follower side for a hosted robot station.
 
@@ -140,6 +155,7 @@ def build_follower_config(request, cameras=None):
     never instantiated. This keeps construction and leader-kind rules in the
     arm registry while staging only the follower calibration files.
     """
+    request = _with_unused_ports(request, "leader")
     arm_type = request_arm_type(request)
     family = arm_registry.get(arm_type)
     if getattr(request, "mode", "single") == "bimanual":
@@ -166,6 +182,7 @@ def build_follower_config(request, cameras=None):
 
 def build_leader_config(request):
     """Build only the leader side for a remote controller."""
+    request = _with_unused_ports(request, "follower")
     arm_type = request_arm_type(request)
     family = arm_registry.get(arm_type)
     if getattr(request, "mode", "single") == "bimanual":

--- a/tests/test_remote_config_requests.py
+++ b/tests/test_remote_config_requests.py
@@ -1,0 +1,75 @@
+"""Build remote device configs from the actual one-sided request models."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from makermodslab.remote_host import HostingRequest
+from makermodslab.remote_teleoperate import RemoteTeleoperateRequest
+from makermodslab.utils import robot_factory
+
+
+@pytest.mark.parametrize(
+    "arm_type,leader_kind", [("so101", ""), ("maker", ""), ("metal", "star"), ("metal", "metal")]
+)
+@pytest.mark.parametrize("mode", ["single", "bimanual"])
+@pytest.mark.parametrize("side", ["follower", "leader"])
+def test_remote_request_builds_only_its_selected_side(
+    monkeypatch, tmp_path, arm_type, leader_kind, mode, side
+):
+    staging = tmp_path / side
+    stages = {
+        "setup_follower_calibration_file": Mock(return_value="selected-follower"),
+        "setup_leader_calibration_file": Mock(return_value="selected-leader"),
+        "stage_bimanual_follower_calibrations": Mock(return_value=(staging, None)),
+        "stage_bimanual_leader_calibrations": Mock(return_value=(staging, None)),
+    }
+    for name, mock in stages.items():
+        monkeypatch.setattr(robot_factory, name, mock)
+
+    fields = {
+        "arm_type": arm_type,
+        "mode": mode,
+        "robot_name": "remote-test",
+        f"{side}_port": "/not-opened-left",
+        f"right_{side}_port": "/not-opened-right",
+        f"{side}_config": "selected-left",
+        f"right_{side}_config": "selected-right",
+    }
+    if side == "follower":
+        request = HostingRequest(**fields)
+        build = robot_factory.build_follower_config
+    else:
+        request = RemoteTeleoperateRequest(**fields, leader_kind=leader_kind, station="test-station")
+        build = robot_factory.build_leader_config
+    before = request.model_dump()
+    before_fields_set = set(request.model_fields_set)
+
+    # Config construction only: no device, serial port, Portal or worker is opened.
+    config = build(request)
+
+    assert request.model_dump() == before
+    assert request.model_fields_set == before_fields_set
+    unused = "leader" if side == "follower" else "follower"
+    assert not hasattr(request, f"{unused}_port")
+    assert not hasattr(request, f"right_{unused}_port")
+    stages[f"setup_{unused}_calibration_file"].assert_not_called()
+    stages[f"stage_bimanual_{unused}_calibrations"].assert_not_called()
+
+    if mode == "single":
+        assert config.id == f"selected-{side}"
+        assert config.port == "/not-opened-left"
+        stages[f"setup_{side}_calibration_file"].assert_called_once()
+        stages[f"stage_bimanual_{side}_calibrations"].assert_not_called()
+    else:
+        assert config.calibration_dir == staging
+        assert config.left_arm_config.port == "/not-opened-left"
+        assert config.right_arm_config.port == "/not-opened-right"
+        stages[f"stage_bimanual_{side}_calibrations"].assert_called_once()
+        stages[f"setup_{side}_calibration_file"].assert_not_called()
+
+    if side == "leader" and arm_type == "metal":
+        expected = "metal_leader" if leader_kind == "metal" else "rebot_102_leader_metal"
+        if mode == "bimanual":
+            expected = "bi_metal_leader" if leader_kind == "metal" else "bi_rebot_102_leader"
+        assert config.type == expected


### PR DESCRIPTION
Starting a hosted robot or remote operator can fail before connection with `AttributeError: ... has no attribute 'leader_port'` or `'follower_port'`. The real `HostingRequest` and `RemoteTeleoperateRequest` models contain only their own side's fields, but the arm-family builders construct a follower/leader config pair. Existing factory tests supplied both sides and missed this failure.

Supply absent, unused port fields on a copied request inside the two remote config builders. Preserve the selected ports, calibration staging and leader kind without changing the request models or the normal paired builders. The unused config is still discarded without constructing or connecting its device.

Validation on staging `e7b7cdacf8472808d6c014ab2cc655bb232e9047` with the declared LeRobot pin:

- All 16 new request-model cases fail on the original code and pass with this fix; coverage includes both remote roles, single/bimanual SO-101, Maker and Metal, and both Metal leader choices.
- 59 focused configuration/remote tests pass.
- Full Python suite: 3,943 passed, 15 skipped, 23 warnings on macOS/Python 3.12.
- Contribution hooks pass, including the unchanged OpenAPI snapshot. Frontend lint, both TypeScript projects and production build pass; lint reports 34 warnings and no errors. Generated frontend files are excluded from the patch.

Validation covers configuration construction and software regressions; no physical hardware testing was performed.
