### PR TITLE
Make per-episode task prompts optional and show them before recording

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -12181,7 +12181,7 @@
     },
     "/api/v1/recording-episode-task": {
       "post": {
-        "description": "Name the task for the episode a per-episode-task session is holding in\nits \"naming\" phase. Mandatory and un-bypassable: an empty description or a\nsubmission outside the naming phase comes back 200 + {success: false} —\nsee handle_submit_episode_task.",
+        "description": "Set the upcoming episode's task and start recording after environment\nreset. An empty description or a submission outside the naming phase\ncomes back 200 + {success: false}.",
         "operationId": "recording_episode_task",
         "requestBody": {
           "content": {

--- a/frontend/src/components/recording/EpisodeTaskPrompt.test.tsx
+++ b/frontend/src/components/recording/EpisodeTaskPrompt.test.tsx
@@ -29,7 +29,7 @@ describe("the per-episode task prompt", () => {
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "fold the towel" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /save task/i }));
+    fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
     expect(onSubmit).toHaveBeenCalledWith("fold the towel");
   });
 
@@ -43,7 +43,7 @@ describe("the per-episode task prompt", () => {
         onSubmit={onSubmit}
       />,
     );
-    const save = screen.getByRole("button", { name: /save task/i });
+    const save = screen.getByRole("button", { name: /start recording/i });
     expect(save).toBeDisabled();
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "   " },
@@ -60,6 +60,37 @@ describe("the per-episode task prompt", () => {
         onSubmit={vi.fn()}
       />,
     );
-    expect(screen.getByRole("button", { name: /save task/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /start recording/i })).toBeDisabled();
   });
+});
+
+it("keeps Space for typing, then starts on Space after Enter finishes editing", () => {
+  const onSubmit = vi.fn();
+  render(<EpisodeTaskPrompt episode={1} defaultTask="pick cube" submitting={false} onSubmit={onSubmit} />);
+  const box = screen.getByRole("textbox");
+  fireEvent.keyDown(box, { key: " " });
+  expect(onSubmit).not.toHaveBeenCalled();
+  fireEvent.keyDown(box, { key: "Enter" });
+  expect(onSubmit).not.toHaveBeenCalled();
+  const start = screen.getByRole("button", { name: /start recording/i });
+  expect(start).toHaveFocus();
+  fireEvent.keyDown(start, { key: " " });
+  expect(onSubmit).toHaveBeenCalledExactlyOnceWith("pick cube");
+});
+
+it("can discard and re-record the previous take without submitting the next task", () => {
+  const onSubmit = vi.fn();
+  const onRerecord = vi.fn();
+  render(<EpisodeTaskPrompt episode={2} defaultTask="pick cube" submitting={false} onSubmit={onSubmit} onRerecord={onRerecord} />);
+  fireEvent.click(screen.getByRole("button", { name: /re-record previous task/i }));
+  expect(onRerecord).toHaveBeenCalledOnce();
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+it("starts on Space after focus moves out of the description", () => {
+  const onSubmit = vi.fn();
+  render(<EpisodeTaskPrompt episode={1} defaultTask="pick cube" submitting={false} onSubmit={onSubmit} />);
+  screen.getByRole("textbox").blur();
+  fireEvent.keyDown(document.body, { key: " " });
+  expect(onSubmit).toHaveBeenCalledExactlyOnceWith("pick cube");
 });

--- a/frontend/src/components/recording/EpisodeTaskPrompt.tsx
+++ b/frontend/src/components/recording/EpisodeTaskPrompt.tsx
@@ -1,41 +1,52 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 interface EpisodeTaskPromptProps {
-  /** 1-based index of the episode just recorded. */
+  /** 1-based index of the episode about to record. */
   episode: number;
-  /** What the box starts filled with — the previous episode's task, or the
-   * dataset-level task before the first one is named. */
   defaultTask: string;
-  /** A submission is in flight; the button is locked until it resolves. */
   submitting: boolean;
   onSubmit: (task: string) => void;
+  onRerecord?: () => void;
 }
 
-/**
- * The blocking card shown between an episode's recording phase and the reset
- * gap when the session records a per-episode task (record.py's "naming"
- * phase). There is no bypass — the session only advances once a non-empty task
- * is submitted — so this renders in place of the whole live HUD, not beside
- * it. Mount it keyed by episode so each episode starts from its own prefill.
- */
+/** No countdown: finish editing with Enter, then press Space when ready.
+ * Spaces inside the description remain ordinary text input. */
 const EpisodeTaskPrompt: React.FC<EpisodeTaskPromptProps> = ({
   episode,
   defaultTask,
   submitting,
   onSubmit,
+  onRerecord,
 }) => {
   const { t } = useTranslation();
   const [value, setValue] = useState(defaultTask);
+  const startButton = useRef<HTMLButtonElement>(null);
   const canSubmit = value.trim().length > 0 && !submitting;
 
   const submit = () => {
-    if (!canSubmit) return;
-    onSubmit(value.trim());
+    if (canSubmit) onSubmit(value.trim());
   };
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (event.repeat || event.isComposing || !canSubmit) return;
+      if (target?.matches("input, textarea") || target?.isContentEditable) return;
+      // Other buttons retain their own keyboard action, including session exits.
+      if (target?.closest("button") && target.closest("button") !== startButton.current) return;
+      if (event.key === " ") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        onSubmit(value.trim());
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [canSubmit, onSubmit, value]);
 
   return (
     <div className="flex flex-col items-center gap-4 py-6 text-center">
@@ -57,21 +68,32 @@ const EpisodeTaskPrompt: React.FC<EpisodeTaskPromptProps> = ({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter") {
+            if (e.key === "Enter" && !e.nativeEvent.isComposing) {
               e.preventDefault();
-              submit();
+              if (canSubmit) startButton.current?.focus();
             }
           }}
           placeholder={t("recording.session.naming.placeholder")}
+          aria-describedby="episodeTaskHint"
         />
+        <p id="episodeTaskHint" className="text-xs text-muted-foreground">
+          {t("recording.session.naming.keyboardHint")}
+        </p>
       </div>
       <Button
+        ref={startButton}
         onClick={submit}
         disabled={!canSubmit}
         className="w-full max-w-md font-semibold"
       >
         {t("recording.session.button.saveEpisodeTask")}
+        <span className="ml-3 text-xs font-mono">SPACE</span>
       </Button>
+      {onRerecord && (
+        <Button variant="outline" disabled={submitting} onClick={onRerecord}>
+          {t("recording.session.naming.rerecordPrevious")}
+        </Button>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/recording/RecordingSessionDialog.naming.test.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.naming.test.tsx
@@ -63,7 +63,7 @@ const namingStatus = {
   session_ended: false,
   current_episode_task_default: "pick the cube",
   available_controls: {
-    stop_recording: false,
+    stop_recording: true,
     exit_early: false,
     rerecord_episode: false,
     pause_recording: false,
@@ -98,7 +98,7 @@ describe("the recording dialog during the naming phase", () => {
     expect(box).toHaveValue("pick the cube");
 
     fireEvent.change(box, { target: { value: "fold the napkin" } });
-    fireEvent.click(screen.getByRole("button", { name: /save task/i }));
+    fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
 
     await waitFor(() => {
       const call = mocks.fetch.mock.calls.find(([u]) =>
@@ -109,14 +109,14 @@ describe("the recording dialog during the naming phase", () => {
     });
   });
 
-  it("offers no Done/Quit exit while the task is unnamed", async () => {
+  it("offers Done/Quit while waiting for the next task", async () => {
     render(<RecordingSessionDialog config={CONFIG} onExit={vi.fn()} />);
     await screen.findByRole("textbox");
     expect(
-      screen.queryByRole("button", { name: /^done$/i }),
-    ).not.toBeInTheDocument();
+      screen.queryByRole("button", { name: /^finish session$/i }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /^quit$/i }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/recording/RecordingSessionDialog.naming.test.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.naming.test.tsx
@@ -113,6 +113,14 @@ const taskCalls = () => mocks.fetch.mock.calls.filter(([url]) =>
 );
 
 describe("task before recording", () => {
+  it("starts normally without a task prompt when per-episode tasks are off", async () => {
+    status = { ...status, current_phase: "recording" };
+    render(<RecordingSessionDialog config={{ ...CONFIG, per_episode_task: false, single_task: "sort socks" }} onExit={vi.fn()} />);
+    await waitFor(() => expect(mocks.startSession).toHaveBeenCalledOnce());
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(taskCalls()).toHaveLength(0);
+  });
+
   it("shows the first task immediately and allows cancel without starting hardware", () => {
     const onExit = vi.fn();
     render(<RecordingSessionDialog config={CONFIG} onExit={onExit} />);

--- a/frontend/src/components/recording/RecordingSessionDialog.naming.test.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.naming.test.tsx
@@ -46,7 +46,7 @@ const CONFIG = {
   per_episode_task: true,
   num_episodes: 3,
   episode_time_s: 60,
-  reset_time_s: 15,
+  reset_time_s: 0,
   fps: 30,
   video: true,
   push_to_hub: false,
@@ -57,9 +57,9 @@ const CONFIG = {
 const namingStatus = {
   recording_active: true,
   current_phase: "naming",
-  current_episode: 2,
+  current_episode: 1,
   total_episodes: 3,
-  saved_episodes: 1,
+  saved_episodes: 0,
   session_ended: false,
   current_episode_task_default: "pick the cube",
   available_controls: {
@@ -77,46 +77,78 @@ const jsonResponse = (body: unknown) => ({
   json: async () => body,
 });
 
+let status = structuredClone(namingStatus);
+
 beforeEach(() => {
+  status = structuredClone(namingStatus);
   vi.clearAllMocks();
   mocks.fetch.mockImplementation(async (url: string) => {
-    if (url.endsWith("/recording-status")) return jsonResponse(namingStatus);
+    if (url.endsWith("/recording-status")) return jsonResponse(status);
     if (url.endsWith("/recording-log")) return jsonResponse({ logs: "" });
-    if (url.endsWith("/recording-episode-task"))
-      return jsonResponse({ success: true, message: "Episode task saved" });
+    if (url.endsWith("/recording-episode-task")) {
+      status = { ...status, current_phase: "recording", available_controls: {
+        ...status.available_controls, exit_early: true, submit_episode_task: false,
+      } };
+      return jsonResponse({ success: true });
+    }
+    if (url.endsWith("/recording-exit-early")) {
+      status = { ...namingStatus, current_episode: 2 };
+      return jsonResponse({ success: true });
+    }
     return jsonResponse({});
   });
 });
 
 afterEach(cleanup);
 
-describe("the recording dialog during the naming phase", () => {
-  it("prompts for the episode's task and posts it to the naming endpoint", async () => {
-    render(<RecordingSessionDialog config={CONFIG} onExit={vi.fn()} />);
+const submitFirstTask = () => {
+  const box = screen.getByRole("textbox");
+  fireEvent.change(box, { target: { value: "pick the cube" } });
+  fireEvent.keyDown(box, { key: "Enter" });
+  fireEvent.keyDown(screen.getByRole("button", { name: /start recording/i }), { key: " " });
+};
 
-    const box = await screen.findByRole("textbox");
-    expect(box).toHaveValue("pick the cube");
+const taskCalls = () => mocks.fetch.mock.calls.filter(([url]) =>
+  String(url).endsWith("/api/v1/recording-episode-task"),
+);
 
-    fireEvent.change(box, { target: { value: "fold the napkin" } });
-    fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
-
-    await waitFor(() => {
-      const call = mocks.fetch.mock.calls.find(([u]) =>
-        String(u).endsWith("/api/v1/recording-episode-task"),
-      );
-      expect(call).toBeTruthy();
-      expect(JSON.parse(call![1].body)).toEqual({ task: "fold the napkin" });
-    });
+describe("task before recording", () => {
+  it("shows the first task immediately and allows cancel without starting hardware", () => {
+    const onExit = vi.fn();
+    render(<RecordingSessionDialog config={CONFIG} onExit={onExit} />);
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(mocks.startSession).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onExit).toHaveBeenCalledOnce();
+    expect(mocks.startSession).not.toHaveBeenCalled();
   });
 
-  it("offers Done/Quit while waiting for the next task", async () => {
+  it("starts the session and submits the first task with one Space", async () => {
     render(<RecordingSessionDialog config={CONFIG} onExit={vi.fn()} />);
-    await screen.findByRole("textbox");
-    expect(
-      screen.queryByRole("button", { name: /^finish session$/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /^quit$/i }),
-    ).toBeInTheDocument();
+    submitFirstTask();
+    await waitFor(() => expect(taskCalls()).toHaveLength(1));
+    expect(mocks.startSession).toHaveBeenCalledOnce();
+    expect(mocks.startSession).toHaveBeenCalledWith("http://test", mocks.fetch,
+      expect.objectContaining({ options: expect.objectContaining({ single_task: "pick the cube" }) }),
+    );
+    expect(JSON.parse(taskCalls()[0][1].body)).toEqual({ task: "pick the cube" });
+    await screen.findByRole("button", { name: /^done/i }, { timeout: 2500 });
+    expect(taskCalls()).toHaveLength(1);
+  });
+
+  it("Space ends capture, then asks for the next task until Space starts it", async () => {
+    render(<RecordingSessionDialog config={CONFIG} onExit={vi.fn()} />);
+    submitFirstTask();
+    await screen.findByRole("button", { name: /^done/i }, { timeout: 2500 });
+    fireEvent.keyDown(window, { key: " " });
+    const box = await screen.findByRole("textbox", {}, { timeout: 2500 });
+    expect(screen.getByRole("button", { name: /^finish session$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^quit$/i })).toBeInTheDocument();
+    expect(taskCalls()).toHaveLength(1);
+    fireEvent.change(box, { target: { value: "fold the napkin" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    fireEvent.keyDown(screen.getByRole("button", { name: /start recording/i }), { key: " " });
+    await waitFor(() => expect(taskCalls()).toHaveLength(2));
+    expect(JSON.parse(taskCalls()[1][1].body)).toEqual({ task: "fold the napkin" });
   });
 });

--- a/frontend/src/components/recording/RecordingSessionDialog.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.tsx
@@ -150,6 +150,8 @@ const RecordingSessionDialog: React.FC<{
     null
   );
   const [recordingSessionStarted, setRecordingSessionStarted] = useState(false);
+  const [initialTask, setInitialTask] = useState<string | null>(null);
+  const pendingInitialTaskRef = useRef<string | null>(null);
   const [logs, setLogs] = useState("");
 
   const [optimisticPhase, setOptimisticPhase] = useState<Phase | null>(null);
@@ -215,10 +217,11 @@ const RecordingSessionDialog: React.FC<{
   useSessionHeartbeat(sessionId, tabOwnerId(), sessionLive);
   useUnloadWarning(sessionLive);
 
-  // Start recording session when the dialog mounts. The ref guard prevents
+  // Collect the first task before starting the hardware session. The ref prevents
   // React StrictMode (and any future re-renders) from POSTing the session
   // start twice — the second call returns 409 and bounces the user out.
   useEffect(() => {
+    if (recordingConfig.per_episode_task && initialTask === null) return;
     if (!startInitiatedRef.current) {
       startInitiatedRef.current = true;
       startRecordingSession();
@@ -226,7 +229,7 @@ const RecordingSessionDialog: React.FC<{
     // startRecordingSession is intentionally omitted: re-running this effect
     // on its identity change would re-fire the session start.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [initialTask, recordingConfig.per_episode_task]);
 
   // Refs so the poll interval below stays stable and reads the latest values
   // without tearing itself down on every state change.
@@ -396,7 +399,7 @@ const RecordingSessionDialog: React.FC<{
         kind: "recording",
         robot,
         owner: tabOwnerId(),
-        options,
+        options: { ...options, single_task: initialTask ?? options.single_task },
       });
       setSessionId(session.id);
       setRecordingSessionStarted(true);
@@ -514,6 +517,15 @@ const RecordingSessionDialog: React.FC<{
     },
     [submittingTask, baseUrl, fetchWithHeaders, toast, t]
   );
+
+  // The first Space already requested capture. Submit once the backend is ready.
+  useEffect(() => {
+    if (backendStatus?.current_phase !== "naming") return;
+    const task = pendingInitialTaskRef.current;
+    if (task === null) return;
+    pendingInitialTaskRef.current = null;
+    void handleSubmitEpisodeTask(task);
+  }, [backendStatus?.current_phase, handleSubmitEpisodeTask]);
 
   const handlePauseRecording = useCallback(async () => {
     if (!backendStatus?.available_controls.pause_recording) return;
@@ -918,7 +930,22 @@ const RecordingSessionDialog: React.FC<{
         </DialogTitle>
 
         {/* Loading state while waiting for the first backend status */}
-        {!backendStatus ? (
+        {recordingConfig.per_episode_task && initialTask === null ? (
+          <div className="space-y-4 py-6">
+            <EpisodeTaskPrompt
+              episode={1}
+              defaultTask={recordingConfig.single_task}
+              submitting={false}
+              onSubmit={(task) => {
+                pendingInitialTaskRef.current = task;
+                setInitialTask(task);
+              }}
+            />
+            <Button variant="ghost" onClick={() => onExit()}>
+              {t("common.cancel")}
+            </Button>
+          </div>
+        ) : !backendStatus ? (
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <div className="mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-red-500" />
             <p className="text-lg">{t("recording.session.connecting")}</p>

--- a/frontend/src/components/recording/RecordingSessionDialog.tsx
+++ b/frontend/src/components/recording/RecordingSessionDialog.tsx
@@ -50,7 +50,7 @@ export interface RecordingConfig {
   robot: string;
   dataset_repo_id: string;
   single_task: string;
-  /** Pause after each episode to name its task (the "naming" phase). */
+  /** Wait before each episode to enter its task (the "naming" phase). */
   per_episode_task: boolean;
   num_episodes: number;
   episode_time_s: number;
@@ -117,7 +117,7 @@ interface BackendStatus {
     rerecord_episode: boolean;
     pause_recording: boolean;
     resume_recording: boolean;
-    // True only during the "naming" phase — the one control that phase offers.
+    // True only during the "naming" phase.
     submit_episode_task?: boolean;
   };
 }
@@ -314,7 +314,7 @@ const RecordingSessionDialog: React.FC<{
         if (prev !== real) {
           if (real === "recording" && prev !== null) {
             playRecordingStartCue();
-          } else if (real === "resetting") {
+          } else if (real === "resetting" || (real === "naming" && prev === "recording")) {
             playResetStartCue();
           }
           prevRealPhaseRef.current = real;
@@ -440,16 +440,12 @@ const RecordingSessionDialog: React.FC<{
     const realPhase = backendStatus.current_phase as Phase;
     const next: Phase | null =
       realPhase === "recording"
-        ? // A per-episode-task session stops at the naming prompt before the
-          // reset gap; every other session goes straight to resetting.
-          recordingConfig.per_episode_task
-          ? "naming"
-          : "resetting"
+        ? "resetting"
         : realPhase === "resetting" ? "recording" : null;
 
     if (!next) return;
 
-    setOptimisticPhase(next);
+    if (!recordingConfig.per_episode_task) setOptimisticPhase(next);
 
     try {
       const response = await fetchWithHeaders(
@@ -479,10 +475,8 @@ const RecordingSessionDialog: React.FC<{
     }
   }, [backendStatus, optimisticPhase, recordingConfig, baseUrl, fetchWithHeaders, toast, t]);
 
-  // Name the just-recorded episode's task and let the session continue. This
-  // is the only way out of the "naming" phase — the backend withdraws every
-  // other control — so a refusal (empty task, phase raced past) only re-enables
-  // the button, it never exits the phase.
+  // Submit the upcoming task and start its recording. A refused request
+  // leaves the prompt open so the operator can correct it and retry.
   const handleSubmitEpisodeTask = useCallback(
     async (task: string) => {
       if (submittingTask) return;
@@ -623,14 +617,14 @@ const RecordingSessionDialog: React.FC<{
       );
       const data = await response.json();
 
-      if (response.ok) {
+      if (response.ok && data.success) {
         setRerecordTick((t) => t + 1);
         toast({
           title: t("recording.session.toast.rerecordTitle"),
           description: t("recording.session.toast.rerecordBody", {
             // Same `?? 1` default the HUD's episode counter uses; the field is
             // always populated on the re-record path.
-            index: backendStatus.current_episode ?? 1,
+            index: (backendStatus.current_episode ?? 1) - (backendStatus.current_phase === "naming" ? 1 : 0),
           }),
         });
       } else {
@@ -786,8 +780,9 @@ const RecordingSessionDialog: React.FC<{
     if (!keyboardActive) return;
 
     const onKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
       const target = e.target as HTMLElement | null;
-      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "BUTTON" || target.isContentEditable)) {
         return;
       }
       if (e.key === " " || e.code === "Space" || e.key === "ArrowRight") {
@@ -932,10 +927,7 @@ const RecordingSessionDialog: React.FC<{
           <>
             {/* Two explicit exits, LIVE-only. Once the session has ended these
                 unmount — no control may imply the session is still alive. */}
-            {/* The naming phase is a hard gate — naming the episode is the
-                only way forward — so the session exits are withdrawn along
-                with every other control while it is open. */}
-            {!sessionEnded && currentPhase !== "naming" && (
+            {!sessionEnded && (
               <div className="mb-3 flex justify-end gap-3">
                 <Button
                   onClick={requestDone}
@@ -961,9 +953,8 @@ const RecordingSessionDialog: React.FC<{
               </div>
             )}
             <div className="bg-card rounded-lg border border-border p-4">
-              {/* Per-episode-task naming: blocks here between the recording
-                  phase and the reset gap. Replaces the live HUD outright —
-                  there is nothing to advance until the task is named. */}
+              {/* Reset the environment and describe the upcoming episode.
+                  Recording waits for the operator; there is no countdown. */}
               {!sessionEnded && currentPhase === "naming" && (
                 <EpisodeTaskPrompt
                   key={currentEpisode}
@@ -972,8 +963,10 @@ const RecordingSessionDialog: React.FC<{
                     backendStatus.current_episode_task_default ??
                     recordingConfig.single_task
                   }
-                  submitting={submittingTask}
+                  submitting={submittingTask || anyExitDialogOpen}
                   onSubmit={handleSubmitEpisodeTask}
+                  onRerecord={backendStatus.available_controls.rerecord_episode
+                    ? handleRerecordEpisode : undefined}
                 />
               )}
 
@@ -1087,7 +1080,7 @@ const RecordingSessionDialog: React.FC<{
                       )}
                     </Button>
                     <div className="flex gap-3">
-                      {(currentPhase === "recording" || currentPhase === "resetting") && (
+                      {!recordingConfig.per_episode_task && (currentPhase === "recording" || currentPhase === "resetting") && (
                         <Button
                           onClick={isPauseActive ? handleResumeRecording : handlePauseRecording}
                           disabled={

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -78,11 +78,8 @@ const CollectPanel: React.FC = () => {
   const {
     formOpen,
     datasetName,
-    singleTask,
-    perEpisodeTask,
     numEpisodes,
     episodeTimeS,
-    resetTimeS,
     streamingEncoding,
     pushToHub,
   } = collectForm;
@@ -181,7 +178,7 @@ const CollectPanel: React.FC = () => {
     // disables on the same condition as a courtesy.
     // With per-episode tasks there is no dataset-level task to require — each
     // episode names its own during the session.
-    if (!datasetName || (!perEpisodeTask && !singleTask)) {
+    if (!datasetName) {
       toast({
         title: t("studio.collect.toast.missingDetailsTitle"),
         description: t("studio.collect.toast.missingDetailsBody"),
@@ -230,11 +227,11 @@ const CollectPanel: React.FC = () => {
       dataset_repo_id: datasetRepoId,
       // Per-episode-task sessions carry no dataset-level task; the first
       // episode's prompt just starts blank.
-      single_task: perEpisodeTask ? "" : singleTask,
-      per_episode_task: perEpisodeTask,
+      single_task: "",
+      per_episode_task: true,
       num_episodes: numEpisodes,
       episode_time_s: episodeTimeS,
-      reset_time_s: resetTimeS,
+      reset_time_s: 0,
       fps: 30,
       video: true,
       push_to_hub: false,
@@ -273,14 +270,11 @@ const CollectPanel: React.FC = () => {
     [setLastRecorded, updateCollectForm],
   );
 
-  // Gate for the pinned Start button: robot ready + every required parameter
-  // filled in (name valid per the backend's rules, task described — unless
-  // each episode names its own task, which drops the dataset-level one).
+  // Task descriptions are entered inside the session before each episode.
   const canStart =
     !!selectedRecord &&
     selectedRecord.is_clean &&
-    datasetNameIssue(datasetName) === null &&
-    (perEpisodeTask || singleTask.trim().length > 0);
+    datasetNameIssue(datasetName) === null;
 
   return (
     <div className="flex flex-1 flex-col gap-5 p-5">
@@ -311,16 +305,10 @@ const CollectPanel: React.FC = () => {
             robot={selectedRecord}
             datasetName={datasetName}
             setDatasetName={(v) => updateCollectForm({ datasetName: v })}
-            singleTask={singleTask}
-            setSingleTask={(v) => updateCollectForm({ singleTask: v })}
-            perEpisodeTask={perEpisodeTask}
-            setPerEpisodeTask={(v) => updateCollectForm({ perEpisodeTask: v })}
             numEpisodes={numEpisodes}
             setNumEpisodes={(v) => updateCollectForm({ numEpisodes: v })}
             episodeTimeS={episodeTimeS}
             setEpisodeTimeS={(v) => updateCollectForm({ episodeTimeS: v })}
-            resetTimeS={resetTimeS}
-            setResetTimeS={(v) => updateCollectForm({ resetTimeS: v })}
             streamingEncoding={streamingEncoding}
             setStreamingEncoding={(v) =>
               updateCollectForm({ streamingEncoding: v })

--- a/frontend/src/components/studio/CollectPanel.tsx
+++ b/frontend/src/components/studio/CollectPanel.tsx
@@ -78,8 +78,11 @@ const CollectPanel: React.FC = () => {
   const {
     formOpen,
     datasetName,
+    singleTask,
+    perEpisodeTask,
     numEpisodes,
     episodeTimeS,
+    resetTimeS,
     streamingEncoding,
     pushToHub,
   } = collectForm;
@@ -178,7 +181,7 @@ const CollectPanel: React.FC = () => {
     // disables on the same condition as a courtesy.
     // With per-episode tasks there is no dataset-level task to require — each
     // episode names its own during the session.
-    if (!datasetName) {
+    if (!datasetName || (!perEpisodeTask && !singleTask.trim())) {
       toast({
         title: t("studio.collect.toast.missingDetailsTitle"),
         description: t("studio.collect.toast.missingDetailsBody"),
@@ -227,11 +230,11 @@ const CollectPanel: React.FC = () => {
       dataset_repo_id: datasetRepoId,
       // Per-episode-task sessions carry no dataset-level task; the first
       // episode's prompt just starts blank.
-      single_task: "",
-      per_episode_task: true,
+      single_task: perEpisodeTask ? "" : singleTask,
+      per_episode_task: perEpisodeTask,
       num_episodes: numEpisodes,
       episode_time_s: episodeTimeS,
-      reset_time_s: 0,
+      reset_time_s: perEpisodeTask ? 0 : resetTimeS,
       fps: 30,
       video: true,
       push_to_hub: false,
@@ -270,11 +273,14 @@ const CollectPanel: React.FC = () => {
     [setLastRecorded, updateCollectForm],
   );
 
-  // Task descriptions are entered inside the session before each episode.
+  // Gate for the pinned Start button: robot ready + every required parameter
+  // filled in (name valid per the backend's rules, task described — unless
+  // each episode names its own task, which drops the dataset-level one).
   const canStart =
     !!selectedRecord &&
     selectedRecord.is_clean &&
-    datasetNameIssue(datasetName) === null;
+    datasetNameIssue(datasetName) === null &&
+    (perEpisodeTask || singleTask.trim().length > 0);
 
   return (
     <div className="flex flex-1 flex-col gap-5 p-5">
@@ -305,10 +311,16 @@ const CollectPanel: React.FC = () => {
             robot={selectedRecord}
             datasetName={datasetName}
             setDatasetName={(v) => updateCollectForm({ datasetName: v })}
+            singleTask={singleTask}
+            setSingleTask={(v) => updateCollectForm({ singleTask: v })}
+            perEpisodeTask={perEpisodeTask}
+            setPerEpisodeTask={(v) => updateCollectForm({ perEpisodeTask: v })}
             numEpisodes={numEpisodes}
             setNumEpisodes={(v) => updateCollectForm({ numEpisodes: v })}
             episodeTimeS={episodeTimeS}
             setEpisodeTimeS={(v) => updateCollectForm({ episodeTimeS: v })}
+            resetTimeS={resetTimeS}
+            setResetTimeS={(v) => updateCollectForm({ resetTimeS: v })}
             streamingEncoding={streamingEncoding}
             setStreamingEncoding={(v) =>
               updateCollectForm({ streamingEncoding: v })

--- a/frontend/src/components/studio/DeployPanel.tsx
+++ b/frontend/src/components/studio/DeployPanel.tsx
@@ -2430,7 +2430,7 @@ const DeployPanel: React.FC = () => {
               </details>
             ) : null}
           </>
-        ) : startBlockedKey ? (
+        ) : startBlockedKey && startBlockedKey !== "studio.deploy.blocked.noCheckpoint" ? (
           <p className="text-xs leading-relaxed text-warn">
             {t(startBlockedKey as never)}
           </p>

--- a/frontend/src/components/studio/RecordingForm.test.tsx
+++ b/frontend/src/components/studio/RecordingForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 vi.mock("@/contexts/HfAuthContext", () => ({
   useHfAuth: () => ({
@@ -19,55 +19,22 @@ const baseProps = {
   robot: null,
   datasetName: "sock_sort",
   setDatasetName: vi.fn(),
-  singleTask: "sort the socks",
-  setSingleTask: vi.fn(),
   numEpisodes: 5,
   setNumEpisodes: vi.fn(),
   episodeTimeS: 60,
   setEpisodeTimeS: vi.fn(),
-  resetTimeS: 15,
-  setResetTimeS: vi.fn(),
   streamingEncoding: true,
   setStreamingEncoding: vi.fn(),
   pushToHub: true,
   setPushToHub: vi.fn(),
-  perEpisodeTask: false,
-  setPerEpisodeTask: vi.fn(),
 };
 
-describe("the recording form's per-episode-task checkbox", () => {
-  it("is offered unchecked next to the task description", () => {
+describe("recording setup", () => {
+  it("asks only for dataset settings before opening the task prompt", () => {
     render(<RecordingForm {...baseProps} />);
-    const box = screen.getByRole("checkbox", {
-      name: /name each episode's task after recording it/i,
-    });
-    expect(box).toHaveAttribute("data-state", "unchecked");
-  });
-
-  it("turns the mode on when the operator ticks it", () => {
-    const setPerEpisodeTask = vi.fn();
-    render(
-      <RecordingForm {...baseProps} setPerEpisodeTask={setPerEpisodeTask} />,
-    );
-    fireEvent.click(
-      screen.getByRole("checkbox", {
-        name: /name each episode's task after recording it/i,
-      }),
-    );
-    expect(setPerEpisodeTask).toHaveBeenCalledWith(true);
-  });
-
-  it("shows the dataset-level task field only while the mode is off", () => {
-    const { rerender } = render(<RecordingForm {...baseProps} />);
-    expect(screen.getByLabelText(/task description/i)).toBeInTheDocument();
-
-    rerender(<RecordingForm {...baseProps} perEpisodeTask={true} />);
+    expect(screen.getByLabelText(/dataset name/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/task description/i)).not.toBeInTheDocument();
-    // The checkbox itself stays put.
-    expect(
-      screen.getByRole("checkbox", {
-        name: /name each episode's task after recording it/i,
-      }),
-    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/reset duration/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: /episode.*task/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/studio/RecordingForm.test.tsx
+++ b/frontend/src/components/studio/RecordingForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 vi.mock("@/contexts/HfAuthContext", () => ({
   useHfAuth: () => ({
@@ -14,11 +14,18 @@ vi.mock("@/components/recording/CameraConfiguration", () => ({
 }));
 
 import RecordingForm from "./RecordingForm";
+import { StudioProvider, useStudio } from "@/contexts/StudioContext";
 
 const baseProps = {
   robot: null,
   datasetName: "sock_sort",
   setDatasetName: vi.fn(),
+  singleTask: "sort socks",
+  setSingleTask: vi.fn(),
+  perEpisodeTask: false,
+  setPerEpisodeTask: vi.fn(),
+  resetTimeS: 15,
+  setResetTimeS: vi.fn(),
   numEpisodes: 5,
   setNumEpisodes: vi.fn(),
   episodeTimeS: 60,
@@ -29,12 +36,31 @@ const baseProps = {
   setPushToHub: vi.fn(),
 };
 
+function FormWithDraft() {
+  const { collectForm, updateCollectForm } = useStudio();
+  return <RecordingForm {...baseProps} {...collectForm}
+    setPerEpisodeTask={(perEpisodeTask) => updateCollectForm({ perEpisodeTask })}
+    setSingleTask={(singleTask) => updateCollectForm({ singleTask })}
+  />;
+}
+
 describe("recording setup", () => {
-  it("asks only for dataset settings before opening the task prompt", () => {
-    render(<RecordingForm {...baseProps} />);
-    expect(screen.getByLabelText(/dataset name/i)).toBeInTheDocument();
+  it("defaults to one task and enables the per-episode flow only when toggled", () => {
+    render(<StudioProvider><FormWithDraft /></StudioProvider>);
+    const toggle = screen.getByRole("switch", { name: "Describe each episode" });
+    expect(toggle).not.toBeChecked();
+    const task = screen.getByLabelText(/task description/i);
+    fireEvent.change(task, { target: { value: "sort socks" } });
+    expect(screen.getByLabelText(/reset duration/i)).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toBeChecked();
     expect(screen.queryByLabelText(/task description/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/reset duration/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: /episode.*task/i })).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).not.toBeChecked();
+    expect(screen.getByLabelText(/task description/i)).toHaveValue("sort socks");
+    expect(screen.getByLabelText(/reset duration/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/studio/RecordingForm.tsx
+++ b/frontend/src/components/studio/RecordingForm.tsx
@@ -21,16 +21,10 @@ interface RecordingFormProps {
   robot: RobotRecord | null;
   datasetName: string;
   setDatasetName: (value: string) => void;
-  singleTask: string;
-  setSingleTask: (value: string) => void;
-  perEpisodeTask: boolean;
-  setPerEpisodeTask: (value: boolean) => void;
   numEpisodes: number;
   setNumEpisodes: (value: number) => void;
   episodeTimeS: number;
   setEpisodeTimeS: (value: number) => void;
-  resetTimeS: number;
-  setResetTimeS: (value: number) => void;
   streamingEncoding: boolean;
   setStreamingEncoding: (value: boolean) => void;
   pushToHub: boolean;
@@ -54,16 +48,10 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
   robot,
   datasetName,
   setDatasetName,
-  singleTask,
-  setSingleTask,
-  perEpisodeTask,
-  setPerEpisodeTask,
   numEpisodes,
   setNumEpisodes,
   episodeTimeS,
   setEpisodeTimeS,
-  resetTimeS,
-  setResetTimeS,
   streamingEncoding,
   setStreamingEncoding,
   pushToHub,
@@ -145,45 +133,6 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
         </div>
 
         <div className="space-y-2">
-          {/* The dataset-level task is gone entirely when each episode names
-              its own — there is no single task for the run to describe. */}
-          {!perEpisodeTask && (
-            <>
-              <Label htmlFor="singleTask">{t("studio.collect.form.task")}</Label>
-              <Input
-                id="singleTask"
-                value={singleTask}
-                onChange={(e) => setSingleTask(e.target.value)}
-                placeholder={t("studio.collect.form.taskPlaceholder")}
-              />
-            </>
-          )}
-          <div
-            className={`flex items-start gap-3 ${
-              perEpisodeTask ? "" : "pt-1"
-            }`}
-          >
-            <Checkbox
-              id="perEpisodeTask"
-              checked={perEpisodeTask}
-              onCheckedChange={(value) => setPerEpisodeTask(value === true)}
-              className="mt-0.5"
-            />
-            <div className="space-y-1">
-              <Label
-                htmlFor="perEpisodeTask"
-                className="cursor-pointer font-medium"
-              >
-                {t("studio.collect.form.perEpisodeTaskLabel")}
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                {t("studio.collect.form.perEpisodeTaskHint")}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="space-y-2">
           <Label htmlFor="numEpisodes">{t("studio.collect.form.numEpisodes")}</Label>
           <NumberInput
             id="numEpisodes"
@@ -196,7 +145,7 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
+        <div>
           <div className="space-y-2">
             <Label htmlFor="episodeTimeS">
               {t("studio.collect.form.episodeTime")}
@@ -207,19 +156,6 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
               value={episodeTimeS}
               onChange={(v) => {
                 if (v !== undefined) setEpisodeTimeS(v);
-              }}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="resetTimeS">
-              {t("studio.collect.form.resetTime")}
-            </Label>
-            <NumberInput
-              id="resetTimeS"
-              min="1"
-              value={resetTimeS}
-              onChange={(v) => {
-                if (v !== undefined) setResetTimeS(v);
               }}
             />
           </div>

--- a/frontend/src/components/studio/RecordingForm.tsx
+++ b/frontend/src/components/studio/RecordingForm.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Checkbox } from "@/components/ui/checkbox";
 import { SessionCameraList } from "@/components/recording/CameraConfiguration";
 import {
@@ -21,10 +22,16 @@ interface RecordingFormProps {
   robot: RobotRecord | null;
   datasetName: string;
   setDatasetName: (value: string) => void;
+  singleTask: string;
+  setSingleTask: (value: string) => void;
+  perEpisodeTask: boolean;
+  setPerEpisodeTask: (value: boolean) => void;
   numEpisodes: number;
   setNumEpisodes: (value: number) => void;
   episodeTimeS: number;
   setEpisodeTimeS: (value: number) => void;
+  resetTimeS: number;
+  setResetTimeS: (value: number) => void;
   streamingEncoding: boolean;
   setStreamingEncoding: (value: boolean) => void;
   pushToHub: boolean;
@@ -48,10 +55,16 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
   robot,
   datasetName,
   setDatasetName,
+  singleTask,
+  setSingleTask,
+  perEpisodeTask,
+  setPerEpisodeTask,
   numEpisodes,
   setNumEpisodes,
   episodeTimeS,
   setEpisodeTimeS,
+  resetTimeS,
+  setResetTimeS,
   streamingEncoding,
   setStreamingEncoding,
   pushToHub,
@@ -133,6 +146,45 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
         </div>
 
         <div className="space-y-2">
+          {/* The dataset-level task is gone entirely when each episode names
+              its own — there is no single task for the run to describe. */}
+          {!perEpisodeTask && (
+              <>
+                <Label htmlFor="singleTask">{t("studio.collect.form.task")}</Label>
+                <Input
+                  id="singleTask"
+                  value={singleTask}
+                  onChange={(e) => setSingleTask(e.target.value)}
+                  placeholder={t("studio.collect.form.taskPlaceholder")}
+                />
+              </>
+          )}
+          <div
+            className={`flex items-start gap-3 ${
+              perEpisodeTask ? "" : "pt-1"
+            }`}
+          >
+            <Switch
+              id="perEpisodeTask"
+              checked={perEpisodeTask}
+              onCheckedChange={(value) => setPerEpisodeTask(value === true)}
+              className="mt-0.5"
+            />
+            <div className="space-y-1">
+              <Label
+                htmlFor="perEpisodeTask"
+                className="cursor-pointer font-medium"
+              >
+                {t("studio.collect.form.perEpisodeTaskLabel")}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {t("studio.collect.form.perEpisodeTaskHint")}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-2">
           <Label htmlFor="numEpisodes">{t("studio.collect.form.numEpisodes")}</Label>
           <NumberInput
             id="numEpisodes"
@@ -145,7 +197,7 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
           />
         </div>
 
-        <div>
+        <div className={perEpisodeTask ? "" : "grid grid-cols-2 gap-4"}>
           <div className="space-y-2">
             <Label htmlFor="episodeTimeS">
               {t("studio.collect.form.episodeTime")}
@@ -159,6 +211,21 @@ const RecordingForm: React.FC<RecordingFormProps> = ({
               }}
             />
           </div>
+          {!perEpisodeTask && (
+            <div className="space-y-2">
+              <Label htmlFor="resetTimeS">
+                {t("studio.collect.form.resetTime")}
+              </Label>
+              <NumberInput
+                id="resetTimeS"
+                min="1"
+                value={resetTimeS}
+                onChange={(v) => {
+                  if (v !== undefined) setResetTimeS(v);
+                }}
+              />
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/contexts/StudioContext.tsx
+++ b/frontend/src/contexts/StudioContext.tsx
@@ -26,14 +26,8 @@ export interface RecordedInfo {
 export interface CollectFormState {
   formOpen: boolean;
   datasetName: string;
-  singleTask: string;
-  /** Pause after every episode to name that episode's task description
-   * (record.py's "naming" phase). `singleTask` stays the baseline / first
-   * prompt's prefill. */
-  perEpisodeTask: boolean;
   numEpisodes: number;
   episodeTimeS: number;
-  resetTimeS: number;
   streamingEncoding: boolean;
   /** Push the finished dataset to the Hugging Face Hub automatically when the
    * session ends (via the background UploadManager, not the recorder's
@@ -49,11 +43,8 @@ export interface CollectFormState {
 const DEFAULT_COLLECT_FORM: CollectFormState = {
   formOpen: false,
   datasetName: "",
-  singleTask: "",
-  perEpisodeTask: false,
   numEpisodes: 5,
   episodeTimeS: 60,
-  resetTimeS: 15,
   streamingEncoding: true,
   pushToHub: true,
 };

--- a/frontend/src/contexts/StudioContext.tsx
+++ b/frontend/src/contexts/StudioContext.tsx
@@ -26,8 +26,12 @@ export interface RecordedInfo {
 export interface CollectFormState {
   formOpen: boolean;
   datasetName: string;
+  singleTask: string;
+  /** Ask for each episode's task before capture and wait for Space to start. */
+  perEpisodeTask: boolean;
   numEpisodes: number;
   episodeTimeS: number;
+  resetTimeS: number;
   streamingEncoding: boolean;
   /** Push the finished dataset to the Hugging Face Hub automatically when the
    * session ends (via the background UploadManager, not the recorder's
@@ -43,8 +47,11 @@ export interface CollectFormState {
 const DEFAULT_COLLECT_FORM: CollectFormState = {
   formOpen: false,
   datasetName: "",
+  singleTask: "",
+  perEpisodeTask: false,
   numEpisodes: 5,
   episodeTimeS: 60,
+  resetTimeS: 15,
   streamingEncoding: true,
   pushToHub: true,
 };

--- a/frontend/src/i18n/locales/en/recording.ts
+++ b/frontend/src/i18n/locales/en/recording.ts
@@ -115,9 +115,9 @@ export default {
       unmute: "Unmute",
     },
     button: {
-      done: "Done",
+      done: "Finish session",
       quit: "Quit",
-      endEpisode: "End Episode",
+      endEpisode: "Done",
       startNextEpisode: "Start Next Episode",
       advance: "Advance",
       pause: "Pause",
@@ -126,16 +126,18 @@ export default {
       keepEpisodes: "Keep episodes & continue",
       discardExit: "Discard & exit",
       backHome: "Back to home",
-      saveEpisodeTask: "Save task & continue",
+      saveEpisodeTask: "Start recording",
     },
-    // The blocking card shown between the recording phase and the reset gap
-    // when the session records a per-episode task (the Collect form checkbox).
+    // The blocking card shown before each episode while resetting the environment
+    // while the operator enters the next task.
     naming: {
-      title: "What was episode {{index}}'s task?",
+      title: "What is the next task?",
       description:
-        "Describe what this episode did. It is saved as the task for every frame of episode {{index}}. The session continues once you save.",
+        "Enter the task description and reset the environment. Start when you are ready.",
       inputLabel: "Task description for episode {{index}}",
       placeholder: "e.g., fold the left sleeve inward",
+      keyboardHint: "Press Enter to finish editing, then Space to start recording.",
+      rerecordPrevious: "Re-record previous task",
     },
     ended: {
       complete: "Recording complete — returning home…",

--- a/frontend/src/i18n/locales/en/studio.ts
+++ b/frontend/src/i18n/locales/en/studio.ts
@@ -68,6 +68,8 @@ export default {
       savedAs: "Will be saved as <0>{{repoId}}</0>",
       loginHint: "Log in to Hugging Face to set the repository owner.",
       task: "Task description *",
+      perEpisodeTaskLabel: "Describe each episode",
+      perEpisodeTaskHint: "Enter a task before each episode. Reset when needed, then press Space to record.",
       taskPlaceholder:
         "e.g., pick up the red block and place it on the blue square",
       numEpisodes: "Number of episodes",

--- a/frontend/src/i18n/locales/en/studio.ts
+++ b/frontend/src/i18n/locales/en/studio.ts
@@ -70,9 +70,6 @@ export default {
       task: "Task description *",
       taskPlaceholder:
         "e.g., pick up the red block and place it on the blue square",
-      perEpisodeTaskLabel: "Name each episode's task after recording it",
-      perEpisodeTaskHint:
-        "After every episode the session pauses and asks you to describe that episode's task, just before the reset. Use it when the episodes in this dataset do different things. There is no single task for the whole dataset.",
       numEpisodes: "Number of episodes",
       episodeTime: "Episode duration (s)",
       resetTime: "Reset duration (s)",
@@ -92,7 +89,7 @@ export default {
       noRobotBody:
         "Select or create a robot first — use the robot menu in the top-right corner.",
       missingDetailsTitle: "Missing dataset details",
-      missingDetailsBody: "Please enter a dataset name and task description.",
+      missingDetailsBody: "Please enter a dataset name.",
       // The body is validateDatasetName's own message — client-side, but owned
       // by lib/datasetName.ts, so only this title is a key.
       invalidNameTitle: "Invalid dataset name",

--- a/frontend/src/i18n/locales/zh-CN/recording.ts
+++ b/frontend/src/i18n/locales/zh-CN/recording.ts
@@ -79,9 +79,9 @@ export default {
       unmute: "取消静音",
     },
     button: {
-      done: "完成",
+      done: "结束会话",
       quit: "退出",
-      endEpisode: "结束回合",
+      endEpisode: "完成",
       startNextEpisode: "开始下一回合",
       advance: "继续",
       pause: "暂停",
@@ -90,14 +90,16 @@ export default {
       keepEpisodes: "保留回合并继续",
       discardExit: "丢弃并退出",
       backHome: "返回首页",
-      saveEpisodeTask: "保存任务并继续",
+      saveEpisodeTask: "开始录制回合",
     },
     naming: {
-      title: "第 {{index}} 个回合的任务是什么？",
+      title: "下一个任务是什么？",
       description:
-        "描述该回合执行的动作。它将作为第 {{index}} 个回合每一帧的任务保存。保存后会话继续。",
+        "输入任务描述并重置环境。准备就绪后开始录制。",
       inputLabel: "第 {{index}} 个回合的任务描述",
       placeholder: "例如：将左袖向内折叠",
+      keyboardHint: "按 Enter 完成编辑，再按空格键开始录制。",
+      rerecordPrevious: "丢弃上次录制并重录",
     },
     ended: {
       complete: "录制完成 — 正在返回首页…",

--- a/frontend/src/i18n/locales/zh-CN/studio.ts
+++ b/frontend/src/i18n/locales/zh-CN/studio.ts
@@ -45,6 +45,8 @@ export default {
       savedAs: "将保存为 <0>{{repoId}}</0>",
       loginHint: "登录 Hugging Face 以设置仓库归属账号。",
       task: "任务描述 *",
+      perEpisodeTaskLabel: "逐回合描述任务",
+      perEpisodeTaskHint: "每回合录制前输入任务。准备好环境后，按空格键开始录制。",
       taskPlaceholder: "例如：拿起红色方块并放到蓝色方格上",
       numEpisodes: "片段数量",
       episodeTime: "单个片段时长（秒）",

--- a/frontend/src/i18n/locales/zh-CN/studio.ts
+++ b/frontend/src/i18n/locales/zh-CN/studio.ts
@@ -46,9 +46,6 @@ export default {
       loginHint: "登录 Hugging Face 以设置仓库归属账号。",
       task: "任务描述 *",
       taskPlaceholder: "例如：拿起红色方块并放到蓝色方格上",
-      perEpisodeTaskLabel: "录制每个片段后为其命名任务描述",
-      perEpisodeTaskHint:
-        "每录完一个片段，会话会在复位前暂停并让你描述该片段的任务。当本数据集中的片段执行的动作各不相同时使用。整个数据集不再有统一的任务描述。",
       numEpisodes: "片段数量",
       episodeTime: "单个片段时长（秒）",
       resetTime: "复位时长（秒）",
@@ -67,7 +64,7 @@ export default {
       noRobotTitle: "未选择机器人",
       noRobotBody: "请先选择或创建机器人 — 使用右上角的机器人菜单。",
       missingDetailsTitle: "数据集信息不完整",
-      missingDetailsBody: "请填写数据集名称和任务描述。",
+      missingDetailsBody: "请填写数据集名称。",
       invalidNameTitle: "数据集名称无效",
       preparingCamerasTitle: "正在准备摄像头资源",
       releasingStreams_other: "正在释放 {{count}} 路摄像头视频流以便录制…",

--- a/frontend/src/lib/sessionApi.ts
+++ b/frontend/src/lib/sessionApi.ts
@@ -68,7 +68,7 @@ export interface TeleoperationSessionOptions {
 export interface RecordingSessionOptions {
   dataset_repo_id: string;
   single_task: string;
-  /** Pause after each episode to name that episode's task (record.py's
+  /** Wait before each episode for its task (record.py's
    * "naming" phase). `single_task` stays required — the baseline task and the
    * first prompt's prefill. */
   per_episode_task?: boolean;

--- a/makermodslab/record.py
+++ b/makermodslab/record.py
@@ -213,24 +213,6 @@ def _set_phase(phase: str) -> None:
     notify_session_changed("recording", recording_active, phase=phase)
 
 
-def _apply_episode_task(dataset, task: str) -> None:
-    """Overwrite every captured frame's task in the pending episode buffer.
-
-    In a per-episode-task session `record_loop` appended the frames with the
-    session's placeholder `single_task`; this swaps in the operator-named
-    string just before `save_episode()` reads the buffer. lerobot's
-    `save_episode()` maps any task string it hasn't seen to a fresh task
-    index, so a distinct per-episode string needs no metadata prep here.
-
-    Tolerant of a buffer that isn't shaped as expected (a lerobot refactor, an
-    empty episode) — a missing task list just means nothing to rewrite."""
-    writer = getattr(dataset, "writer", None)
-    buffer = getattr(writer, "episode_buffer", None)
-    if not buffer or not buffer.get("task"):
-        return
-    buffer["task"] = [task] * len(buffer["task"])
-
-
 # Set only while current_phase == "reconnecting_robot" (the teardown and
 # backoff sleep between connect retries below); 0 otherwise — including on a
 # successful connect and on the terminal failure, so a reader can treat
@@ -431,10 +413,9 @@ class RecordingRequest(BaseModel):
     leader_kind: str | None = None
     dataset_repo_id: str
     single_task: str
-    # When true, the session pauses in a "naming" phase after every episode's
-    # recording phase and blocks until the operator names THAT episode's task
-    # description (handle_submit_episode_task). `single_task` stays required —
-    # it is the baseline task and the prefill for the first episode's prompt.
+    # When true, wait for a task before recording each episode. Between takes
+    # the operator resets the environment and can re-record the pending take.
+    # `single_task` may be empty; the first prompt then starts blank.
     # Off ⇒ every episode records under `single_task`, exactly as before.
     per_episode_task: bool = False
     num_episodes: int = 5
@@ -1104,6 +1085,8 @@ def handle_exit_early() -> dict[str, Any]:
     """Handle exit early request - replaces right arrow key"""
     if not recording_active or recording_events is None:
         return {"success": False, "message": "No recording session is active"}
+    if current_phase == "naming":
+        return {"success": False, "message": "Enter the episode task before recording"}
     if _reset_paused():
         # Design decision: skip-to-next-episode is disabled while paused (the
         # operator must explicitly resume first). Enforced here, not just in
@@ -1133,6 +1116,12 @@ def handle_rerecord_episode() -> dict[str, Any]:
     """Handle rerecord episode request - replaces left arrow key"""
     if not recording_active or recording_events is None:
         return {"success": False, "message": "No recording session is active"}
+    if current_phase != "recording" and not (
+        current_phase == "naming" and recording_events.get("pending_episode", False)
+    ):
+        return {"success": False, "message": "No episode is available to re-record"}
+    if recording_events.get("episode_task_submitted"):
+        return {"success": False, "message": "The next episode is already starting"}
     recording_events["rerecord_episode"] = True
     recording_events["exit_early"] = True
     logger.info("Re-record episode triggered")
@@ -1204,8 +1193,8 @@ def handle_submit_episode_task(task: str) -> dict[str, Any]:
     """Name the task for the episode the session is holding in the "naming"
     phase (per-episode-task sessions only — see RecordingRequest).
 
-    This is the ONLY way the naming phase advances: there is no timeout and no
-    bypass, so a blank description is refused (the phase keeps waiting) and a
+    Recording only starts with a non-empty description: there is no timeout
+    or skip. Done/Quit can end the session without starting another take. A
     submission outside the naming phase is refused rather than applied to the
     wrong episode. A refusal comes back as HTTP 200 + {success: False}, the
     same shape the pause/exit-early controls use — the frontend reads
@@ -1220,6 +1209,8 @@ def handle_submit_episode_task(task: str) -> dict[str, Any]:
             "message": "The session is not waiting for an episode task",
             "current_phase": current_phase,
         }
+    if recording_events.get("episode_task_submitted") or recording_events.get("rerecord_episode"):
+        return {"success": False, "message": "An episode transition is already pending"}
     cleaned = (task or "").strip()
     if not cleaned:
         return {"success": False, "message": "An episode task description is required"}
@@ -1297,19 +1288,23 @@ def handle_recording_status() -> dict[str, Any]:
         # which is available in both phases.
         "pause_armed": _pause_armed(),
         "available_controls": {
-            # The "naming" phase (per-episode-task sessions) is a hard gate:
-            # every control below is withdrawn so there is no way past it but
-            # to name the task. submit_episode_task is the only control it
-            # offers.
-            # ESC key replacement.
-            "stop_recording": recording_active and current_phase != "naming",
+            # Naming gates the next recording, but the operator can still
+            # finish the session or discard and re-record the pending take.
+            "stop_recording": recording_active,
             "exit_early": recording_active
             and current_phase != "naming"
             and not _reset_paused(),  # Right arrow key replacement; disabled while paused
             "rerecord_episode": recording_active
-            and current_phase == "recording",  # Only during recording phase
+            and (
+                current_phase == "recording"
+                or (
+                    current_phase == "naming"
+                    and bool(recording_events and recording_events.get("pending_episode"))
+                )
+            ),
             "pause_recording": recording_active
             and current_phase in ("recording", "resetting")
+            and not getattr(recording_config, "per_episode_task", False)
             and not _pause_armed(),
             "resume_recording": recording_active
             and current_phase in ("recording", "resetting")
@@ -2120,6 +2115,87 @@ def _reset_loop_with_pause(
         reset_phase_elapsed_s = None
 
 
+def _record_task_episodes(
+    cfg: RecordConfig,
+    dataset: LeRobotDataset,
+    events: dict,
+    capture: Callable[[str], None],
+    prepare: Callable[[], bool],
+    preview: Callable[[], None],
+) -> None:
+    """Manually gated episodes. Hold the completed buffer until Next or Done
+    so Re-record can discard it without deleting an already saved episode.
+    Task strings are passed into capture, never rewritten after recording.
+    """
+    global current_episode, saved_episodes, phase_start_time
+    global paused_accum_seconds, pause_started_at, reset_phase_elapsed_s
+
+    pending = False
+    while saved_episodes < cfg.dataset.num_episodes:
+        events.update(episode_task_submitted=None, exit_early=False, rerecord_episode=False, paused=False)
+        events["pending_episode"] = pending
+        current_episode = saved_episodes + (2 if pending else 1)
+        phase_start_time = time.time()
+        paused_accum_seconds = 0.0
+        pause_started_at = None
+        reset_phase_elapsed_s = None
+        _set_phase("naming")
+        while recording_active and not events.get("stop_recording"):
+            if events.get("episode_task_submitted") or events.get("rerecord_episode"):
+                break
+            # Keep camera previews fresh without teleoperating or writing frames.
+            preview()
+            time.sleep(0.1)
+
+        if events.get("stop_recording") or not recording_active:
+            if pending and not discard_requested:
+                dataset.save_episode()
+                saved_episodes += 1
+            else:
+                dataset.clear_episode_buffer()
+            events["pending_episode"] = False
+            return
+
+        if events.get("rerecord_episode"):
+            _set_phase("preparing")
+            dataset.clear_episode_buffer()
+            pending = False
+            continue
+
+        # Close the gate before consuming the submission, including during
+        # slow disk I/O or alignment; duplicate requests must stay refused.
+        _set_phase("preparing")
+        task = events.pop("episode_task_submitted")
+        events["pending_episode"] = False
+        if pending:
+            dataset.save_episode()
+            saved_episodes += 1
+            pending = False
+        current_episode = saved_episodes + 1
+        events["exit_early"] = False
+        events["_exit_early_triggered"] = False
+        phase_start_time = None
+        if not prepare():
+            return
+        if events.get("stop_recording") or not recording_active:
+            return
+        phase_start_time = time.time()
+        _set_phase("recording")
+        capture(task)
+        if events.get("stop_recording"):
+            dataset.clear_episode_buffer()
+            return
+        # Preserve the existing timeout policy: unfinished takes are discarded.
+        if events.get("rerecord_episode") or not events.get("_exit_early_triggered"):
+            dataset.clear_episode_buffer()
+            continue
+        pending = True
+        if saved_episodes + 1 == cfg.dataset.num_episodes:
+            dataset.save_episode()
+            saved_episodes += 1
+            return
+
+
 def record_with_web_events(
     cfg: RecordConfig,
     web_events: dict,
@@ -2463,7 +2539,40 @@ def record_with_web_events(
     prepare_alignment = partial(realign, require_settled=True)
     try:
         prepared_encoder = install_episode_preparation(dataset)
-        while saved_episodes < cfg.dataset.num_episodes:
+        per_episode_task = getattr(recording_config, "per_episode_task", False)
+        if per_episode_task:
+
+            def capture_task(task):
+                record_loop(
+                    robot=robot,
+                    events=web_events,
+                    fps=cfg.dataset.fps,
+                    teleop_action_processor=teleop_action_processor,
+                    robot_action_processor=robot_action_processor,
+                    robot_observation_processor=process_observation,
+                    teleop=teleop,
+                    dataset=dataset,
+                    control_time_s=cfg.dataset.episode_time_s,
+                    single_task=task,
+                    display_data=cfg.display_data,
+                )
+
+            _record_task_episodes(
+                cfg,
+                dataset,
+                web_events,
+                capture_task,
+                lambda: prepare_recording_episode(
+                    robot,
+                    dataset,
+                    prepared_encoder,
+                    prepare_alignment,
+                    cancelled,
+                    observation_processor=process_observation,
+                ),
+                lambda: publish_preview(robot.get_observation()),
+            )
+        while not per_episode_task and saved_episodes < cfg.dataset.num_episodes:
             _set_phase("preparing")
             phase_start_time = None
             if not prepare_recording_episode(
@@ -2624,44 +2733,6 @@ def record_with_web_events(
 
                 # Don't increment current_episode or saved_episodes - we're re-recording the same episode
                 continue
-
-            # PER-EPISODE TASK NAMING PHASE. The episode's frames are captured
-            # (record_loop ran with the placeholder single_task); block here
-            # until the operator names THIS episode's task, then rewrite the
-            # buffer's per-frame task before the save below reads it. No
-            # timeout and no bypass — the frontend withdraws every other
-            # control (available_controls) so naming is the only way forward.
-            # The exits are: a submitted task (handle_submit_episode_task), or
-            # a teardown that trips stop_recording (lease-expiry safety stop,
-            # a disconnect) — that abandons the unnamed episode and ends the
-            # session, mirroring a stop mid-recording.
-            if getattr(recording_config, "per_episode_task", False) and not web_events["stop_recording"]:
-                _set_phase("naming")
-                phase_start_time = time.time()
-                web_events["episode_task_submitted"] = None
-                logger.info(f"⏸️  Waiting for the operator to name episode {current_episode}'s task")
-                print(f"⏸️  STATUS CHANGE: Naming the task for episode {current_episode}")
-                log_say(f"Name the task for episode {current_episode}", cfg.play_sounds)
-
-                while recording_active and not web_events["episode_task_submitted"]:
-                    if web_events["stop_recording"]:
-                        break
-                    time.sleep(0.1)
-
-                named_task = web_events["episode_task_submitted"]
-                if not named_task:
-                    logger.info(
-                        "Naming phase ended without a task — discarding unnamed episode %s and ending session",
-                        current_episode,
-                    )
-                    print(
-                        f"🛑 STATUS CHANGE: Session ended before episode {current_episode} was named — episode discarded"
-                    )
-                    dataset.clear_episode_buffer()
-                    break
-
-                _apply_episode_task(dataset, named_task)
-                logger.info(f"Episode {current_episode} task set to {named_task!r}")
 
             # Save episode immediately after recording phase (matches expected flow)
             logger.info(f"💾 Saving episode {current_episode}...")

--- a/makermodslab/schemas/sessions.py
+++ b/makermodslab/schemas/sessions.py
@@ -144,7 +144,7 @@ class RecordingOptions(BaseModel):
     resume: bool = False
     streaming_encoding: bool = True
     skip_identity_check: bool = False
-    # Pause after every episode to let the operator name THAT episode's task
+    # Wait before every episode for the operator to enter its task
     # description (record.py's "naming" phase). `single_task` stays the
     # required baseline / first-episode prefill.
     per_episode_task: bool = False

--- a/makermodslab/server.py
+++ b/makermodslab/server.py
@@ -2315,10 +2315,9 @@ class RecordingControlResponse(BaseModel):
     tags=["recording"],
 )
 def recording_episode_task(body: EpisodeTaskBody):
-    """Name the task for the episode a per-episode-task session is holding in
-    its "naming" phase. Mandatory and un-bypassable: an empty description or a
-    submission outside the naming phase comes back 200 + {success: false} —
-    see handle_submit_episode_task."""
+    """Set the upcoming episode's task and start recording after environment
+    reset. An empty description or a submission outside the naming phase
+    comes back 200 + {success: false}."""
     return handle_submit_episode_task(body.task)
 
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -3856,8 +3856,8 @@ def test_teleop_connect_failure_releases_both_devices(
 
 # ---------------------------------------------------------------------------
 # Per-episode task naming — the operator names each episode's task description
-# right after recording it (a checkbox on the Collect form). The session pauses
-# in a dedicated "naming" phase between the recording phase and the reset gap.
+# before recording it. The session waits in a dedicated "naming" phase
+# while the operator resets the environment and describes the next task.
 # ---------------------------------------------------------------------------
 
 
@@ -3878,23 +3878,6 @@ def test_recording_request_per_episode_task_defaults_off() -> None:
 
     ticked = req.model_copy(update={"per_episode_task": True})
     assert ticked.per_episode_task is True
-
-
-def test_apply_episode_task_rewrites_every_frame_in_the_pending_buffer() -> None:
-    """record_loop appended the captured frames with the session's placeholder
-    task; _apply_episode_task swaps in the operator-named string before
-    save_episode() reads the buffer."""
-    from makermodslab.record import _apply_episode_task
-
-    dataset = type(
-        "FakeDataset",
-        (),
-        {"writer": type("W", (), {"episode_buffer": {"task": ["placeholder"] * 4, "size": 4}})()},
-    )()
-
-    _apply_episode_task(dataset, "fold the left sleeve")
-
-    assert dataset.writer.episode_buffer["task"] == ["fold the left sleeve"] * 4
 
 
 def test_handle_submit_episode_task_stashes_the_task_during_the_naming_phase(
@@ -3952,12 +3935,10 @@ def test_handle_submit_episode_task_refused_outside_the_naming_phase(
     assert events["episode_task_submitted"] is None
 
 
-def test_recording_status_naming_phase_locks_every_control_but_the_task_submit(
+def test_recording_status_naming_phase_allows_stop_but_blocks_unnamed_recording(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """While the session waits for an episode task there is no bypass: Stop,
-    skip-to-next, re-record and pause are all withdrawn, and the status carries
-    the prefill for the prompt (the previous episode's task)."""
+    """Naming gates capture, while Done/Quit remain available."""
     import makermodslab.record as record
 
     monkeypatch.setattr(record, "recording_active", True)
@@ -3980,7 +3961,7 @@ def test_recording_status_naming_phase_locks_every_control_but_the_task_submit(
 
     controls = status["available_controls"]
     assert controls["submit_episode_task"] is True
-    assert controls["stop_recording"] is False
+    assert controls["stop_recording"] is True
     assert controls["exit_early"] is False
     assert controls["rerecord_episode"] is False
     assert controls["pause_recording"] is False
@@ -4082,3 +4063,147 @@ def test_strict_preparation_finishes_pending_startup_sync_with_measured_hold(mon
         robot, _RealignTeleop({"shoulder_pan.pos": 10}), "maker", _identity, _identity, require_settled=True
     )
     assert sent == [{"shoulder_pan.pos": 9.5}]
+
+
+@pytest.mark.parametrize("action", ["next", "rerecord", "done", "quit", "lease_expiry", "timeout"])
+def test_task_workflow_labels_before_capture_and_handles_pending_take(monkeypatch, action):
+    """Exercise the real gate/record/save loop without hardware or disk I/O."""
+    from types import SimpleNamespace
+
+    import makermodslab.record as record
+
+    events = {"stop_recording": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "saved_episodes", 0)
+    monkeypatch.setattr(record, "discard_requested", False)
+    monkeypatch.setattr(record, "last_episode_task", "")
+    monkeypatch.setattr(record.time, "sleep", lambda _: None)
+    buffer = []
+    saved = []
+    captured = []
+    prompts = []
+    alignments = []
+
+    def save():
+        saved.append(buffer.copy())
+        buffer.clear()
+
+    dataset = SimpleNamespace(save_episode=save, clear_episode_buffer=buffer.clear)
+    cfg = SimpleNamespace(dataset=SimpleNamespace(num_episodes=2))
+
+    def prompt():
+        assert record.current_phase == "naming"
+        prompts.append(record.current_episode)
+        if len(prompts) == 1:
+            assert not captured  # The first prompt precedes ALL recording.
+            assert record.handle_exit_early()["success"] is False
+            assert record.handle_submit_episode_task("pick cube")["success"]
+        elif len(prompts) == 2:
+            assert not saved  # Completed take still available to re-record.
+            if action == "rerecord":
+                assert record.handle_rerecord_episode()["success"]
+            elif action in ("done", "quit"):
+                record.handle_stop_recording(discard=action == "quit")
+            elif action == "lease_expiry":
+                events["stop_recording"] = True
+            else:
+                assert record.handle_submit_episode_task("fold towel")["success"]
+        else:
+            assert record.handle_submit_episode_task("fold towel")["success"]
+
+    def capture(task):
+        assert record.current_phase == "recording"
+        assert len(alignments) == len(captured) + 1
+        captured.append(task)
+        buffer.extend([task] * 3)
+        events["_exit_early_triggered"] = not (action == "timeout" and len(captured) == 1)
+
+    record._record_task_episodes(
+        cfg, dataset, events, capture, lambda: alignments.append(True) or True, prompt
+    )
+
+    if action in ("done", "lease_expiry"):
+        assert saved == [["pick cube"] * 3]
+    elif action == "quit":
+        assert saved == []
+    elif action in ("rerecord", "timeout"):
+        assert saved == [["fold towel"] * 3, ["fold towel"] * 3]
+        assert prompts == ([1, 2, 1, 2] if action == "rerecord" else [1, 1, 2])
+    else:
+        assert saved == [["pick cube"] * 3, ["fold towel"] * 3]
+        assert prompts == [1, 2]
+    assert record.saved_episodes == len(saved)
+    assert not buffer
+
+
+def test_task_prompt_keeps_waiting_without_recording(monkeypatch):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    import makermodslab.record as record
+
+    events = {"stop_recording": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "saved_episodes", 0)
+    monkeypatch.setattr(record, "discard_requested", False)
+    monkeypatch.setattr(record.time, "sleep", lambda _: None)
+    ticks = []
+
+    def preview():
+        ticks.append(True)
+        assert not record.handle_submit_episode_task("   ")["success"]
+        if len(ticks) == 5:
+            record.handle_stop_recording()
+
+    capture, realign, dataset = Mock(), Mock(), Mock()
+    record._record_task_episodes(
+        SimpleNamespace(dataset=SimpleNamespace(num_episodes=2)), dataset, events, capture, realign, preview
+    )
+    assert len(ticks) == 5
+    capture.assert_not_called()
+    realign.assert_not_called()
+    dataset.save_episode.assert_not_called()
+
+
+@pytest.mark.parametrize("prepare_result", [True, False])
+def test_task_workflow_prepares_only_after_description_and_before_timer(monkeypatch, prepare_result):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    import makermodslab.record as record
+
+    events = {"stop_recording": False}
+    monkeypatch.setattr(record, "recording_active", True)
+    monkeypatch.setattr(record, "recording_events", events)
+    monkeypatch.setattr(record, "saved_episodes", 0)
+    monkeypatch.setattr(record, "discard_requested", False)
+    monkeypatch.setattr(record.time, "sleep", lambda _: None)
+    calls = []
+
+    def prompt():
+        assert calls == []
+        assert record.handle_submit_episode_task("pick cube")["success"]
+        calls.append("task")
+
+    def prepare():
+        assert calls == ["task"]
+        assert record.current_phase == "preparing"
+        assert record.phase_start_time is None
+        calls.append("prepare")
+        return prepare_result
+
+    def capture(task):
+        assert task == "pick cube"
+        assert record.current_phase == "recording"
+        assert record.phase_start_time is not None
+        calls.append("capture")
+        events["_exit_early_triggered"] = True
+
+    dataset = Mock()
+    record._record_task_episodes(
+        SimpleNamespace(dataset=SimpleNamespace(num_episodes=1)), dataset, events, capture, prepare, prompt
+    )
+    assert calls == (["task", "prepare", "capture"] if prepare_result else ["task", "prepare"])
+    assert dataset.save_episode.call_count == int(prepare_result)


### PR DESCRIPTION
The optional **Describe each episode** toggle now asks for the upcoming task before recording, instead of naming the episode afterward. The toggle stays off by default, preserving the normal single-task recording flow.

When enabled, Record opens the first task prompt immediately. After entering the task, press Enter to finish editing, then Space to start capture. Space during capture ends the episode and opens the next task prompt. Operators can reset the environment at their own pace with no reset countdown, or re-record the previous task.

Also removes the “Pick a policy and a checkpoint.” message from the Deploy UI while preserving the disabled Run guard.

Validation: 504 frontend tests passed; 3,935 Python tests passed, 15 skipped; frontend type checks, lint, production build, and pre-commit checks passed. The bundled UI is running locally. Generated frontend assets are excluded from this PR.
