### PR TITLE
Add gs_usb adapter support for Maker followers

### DIFF
--- a/frontend/src/components/dialogs/RobotConfigDialog.test.tsx
+++ b/frontend/src/components/dialogs/RobotConfigDialog.test.tsx
@@ -344,3 +344,34 @@ describe("zero-pose calibration", () => {
     expect(screen.getByRole("button", { name: "Calibrate all" })).toBeEnabled();
   });
 });
+
+
+describe("leader port detection with a gs_usb follower attached", () => {
+  it.each([0, 1])("uses leader device for swing button %s despite follower setup selection", async (index) => {
+    mode = "bimanual";
+    const original = mocks.fetch.getMockImplementation();
+    mocks.fetch.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.endsWith("/maker/identify-arm")) {
+        return { ok: true, json: async () => ({ success: false, message: "Mock: no motion" }) };
+      }
+      const response = await original?.(url, options);
+      if (url.includes("/robots/")) {
+        const data = await response.json();
+        // A calibrated leader makes initial setup select the follower.
+        data.robot.leader_config = "leader.json";
+        return { ok: true, json: async () => data };
+      }
+      if (url.endsWith("/available-ports")) {
+        return { ok: true, json: async () => ({ ports: ["leader", "right-leader", "gs_usb:A"] }) };
+      }
+      return response;
+    });
+    render(<RobotConfigDialog open robotName="test" onOpenChange={() => {}} />);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "Detect by swing" })).toHaveLength(2));
+    fireEvent.click(screen.getAllByRole("button", { name: "Detect by swing" })[index]);
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledWith(
+      "http://test/api/v1/maker/identify-arm",
+      expect.objectContaining({ body: JSON.stringify({ device_type: "teleop", arm_type: "maker" }) }),
+    ));
+  });
+});

--- a/frontend/src/components/dialogs/RobotConfigDialog.tsx
+++ b/frontend/src/components/dialogs/RobotConfigDialog.tsx
@@ -384,7 +384,7 @@ const DeviceSlotCell = ({
             return (
               <SelectItem key={p} value={p}>
                 <span className="flex items-center gap-2 font-mono text-xs">
-                  {p}
+                  {p.startsWith("gs_usb:") ? `gs_usb · ${p.slice(7)}` : p}
                   {/* Naming the holder beats a bare "in use": on a bimanual
                       rig there are three other slots it could be, and picking
                       this port takes it off whichever one is named. */}
@@ -1339,7 +1339,11 @@ const RobotConfigWindow = ({
           releasedLabel: conflictingField
             ? portFieldLabel(conflictingField)
             : null,
-          swapPort: conflictingField && currentPort ? currentPort : null,
+          swapPort:
+            conflictingField && currentPort &&
+            !(currentPort.startsWith("gs_usb:") && conflictingField.includes("leader"))
+              ? currentPort
+              : null,
         });
       } else {
         toast({
@@ -1449,7 +1453,10 @@ const RobotConfigWindow = ({
         targetLabel: portFieldLabel(field),
         releasedField: conflictingField,
         releasedLabel: portFieldLabel(conflictingField),
-        swapPort: currentPort || null,
+        swapPort:
+          currentPort.startsWith("gs_usb:") && conflictingField.includes("leader")
+            ? null
+            : currentPort || null,
       });
       return;
     }
@@ -3306,7 +3313,10 @@ const RobotConfigWindow = ({
                         port={draftPort(slot.portField)}
                         portDetected={slotPortDetected(slot)}
                         configured={!!(robot?.[slot.cfgField] as string)}
-                        availablePorts={availablePorts}
+                        availablePorts={availablePorts.filter(
+                          (p) => !p.startsWith("gs_usb:") ||
+                            (armType === "maker" && slot.device === "robot"),
+                        )}
                         heldByLabel={(p) => {
                           const holder = portFields.find(
                             (f) => f !== slot.portField && draftPort(f) === p,

--- a/internal_docs/gs-usb.md
+++ b/internal_docs/gs-usb.md
@@ -1,0 +1,21 @@
+# candleLight / gs_usb Maker adapters
+
+Install `uv sync --extra gs-usb`; macOS also needs `brew install libusb`.
+Refresh ports in Robot Configuration, choose the Maker follower slot, and select
+`gs_usb · <USB serial>`. The saved value is `gs_usb:<USB serial>`; USB bus/address
+changes do not alter it. Star leaders, SO-101 and Metal slots use their existing ports.
+
+Listing reads USB descriptors only. Detect sends non-clearing MIT fault queries
+to IDs 1–7; a valid reply confirms communication, not the arm model. Multiple
+adapters can be assigned by serial; hand-motion port detection is unavailable
+for gs_usb. Normal user-started robot sessions retain the driver's existing
+handshake and torque behavior. Transport support has mock validation only;
+teleoperation and recording over this transport require hardware validation.
+
+Close other CAN programs before connecting. On Linux, if the kernel owns the
+USB device use its configured SocketCAN interface; this transport does not
+detach kernel drivers. Missing optional dependencies leave serial discovery
+available. On macOS the normal Homebrew libusb locations are checked.
+
+Source: python-can 4.6.1 gs_usb backend and gs-usb 0.3.1.
+https://python-can.readthedocs.io/en/stable/interfaces/gs_usb.html

--- a/internal_docs/journal/2026-09-11-gs-usb-app.md
+++ b/internal_docs/journal/2026-09-11-gs-usb-app.md
@@ -1,0 +1,72 @@
+# 2026-09-11 — gs_usb Maker adapter in app
+
+Implemented in isolated worktree `/private/tmp/makermodslab-gs-usb-app`, branch
+`codex/gs-usb-app`, base `0b7db4e1`; main working tree untouched.
+
+- Stable `gs_usb:<USB serial>` discovery and existing robot-record persistence;
+  dropdown limits USB tokens to Maker followers and displays transport + serial.
+  Swap handling cannot transfer a USB token into a leader slot.
+- Extracted small bounded classic-CAN BusABC adapter with exact serial selection,
+  transmit-echo rejection, positive USB timeout rounding, FD rejection, optional
+  dependencies and macOS Homebrew libusb lookup. No USB reset/index selection.
+- Narrow idempotent Robstride connect hook preserves ordinary ports and normal
+  user-started session handshake; closes selected handle on handshake failure.
+  Installed in factory, probes, calibration and standalone rollout/eval/dagger/
+  DRTC processes. Metadata-only package import stays unchanged.
+- Detect uses only non-clearing MIT fault query (RS00/RS02 manual260713 §6.7,
+  meaningful5 bytes or padded8), IDs1–7. Adapter discovery does not prove motor
+  communication. Multiple gs_usb adapters need manual serial assignment;
+  hand-motion port detection refuses gs_usb rather than use clearing reads.
+- Optional extra pins gs-usb0.3.1 + pyusb>=1.3.1; coordinator regenerated lock,
+  reporting only two new packages. Source compatibility inspected against
+  installed python-can4.6.1 and gs-usb0.3.1.
+
+Validation actually performed: 190 tests across new transport + existing Maker,
+config and identify suites passed; 310 existing rollout tests passed (7 existing
+FastAPI warnings per run). Frontend app typecheck passed. Focused Ruff passed.
+All checks use mocks/temporary data, no hardware initialization or robot motion.
+No server/UI sessions, build artifacts, commits, pushes, or merges. Live transport
+teleoperation/recording remains unverified; frontend dist not rebuilt per policy.
+
+Final combined regression: 500 passed, 7 existing warnings in 15.18s; output
+`/private/tmp/makermodslab-gs-usb-app-checks.log`. Both TypeScript projects and
+scoped Ruff pass. Dialog ESLint: zero errors, one existing hook cleanup warning
+at line784. Scoped git diff whitespace check passes. Setup notes:
+`internal_docs/gs-usb.md` (top-level docs directory ignores new pages).
+
+## PR preparation on current staging
+
+Ported the focused changes into `/private/tmp/makermodslab-gs-usb-pr`, branch
+`codex/gs-usb-support`, based on staging `5b4d3c4d`. Adapted the factory hook and
+port detection to the current arm-family registry; existing remote-host follower
+construction also imports that factory. Preserved the new leader presets and
+staging's lerobot pin `0efbaf55be27cfab8cfd0d29afe2f8aeac0afdb9`. Coordinator
+regenerated the lock: only gs-usb 0.3.1 and pyusb 1.3.1 added. Motor-ID wizard,
+foreign working changes, hydrated LFS meshes and frontend/dist are excluded.
+
+Verified with the pinned lerobot source on PYTHONPATH (the shared installed
+venv still contains the older pin): 540 mock regression tests passed across
+transport, Maker, trigger leader, config, identification and rollout; 5 API
+contract tests also passed, including OpenAPI snapshot freshness. Logs:
+`/private/tmp/gsusb-pr-exact-pytest.log`, `/private/tmp/gsusb-pr-contract.log`.
+Both frontend TypeScript projects passed; dialog ESLint has zero errors and its
+existing cleanup-ref warning. The older-venv test attempt was stopped and
+superseded by this pinned-source run. Hardware and live sessions remain unrun.
+Coordinator is completing final hook checks and reviewing the exact diff before
+publication; this entry does not claim a commit, push, PR publication or merge.
+
+## User-selected main target
+
+The user explicitly selected `main` as the PR target. Coordinator created
+`codex/gs-usb-main` in `/private/tmp/makermodslab-gs-usb-main`, based on main
+`e4a14679`, and applied only the gs_usb change as `b36f363e`. The integration
+seams match staging; main's absence of the trigger-leader additions does not
+change the transport hooks. Retained main's lerobot pin
+`5ce2fe41a63647c20b2ab6e84bcb4cc7295a9b21` and verified with that exact source on
+PYTHONPATH: **535 regression/API contract tests passed**, including OpenAPI
+freshness (11 existing warnings; 29.85 seconds). Log:
+`/private/tmp/gsusb-main-exact-pytest.log`. Both TypeScript projects passed;
+dialog ESLint has zero errors and its existing cleanup-ref warning. Coordinator
+reported full pre-commit success with export-openapi skipped because freshness
+is independently tested, plus a successful lock consistency check. No hardware
+or live sessions ran. PR publication remains coordinator-owned.

--- a/internal_docs/journal/2026-09-11-gs-usb-app.md
+++ b/internal_docs/journal/2026-09-11-gs-usb-app.md
@@ -70,3 +70,16 @@ dialog ESLint has zero errors and its existing cleanup-ref warning. Coordinator
 reported full pre-commit success with export-openapi skipped because freshness
 is independently tested, plus a successful lock consistency check. No hardware
 or live sessions ran. PR publication remains coordinator-owned.
+
+## Leader Detect regression on main-based PR156
+
+- The active older checkout's Detect handler used calibration selection instead
+  of the clicked slot. Main-based PR156 already derives device type from the
+  clicked port field and passes it into both gesture payload and probe candidate
+  selection; preserved this newer implementation and safety behavior.
+- Added two mocked dialog regressions for left/right Star leaders with a gs_usb
+  follower attached and initial setup defaulting to the follower. Preserved all
+  eight existing dialog tests. All10 dialog tests passed; no hardware/API calls
+  reached a live server. Both TypeScript projects passed; app TypeScript and test ESLint passed
+  again after the final test-harness adaptation. Diff whitespace check passed.
+  No commit, push, or merge by the implementing agent.

--- a/makermodslab/calibrate.py
+++ b/makermodslab/calibrate.py
@@ -38,10 +38,13 @@ from lerobot.teleoperators import (
     make_teleoperator_from_config,
 )
 from lerobot.utils.utils import init_logging
+from makermodslab.maker_can import install as _install_maker_can
 
 from .api_errors import ErrorCode
 from .session_events import notify_session_changed
 from .utils.config import calibration_dir_for_device, save_robot_record
+
+_install_maker_can()
 
 logger = logging.getLogger(__name__)
 

--- a/makermodslab/dagger_runner.py
+++ b/makermodslab/dagger_runner.py
@@ -134,6 +134,7 @@ from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.process import ProcessSignalHandler
 from lerobot.utils.robot_utils import precise_sleep
 from lerobot.utils.utils import init_logging
+from makermodslab.maker_can import install as _install_maker_can
 
 # Imported for its SIDE EFFECT: a non-zero sync_read retry default for this
 # process. Without it a single dropped serial reply — routine when arm
@@ -173,6 +174,8 @@ from .dagger_protocol import (
 )
 from .log_exceptions import restore_traceback_rendering
 from .torque import force_disable_bus_torque
+
+_install_maker_can()
 
 logger = logging.getLogger(__name__)
 

--- a/makermodslab/drtc/robot_rtc.py
+++ b/makermodslab/drtc/robot_rtc.py
@@ -116,6 +116,7 @@ from lerobot.robots import (  # noqa: F401
     so_follower,
 )
 from lerobot.utils.import_utils import register_third_party_plugins
+from makermodslab.maker_can import install as _install_maker_can
 
 from ..drtc_protocol import (
     EVENT_BYE,
@@ -166,6 +167,8 @@ from ._session_glue import (
     say,
     shielded,
 )
+
+_install_maker_can()
 
 register_third_party_plugins()
 

--- a/makermodslab/drtc/robot_sync.py
+++ b/makermodslab/drtc/robot_sync.py
@@ -146,6 +146,7 @@ from lerobot.robots import (  # noqa: F401
     so_follower,
 )
 from lerobot.utils.import_utils import register_third_party_plugins
+from makermodslab.maker_can import install as _install_maker_can
 
 from ..drtc_protocol import (
     EVENT_BYE,
@@ -183,6 +184,8 @@ from ._session_glue import (
     shielded,
 )
 from ._sync_player import AdaptiveBlockPlayer
+
+_install_maker_can()
 
 # Register any third-party robot/camera plugins (entry points) BEFORE draccus
 # parses `--robot.type`. Built-in so100/so101 register on import above.

--- a/makermodslab/eval_runner.py
+++ b/makermodslab/eval_runner.py
@@ -79,6 +79,7 @@ from lerobot.rollout import (
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.process import ProcessSignalHandler
 from lerobot.utils.utils import init_logging
+from makermodslab.maker_can import install as _install_maker_can
 
 # Imported for its SIDE EFFECT: a non-zero sync_read retry default for this
 # process. Without it a single dropped serial reply — routine when arm
@@ -99,6 +100,8 @@ from .eval_protocol import (
     format_event,
 )
 from .log_exceptions import restore_traceback_rendering
+
+_install_maker_can()
 
 logger = logging.getLogger(__name__)
 

--- a/makermodslab/gs_usb_transport.py
+++ b/makermodslab/gs_usb_transport.py
@@ -1,0 +1,258 @@
+# Copyright 2026 MakerMods contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Exact-serial candleLight transport; optional USB imports stay lazy."""
+
+import logging
+import math
+import sys
+from pathlib import Path
+
+import can
+
+GS_USB_INSTALL = "Install makermodslab[gs-usb] and libusb (macOS: brew install libusb)."
+
+
+class DiagnosticError(RuntimeError):
+    """USB transport could not complete an operation."""
+
+
+def discover_gs_usb():
+    """Descriptor-only discovery; never call GsUsb.start/scan/reset."""
+    try:
+        import usb.core
+        from gs_usb.gs_usb import GsUsb
+        from usb.backend import libusb1
+
+        backend = libusb1.get_backend()
+        if backend is None and sys.platform == "darwin":
+            for path in (
+                "/opt/homebrew/opt/libusb/lib/libusb-1.0.dylib",
+                "/usr/local/opt/libusb/lib/libusb-1.0.dylib",
+            ):
+                if Path(path).is_file():
+                    backend = libusb1.get_backend(find_library=lambda _, path=path: path)
+                    if backend is not None:
+                        break
+        if backend is None:
+            raise DiagnosticError(f"libusb backend not found. {GS_USB_INSTALL}")
+        return [
+            GsUsb(dev)
+            for dev in usb.core.find(find_all=True, custom_match=GsUsb.is_gs_usb_device, backend=backend)
+        ]
+    except DiagnosticError:
+        raise
+    except Exception as exc:
+        raise DiagnosticError(f"USB enumeration failed: {exc}. {GS_USB_INSTALL}") from exc
+
+
+def dispose_usb(raw):
+    import usb.util
+
+    usb.util.dispose_resources(raw)
+
+
+def select_gs_usb(serial):
+    devices = discover_gs_usb()
+    matches = []
+    try:
+        for dev in devices:
+            try:
+                if dev.serial_number == serial:
+                    matches.append(dev)
+            except Exception:
+                continue
+        if len(matches) != 1:
+            raise DiagnosticError(
+                f"Expected exactly one gs_usb adapter with serial {serial!r}; found {len(matches)}. Run ports; check USB permissions and descriptor availability."
+            )
+        return matches[0]
+    finally:
+        for dev in devices:
+            if len(matches) != 1 or dev is not matches[0]:
+                dispose_usb(dev.gs_usb)
+
+
+class BoundedGsUsb(can.BusABC):
+    """gs-usb 0.3.1 frame codec with bounded PyUSB I/O on one selected handle.
+
+    python-can 4.6.1's gs_usb send ignores its timeout and shutdown may rescan
+    by index. Upstream GsUsb.read also swallows all USB errors. Avoid all three.
+    Sources: https://python-can.readthedocs.io/en/stable/interfaces/gs_usb.html
+    https://github.com/jxltom/gs_usb/blob/master/gs_usb/gs_usb.py
+    No USB reset, automatic kernel detach, threads or index-based discovery.
+    """
+
+    def __init__(self, device, bitrate=1_000_000, timeout=0.1):
+        super().__init__(channel=device.serial_number)
+        self.io_timeout = timeout
+        import can
+        import usb.util
+        from gs_usb.constants import GS_CAN_MODE_HW_TIMESTAMP
+        from gs_usb.gs_usb_structures import DeviceMode
+
+        self.device = device
+        self.raw = device.gs_usb
+        self.closed = False
+        self.claimed = False
+        self.started = False
+        self.raw.default_timeout = self.milliseconds(timeout)
+        try:
+            usb.util.claim_interface(self.raw, 0)
+            self.claimed = True
+            timing = can.BitTiming.from_sample_point(
+                f_clock=device.device_capability.fclk_can, bitrate=bitrate, sample_point=87.5
+            )
+            device.set_timing(1, timing.tseg1 - 1, timing.tseg2, timing.sjw, timing.brp)
+            device.device_flags = GS_CAN_MODE_HW_TIMESTAMP & device.device_capability.feature
+            # gs_usb MODE request 2, START mode 1. Unlike GsUsb.start, no USB reset.
+            self.started = True  # Cleanup even if the start transfer fails partway.
+            self.raw.ctrl_transfer(0x41, 2, 0, 0, DeviceMode(1, device.device_flags).pack())
+        except Exception as exc:
+            try:
+                self.shutdown()
+            except Exception as cleanup_error:
+                exc.add_note(f"Selected USB adapter cleanup also failed: {cleanup_error}")
+            raise
+
+    @staticmethod
+    def milliseconds(timeout):
+        return max(1, math.ceil(timeout * 1000))
+
+    def send(self, msg, timeout=None):
+        timeout = self.io_timeout if timeout is None else timeout
+        from gs_usb.constants import GS_CAN_MODE_HW_TIMESTAMP
+        from gs_usb.gs_usb_frame import GsUsbFrame
+
+        if msg.is_extended_id or msg.is_remote_frame or msg.is_error_frame or msg.is_fd or msg.dlc != 8:
+            raise DiagnosticError("This gs_usb utility sends only classic 8-byte standard data frames")
+        packet = GsUsbFrame(can_id=msg.arbitration_id, data=bytes(msg.data))
+        data = packet.pack(bool(self.device.device_flags & GS_CAN_MODE_HW_TIMESTAMP))
+        count = self.raw.write(0x02, data, timeout=self.milliseconds(timeout))
+        if count != len(data):
+            raise DiagnosticError("Incomplete gs_usb write; command may have been transmitted")
+
+    def _recv_internal(self, timeout):
+        timeout = self.io_timeout if timeout is None else timeout
+        import can
+        import usb.core
+        from gs_usb.constants import GS_CAN_MODE_HW_TIMESTAMP
+        from gs_usb.gs_usb_frame import GS_USB_NONE_ECHO_ID, GsUsbFrame
+
+        packet = GsUsbFrame()
+        timestamps = bool(self.device.device_flags & GS_CAN_MODE_HW_TIMESTAMP)
+        try:
+            data = self.raw.read(0x81, packet.__sizeof__(timestamps), timeout=self.milliseconds(timeout))
+        except usb.core.USBTimeoutError:
+            return None, False
+        GsUsbFrame.unpack_into(packet, data, timestamps)
+        if packet.channel != 0 or packet.can_dlc > 8 or packet.flags:
+            raise DiagnosticError(
+                "Unexpected gs_usb channel or CAN-FD frame; only classic channel 0 is supported"
+            )
+        if packet.echo_id != GS_USB_NONE_ECHO_ID:
+            return None, False
+        return can.Message(
+            arbitration_id=packet.arbitration_id,
+            is_extended_id=packet.is_extended_id,
+            is_remote_frame=packet.is_remote_frame,
+            is_error_frame=packet.is_error_frame,
+            dlc=packet.can_dlc,
+            data=bytes(packet.data[: packet.can_dlc]),
+            is_rx=True,
+        ), False
+
+    def shutdown(self):
+        from gs_usb.gs_usb_structures import DeviceMode
+
+        if self.closed:
+            return
+        self.closed = True
+        super().shutdown()
+        try:
+            if self.started:
+                self.raw.ctrl_transfer(0x41, 2, 0, 0, DeviceMode(0, 0).pack())
+        finally:
+            dispose_usb(self.raw)
+
+
+def available_gs_usb_ports():
+    """Descriptor-only tokens; unavailable optional dependencies do not break serial discovery."""
+    try:
+        devices = discover_gs_usb()
+    except DiagnosticError as exc:
+        logging.getLogger(__name__).debug("gs_usb discovery unavailable: %s", exc)
+        return []
+    serials = []
+    for device in devices:
+        try:
+            serial = device.serial_number
+            if serial and not any(c.isspace() for c in serial):
+                serials.append(serial)
+        except Exception:
+            logging.getLogger(__name__).debug("Cannot read USB serial", exc_info=True)
+        finally:
+            try:
+                dispose_usb(device.gs_usb)
+            except Exception:
+                logging.getLogger(__name__).debug("USB descriptor cleanup failed", exc_info=True)
+    return sorted("gs_usb:" + serial for serial in set(serials) if serials.count(serial) == 1)
+
+
+def open_gs_usb(port, bitrate=1_000_000):
+    if not port.startswith("gs_usb:") or not port[7:] or any(c.isspace() for c in port[7:]):
+        raise DiagnosticError("Expected gs_usb:<exact USB serial>")
+    try:
+        return BoundedGsUsb(select_gs_usb(port[7:]), bitrate)
+    except Exception as exc:
+        raise DiagnosticError(
+            f"Cannot open {port}: {exc}. Close other CAN software; check USB permissions. {GS_USB_INSTALL}"
+        ) from exc
+
+
+def probe_maker(port):
+    """Non-clearing MIT fault query; adapter presence alone is not a motor reply.
+
+    RS00/RS02 manual 260713 section 6.7: FF*6 00 FB, host 0xFD,
+    motor ID then little-endian fault word (firmware uses 5 or padded 8 bytes).
+    """
+    import time
+
+    bus = open_gs_usb(port)
+    try:
+        for motor in range(1, 8):
+            bus.send(
+                can.Message(arbitration_id=motor, is_extended_id=False, data=b"\xff" * 6 + b"\x00\xfb"),
+                timeout=0.1,
+            )
+            deadline = time.monotonic() + 0.1
+            while time.monotonic() < deadline:
+                msg = bus.recv(timeout=max(0, deadline - time.monotonic()))
+                if msg is None:
+                    continue
+                if (
+                    msg.is_rx
+                    and not msg.is_extended_id
+                    and not msg.is_error_frame
+                    and not msg.is_remote_frame
+                    and not msg.is_fd
+                    and msg.arbitration_id == 0xFD
+                    and msg.dlc in (5, 8)
+                    and len(msg.data) == msg.dlc
+                    and msg.data[0] == motor
+                    and (msg.dlc == 5 or bytes(msg.data[5:]) == b"\x00" * 3)
+                ):
+                    return True
+        return False
+    finally:
+        bus.shutdown()

--- a/makermodslab/identify.py
+++ b/makermodslab/identify.py
@@ -154,7 +154,8 @@ async def identify_arm_by_motion(ports: list[str] | None = None) -> dict:
     """
     candidates = [p.strip() for p in (ports or []) if p and p.strip()]
     if not candidates:
-        candidates = find_available_ports()
+        candidates = [p for p in find_available_ports() if not p.startswith("gs_usb:")]
+    candidates = [p for p in candidates if not p.startswith("gs_usb:")]
     candidates = list(dict.fromkeys(candidates))  # dedupe, keep order
     if not candidates:
         return {

--- a/makermodslab/maker_can.py
+++ b/makermodslab/maker_can.py
@@ -1,0 +1,52 @@
+# Copyright 2026 MakerMods contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Narrow compatibility hook for the pinned Maker driver's port-only configuration."""
+
+from functools import wraps
+
+
+def install():
+    from lerobot.motors.robstride import RobstrideMotorsBus
+
+    original = RobstrideMotorsBus.connect
+    if getattr(original, "_makermodslab_gs_usb", False):
+        return
+
+    @wraps(original)
+    def connect(self, handshake=True):
+        if not isinstance(self.port, str) or not self.port.startswith("gs_usb:"):
+            return original(self, handshake=handshake)
+        from .gs_usb_transport import open_gs_usb
+
+        if self.is_connected:
+            raise RuntimeError("RobStride bus is already connected")
+        if self.use_can_fd:
+            raise ValueError("Maker gs_usb supports classic CAN only")
+        bus = open_gs_usb(self.port, self.bitrate)
+        self.canbus = bus
+        self._is_connected = True
+        try:
+            if handshake:
+                self._handshake()
+        except BaseException as exc:
+            self._is_connected = False
+            self.canbus = None
+            try:
+                bus.shutdown()
+            except Exception as cleanup:
+                exc.add_note(f"USB cleanup also failed: {cleanup}")
+            raise
+
+    connect._makermodslab_gs_usb = True
+    RobstrideMotorsBus.connect = connect

--- a/makermodslab/maker_ports.py
+++ b/makermodslab/maker_ports.py
@@ -55,7 +55,10 @@ import logging
 import time
 
 from .arms import registry as arm_registry
+from .maker_can import install as _install_maker_can
 from .utils.config import find_available_ports, normalize_arm_type
+
+_install_maker_can()
 
 logger = logging.getLogger(__name__)
 
@@ -372,6 +375,16 @@ def _probe_sync(ports: list[str], arm_type: str = "maker") -> dict:
 
     openers = _openers_for(arm_type)
     for port in ports:
+        if port.startswith("gs_usb:"):
+            from .gs_usb_transport import probe_maker
+
+            try:
+                found_usb = normalize_arm_type(arm_type) == "maker" and probe_maker(port)
+            except Exception as exc:
+                logger.debug("gs_usb motor probe failed for %s: %s", port, exc)
+                found_usb = False
+            (follower_ports if found_usb else unknown).append(port)
+            continue
         found = None
         for device_type in ("teleop", "robot"):
             opener, releaser, _ = openers[device_type]
@@ -588,6 +601,14 @@ async def identify_maker_arm_by_motion(
             leader_kind,
         )
     candidates = _candidate_ports(ports)
+    if device_type == "teleop":
+        candidates = [port for port in candidates if not port.startswith("gs_usb:")]
+    if any(port.startswith("gs_usb:") for port in candidates):
+        return {
+            "success": False,
+            "message": "Hand-motion port detection is unavailable for gs_usb. Select the adapter by its USB serial, or connect one follower adapter at a time and use Detect.",
+            "skipped": candidates,
+        }
     if not candidates:
         return {
             "success": False,

--- a/makermodslab/maker_rollout.py
+++ b/makermodslab/maker_rollout.py
@@ -1,0 +1,22 @@
+# Copyright 2026 MakerMods contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run the upstream rollout with Lab's Maker transport installed."""
+
+from lerobot.scripts.lerobot_rollout import main
+from makermodslab.maker_can import install as _install_maker_can
+
+_install_maker_can()
+
+if __name__ == "__main__":
+    main()

--- a/makermodslab/rollout.py
+++ b/makermodslab/rollout.py
@@ -2210,7 +2210,7 @@ def _build_rollout_cmd(request: InferenceRequest, policy_path: str, robot_args: 
     return [
         sys.executable,
         "-m",
-        "lerobot.scripts.lerobot_rollout",
+        "makermodslab.maker_rollout",
         *_rollout_cli_args(request, policy_path, robot_args),
     ]
 

--- a/makermodslab/utils/config.py
+++ b/makermodslab/utils/config.py
@@ -782,7 +782,9 @@ def find_available_ports():
         #   Linux:  /dev/ttyUSB*        /dev/ttyACM*
         patterns = ("tty.usbmodem*", "tty.usbserial*", "ttyUSB*", "ttyACM*")
         ports = [str(path) for pattern in patterns for path in Path("/dev").glob(pattern)]
-    return sorted(ports)
+    from makermodslab.gs_usb_transport import available_gs_usb_ports
+
+    return sorted(ports + available_gs_usb_ports())
 
 
 def get_saved_robot_port(robot_type: RobotSide) -> str | None:

--- a/makermodslab/utils/robot_factory.py
+++ b/makermodslab/utils/robot_factory.py
@@ -80,6 +80,7 @@ from lerobot.teleoperators.rebot_102_leader.config_rebot_102_leader_metal import
 from lerobot.teleoperators.so_leader import SO101LeaderConfig  # noqa: F401
 
 from ..arms import MAKER, METAL, registry as arm_registry
+from ..maker_can import install as _install_maker_can
 from .config import (
     bimanual_base_id,
     normalize_arm_type,
@@ -90,6 +91,8 @@ from .config import (
     stage_bimanual_follower_calibrations,
     stage_bimanual_leader_calibrations,
 )
+
+_install_maker_can()
 
 
 def request_arm_type(request) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+gs-usb = ["gs-usb==0.3.1", "pyusb>=1.3.1"]
 # `dev` pulls in `test` rather than restating pytest, so the two can never drift
 # apart — installing `.[dev]` always gets everything needed to run the suite.
 dev = [

--- a/tests/test_gs_usb_transport.py
+++ b/tests/test_gs_usb_transport.py
@@ -1,0 +1,208 @@
+from collections import deque
+from types import SimpleNamespace
+
+import can
+import pytest
+
+from makermodslab import gs_usb_transport as ids
+
+
+def frame():
+    return can.Message(arbitration_id=1, is_extended_id=False, data=b"\xff" * 6 + b"\x00\xfb")
+
+
+class UsbRaw:
+    def __init__(self):
+        self.writes = []
+        self.controls = []
+        self.reads = deque()
+        self.read_timeouts = []
+
+    def write(self, endpoint, data, timeout):
+        self.writes.append((endpoint, data, timeout))
+        return len(data)
+
+    def read(self, endpoint, size, timeout):
+        self.read_timeouts.append(timeout)
+        value = self.reads.popleft()
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def ctrl_transfer(self, *args):
+        self.controls.append(args)
+
+
+@pytest.fixture
+def gs_device(monkeypatch):
+    pytest.importorskip("gs_usb")
+    import usb.util
+
+    raw = UsbRaw()
+    device = SimpleNamespace(
+        serial_number="ABC",
+        gs_usb=raw,
+        device_capability=SimpleNamespace(fclk_can=48000000, feature=16),
+        set_timing=lambda *args: None,
+    )
+    monkeypatch.setattr(usb.util, "claim_interface", lambda *args: None)
+    disposed = []
+    monkeypatch.setattr(ids, "dispose_usb", disposed.append)
+    return device, raw, disposed
+
+
+def test_gs_bounded_write_no_message_mutation_and_exact_close(gs_device):
+    device, raw, disposed = gs_device
+    bus = ids.BoundedGsUsb(device, 1000000, 0.3)
+    msg = frame()
+    original = bytes(msg.data)
+    bus.send(msg, 0.0001)
+    assert raw.writes[0][0] == 2
+    assert raw.writes[0][2] == 1
+    assert bytes(msg.data) == original
+    assert raw.default_timeout == 300
+    bus.shutdown()
+    bus.shutdown()
+    assert len(raw.controls) == 2
+    assert disposed == [raw]
+
+
+def test_gs_receive_timeout_rounding_echo_and_errors(gs_device):
+    import usb.core
+    from gs_usb.gs_usb_frame import GS_USB_NONE_ECHO_ID, GsUsbFrame
+
+    device, raw, _ = gs_device
+    bus = ids.BoundedGsUsb(device, 1000000, 0.3)
+    packet = GsUsbFrame(can_id=0xFD, data=bytes([1]) + bytes(7))
+    raw.reads.append(packet.pack(True))
+    assert bus._recv_internal(0.00001) == (None, False)
+    packet.echo_id = GS_USB_NONE_ECHO_ID
+    raw.reads.append(packet.pack(True))
+    assert bus.recv(0).is_rx
+    raw.reads.append(usb.core.USBTimeoutError("timeout"))
+    assert bus._recv_internal(0.3) == (None, False)
+    raw.reads.append(usb.core.USBError("unplugged"))
+    with pytest.raises(usb.core.USBError):
+        bus.recv(0.3)
+    assert raw.read_timeouts == [1, 1, 300, 300]
+    bus.shutdown()
+
+
+def test_gs_partial_send_failure_and_failed_start_cleanup(gs_device, monkeypatch):
+    device, raw, disposed = gs_device
+    bus = ids.BoundedGsUsb(device, 1000000, 0.3)
+    monkeypatch.setattr(raw, "write", lambda *args, **kwargs: 1)
+    with pytest.raises(ids.DiagnosticError, match="may have been transmitted"):
+        bus.send(frame(), 0.3)
+    bus.shutdown()
+
+    def fail(*args):
+        raise OSError("start failed")
+
+    monkeypatch.setattr(raw, "ctrl_transfer", fail)
+    with pytest.raises(OSError):
+        ids.BoundedGsUsb(device, 1000000, 0.3)
+    assert disposed == [raw, raw]
+
+
+def test_gs_rejects_fd_flag_with_short_payload(gs_device):
+    from gs_usb.gs_usb_frame import GsUsbFrame
+
+    device, raw, _ = gs_device
+    bus = ids.BoundedGsUsb(device, 1000000, 0.3)
+    packet = GsUsbFrame(can_id=0xFD, data=bytes([1]) + bytes(7))
+    packet.flags = 2  # GS_CAN_FLAG_FD, even though DLC fits classic CAN.
+    raw.reads.append(packet.pack(True))
+    with pytest.raises(ids.DiagnosticError, match="CAN-FD"):
+        bus.recv(0.3)
+    bus.shutdown()
+
+
+def test_discovery_absent_preserves_serial_listing(monkeypatch):
+    monkeypatch.setattr(ids, "discover_gs_usb", lambda: (_ for _ in ()).throw(ids.DiagnosticError("missing")))
+    assert ids.available_gs_usb_ports() == []
+
+
+def test_tokens_stable_unique_and_disposed(monkeypatch):
+    devices = [SimpleNamespace(serial_number=s, gs_usb=object()) for s in ["B", "A", "B"]]
+    disposed = []
+    monkeypatch.setattr(ids, "discover_gs_usb", lambda: devices)
+    monkeypatch.setattr(ids, "dispose_usb", disposed.append)
+    assert ids.available_gs_usb_ports() == ["gs_usb:A"]
+    assert len(disposed) == 3
+
+
+def test_hook_no_global_bus_patch_and_cleanup(monkeypatch):
+    from lerobot.motors.robstride import RobstrideMotorsBus
+    from makermodslab import maker_can
+
+    maker_can.install()
+    original_can = can.interface.Bus
+    hook = RobstrideMotorsBus.connect
+    maker_can.install()
+    assert RobstrideMotorsBus.connect is hook
+    assert can.interface.Bus is original_can
+    closed = []
+    usb = SimpleNamespace(shutdown=lambda: closed.append(True))
+    monkeypatch.setattr(ids, "open_gs_usb", lambda *a: usb)
+    fake = SimpleNamespace(
+        port="gs_usb:A",
+        is_connected=False,
+        use_can_fd=False,
+        bitrate=1000000,
+        _handshake=lambda: (_ for _ in ()).throw(ValueError("bad handshake")),
+    )
+    with pytest.raises(ValueError, match="bad handshake"):
+        hook(fake)
+    assert closed == [True]
+    assert not fake._is_connected and fake.canbus is None
+
+
+def test_probe_only_fault_query_and_requires_rx(monkeypatch):
+    sent = []
+    bus = SimpleNamespace(
+        send=lambda msg, **kw: sent.append(msg),
+        recv=lambda **kw: can.Message(arbitration_id=0xFD, is_extended_id=False, data=b"\x01" + bytes(4)),
+        shutdown=lambda: None,
+    )
+    monkeypatch.setattr(ids, "open_gs_usb", lambda p: bus)
+    assert ids.probe_maker("gs_usb:A")
+    assert len(sent) == 1
+    assert bytes(sent[0].data) == b"\xff" * 6 + b"\x00\xfb"
+
+
+def test_gs_probe_skips_leader_and_metal(monkeypatch):
+    from makermodslab import maker_ports
+
+    calls = []
+    monkeypatch.setattr(ids, "probe_maker", lambda p: calls.append(p) or True)
+    assert maker_ports._probe_sync(["gs_usb:A"])["follower_ports"] == ["gs_usb:A"]
+    assert maker_ports._probe_sync(["gs_usb:A"], "metal")["unknown_ports"] == ["gs_usb:A"]
+    assert calls == ["gs_usb:A"]
+
+
+def test_token_record_roundtrip(tmp_path, monkeypatch):
+    from makermodslab.utils import config
+
+    monkeypatch.setattr(config, "ROBOTS_PATH", str(tmp_path))
+    assert config.save_robot_record("usb_arm", {"arm_type": "maker", "follower_port": "gs_usb:ABC"})
+    assert config.get_robot_record("usb_arm")["follower_port"] == "gs_usb:ABC"
+
+
+@pytest.mark.asyncio
+async def test_leader_motion_filters_usb_tokens(monkeypatch):
+    from makermodslab import maker_ports
+
+    seen = []
+    monkeypatch.setattr(
+        maker_ports, "_identify_sync", lambda ports, *a: seen.extend(ports) or {"success": True}
+    )
+    result = await maker_ports.identify_maker_arm_by_motion("teleop", ["gs_usb:A", "COM3"])
+    assert result["success"]
+    assert seen == ["COM3"]
+
+
+def test_discovery_cleanup_failure_does_not_hide_serials(monkeypatch):
+    monkeypatch.setattr(ids, "discover_gs_usb", lambda: [SimpleNamespace(serial_number="A", gs_usb=object())])
+    monkeypatch.setattr(ids, "dispose_usb", lambda dev: (_ for _ in ()).throw(OSError("cleanup")))
+    assert ids.available_gs_usb_ports() == ["gs_usb:A"]

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -787,7 +787,7 @@ def test_handle_start_inference_pins_return_to_initial_position(monkeypatch, tmp
     cmd = captured["cmd"]
     assert "--return_to_initial_position=true" in cmd
     # Sanity: the core rollout invocation is intact around our pinned flag.
-    assert "lerobot.scripts.lerobot_rollout" in cmd
+    assert "makermodslab.maker_rollout" in cmd
     assert "--strategy.type=base" in cmd
 
 
@@ -979,7 +979,7 @@ def test_build_rollout_cmd_wraps_robot_args_with_shared_flags() -> None:
 
     robot_args = ["--robot.type=so101_follower", "--robot.port=/dev/ttyUSB0"]
     cmd = _build_rollout_cmd(_stub_request(), "/local/pretrained_model", robot_args)
-    assert "lerobot.scripts.lerobot_rollout" in cmd
+    assert "makermodslab.maker_rollout" in cmd
     assert "--strategy.type=base" in cmd
     assert "--policy.path=/local/pretrained_model" in cmd
     assert "--robot.type=so101_follower" in cmd
@@ -2998,7 +2998,7 @@ def test_eval_runner_and_rollout_argv_share_every_flag() -> None:
     rollout_cmd = _build_rollout_cmd(request, *args)
     runner_cmd = _build_eval_runner_cmd(request, *args)
 
-    assert rollout_cmd[1:3] == ["-m", "lerobot.scripts.lerobot_rollout"]
+    assert rollout_cmd[1:3] == ["-m", "makermodslab.maker_rollout"]
     assert runner_cmd[1:3] == ["-m", "makermodslab.eval_runner"]
     assert rollout_cmd[3:] == runner_cmd[3:]
     assert "--return_to_initial_position=true" in runner_cmd
@@ -3115,7 +3115,7 @@ def test_single_episode_start_still_spawns_lerobot_rollout(monkeypatch, tmp_path
     monkeypatch.setattr(rollout.subprocess, "Popen", _FakeProc)
 
     assert rollout.handle_start_inference(_eval_request(1))["success"] is True
-    assert captured["cmd"][1:3] == ["-m", "lerobot.scripts.lerobot_rollout"]
+    assert captured["cmd"][1:3] == ["-m", "makermodslab.maker_rollout"]
     assert captured["stdin"].closed is True
     assert rollout._eval_session is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -959,6 +959,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gs-usb"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyusb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/d8/bb03645332d0de656b913cf4ac151aabc5c2c6e3c0c1fa30814fd4c45126/gs_usb-0.3.1.tar.gz", hash = "sha256:a8a76285fda29b45a5a633cfe232a08058f642441b3d030877dc28ef6e0b7807", size = 6605, upload-time = "2026-02-25T11:01:02.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/08/13b4e21ff15df9b7017e7e6265282df78098e50275bb99efc26b5d14ce29/gs_usb-0.3.1-py2.py3-none-any.whl", hash = "sha256:1c35d4404427db3f7955a687a1235b5829f94c61ece56eb0cf3f3b23e2d44883", size = 7333, upload-time = "2026-02-25T11:01:01.439Z" },
+]
+
+[[package]]
 name = "gymnasium"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1294,6 +1306,10 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+gs-usb = [
+    { name = "gs-usb" },
+    { name = "pyusb" },
+]
 metal-leader = [
     { name = "lerobot", extra = ["pin-dep"] },
 ]
@@ -1312,6 +1328,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
+    { name = "gs-usb", marker = "extra == 'gs-usb'", specifier = "==0.3.1" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27" },
     { name = "lerobot", extras = ["core-scripts", "feetech", "training", "maker", "damiao", "rebot"], git = "https://github.com/makermods-robotics/lerobot.git?rev=5ce2fe41a63647c20b2ab6e84bcb4cc7295a9b21" },
     { name = "lerobot", extras = ["pin-dep"], marker = "extra == 'metal-leader'", git = "https://github.com/makermods-robotics/lerobot.git?rev=5ce2fe41a63647c20b2ab6e84bcb4cc7295a9b21" },
@@ -1326,11 +1343,12 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
     { name = "python-dotenv", marker = "extra == 'remote'", specifier = ">=1" },
+    { name = "pyusb", marker = "extra == 'gs-usb'", specifier = ">=1.3.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "uvicorn", specifier = ">=0.24.0" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
-provides-extras = ["dev", "remote", "test", "metal-leader"]
+provides-extras = ["gs-usb", "dev", "remote", "test", "metal-leader"]
 
 [[package]]
 name = "markdown-it-py"
@@ -2354,6 +2372,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pyusb"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/6b/ce3727395e52b7b76dfcf0c665e37d223b680b9becc60710d4bc08b7b7cb/pyusb-1.3.1.tar.gz", hash = "sha256:3af070b607467c1c164f49d5b0caabe8ac78dbed9298d703a8dbf9df4052d17e", size = 77281, upload-time = "2025-01-08T23:45:01.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b8/27e6312e86408a44fe16bd28ee12dd98608b39f7e7e57884a24e8f29b573/pyusb-1.3.1-py3-none-any.whl", hash = "sha256:bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430", size = 58465, upload-time = "2025-01-08T23:45:00.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Maker followers can now discover candleLight/gs_usb adapters and save them by stable USB serial, then use them through calibration and robot sessions. The follower dropdown labels these adapters explicitly and prevents assigning them to leader slots.

The optional transport uses bounded classic-CAN I/O, exact adapter selection, transmit-echo rejection, and cleanup on connection failure. Detect uses non-clearing MIT fault queries; hand-motion port identification is unavailable for gs_usb. Install with `uv sync --extra gs-usb` and, on macOS, `brew install libusb`.

Validation:
- Focused regression and API contract tests, including OpenAPI snapshot freshness, against main's pinned LeRobot source.
- Both TypeScript projects passed; dialog ESLint has no errors and one existing warning.
- All CI-equivalent pre-commit hooks passed (`export-openapi` skipped; freshness tested separately).
- `uv lock --check` passed.

End-to-end teleoperation and recording over gs_usb remain unverified on hardware. This PR contains only gs_usb app support; motor-ID scripts and hardware configuration changes are excluded. Targets main as requested.
