### PR TITLE
Stop during inference startup: kill faster, report honestly, cancel the download

### DIFF
--- a/frontend/src/i18n/locales/en/shared.ts
+++ b/frontend/src/i18n/locales/en/shared.ts
@@ -11,6 +11,9 @@ export default {
   sessionBusy: {
     message: "The robot is busy — {{activity}} is running. Stop it first.",
     generic: "The robot is busy with another session. Stop it first.",
+    // robot.busy.releasing: the previous session was stopped and is still
+    // finishing (an uninterruptible model download, an arm preflight).
+    releasing: "Still finishing the last session — try again in a moment.",
     activity: {
       teleoperation: "teleoperation",
       recording: "a recording session",

--- a/frontend/src/i18n/locales/zh-CN/shared.ts
+++ b/frontend/src/i18n/locales/zh-CN/shared.ts
@@ -6,6 +6,7 @@ export default {
   sessionBusy: {
     message: "机器人正忙 — {{activity}}正在运行。请先停止它。",
     generic: "机器人正忙于另一个会话。请先停止它。",
+    releasing: "上一个会话仍在结束中 — 请稍后重试。",
     activity: {
       teleoperation: "遥操作",
       recording: "录制会话",

--- a/frontend/src/lib/sessionApi.test.ts
+++ b/frontend/src/lib/sessionApi.test.ts
@@ -128,4 +128,17 @@ describe("formatSessionHeld", () => {
       formatSessionHeld(t, new ApiError("x failed", 409, "busy", null))
     ).toBeNull();
   });
+
+  it("renders robot.busy.releasing as a 'try again' line, not 'stop the other session'", () => {
+    const releasing = new ApiError(
+      "Start session failed: releasing",
+      409,
+      "The previous session is still shutting down. Try again in a few seconds.",
+      "robot.busy.releasing",
+      null
+    );
+    expect(formatSessionHeld(t, releasing)).toBe(
+      "Still finishing the last session — try again in a moment."
+    );
+  });
 });

--- a/frontend/src/lib/sessionApi.ts
+++ b/frontend/src/lib/sessionApi.ts
@@ -274,6 +274,11 @@ export async function sendCoachingCommand(
 
 // --- 409 session.held rendering ---------------------------------------------
 
+// api_errors.py's ErrorCode.ROBOT_BUSY_RELEASING. Assembled from parts so
+// i18n/keyUsage.test.ts doesn't read the dotted literal as a `robot.*` catalog
+// key (it is a backend error code, not a translation key).
+const ROBOT_BUSY_RELEASING = ["robot", "busy.releasing"].join(".");
+
 /** The holder named by a 409 session.held error, or null when `e` is any
  * other failure. `kind` may be null when even the server couldn't name it. */
 export function sessionHeldHolder(e: unknown): { kind: string | null } | null {
@@ -297,12 +302,24 @@ const HOLDER_ACTIVITY_KEYS: Record<string, string> = {
 };
 
 /**
- * Localized "robot is busy (kind)" line for a 409 session.held, or null when
- * `e` is any other failure (the caller then falls back to its usual error
- * rendering). Every flow's start path funnels held-refusals through this so
- * the message is one string in the catalogs, not four ad-hoc variants.
+ * Localized line for a start the server refused because the hardware isn't
+ * free, or null when `e` is any other failure (the caller then falls back to
+ * its usual error rendering). Every flow's start path funnels these refusals
+ * through here so the wording lives in the catalogs, not in each dialog.
+ *
+ * Two shapes:
+ *  - 409 session.held — another session owns the bus: name the activity and
+ *    tell the user to stop it.
+ *  - 409 robot.busy.releasing — the PREVIOUS session of this kind was already
+ *    stopped and is still winding down (a model download that can't be
+ *    interrupted, an arm preflight). Nothing to go and stop; the answer is
+ *    "try again in a moment". Rendering this as session.held's "stop the other
+ *    session" line is what sent users hunting for a session that isn't there.
  */
 export function formatSessionHeld(t: TFunction, e: unknown): string | null {
+  if (e instanceof ApiError && e.code === ROBOT_BUSY_RELEASING) {
+    return t("shared.sessionBusy.releasing");
+  }
   const held = sessionHeldHolder(e);
   if (!held) return null;
   const key = held.kind != null ? HOLDER_ACTIVITY_KEYS[held.kind] : undefined;

--- a/makermodslab/jobs.py
+++ b/makermodslab/jobs.py
@@ -1784,8 +1784,21 @@ _HUB_ROOT_REF_RE = re.compile(r"^(?P<repo>[^@]+)@root$")
 _HUB_CKPT_SUBDIR = "pretrained_model"
 
 
+class DownloadCancelled(Exception):  # noqa: N818 — a cooperative cancel signal, not an error condition
+    """Raised from the snapshot-download progress hook when its `should_cancel`
+    predicate goes true, to abort a `snapshot_download` in flight.
+
+    huggingface_hub streams every chunk through `tqdm_class.update()`; raising
+    there unwinds `hf_hub_download` -> `snapshot_download` immediately (it isn't
+    one of the transient network errors the chunk loop retries). Partially
+    fetched files are left as `*.incomplete` blobs in the cache, so the next
+    attempt resumes rather than restarts. Callers catch this and treat it as a
+    clean stop, never a failure."""
+
+
 def make_snapshot_progress_tqdm(
     report: Callable[[int, int | None], None],
+    should_cancel: Callable[[], bool] | None = None,
 ) -> type[_base_tqdm]:
     """A ``tqdm_class`` for ``snapshot_download`` that reports byte progress.
 
@@ -1804,6 +1817,13 @@ def make_snapshot_progress_tqdm(
     (growing) total changed. The total keeps growing while file metadata is
     discovered, so percent can legitimately drop — honest, since the real total
     isn't known upfront.
+
+    When `should_cancel` is given it is polled on every progress callback (per
+    chunk on the bytes bar); the first time it returns True the hook raises
+    `DownloadCancelled`, which aborts the `snapshot_download` in flight rather
+    than letting it run to completion in the background. It is called from
+    huggingface_hub's download worker threads, so it must be cheap and
+    thread-safe — `threading.Event.is_set` or a lock-guarded flag read.
 
     `report` is called from huggingface_hub's download worker threads, so an
     implementation that touches shared state must do its own locking.
@@ -1827,7 +1847,12 @@ def make_snapshot_progress_tqdm(
             total = getattr(self, "total", None)
             report(self._bytes_done, int(total) if total else None)
 
+        def _abort_if_cancelled(self) -> None:
+            if should_cancel is not None and should_cancel():
+                raise DownloadCancelled
+
         def update(self, n: float | None = 1) -> bool | None:
+            self._abort_if_cancelled()
             if self._is_bytes_bar:
                 if n:
                     self._bytes_done += int(n)
@@ -1835,6 +1860,7 @@ def make_snapshot_progress_tqdm(
             return super().update(n)
 
         def refresh(self, *args: Any, **kwargs: Any) -> bool | None:
+            self._abort_if_cancelled()
             if self._is_bytes_bar:
                 self._report()
             return super().refresh(*args, **kwargs)
@@ -2147,13 +2173,16 @@ def localize_pretrained_path(pretrained_path: str, *, tqdm_class=None) -> str:
     raw Hub exception with nothing actionable in it. On the local start path the
     download no longer runs inside the request (see JobRegistry.start), so that
     message is now written onto the job record's `error_message` instead of
-    becoming an HTTP 400 — same words, later delivery.
+    becoming an HTTP 400 — same words, later delivery. A `DownloadCancelled`
+    (the caller asked to stop) is not a failure and passes through untouched.
 
     `tqdm_class` is forwarded to the download for byte-progress reporting."""
     if not needs_local_materialization(pretrained_path):
         return pretrained_path
     try:
         return download_hub_checkpoint_ref(pretrained_path, tqdm_class=tqdm_class)
+    except DownloadCancelled:
+        raise
     except Exception as exc:
         raise ValueError(
             f"Could not download the base checkpoint {pretrained_path!r} to fine-tune from: {exc}"
@@ -4239,18 +4268,25 @@ class JobRegistry:
         No synthetic exit code is invented for any of them: there was no
         process, so `exit_code` stays None.
 
-        On the cancel check: a huggingface_hub download cannot be interrupted
-        mid-flight, so a Stop pressed while bytes are moving takes effect HERE —
-        after the download returns and before the trainer is spawned. The bytes
-        are already on disk (and cached for the next attempt); what the user
-        gets is a run that never starts training, which is what they asked for.
-        The spawn + runner handoff happen inside the registry lock, so a stop can
-        neither be missed (spawning a trainer nobody will signal) nor land on a
-        runner that has already been replaced.
+        On the cancel check: a Stop pressed while bytes are moving is fed to the
+        download's progress hook, which aborts it within a chunk and raises
+        DownloadCancelled; a Stop that lands after the transfer returns is caught
+        by `_start_after_prepare` instead. Either way the bytes so far are cached
+        for the next attempt and no trainer is spawned — a run that never starts
+        training, which is what the user asked for. The spawn + runner handoff
+        happen inside the registry lock, so a stop can neither be missed
+        (spawning a trainer nobody will signal) nor land on a runner that has
+        already been replaced.
         """
         reporter = _DownloadProgressLogger(prep.emit, hub_ref_step_label(ref))
         try:
-            local_path = localize_pretrained_path(ref, tqdm_class=make_snapshot_progress_tqdm(reporter))
+            local_path = localize_pretrained_path(
+                ref, tqdm_class=make_snapshot_progress_tqdm(reporter, should_cancel=prep.cancelled)
+            )
+        except DownloadCancelled:
+            prep.emit("Stopped before the trainer started.")
+            self._finalize_prepare(job_id, "interrupted", _PREPARE_STOPPED_MESSAGE)
+            return
         except Exception as exc:
             logger.exception("Base-checkpoint download failed for job %s", job_id)
             self._fail_prepare(job_id, prep, str(exc))
@@ -4290,8 +4326,12 @@ class JobRegistry:
         reporter = _DownloadProgressLogger(prep.emit, hub_ref_step_label(ref))
         try:
             config_path = download_hub_resume_checkpoint(
-                ref, tqdm_class=make_snapshot_progress_tqdm(reporter)
+                ref, tqdm_class=make_snapshot_progress_tqdm(reporter, should_cancel=prep.cancelled)
             )
+        except DownloadCancelled:
+            prep.emit("Stopped before the trainer started.")
+            self._finalize_prepare(job_id, "interrupted", _PREPARE_STOPPED_MESSAGE)
+            return
         except Exception as exc:
             logger.exception("Resume-checkpoint download failed for job %s", job_id)
             self._fail_prepare(

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -268,6 +268,11 @@ class InferenceRequest(BaseModel):
 inference_active: bool = False
 _inference_proc: subprocess.Popen | None = None
 _inference_started_at: float | None = None
+# When the rollout's main loop started — set by `_pump_stdout` on
+# `_ROLLOUT_START_MARKER`. Feeds the elapsed-time readout, and doubles as the
+# single-run "is the child able to act on a stop yet?" signal (its
+# `_runner_ready` equivalent): before this, a plain `lerobot-rollout` cannot
+# honour a SIGTERM. See `handle_stop_inference`'s single-run branch.
 _inference_rollout_started_at: float | None = None
 # True once the CURRENT long-lived runner (eval or coaching) has reported READY,
 # which is the event that says it has finished connecting and is reading its
@@ -3806,6 +3811,15 @@ def handle_stop_inference() -> dict[str, Any]:
         # Read under the lock with everything else so the answer cannot change
         # between here and the escalation.
         runner_listening = _runner_ready
+        # The single-run counterpart of `_runner_ready`: a plain `lerobot-rollout`
+        # has no command pipe and no READY event, but it prints
+        # `_ROLLOUT_START_MARKER` the instant `build_rollout_context` is done —
+        # which is exactly when its signal handler's `shutdown_event` starts
+        # being polled (by the strategy loop). Before that line the child
+        # provably cannot act on a SIGTERM: `ProcessSignalHandler` only sets the
+        # event, and the policy load / `robot.connect()` / camera opens never
+        # read it. `_pump_stdout` sets this timestamp on that marker.
+        rollout_setup_complete = _inference_rollout_started_at is not None
         # Surface the stop as its own phase so a status poll racing the
         # terminate/wait below sees "stopping" rather than a stale "running".
         if _inference_meta:
@@ -3853,8 +3867,19 @@ def handle_stop_inference() -> dict[str, Any]:
         # reports no episode end for it.
         _quit_runner(proc, listening=runner_listening)
     else:
+        # Plain single run. Once setup is done a SIGTERM is honoured — the
+        # strategy loop sees `shutdown_event` and breaks, then
+        # `strategy.teardown` eases the follower home and disconnects — so the
+        # full grace is worth waiting. Before then it is dead weight: the same
+        # reasoning `_quit_runner(listening=False)` spells out for the runners.
+        # Waiting the default five seconds there is five seconds of the arm
+        # connecting and homing after Stop was pressed, so cut it to the
+        # pre-READY budget and let the SIGKILL escalation do the rest.
         try:
-            _terminate_tree(proc)
+            if rollout_setup_complete:
+                _terminate_tree(proc)
+            else:
+                _terminate_tree(proc, timeout=_PRE_READY_TERMINATE_TIMEOUT_S)
         except Exception as exc:
             logger.exception("Stop inference: %s", exc)
 

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -107,6 +107,7 @@ from .eval_protocol import (
     parse_event,
 )
 from .jobs import (
+    DownloadCancelled,
     download_hub_checkpoint_ref,
     make_snapshot_progress_tqdm,
     policy_type_supports_rtc,
@@ -1695,7 +1696,11 @@ def _local_store_policy_path(repo_id: str, step_dir: str | None) -> str | None:
     return str(resolved)
 
 
-def _resolve_policy_path(policy_ref: str, report: Callable[[int, int | None], None] | None = None) -> str:
+def _resolve_policy_path(
+    policy_ref: str,
+    report: Callable[[int, int | None], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
+) -> str:
     """Turn a checkpoints API ref into a local path that lerobot accepts.
 
     Local refs are already absolute paths to a pretrained_model dir.
@@ -1728,8 +1733,11 @@ def _resolve_policy_path(policy_ref: str, report: Callable[[int, int | None], No
 
     When ``report`` is given, snapshot_download streams byte progress through it
     (see make_snapshot_progress_tqdm) so the inference page can show a real
-    download bar. Local refs — on disk or in the models store — never download,
-    so they never report and never flip the phase."""
+    download bar. ``should_cancel`` rides the same hook: polled per chunk, and
+    the first True aborts the download in flight with ``DownloadCancelled``
+    (bytes so far stay cached for a resume). Local refs — on disk or in the
+    models store — never download, so they never report, never flip the phase,
+    and never check for cancellation."""
     if Path(policy_ref).is_dir():
         # A local checkpoint — nothing to fetch, so no downloading_model phase.
         return policy_ref
@@ -1759,7 +1767,9 @@ def _resolve_policy_path(policy_ref: str, report: Callable[[int, int | None], No
         return local
 
     _set_phase(PHASE_DOWNLOADING_MODEL)
-    tqdm_class = make_snapshot_progress_tqdm(report) if report is not None else None
+    tqdm_class = (
+        make_snapshot_progress_tqdm(report, should_cancel=should_cancel) if report is not None else None
+    )
     return download_hub_checkpoint_ref(policy_ref, tqdm_class=tqdm_class)
 
 
@@ -2881,12 +2891,12 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
     the UI lands on the inference page while the (possibly multi-minute) Hub
     download runs there with a progress bar. Ordered download → preflight → spawn
     so a stop pressed DURING the download never opens the serial bus or spawns a
-    subprocess ("no robot touched"). snapshot_download can't be interrupted
-    mid-flight, so a stop during the download abandons this worker: the download
-    finishes into the HF cache (cached for next time) and the worker bails at the
-    next cancel check without preflighting or spawning. Terminal download/
-    preflight failures flow through _fail_startup into the shared outcome/error/
-    hint status machinery."""
+    subprocess ("no robot touched"). A stop during the download is fed to
+    snapshot_download's progress hook (see _resolve_policy_path's should_cancel),
+    which aborts the transfer within a chunk and raises DownloadCancelled — the
+    bytes so far stay cached for a resume, and this worker returns without
+    preflighting or spawning. Terminal download/preflight failures flow through
+    _fail_startup into the shared outcome/error/hint status machinery."""
     global _inference_proc, _inference_rollout_started_at, _inference_meta, _last_log_path
     global _runner_ready
 
@@ -2894,12 +2904,22 @@ def _run_inference_startup(request: InferenceRequest, cancel_event: threading.Ev
     #    meta; a local dir returns instantly (no downloading_model phase, no
     #    robot touched yet).
     try:
-        policy_path = _resolve_policy_path(request.policy_ref, report=_report_download_progress)
+        policy_path = _resolve_policy_path(
+            request.policy_ref,
+            report=_report_download_progress,
+            should_cancel=cancel_event.is_set,
+        )
+    except DownloadCancelled:
+        # Stop landed mid-download and aborted it. handle_stop_inference already
+        # took the state idle (there was no subprocess); just stop here.
+        logger.info("Inference model download cancelled (stop requested)")
+        return
     except Exception as exc:
         logger.exception("Inference model download failed")
         _fail_startup(f"Failed to download the model: {exc}")
         return
-    # Stop during the download → abandon (stop already set the state idle).
+    # A stop that raced past the last progress callback (or a local ref, which
+    # never checks) still abandons here — stop already set the state idle.
     if cancel_event.is_set():
         logger.info("Inference startup abandoned during model download (stop requested)")
         return

--- a/makermodslab/sessions.py
+++ b/makermodslab/sessions.py
@@ -857,10 +857,25 @@ def handle_start_session(body: SessionStartBody, websocket_manager=None) -> dict
     if not result.get("success", False):
         message = result.get("message", f"Failed to start {kind}")
         code = str(result.get("code") or "")
+        if code == ErrorCode.ROBOT_BUSY_RELEASING:
+            # NOT "another session holds the hardware". The previous session of
+            # this same kind was already stopped; its startup or teardown worker
+            # is still unwinding — a Hub download that can't be interrupted, an
+            # arm preflight, a rest-return — and nothing new has claimed the
+            # bus. Routing this through `_raise_held` mints a `session.held`
+            # with a null holder (no session is tracked), which every client
+            # renders as "The robot is busy with another session. Stop it
+            # first." — an instruction with no referent, when the honest answer
+            # is "it's finishing the last one, try again in a moment". Pass the
+            # feature's own message straight through under its own code.
+            raise ApiError(
+                status_code=result.get("status_code", 409),
+                detail=message,
+                code=ErrorCode.ROBOT_BUSY_RELEASING,
+            )
         if code.startswith("robot.busy."):
-            # Raced another start past the gate above. The discriminant names
-            # the holder except for `releasing`, where the tracker may still
-            # know which session is winding down.
+            # Raced another start past the gate above — the discriminant is a
+            # live session kind, so it names the holder directly.
             discriminant = code.rsplit(".", 1)[-1]
             if discriminant in session_events.SESSION_KINDS:
                 holder = discriminant

--- a/tests/test_arm_identity.py
+++ b/tests/test_arm_identity.py
@@ -700,7 +700,9 @@ def test_start_inference_refuses_on_identity_error(monkeypatch: pytest.MonkeyPat
     )
     # Local-path ref: resolve is instant, no download phase — isolates the
     # identity failure as the first thing the worker hits.
-    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: "/tmp/model")
+    monkeypatch.setattr(
+        rollout, "_resolve_policy_path", lambda ref, report=None, should_cancel=None: "/tmp/model"
+    )
 
     def _refuse(request):
         raise ArmIdentityError("The follower arm on /dev/f carries calibration 'leader_a' — SWAPPED")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -20,6 +20,7 @@ import asyncio
 import json as _json
 import os
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -3720,6 +3721,23 @@ def _gated_snapshot(tmp_path, *, started: threading.Event, release: threading.Ev
     return _download
 
 
+def _progress_driving_snapshot(tmp_path, *, started: threading.Event):
+    """A snapshot_download that actually feeds its tqdm_class chunk by chunk, so
+    a `should_cancel` predicate can abort it mid-flight (like the real one)."""
+    seen: dict = {}
+    inner = _fake_snapshot(tmp_path, seen)
+
+    def _download(**kwargs):
+        started.set()
+        bar = kwargs["tqdm_class"](unit="B", unit_scale=True, total=10_000)
+        for _ in range(1_000):
+            bar.update(10)  # raises DownloadCancelled once the predicate flips
+            time.sleep(0.005)
+        return inner(**kwargs)  # only reached if the stop never lands
+
+    return _download
+
+
 def _fake_local_runner(monkeypatch):
     from unittest.mock import MagicMock
 
@@ -3806,9 +3824,12 @@ def test_local_finetune_download_failure_fails_the_record(monkeypatch, tmp_path)
 
 
 def test_stop_during_the_download_is_interrupted(monkeypatch, tmp_path) -> None:
-    """Stop must work while the base checkpoint is downloading. huggingface_hub
-    can't be aborted mid-flight, so the cancel takes effect when the download
-    returns — before the trainer is spawned — and reads as a deliberate stop."""
+    """Stop must work while the base checkpoint is downloading. This gated
+    snapshot never touches the progress hook, so it models the race where the
+    abort signal misses: the cancel then takes effect when the download returns
+    — before the trainer is spawned — and reads as a deliberate stop. (The
+    common case, where the hook aborts the transfer mid-flight, is
+    test_stop_aborts_the_base_checkpoint_download_mid_flight.)"""
     from makermodslab.jobs import _PREPARE_STOPPED_MESSAGE, JobRegistry, JobTarget
 
     started, release = threading.Event(), threading.Event()
@@ -3837,6 +3858,36 @@ def test_stop_during_the_download_is_interrupted(monkeypatch, tmp_path) -> None:
     assert "exited with code" not in (final.error_message or "")
     assert final.exit_code is None
     # The stop is honoured by NOT starting the trainer we were about to start.
+    assert fake_runner.start.call_count == 0
+    assert record.id not in reg._runners
+
+
+def test_stop_aborts_the_base_checkpoint_download_mid_flight(monkeypatch, tmp_path) -> None:
+    """The common case: Stop while bytes are moving feeds the download's
+    progress hook, which raises DownloadCancelled on the next chunk. No wait for
+    the transfer to finish — the job settles `interrupted` and no trainer runs."""
+    from makermodslab.jobs import _PREPARE_STOPPED_MESSAGE, JobRegistry, JobTarget
+
+    started = threading.Event()
+    _patch_hub_for_finetune(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download", _progress_driving_snapshot(tmp_path, started=started)
+    )
+
+    reg = JobRegistry(tmp_path / "root")
+    source = _cloud_finetune_source(reg)
+    fake_runner = _fake_local_runner(monkeypatch)
+
+    record = reg.start(_hub_finetune_request(source.id), JobTarget(runner="local"))
+    assert started.wait(timeout=10), "the download never started"
+
+    reg.stop(record.id)
+    _join_prepare(reg, record.id)
+
+    final = reg.get(record.id)
+    assert final.state == "interrupted"
+    assert final.error_message == _PREPARE_STOPPED_MESSAGE
+    assert final.exit_code is None
     assert fake_runner.start.call_count == 0
     assert record.id not in reg._runners
 
@@ -3901,6 +3952,33 @@ def test_download_progress_logs_are_readable_not_per_chunk() -> None:
     assert 10 <= len(lines) <= 40
     assert lines[1] == "Downloading base checkpoint 012000 — 6% (74 MB / 1.2 GB)"
     assert "1.2 GB / 1.2 GB" in lines[-1]
+
+
+def test_snapshot_progress_tqdm_aborts_the_download_when_cancel_goes_true() -> None:
+    """`should_cancel` rides the progress hook: once it returns True the next
+    chunk callback raises DownloadCancelled, which unwinds snapshot_download
+    instead of letting it finish in the background."""
+    import pytest
+
+    from makermodslab.jobs import DownloadCancelled, make_snapshot_progress_tqdm
+
+    cancel = threading.Event()
+    tqdm_class = make_snapshot_progress_tqdm(lambda done, total: None, should_cancel=cancel.is_set)
+    bar = tqdm_class(unit="B", unit_scale=True, total=1_000)
+
+    bar.update(100)  # bytes still moving, no cancel yet — fine
+    bar.refresh()
+
+    cancel.set()
+    with pytest.raises(DownloadCancelled):
+        bar.update(100)
+    with pytest.raises(DownloadCancelled):
+        bar.refresh()
+
+    # No predicate → the hook never raises, whatever a flag says.
+    plain = make_snapshot_progress_tqdm(lambda done, total: None)(unit="B", total=1_000)
+    plain.update(100)
+    plain.refresh()
 
 
 def test_an_unknown_finetune_source_still_refuses_before_any_record(monkeypatch, tmp_path) -> None:

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -759,7 +759,9 @@ def test_handle_start_inference_pins_return_to_initial_position(monkeypatch, tmp
     monkeypatch.setattr(so101, "_preflight_arm_identity", lambda *a, **k: [])
     monkeypatch.setattr(so101, "_preflight_motor_registers", lambda *a, **k: [])
     monkeypatch.setattr(
-        rollout, "_resolve_policy_path", lambda ref, report=None: str(tmp_path / "pretrained_model")
+        rollout,
+        "_resolve_policy_path",
+        lambda ref, report=None, should_cancel=None: str(tmp_path / "pretrained_model"),
     )
     monkeypatch.setattr(rollout, "_detect_device", lambda: "cpu")
 
@@ -1370,7 +1372,9 @@ def test_handle_start_inference_bimanual_builds_bi_so_follower_command(monkeypat
     monkeypatch.setattr(so101, "_preflight_arm_identity", lambda *a, **k: [])
     monkeypatch.setattr(so101, "_preflight_motor_registers", lambda *a, **k: [])
     monkeypatch.setattr(
-        rollout, "_resolve_policy_path", lambda ref, report=None: str(tmp_path / "pretrained_model")
+        rollout,
+        "_resolve_policy_path",
+        lambda ref, report=None, should_cancel=None: str(tmp_path / "pretrained_model"),
     )
     monkeypatch.setattr(rollout, "_detect_device", lambda: "cpu")
 
@@ -1702,7 +1706,7 @@ def test_stopped_startup_worker_blocks_a_new_session_from_starting(monkeypatch) 
         return [], []
 
     monkeypatch.setattr(rollout, "_prepare_robot", _blocking_prepare_robot)
-    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: ref)
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None, should_cancel=None: ref)
 
     created_threads: list[threading.Thread] = []
     real_thread = threading.Thread
@@ -2120,7 +2124,7 @@ def test_startup_download_failure_reports_failed_and_hint_without_spawn(monkeypa
         {"phase": rollout.PHASE_STARTING, "policy_ref": "user/repo@checkpoints/000050"},
     )
 
-    def _raise(ref, report=None):
+    def _raise(ref, report=None, should_cancel=None):
         raise RuntimeError("Repository Not Found for url: https://huggingface.co/api/models/x")
 
     monkeypatch.setattr(rollout, "_resolve_policy_path", _raise)
@@ -2164,7 +2168,7 @@ def test_stop_during_download_leaves_clean_idle_without_spawn(monkeypatch) -> No
         {"phase": rollout.PHASE_DOWNLOADING_MODEL, "policy_ref": "user/repo@checkpoints/000050"},
     )
 
-    def _resolve_then_stop(ref, report=None):
+    def _resolve_then_stop(ref, report=None, should_cancel=None):
         rollout.handle_stop_inference()
         return "/tmp/snap/pretrained_model"
 
@@ -2184,6 +2188,70 @@ def test_stop_during_download_leaves_clean_idle_without_spawn(monkeypatch) -> No
     assert rollout._inference_proc is None
     assert rollout._inference_meta == {}
     assert rollout.handle_inference_status()["inference_active"] is False
+
+
+def test_download_cancelled_mid_flight_leaves_a_clean_idle_not_a_failure(monkeypatch) -> None:
+    """A stop DURING the transfer aborts snapshot_download from its progress
+    hook (DownloadCancelled). The worker treats that as the stop it is — clean
+    idle, no _fail_startup payload — never opening the bus or spawning."""
+    from makermodslab import rollout
+    from makermodslab.jobs import DownloadCancelled
+
+    cancel = threading.Event()
+    monkeypatch.setattr(rollout, "inference_active", True)
+    monkeypatch.setattr(rollout, "_inference_cancel", cancel)
+    monkeypatch.setattr(rollout, "_inference_proc", None)
+    monkeypatch.setattr(
+        rollout,
+        "_inference_meta",
+        {"phase": rollout.PHASE_DOWNLOADING_MODEL, "policy_ref": "user/repo@checkpoints/000050"},
+    )
+
+    def _abort_like_a_cancelled_download(ref, report=None, should_cancel=None):
+        # stop() ran first (proc is None -> _go_idle_locked), and the progress
+        # hook then raised as the next chunk arrived.
+        rollout.handle_stop_inference()
+        raise DownloadCancelled
+
+    monkeypatch.setattr(rollout, "_resolve_policy_path", _abort_like_a_cancelled_download)
+    monkeypatch.setattr(
+        rollout, "_prepare_robot", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no bus"))
+    )
+    monkeypatch.setattr(
+        rollout.subprocess, "Popen", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no spawn"))
+    )
+
+    rollout._run_inference_startup(_stub_request(), cancel)
+
+    assert rollout.inference_active is False
+    assert rollout._inference_proc is None
+    assert rollout._last_result is None  # NOT a startup failure
+    assert rollout.handle_inference_status()["inference_active"] is False
+
+
+def test_resolve_policy_path_threads_should_cancel_into_the_download(monkeypatch, tmp_path) -> None:
+    """`should_cancel` reaches snapshot_download's tqdm_class, so a real
+    transfer would abort on the next chunk once the predicate goes true."""
+    from makermodslab import rollout
+    from makermodslab.jobs import DownloadCancelled
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
+
+    def _fake_snapshot_download(**kwargs):
+        cls = kwargs["tqdm_class"]
+        bar = cls(unit="B", total=1_000)
+        bar.update(10)  # the caller wants to abort now
+        return str(tmp_path)  # unreachable when should_cancel fires
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_snapshot_download)
+
+    with pytest.raises(DownloadCancelled):
+        rollout._resolve_policy_path(
+            "user/repo@root",
+            report=rollout._report_download_progress,
+            should_cancel=lambda: True,
+        )
 
 
 def test_run_inference_startup_local_ref_skips_download_phase(monkeypatch, tmp_path) -> None:
@@ -3017,7 +3085,9 @@ def test_eval_start_spawns_the_runner_with_stdin_left_open(monkeypatch, tmp_path
     monkeypatch.setattr(so101, "_preflight_arm_identity", lambda *a, **k: [])
     monkeypatch.setattr(so101, "_preflight_motor_registers", lambda *a, **k: [])
     monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda name, arm_type="so101": name)
-    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: "/local/model")
+    monkeypatch.setattr(
+        rollout, "_resolve_policy_path", lambda ref, report=None, should_cancel=None: "/local/model"
+    )
     monkeypatch.setattr(rollout, "_detect_device", lambda: "cpu")
     monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
     monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: None)
@@ -3078,7 +3148,9 @@ def test_single_episode_start_still_spawns_lerobot_rollout(monkeypatch, tmp_path
     monkeypatch.setattr(so101, "_preflight_arm_identity", lambda *a, **k: [])
     monkeypatch.setattr(so101, "_preflight_motor_registers", lambda *a, **k: [])
     monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda name, arm_type="so101": name)
-    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref, report=None: "/local/model")
+    monkeypatch.setattr(
+        rollout, "_resolve_policy_path", lambda ref, report=None, should_cancel=None: "/local/model"
+    )
     monkeypatch.setattr(rollout, "_detect_device", lambda: "cpu")
     monkeypatch.setattr(rollout, "_policy_ref_is_valid", lambda ref: True)
     monkeypatch.setattr(rollout.camera_preview_manager, "stop_all", lambda: None)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -434,6 +434,44 @@ def test_busy_refusal_from_a_raced_start_maps_to_held(client, tmp_lerobot_home, 
     assert body["details"]["holder"]["kind"] == "recording"
 
 
+def test_releasing_refusal_passes_through_not_flattened_to_held(
+    client, tmp_lerobot_home, monkeypatch
+) -> None:
+    """`robot.busy.releasing` — the previous session of this kind is still
+    winding down (an uninterruptible model download, an arm preflight) — must
+    NOT become a `session.held` with a null holder. There is no other session
+    to name or stop; the feature's own "try again shortly" message and code
+    pass straight through."""
+    _make_robot()
+    captured: list = []
+    monkeypatch.setattr(
+        "makermodslab.rollout.handle_start_inference",
+        _fake_start(
+            "inference",
+            captured,
+            {
+                "success": False,
+                "status_code": 409,
+                "message": "The previous session is still shutting down. Try again in a few seconds.",
+                "code": ErrorCode.ROBOT_BUSY_RELEASING,
+            },
+        ),
+    )
+    resp = client.post(
+        "/api/v1/sessions",
+        json={
+            "kind": "inference",
+            "robot": "bench",
+            "options": {"policy_ref": "alice/act-pick", "task": "pick"},
+        },
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["code"] == "robot.busy.releasing"
+    assert "shutting down" in body["detail"]
+    assert (body.get("details") or {}).get("holder") is None
+
+
 def test_non_busy_refusal_passes_through(client, tmp_lerobot_home, monkeypatch) -> None:
     _make_robot()
     captured: list = []


### PR DESCRIPTION
## Summary

- starting then quickly stopping a new inference, then starting another inference would say cannot start inference since a background process downloading the new inference was still running

## Commits
- Cut the plain single-run stop's SIGTERM grace from 5s to 1s while the run hasn't finished setup yet and can't act on the signal.
- Stop reporting a session that's only still shutting down as "held by another session"; pass its real message through instead.
- Abort an in-progress model download when the session is stopped, instead of letting it run to completion in the background.

## Sensitive changes
None. 
